### PR TITLE
fix(imagetool): isolate workspace readers from saves

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -385,12 +385,6 @@ Use {menuselection}`File --> Offload to Workspace` to make the selected data laz
 the workspace file. This frees up memory but will slow down indexing and slicing. Use
 {menuselection}`Dask --> Load Into Memory` in ImageTool to bring it back into memory.
 
-:::{versionchanged} 3.27.0
-Workspace-backed Dask arrays can use thread or process workers. Each process opens the
-workspace as read-only for one chunk and closes it after the read. Workers on another
-computer must have read access to the same workspace path.
-:::
-
 If the workspace contains watched notebook variables, the watched rows reopen with
 their variable-name badges. The rows stay disconnected until a notebook defines the
 matching variables and reconnects them, as described in

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -385,6 +385,12 @@ Use {menuselection}`File --> Offload to Workspace` to make the selected data laz
 the workspace file. This frees up memory but will slow down indexing and slicing. Use
 {menuselection}`Dask --> Load Into Memory` in ImageTool to bring it back into memory.
 
+:::{versionchanged} 3.27.0
+Workspace-backed Dask arrays can use thread or process workers. Each process opens the
+workspace as read-only for one chunk and closes it after the read. Workers on another
+computer must have read access to the same workspace path.
+:::
+
 If the workspace contains watched notebook variables, the watched rows reopen with
 their variable-name badges. The rows stay disconnected until a notebook defines the
 matching variables and reconnects them, as described in

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -110,6 +110,7 @@ COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
         "tests/interactive/imagetool/manager/workspace/test_pending.py",
         "tests/interactive/imagetool/manager/workspace/test_pending_preview.py",
         "tests/interactive/imagetool/manager/workspace/test_storage.py",
+        "tests/interactive/imagetool/manager/workspace/test_store.py",
     ),
     "cov-qt-manager-provenance-console": (
         "tests/interactive/imagetool/manager/provenance",

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -231,23 +231,6 @@ class WorkspaceOptions(BaseModel):
             ],
         ),
     )
-    use_incremental: bool = Field(
-        default=True,
-        title="Use incremental saves",
-        description=(
-            "Use fast incremental saves for ImageTool Manager workspace files "
-            "for small changes."
-        ),
-    )
-    incremental_save_on_remote: bool = Field(
-        default=False,
-        title="Incremental save on remote",
-        description=(
-            "Allow incremental workspace saves on network drives and common "
-            "cloud-sync paths. When disabled, ImageTool Manager uses full saves "
-            "for these paths."
-        ),
-    )
 
     @model_validator(mode="before")
     @classmethod

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -381,6 +381,7 @@ class BaseImageTool(QtWidgets.QMainWindow):
 
     def closeEvent(self, evt: QtGui.QCloseEvent | None) -> None:
         self.slicer_area._discard_pending_history_entry()
+        self.slicer_area._close_data_resource_cache()
         self.slicer_area.close_associated_windows()
         super().closeEvent(evt)
 

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -1441,7 +1441,7 @@ class _ActionsController:
             )
 
     def _show_operation_error(self, log_message: str, text: str) -> None:
-        logger.exception(log_message, extra={"suppress_ui_alert": True})
+        logger.error(log_message, extra={"suppress_ui_alert": True})
         erlab.interactive.utils.MessageDialog.critical(
             self._manager,
             "Error",
@@ -1455,15 +1455,9 @@ class _ActionsController:
         self, error: workspace_saving._WorkspaceSaveError
     ) -> None:
         source_path = error.missing_source_path
-        if source_path is None:
-            title = "Error"
-            text = "An error occurred while saving the workspace file."
-            logger.error(
-                "Error while saving workspace\n%s",
-                error.traceback_text,
-                extra={"suppress_ui_alert": True},
-            )
-        else:
+        conflict_path = error.publication_conflict_path
+        access_denied_path = error.access_denied_path
+        if source_path is not None:
             title = "Workspace Backing File Missing"
             text = (
                 "ImageTool Manager could not save this workspace because it still "
@@ -1476,12 +1470,38 @@ class _ActionsController:
                 "memory cannot be recovered. Items already loaded may remain available "
                 "in the current session."
             )
-            logger.error(
-                "Error while saving workspace; backing file is missing: %s\n%s",
-                source_path,
-                error.traceback_text,
-                extra={"suppress_ui_alert": True},
+            log_message = f"Workspace backing file is missing: {source_path}"
+        elif conflict_path is not None:
+            title = "Workspace Changed on Disk"
+            text = (
+                "ImageTool Manager did not overwrite the workspace because the file "
+                "changed while the save was in progress:\n\n"
+                f"{conflict_path}\n\n"
+                "Your changes remain open in ImageTool Manager. Reopen the file to use "
+                "the version on disk, or use Save As to keep your open changes."
             )
+            log_message = f"Workspace changed during save: {conflict_path}"
+        elif access_denied_path is not None:
+            title = "Workspace File Cannot Be Updated"
+            text = (
+                "ImageTool Manager could not update this workspace file:\n\n"
+                f"{access_denied_path}\n\n"
+                "Another program may have the file open, or the folder may not permit "
+                "changes. Close file previews and other programs that use the file. "
+                "Also verify that you can write to the folder, and then try again.\n\n"
+                "Your changes remain open in ImageTool Manager."
+            )
+            log_message = f"Access was denied while saving: {access_denied_path}"
+        else:
+            title = "Error"
+            text = "An error occurred while saving the workspace file."
+            log_message = "Error while saving workspace"
+        logger.error(
+            "%s\n%s",
+            log_message,
+            error.traceback_text,
+            extra={"suppress_ui_alert": True},
+        )
         erlab.interactive.utils.MessageDialog.critical(
             self._manager,
             title,

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1141,16 +1141,6 @@ class ImageToolManager(_ImageToolManagerBase):
                         event.ignore()
                     return
 
-            def _close_after_compaction() -> None:
-                self.close()
-
-            if self._workspace_controller._compact_workspace_before_shutdown(
-                on_finished=_close_after_compaction
-            ):
-                if event:
-                    event.ignore()
-                return
-
             logger.debug("Stopping servers...")
             self._registry_heartbeat_timer.stop()
             self._registry_heartbeat.stop()
@@ -2191,10 +2181,6 @@ class ImageToolManager(_ImageToolManagerBase):
         schema_version: int,
         *,
         native: bool = True,
-        delta_save_count: int = 0,
-        estimated_obsolete_bytes: int = 0,
-        replacement_delta_count: int = 0,
-        repack_estimate_known: bool = True,
         workspace_access: _WorkspaceDocumentAccess | None = None,
         rebind_data: bool = True,
     ) -> None:
@@ -2202,10 +2188,6 @@ class ImageToolManager(_ImageToolManagerBase):
             fname,
             schema_version,
             native=native,
-            delta_save_count=delta_save_count,
-            estimated_obsolete_bytes=estimated_obsolete_bytes,
-            replacement_delta_count=replacement_delta_count,
-            repack_estimate_known=repack_estimate_known,
             workspace_access=workspace_access,
             rebind_data=rebind_data,
         )

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1186,6 +1186,7 @@ class ImageToolManager(_ImageToolManagerBase):
                 self.console.deleteLater()
 
             logger.debug("Releasing workspace lock...")
+            self._workspace_controller._release_imported_workspace_accesses()
             self._workspace_controller._release_workspace_lock()
 
             logger.debug("Closing dask client (if any)...")
@@ -1265,6 +1266,8 @@ class ImageToolManager(_ImageToolManagerBase):
         if not self._workspace_state.closing_document:
             self._refresh_dependency_dependents(uid)
             self._figure_workflows._refresh_figure_source_controls()
+        if self._workspace_state.loading_depth == 0:
+            self._workspace_controller._release_unused_imported_workspace_accesses()
 
     def _iter_descendant_uids(self, uid: str) -> list[str]:
         return self._tool_graph.descendant_uids(uid)
@@ -1477,6 +1480,8 @@ class ImageToolManager(_ImageToolManagerBase):
             self._figure_workflows._refresh_figure_source_controls()
         wrapper.dispose()
         wrapper.deleteLater()
+        if self._workspace_state.loading_depth == 0:
+            self._workspace_controller._release_unused_imported_workspace_accesses()
 
     @contextlib.contextmanager
     def _bulk_remove_context(self) -> Iterator[None]:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 import h5netcdf
 import hdf5plugin
 import numpy as np
+import psutil
 import xarray as xr
 from xarray.backends import CachingFileManager, H5NetCDFStore
 from xarray.backends.locks import SerializableLock
@@ -128,17 +129,11 @@ def _workspace_reader_directory() -> pathlib.Path:
 
 
 def _workspace_process_is_running(process_id: int) -> bool:
-    if process_id == os.getpid():
-        return True
     try:
-        os.kill(process_id, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
+        return psutil.pid_exists(process_id)
+    except (OSError, psutil.Error):
+        # Stale cleanup must not remove files when liveness is uncertain.
         return True
-    except OSError:
-        return True
-    return True
 
 
 def _cleanup_stale_workspace_reader_directories() -> None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -359,7 +359,13 @@ class WorkspaceFileManager(CachingFileManager):
             return
 
         ensure_workspace_hdf5_filters_registered()
-        self.lock = SerializableLock()
+        reader_key = (
+            "erlab-workspace-reader",
+            *_workspace_file_identity(target),
+            "r",
+        )
+        with _WORKSPACE_FILE_LOCKS_LOCK:
+            self.lock = SerializableLock(reader_key)
         super().__init__(
             h5netcdf.File,
             target,
@@ -370,11 +376,7 @@ class WorkspaceFileManager(CachingFileManager):
                 "decode_vlen_strings": True,
             },
             lock=self.lock,
-            manager_id=(
-                "erlab-workspace-reader",
-                *_workspace_file_identity(target),
-                "r",
-            ),
+            manager_id=reader_key,
         )
 
     def _check_process(self) -> None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -422,7 +422,7 @@ class WorkspaceFileManager(CachingFileManager):
     @property
     def legacy_group_path(self) -> str | None:
         """Return the group needed by a pre-generation lazy reader."""
-        if self._store is None or self._object_id is not None:
+        if self._object_id is not None:
             return None
         first_component = (self._group_path or "/").strip("/").partition("/")[0]
         if first_component.startswith("__itws_"):
@@ -557,12 +557,25 @@ class WorkspaceFileManager(CachingFileManager):
         reader_path = self.reader_path if store is None else str(store.path)
         workspace_path = self.workspace_path if store is None else reader_path
         workspace_id = self._workspace_id if store is None else store.workspace_id
-        workspace_store.WorkspaceStore.pin_serialized_reader(
-            workspace_id=workspace_id,
-            path=reader_path,
-            object_id=self._object_id,
-            legacy_group_path=self.legacy_group_path,
-        )
+        pin_store = store
+        if pin_store is None:
+            active_store = workspace_store.WorkspaceStore.active(reader_path)
+            if active_store is not None and (
+                workspace_id is None or active_store.workspace_id == workspace_id
+            ):
+                pin_store = active_store
+        if pin_store is None:
+            workspace_store.WorkspaceStore.pin_serialized_reader(
+                workspace_id=workspace_id,
+                path=reader_path,
+                object_id=self._object_id,
+                legacy_group_path=self.legacy_group_path,
+            )
+        else:
+            pin_store.pin_serialized_reader_reference(
+                object_id=self._object_id,
+                legacy_group_path=self.legacy_group_path,
+            )
         return (
             "erlab-workspace-bounded-reader-v1",
             workspace_path,

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -681,6 +681,13 @@ class _WorkspaceBackendArray(BackendArray):
 class _WorkspaceH5NetCDFStore(H5NetCDFStore):
     """Build workspace arrays with a process-safe read boundary."""
 
+    def __dask_tokenize__(
+        self,
+    ) -> tuple[str, tuple[str, str, str | None, str | None]]:
+        """Return a stable token without serializing the workspace reader."""
+        manager = typing.cast("WorkspaceFileManager", self._manager)
+        return type(self).__name__, manager.__dask_tokenize__()
+
     def open_store_variable(self, name: str, var: typing.Any) -> xr.Variable:
         variable = super().open_store_variable(name, var)
         data = indexing.LazilyIndexedArray(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -2,17 +2,25 @@
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import os
 import pathlib
+import shutil
+import stat
+import tempfile
 import threading
 import typing
+import uuid
+import weakref
+from dataclasses import dataclass, field
 
 import h5netcdf
 import hdf5plugin
 import numpy as np
 import xarray as xr
 from xarray.backends import CachingFileManager, H5NetCDFStore
+from xarray.backends.locks import SerializableLock
 
 import erlab
 from erlab.interactive.imagetool import _serialization
@@ -37,6 +45,13 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 )
 
 _WORKSPACE_FILE_LOCKS: dict[str, threading.RLock] = {}
+_WORKSPACE_FILE_LOCKS_LOCK = threading.Lock()
+_WORKSPACE_READER_SNAPSHOTS: dict[tuple[object, ...], _WorkspaceReaderSnapshot] = {}
+_WORKSPACE_READER_SNAPSHOTS_BY_PATH: dict[str, _WorkspaceReaderSnapshot] = {}
+_WORKSPACE_READER_SNAPSHOTS_LOCK = threading.RLock()
+_WORKSPACE_READER_OWNER_PID = os.getpid()
+_WORKSPACE_READER_SESSION_ID = uuid.uuid4().hex
+_WORKSPACE_READER_STALE_CLEANUP_DONE = False
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
 _SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
@@ -73,22 +88,367 @@ def _workspace_file_lock(path: str | os.PathLike[str]) -> threading.RLock:
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
-    lock = _WORKSPACE_FILE_LOCKS.get(target)
-    if lock is None:
-        lock = threading.RLock()
-        _WORKSPACE_FILE_LOCKS[target] = lock
-    return lock
+    with _WORKSPACE_FILE_LOCKS_LOCK:
+        lock = _WORKSPACE_FILE_LOCKS.get(target)
+        if lock is None:
+            lock = threading.RLock()
+            _WORKSPACE_FILE_LOCKS[target] = lock
+        return lock
 
 
-def _workspace_file_identity(path: str | os.PathLike[str]) -> tuple[str, int, int, int]:
+def _workspace_save_lock(path: str | os.PathLike[str]) -> threading.RLock:
+    """Return the single-writer lock for one published workspace document."""
+    return _workspace_file_lock(path)
+
+
+def _workspace_file_identity(
+    path: str | os.PathLike[str],
+) -> tuple[str, int, int, int, int]:
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
     try:
         stat_result = os.stat(target)
+    except (FileNotFoundError, NotADirectoryError):
+        return target, 0, 0, 0, 0
+    return (
+        target,
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+    )
+
+
+def _workspace_reader_directory() -> pathlib.Path:
+    """Return the private directory for immutable workspace reader files."""
+    return pathlib.Path(tempfile.gettempdir()) / (
+        f"erlab-itws-readers-{os.getpid()}-{_WORKSPACE_READER_SESSION_ID}"
+    )
+
+
+def _workspace_process_is_running(process_id: int) -> bool:
+    if process_id == os.getpid():
+        return True
+    try:
+        os.kill(process_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
     except OSError:
-        return target, 0, 0, 0
-    return target, stat_result.st_dev, stat_result.st_ino, stat_result.st_mtime_ns
+        return True
+    return True
+
+
+def _cleanup_stale_workspace_reader_directories() -> None:
+    """Remove private reader files left by terminated manager processes."""
+    global _WORKSPACE_READER_STALE_CLEANUP_DONE
+
+    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+        if _WORKSPACE_READER_STALE_CLEANUP_DONE:
+            return
+        _WORKSPACE_READER_STALE_CLEANUP_DONE = True
+    prefix = "erlab-itws-readers-"
+    try:
+        candidates = tuple(pathlib.Path(tempfile.gettempdir()).glob(f"{prefix}*"))
+    except OSError:
+        return
+    for directory in candidates:
+        try:
+            directory_stat = directory.lstat()
+            process_id_text = directory.name.removeprefix(prefix).split("-", 1)[0]
+            process_id = int(process_id_text)
+        except (OSError, ValueError):
+            continue
+        if stat.S_ISLNK(directory_stat.st_mode) or not stat.S_ISDIR(
+            directory_stat.st_mode
+        ):
+            continue
+        if hasattr(os, "getuid") and directory_stat.st_uid != os.getuid():
+            continue
+        if _workspace_process_is_running(process_id):
+            continue
+        try:
+            children = tuple(directory.iterdir())
+        except OSError:
+            continue
+        if any(
+            child.is_symlink()
+            or not child.is_file()
+            or not child.name.startswith("reader-")
+            or child.suffix != ".itws"
+            for child in children
+        ):
+            continue
+        for child in children:
+            with contextlib.suppress(OSError):
+                child.unlink()
+        with contextlib.suppress(OSError):
+            directory.rmdir()
+
+
+def _ensure_workspace_reader_directory() -> pathlib.Path:
+    _cleanup_stale_workspace_reader_directories()
+    directory = _workspace_reader_directory()
+    try:
+        directory.mkdir(mode=0o700)
+    except FileExistsError:
+        directory_stat = directory.lstat()
+        if stat.S_ISLNK(directory_stat.st_mode) or not stat.S_ISDIR(
+            directory_stat.st_mode
+        ):
+            raise OSError(
+                f"Workspace reader path is not a private directory: {directory}"
+            ) from None
+    return directory
+
+
+def _cleanup_workspace_reader_path(path: pathlib.Path) -> None:
+    with contextlib.suppress(OSError):
+        path.unlink()
+    with contextlib.suppress(OSError):
+        path.parent.rmdir()
+
+
+@dataclass
+class _WorkspaceReaderSnapshot:
+    """One immutable local copy used by live workspace readers."""
+
+    cache_key: tuple[object, ...]
+    workspace_path: str
+    path: str
+    identity: tuple[int, int, int, int]
+    owner_pid: int
+    lock: SerializableLock = field(default_factory=SerializableLock)
+    managers: weakref.WeakSet[WorkspaceFileManager] = field(
+        default_factory=weakref.WeakSet
+    )
+    manager_count: int = 0
+    exported: bool = False
+    disposed: bool = False
+
+
+def _create_workspace_reader_file(
+    source_path: str | os.PathLike[str], *, copy_only: bool
+) -> pathlib.Path:
+    """Create one immutable reader file from a stable source."""
+    source = pathlib.Path(source_path)
+    destination = _ensure_workspace_reader_directory() / (
+        f"reader-{os.getpid()}-{uuid.uuid4().hex}.itws"
+    )
+    try:
+        if copy_only:
+            shutil.copyfile(source, destination)
+        else:
+            try:
+                os.link(source, destination)
+            except OSError:
+                shutil.copyfile(source, destination)
+    except BaseException:
+        _cleanup_workspace_reader_path(destination)
+        raise
+    return destination
+
+
+def _register_workspace_reader_snapshot(
+    snapshot: _WorkspaceReaderSnapshot,
+) -> _WorkspaceReaderSnapshot:
+    _WORKSPACE_READER_SNAPSHOTS[snapshot.cache_key] = snapshot
+    normalized_path = _normalized_file_path(snapshot.path)
+    if normalized_path is None:
+        normalized_path = snapshot.path
+    _WORKSPACE_READER_SNAPSHOTS_BY_PATH[normalized_path] = snapshot
+    return snapshot
+
+
+def _workspace_reader_snapshot(
+    workspace_path: str | os.PathLike[str],
+) -> _WorkspaceReaderSnapshot:
+    """Return an immutable local copy of one published workspace generation."""
+    target = _normalized_file_path(workspace_path)
+    if target is None:
+        target = os.fsdecode(workspace_path)
+    with _workspace_save_lock(target):
+        source_identity = _workspace_file_identity(target)
+        if source_identity[1:] == (0, 0, 0, 0):
+            raise FileNotFoundError(target)
+        cache_key: tuple[object, ...] = ("workspace", *source_identity)
+        with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+            snapshot = _WORKSPACE_READER_SNAPSHOTS.get(cache_key)
+            if snapshot is not None and pathlib.Path(snapshot.path).exists():
+                return snapshot
+
+        reader_path = _create_workspace_reader_file(target, copy_only=True)
+        source_identity_after = _workspace_file_identity(target)
+        if source_identity_after != source_identity:
+            _cleanup_workspace_reader_path(reader_path)
+            raise RuntimeError(
+                "Workspace changed while its immutable reader copy was created: "
+                f"{target}"
+            )
+        try:
+            reader_file_identity = _workspace_file_identity(reader_path)
+            snapshot = _WorkspaceReaderSnapshot(
+                cache_key=cache_key,
+                workspace_path=target,
+                path=reader_file_identity[0],
+                identity=reader_file_identity[1:],
+                owner_pid=os.getpid(),
+            )
+            with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+                existing = _WORKSPACE_READER_SNAPSHOTS.get(cache_key)
+                if existing is not None and pathlib.Path(existing.path).exists():
+                    _cleanup_workspace_reader_path(reader_path)
+                    return existing
+                return _register_workspace_reader_snapshot(snapshot)
+        except BaseException:
+            _cleanup_workspace_reader_path(reader_path)
+            raise
+
+
+def _workspace_reader_snapshot_from_state(
+    workspace_path: str,
+    reader_path: str,
+    expected_identity: tuple[int, int, int, int],
+) -> _WorkspaceReaderSnapshot:
+    """Create or reuse a process-owned reader for serialized immutable data."""
+    normalized_reader_path = _normalized_file_path(reader_path)
+    if normalized_reader_path is None:
+        normalized_reader_path = os.fsdecode(reader_path)
+    cache_key: tuple[object, ...] = (
+        "serialized",
+        normalized_reader_path,
+        *expected_identity,
+    )
+    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+        owned = _WORKSPACE_READER_SNAPSHOTS_BY_PATH.get(normalized_reader_path)
+        if (
+            owned is not None
+            and owned.owner_pid == os.getpid()
+            and owned.identity == expected_identity
+            and pathlib.Path(owned.path).exists()
+        ):
+            return owned
+        existing = _WORKSPACE_READER_SNAPSHOTS.get(cache_key)
+        if existing is not None and pathlib.Path(existing.path).exists():
+            return existing
+
+    source_identity = _workspace_file_identity(normalized_reader_path)[1:]
+    if source_identity != expected_identity:
+        raise RuntimeError(
+            "Serialized workspace reader is no longer available: "
+            f"{normalized_reader_path}"
+        )
+    local_path = _create_workspace_reader_file(normalized_reader_path, copy_only=False)
+    if _workspace_file_identity(normalized_reader_path)[1:] != expected_identity:
+        _cleanup_workspace_reader_path(local_path)
+        raise RuntimeError(
+            "Serialized workspace reader changed while it was imported: "
+            f"{normalized_reader_path}"
+        )
+    try:
+        local_file_identity = _workspace_file_identity(local_path)
+        snapshot = _WorkspaceReaderSnapshot(
+            cache_key=cache_key,
+            workspace_path=workspace_path,
+            path=local_file_identity[0],
+            identity=local_file_identity[1:],
+            owner_pid=os.getpid(),
+        )
+        with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+            existing = _WORKSPACE_READER_SNAPSHOTS.get(cache_key)
+            if existing is not None and pathlib.Path(existing.path).exists():
+                _cleanup_workspace_reader_path(local_path)
+                return existing
+            return _register_workspace_reader_snapshot(snapshot)
+    except BaseException:
+        _cleanup_workspace_reader_path(local_path)
+        raise
+
+
+def _acquire_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> None:
+    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+        if snapshot.disposed or snapshot.owner_pid != os.getpid():
+            raise RuntimeError("Workspace reader belongs to another process")
+        snapshot.manager_count += 1
+
+
+def _dispose_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> None:
+    if snapshot.owner_pid != os.getpid():
+        return
+    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+        if snapshot.disposed:
+            return
+        snapshot.disposed = True
+        if _WORKSPACE_READER_SNAPSHOTS.get(snapshot.cache_key) is snapshot:
+            del _WORKSPACE_READER_SNAPSHOTS[snapshot.cache_key]
+        if _WORKSPACE_READER_SNAPSHOTS_BY_PATH.get(snapshot.path) is snapshot:
+            del _WORKSPACE_READER_SNAPSHOTS_BY_PATH[snapshot.path]
+    _cleanup_workspace_reader_path(pathlib.Path(snapshot.path))
+
+
+def _release_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> None:
+    if snapshot.owner_pid != os.getpid():
+        return
+    dispose = False
+    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+        if snapshot.disposed:
+            return
+        snapshot.manager_count -= 1
+        dispose = snapshot.manager_count == 0 and not snapshot.exported
+    if dispose:
+        _dispose_workspace_reader_snapshot(snapshot)
+
+
+def _export_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> None:
+    if snapshot.owner_pid != os.getpid():
+        raise RuntimeError(
+            "Workspace readers cannot be inherited across fork; use spawn"
+        )
+    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+        if snapshot.disposed or not pathlib.Path(snapshot.path).exists():
+            raise RuntimeError("Workspace reader is no longer available")
+        snapshot.exported = True
+
+
+def _cleanup_workspace_reader_snapshots() -> None:
+    if os.getpid() != _WORKSPACE_READER_OWNER_PID:
+        return
+    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
+        snapshots = tuple(_WORKSPACE_READER_SNAPSHOTS.values())
+    for snapshot in snapshots:
+        for manager in tuple(snapshot.managers):
+            manager.close()
+        _dispose_workspace_reader_snapshot(snapshot)
+
+
+def _reset_workspace_reader_state_after_fork() -> None:
+    """Drop inherited registries without cleaning parent-owned reader files."""
+    global _WORKSPACE_FILE_LOCKS
+    global _WORKSPACE_FILE_LOCKS_LOCK
+    global _WORKSPACE_READER_SNAPSHOTS
+    global _WORKSPACE_READER_SNAPSHOTS_BY_PATH
+    global _WORKSPACE_READER_SNAPSHOTS_LOCK
+    global _WORKSPACE_READER_OWNER_PID
+    global _WORKSPACE_READER_SESSION_ID
+    global _WORKSPACE_READER_STALE_CLEANUP_DONE
+
+    _WORKSPACE_FILE_LOCKS = {}
+    _WORKSPACE_FILE_LOCKS_LOCK = threading.Lock()
+    _WORKSPACE_READER_SNAPSHOTS = {}
+    _WORKSPACE_READER_SNAPSHOTS_BY_PATH = {}
+    _WORKSPACE_READER_SNAPSHOTS_LOCK = threading.RLock()
+    _WORKSPACE_READER_OWNER_PID = os.getpid()
+    _WORKSPACE_READER_SESSION_ID = uuid.uuid4().hex
+    _WORKSPACE_READER_STALE_CLEANUP_DONE = False
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_workspace_reader_state_after_fork)
+
+
+atexit.register(_cleanup_workspace_reader_snapshots)
 
 
 def _xarray_source_path(value: object) -> str | None:
@@ -110,6 +470,61 @@ def dataarray_source_paths(data_array: xr.DataArray) -> tuple[str, ...]:
     for coord in data_array.coords.values():
         _append_source(coord.encoding.get("source"))
     return tuple(paths)
+
+
+def _workspace_xarray_variables(
+    value: xr.DataArray | xr.Dataset,
+) -> tuple[xr.Variable, ...]:
+    if isinstance(value, xr.Dataset):
+        return tuple(value.variables.values())
+    return (value.variable, *(coord.variable for coord in value.coords.values()))
+
+
+def _workspace_xarray_source_snapshot(
+    value: xr.DataArray | xr.Dataset,
+) -> tuple[tuple[xr.Variable, bool, typing.Any], ...]:
+    """Return source encodings that can be restored after a failed retarget."""
+    return tuple(
+        (variable, "source" in variable.encoding, variable.encoding.get("source"))
+        for variable in _workspace_xarray_variables(value)
+    )
+
+
+def _restore_workspace_xarray_source_snapshot(
+    snapshot: Iterable[tuple[xr.Variable, bool, typing.Any]],
+) -> None:
+    for variable, had_source, source in reversed(tuple(snapshot)):
+        if had_source:
+            variable.encoding["source"] = source
+        else:
+            variable.encoding.pop("source", None)
+
+
+def retarget_workspace_xarray_sources(
+    value: xr.DataArray | xr.Dataset,
+    old_workspace_path: str | os.PathLike[str],
+    new_workspace_path: str | os.PathLike[str],
+) -> None:
+    """Update logical workspace provenance without changing data backing."""
+    old_path = _normalized_file_path(old_workspace_path)
+    new_path = _normalized_file_path(new_workspace_path)
+    if old_path is None or new_path is None or old_path == new_path:
+        return
+    for variable in _workspace_xarray_variables(value):
+        if _normalized_file_path(variable.encoding.get("source")) == old_path:
+            variable.encoding["source"] = new_path
+
+
+def set_workspace_xarray_sources(
+    value: xr.DataArray | xr.Dataset,
+    workspace_path: str | os.PathLike[str],
+) -> None:
+    """Mark all variables as logically stored in a saved workspace."""
+    target = _normalized_file_path(workspace_path)
+    if target is None:
+        return
+    for variable in _workspace_xarray_variables(value):
+        variable.encoding["source"] = target
 
 
 def dataarray_is_numpy_backed(data_array: xr.DataArray) -> bool:
@@ -226,29 +641,82 @@ def workspace_dataset_encoding(
 class WorkspaceFileManager(CachingFileManager):
     """xarray file manager for manager-owned workspace readers."""
 
-    def __init__(self, path: str | os.PathLike[str]) -> None:
+    _base_del = CachingFileManager.__del__
 
-        ensure_workspace_hdf5_filters_registered()
+    def __init__(self, path: str | os.PathLike[str]) -> None:
         target = _normalized_file_path(path)
         if target is None:
             target = os.fsdecode(path)
-        identity = _workspace_file_identity(target)
-        super().__init__(
-            h5netcdf.File,
-            target,
-            mode="r+",
-            kwargs={
-                "invalid_netcdf": None,
-                "phony_dims": "sort",
-                "decode_vlen_strings": True,
-            },
-            lock=_workspace_file_lock(target),
-            # xarray documents manager_id as a test/dependency-injection hook,
-            # but the manager needs repeated workspace readers for the same
-            # file identity to share one cached h5netcdf handle.
-            manager_id=("erlab-workspace", *identity, "r+"),
+        self._initialize(_workspace_reader_snapshot(target))
+
+    def _initialize(self, snapshot: _WorkspaceReaderSnapshot) -> None:
+        """Initialize this manager from a process-owned immutable reader."""
+        self._snapshot = snapshot
+        self._process_id = os.getpid()
+        self.workspace_path = snapshot.workspace_path
+        self.reader_path = snapshot.path
+        _acquire_workspace_reader_snapshot(snapshot)
+        try:
+            ensure_workspace_hdf5_filters_registered()
+            super().__init__(
+                h5netcdf.File,
+                snapshot.path,
+                mode="r",
+                kwargs={
+                    "invalid_netcdf": None,
+                    "phony_dims": "sort",
+                    "decode_vlen_strings": True,
+                },
+                lock=snapshot.lock,
+                # Readers for one immutable file can share a cached handle.
+                manager_id=("erlab-workspace-reader", *snapshot.identity, "r"),
+            )
+        except BaseException:
+            _release_workspace_reader_snapshot(snapshot)
+            raise
+        snapshot.managers.add(self)
+        self._snapshot_finalizer = weakref.finalize(
+            self, _release_workspace_reader_snapshot, snapshot
         )
-        self.workspace_path = target
+
+    def _check_process(self) -> None:
+        if self._process_id != os.getpid():
+            raise RuntimeError(
+                "Workspace readers cannot be inherited across fork; "
+                "pass the data through process serialization instead"
+            )
+
+    def acquire(self, needs_lock: bool = True) -> typing.Any:
+        self._check_process()
+        return super().acquire(needs_lock)
+
+    def acquire_context(self, needs_lock: bool = True) -> typing.Any:
+        self._check_process()
+        return super().acquire_context(needs_lock)
+
+    def close(self, needs_lock: bool = True) -> None:
+        if self._process_id == os.getpid():
+            super().close(needs_lock)
+
+    def __getstate__(self) -> tuple[str, str, tuple[int, int, int, int]]:
+        self._check_process()
+        _export_workspace_reader_snapshot(self._snapshot)
+        return self.workspace_path, self.reader_path, self._snapshot.identity
+
+    def __setstate__(self, state: tuple[str, str, tuple[int, int, int, int]]) -> None:
+        workspace_path, reader_path, identity = state
+        self._initialize(
+            _workspace_reader_snapshot_from_state(workspace_path, reader_path, identity)
+        )
+
+    def __dask_tokenize__(
+        self,
+    ) -> tuple[str, str, tuple[int, int, int, int]]:
+        return type(self).__name__, self.workspace_path, self._snapshot.identity
+
+    def __del__(self) -> None:
+        if hasattr(self, "_ref_counter"):
+            self._base_del()
 
 
 def _iter_h5netcdf_group_paths(group: object, path: str = "/") -> Iterator[str]:
@@ -268,13 +736,17 @@ def _open_workspace_dataset_from_manager(
     store = H5NetCDFStore(
         file_manager,
         group=group,
-        mode="r+",
-        lock=_workspace_file_lock(file_manager.workspace_path),
+        mode="r",
+        lock=file_manager._snapshot.lock,
         autoclose=False,
     )
     if chunks is None:
-        return xr.open_dataset(store)
-    return xr.open_dataset(store, chunks=chunks)
+        ds = xr.open_dataset(store)
+    else:
+        ds = xr.open_dataset(store, chunks=chunks)
+    for variable in ds.variables.values():
+        variable.encoding["source"] = file_manager.workspace_path
+    return ds
 
 
 def open_workspace_dataset(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -557,6 +557,12 @@ class WorkspaceFileManager(CachingFileManager):
         reader_path = self.reader_path if store is None else str(store.path)
         workspace_path = self.workspace_path if store is None else reader_path
         workspace_id = self._workspace_id if store is None else store.workspace_id
+        workspace_store.WorkspaceStore.pin_serialized_reader(
+            workspace_id=workspace_id,
+            path=reader_path,
+            object_id=self._object_id,
+            legacy_group_path=self.legacy_group_path,
+        )
         return (
             "erlab-workspace-bounded-reader-v1",
             workspace_path,

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -109,10 +109,10 @@ def _open_workspace_h5_file_for_read(
     """
     active_store = workspace_store.WorkspaceStore.active(path)
     if active_store is not None:
-        with active_store.lock:
+        with active_store.read_session() as h5_file:
             with contextlib.suppress(workspace_store.WorkspaceStoreConflictError):
                 active_store.require_current_path()
-            yield active_store.read_h5_file
+            yield h5_file
         return
 
     ensure_workspace_hdf5_filters_registered()
@@ -160,28 +160,16 @@ def dataarray_source_paths(data_array: xr.DataArray) -> tuple[str, ...]:
     return tuple(paths)
 
 
-@contextlib.contextmanager
-def workspace_computation_session(
-    value: xr.DataArray | xr.Dataset,
-) -> Iterator[None]:
-    """Keep an active workspace stable while *value* computes.
-
-    A process worker opens and closes its own read-only handle for each chunk.
-    This manager-side gate prevents a save or compaction from changing the file
-    while those bounded reads are in progress.
-    """
-    stores: dict[str, workspace_store.WorkspaceStore] = {}
+def workspace_write_in_progress(value: xr.DataArray | xr.Dataset) -> bool:
+    """Return whether a source workspace is waiting to write or is writing."""
     for variable in _workspace_xarray_variables(value):
         source = _normalized_file_path(variable.encoding.get("source"))
         if source is None:
             continue
         store = workspace_store.WorkspaceStore.active(source)
-        if store is not None:
-            stores[str(store.path)] = store
-    with contextlib.ExitStack() as stack:
-        for path in sorted(stores):
-            stack.enter_context(stores[path].computation_session())
-        yield
+        if store is not None and store.write_in_progress:
+            return True
+    return False
 
 
 def _workspace_xarray_variables(
@@ -354,8 +342,9 @@ def workspace_dataset_encoding(
 class WorkspaceFileManager(CachingFileManager):
     """xarray file manager for one workspace payload.
 
-    Associated workspaces acquire the manager-owned HDF5 handle. Other files use
-    xarray's read-only file cache and do not create private workspace copies.
+    Associated workspaces acquire the manager-owned HDF5 handle. Other local
+    readers keep xarray's cache until a store adopts and closes it. Serialized
+    workers use bounded handles.
     """
 
     _base_del = CachingFileManager.__del__
@@ -382,18 +371,9 @@ class WorkspaceFileManager(CachingFileManager):
         self._process_id = os.getpid()
         self.workspace_path = target
         self.reader_path = target
-        self._store = workspace_store.WorkspaceStore.active(target)
         self._object_id = object_id
         reader_key = ("erlab-workspace-reader", target)
         self.lock = SerializableLock(reader_key)
-        if self._store is not None:
-            self._workspace_id = self._store.workspace_id
-            self._store.register_reader(self)
-            if object_id is not None:
-                self._store.acquire_object(object_id)
-                self._store_lease_released = False
-            return
-
         ensure_workspace_hdf5_filters_registered()
         cache_key = (
             "erlab-workspace-reader",
@@ -408,10 +388,30 @@ class WorkspaceFileManager(CachingFileManager):
                 "invalid_netcdf": None,
                 "phony_dims": "sort",
                 "decode_vlen_strings": True,
+                "locking": "best-effort",
             },
             lock=self.lock,
             manager_id=cache_key,
         )
+        store = workspace_store.WorkspaceStore.register_path_reader(target, self)
+        if store is not None:
+            self._attach_store(store)
+
+    def _attach_store(self, store: workspace_store.WorkspaceStore) -> None:
+        """Attach this reader to the store that now owns its path."""
+        if self._store is store:
+            return
+        if self._store is not None:
+            raise RuntimeError("Workspace reader is already attached to a store")
+        with self.lock:
+            if hasattr(self, "_ref_counter"):
+                super().close(needs_lock=False)
+            self._store = store
+            self._workspace_id = store.workspace_id
+            store.register_reader(self)
+            if self._object_id is not None:
+                store.acquire_object(self._object_id)
+                self._store_lease_released = False
 
     def _check_process(self) -> None:
         if self._process_id != os.getpid():
@@ -447,14 +447,13 @@ class WorkspaceFileManager(CachingFileManager):
                 invalid_netcdf=True,
                 phony_dims="sort",
                 decode_vlen_strings=True,
+                locking="best-effort",
             )
             self._store_handle_generation = store.handle_generation
         return self._netcdf_file
 
     def _read_bounded_variable(self, variable_name: str, key: typing.Any) -> typing.Any:
         """Read one array selection through a worker-owned file handle."""
-        if not self._serialized_worker:
-            raise RuntimeError("A bounded workspace read requires worker state")
 
         def _read() -> typing.Any:
             ensure_workspace_hdf5_filters_registered()
@@ -464,6 +463,7 @@ class WorkspaceFileManager(CachingFileManager):
                 invalid_netcdf=True,
                 phony_dims="sort",
                 decode_vlen_strings=True,
+                locking="best-effort",
             ) as netcdf_file:
                 workspace_id = netcdf_file.attrs.get(workspace_store._WORKSPACE_ID_ATTR)
                 if isinstance(workspace_id, bytes):
@@ -483,7 +483,7 @@ class WorkspaceFileManager(CachingFileManager):
                 return group.variables[variable_name][key]
 
         try:
-            return workspace_store._retry_file_access(_read)
+            return workspace_store._wait_for_hdf5_access(_read)
         except (FileNotFoundError, PermissionError) as exc:
             raise WorkspaceWorkerAccessError(
                 "A Dask worker cannot read the workspace file. The workspace "
@@ -498,6 +498,15 @@ class WorkspaceFileManager(CachingFileManager):
         if netcdf_file is not None:
             netcdf_file.close()
 
+    def _remember_workspace_id(self, netcdf_file: h5netcdf.File) -> None:
+        if self._workspace_id is not None:
+            return
+        workspace_id = netcdf_file.attrs.get(workspace_store._WORKSPACE_ID_ATTR)
+        if isinstance(workspace_id, bytes):
+            workspace_id = workspace_id.decode()
+        if isinstance(workspace_id, str) and workspace_id:
+            self._workspace_id = workspace_id
+
     def acquire(self, needs_lock: bool = True) -> typing.Any:
         self._check_process()
         if self._serialized_worker:
@@ -506,10 +515,12 @@ class WorkspaceFileManager(CachingFileManager):
             )
         if self._store is not None:
             if needs_lock:
-                with self._store.lock:
+                with self._store.read_session():
                     return self._active_netcdf_file()
             return self._active_netcdf_file()
-        return super().acquire(needs_lock)
+        netcdf_file = super().acquire(needs_lock)
+        self._remember_workspace_id(netcdf_file)
+        return netcdf_file
 
     @contextlib.contextmanager
     def acquire_context(self, needs_lock: bool = True) -> Iterator[typing.Any]:
@@ -520,20 +531,25 @@ class WorkspaceFileManager(CachingFileManager):
             )
         if self._store is not None:
             if needs_lock:
-                with self._store.lock:
+                with self._store.read_session():
                     yield self._active_netcdf_file()
             else:
                 yield self._active_netcdf_file()
             return
         with super().acquire_context(needs_lock) as file:
+            self._remember_workspace_id(file)
             yield file
 
     def close(self, needs_lock: bool = True) -> None:
-        if (
-            self._store is None
-            and not self._serialized_worker
-            and self._process_id == os.getpid()
-        ):
+        if self._serialized_worker or self._process_id != os.getpid():
+            return
+        if self._store is not None:
+            if needs_lock:
+                with self._store.lock:
+                    self._close_store_wrapper()
+            else:
+                self._close_store_wrapper()
+        else:
             super().close(needs_lock)
 
     def __getstate__(self) -> typing.Any:
@@ -600,6 +616,13 @@ class WorkspaceFileManager(CachingFileManager):
                     self._close_store_wrapper()
                     store.unregister_reader(self)
                     self._release_store_lease()
+            else:
+                workspace_path = getattr(self, "workspace_path", None)
+                if workspace_path is not None:
+                    workspace_store.WorkspaceStore.unregister_path_reader(
+                        workspace_path,
+                        self,
+                    )
         if not getattr(self, "_serialized_worker", False) and hasattr(
             self, "_ref_counter"
         ):
@@ -643,7 +666,7 @@ class _WorkspaceBackendArray(BackendArray):
                     self.variable_name
                 ]
                 return array[key]
-        with store.lock:
+        with store.read_session():
             array = self.datastore._acquire(needs_lock=False).variables[
                 self.variable_name
             ]
@@ -692,10 +715,13 @@ def _open_workspace_dataset_from_manager(
         lock=file_manager.lock,
         autoclose=False,
     )
-    if chunks is None:
-        ds = xr.open_dataset(store)
-    else:
-        ds = xr.open_dataset(store, chunks=chunks)
+    try:
+        if chunks is None:
+            ds = xr.open_dataset(store)
+        else:
+            ds = xr.open_dataset(store, chunks=chunks)
+    finally:
+        file_manager.close()
     for variable in ds.variables.values():
         variable.encoding["source"] = file_manager.workspace_path
     return ds
@@ -795,8 +821,8 @@ def _read_workspace_root_attrs_h5py(
     ensure_workspace_hdf5_filters_registered()
     active_store = workspace_store.WorkspaceStore.active(fname)
     if active_store is not None:
-        with active_store.lock:
-            attrs = _h5py_attrs_to_dict(active_store.read_h5_file.attrs)
+        with active_store.read_session() as h5_file:
+            attrs = _h5py_attrs_to_dict(h5_file.attrs)
             if int(attrs.get("imagetool_workspace_schema_version", 1)) == 5:
                 attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(
                     active_store.current_generation().manifest

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import json
 import os
 import pathlib
@@ -13,10 +14,11 @@ import h5netcdf
 import hdf5plugin
 import numpy as np
 import xarray as xr
-from xarray.backends import CachingFileManager, H5NetCDFStore
+from xarray.backends import BackendArray, CachingFileManager, H5NetCDFStore
 from xarray.backends.common import ArrayWriter
 from xarray.backends.locks import SerializableLock
 from xarray.backends.writers import dump_to_store
+from xarray.core import indexing
 
 import erlab
 from erlab.interactive.imagetool import _serialization
@@ -50,6 +52,10 @@ _SAVED_TOOL_DATA_BLOB_DIM_PREFIX = _serialization.SAVED_TOOL_DATA_BLOB_DIM_PREFI
 _WORKSPACE_H5PY_DIMENSION_SCALE_ATTRS = frozenset(
     {"CLASS", "NAME", "DIMENSION_LIST", "REFERENCE_LIST"}
 )
+
+
+class WorkspaceWorkerAccessError(RuntimeError):
+    """A Dask worker cannot read the workspace document at its shared path."""
 
 
 def _replace_h5_attrs(target_attrs, attrs: Mapping[typing.Any, typing.Any]) -> None:
@@ -154,6 +160,30 @@ def dataarray_source_paths(data_array: xr.DataArray) -> tuple[str, ...]:
     return tuple(paths)
 
 
+@contextlib.contextmanager
+def workspace_computation_session(
+    value: xr.DataArray | xr.Dataset,
+) -> Iterator[None]:
+    """Keep an active workspace stable while *value* computes.
+
+    A process worker opens and closes its own read-only handle for each chunk.
+    This manager-side gate prevents a save or compaction from changing the file
+    while those bounded reads are in progress.
+    """
+    stores: dict[str, workspace_store.WorkspaceStore] = {}
+    for variable in _workspace_xarray_variables(value):
+        source = _normalized_file_path(variable.encoding.get("source"))
+        if source is None:
+            continue
+        store = workspace_store.WorkspaceStore.active(source)
+        if store is not None:
+            stores[str(store.path)] = store
+    with contextlib.ExitStack() as stack:
+        for path in sorted(stores):
+            stack.enter_context(stores[path].computation_session())
+        yield
+
+
 def _workspace_xarray_variables(
     value: xr.DataArray | xr.Dataset,
 ) -> tuple[xr.Variable, ...]:
@@ -214,6 +244,7 @@ def dataarray_is_numpy_backed(data_array: xr.DataArray) -> bool:
     return isinstance(data_array.variable._data, (np.ndarray, np.generic))
 
 
+@functools.cache
 def ensure_workspace_hdf5_filters_registered() -> None:
     """Register HDF5 filters needed by compressed workspace files."""
     hdf5plugin.register(force=False)
@@ -342,6 +373,8 @@ class WorkspaceFileManager(CachingFileManager):
         self._store_lease_released = True
         self._netcdf_file: h5netcdf.File | None = None
         self._store_handle_generation = -1
+        self._serialized_worker = False
+        self._workspace_id: str | None = None
         self.lock: typing.Any
         target = _normalized_file_path(path)
         if target is None:
@@ -351,8 +384,10 @@ class WorkspaceFileManager(CachingFileManager):
         self.reader_path = target
         self._store = workspace_store.WorkspaceStore.active(target)
         self._object_id = object_id
+        reader_key = ("erlab-workspace-reader", target)
+        self.lock = SerializableLock(reader_key)
         if self._store is not None:
-            self.lock = self._store.lock
+            self._workspace_id = self._store.workspace_id
             self._store.register_reader(self)
             if object_id is not None:
                 self._store.acquire_object(object_id)
@@ -360,13 +395,11 @@ class WorkspaceFileManager(CachingFileManager):
             return
 
         ensure_workspace_hdf5_filters_registered()
-        reader_key = (
+        cache_key = (
             "erlab-workspace-reader",
             *_workspace_file_identity(target),
             "r",
         )
-        with _WORKSPACE_FILE_LOCKS_LOCK:
-            self.lock = SerializableLock(reader_key)
         super().__init__(
             h5netcdf.File,
             target,
@@ -377,7 +410,7 @@ class WorkspaceFileManager(CachingFileManager):
                 "decode_vlen_strings": True,
             },
             lock=self.lock,
-            manager_id=reader_key,
+            manager_id=cache_key,
         )
 
     def _check_process(self) -> None:
@@ -418,6 +451,46 @@ class WorkspaceFileManager(CachingFileManager):
             self._store_handle_generation = store.handle_generation
         return self._netcdf_file
 
+    def _read_bounded_variable(self, variable_name: str, key: typing.Any) -> typing.Any:
+        """Read one array selection through a worker-owned file handle."""
+        if not self._serialized_worker:
+            raise RuntimeError("A bounded workspace read requires worker state")
+
+        def _read() -> typing.Any:
+            ensure_workspace_hdf5_filters_registered()
+            with h5netcdf.File(
+                self.reader_path,
+                mode="r",
+                invalid_netcdf=True,
+                phony_dims="sort",
+                decode_vlen_strings=True,
+            ) as netcdf_file:
+                workspace_id = netcdf_file.attrs.get(workspace_store._WORKSPACE_ID_ATTR)
+                if isinstance(workspace_id, bytes):
+                    workspace_id = workspace_id.decode()
+                if (
+                    self._workspace_id is not None
+                    and workspace_id != self._workspace_id
+                ):
+                    raise workspace_store.WorkspaceStoreConflictError(
+                        "Workspace file identity changed before a Dask chunk read: "
+                        f"{self.reader_path}"
+                    )
+                group: typing.Any = netcdf_file
+                for part in (self._group_path or "/").strip("/").split("/"):
+                    if part:
+                        group = group.groups[part]
+                return group.variables[variable_name][key]
+
+        try:
+            return workspace_store._retry_file_access(_read)
+        except (FileNotFoundError, PermissionError) as exc:
+            raise WorkspaceWorkerAccessError(
+                "A Dask worker cannot read the workspace file. The workspace "
+                "path must identify the same readable file on every worker: "
+                f"{self.reader_path}"
+            ) from exc
+
     def _close_store_wrapper(self) -> None:
         netcdf_file = self._netcdf_file
         self._netcdf_file = None
@@ -427,9 +500,13 @@ class WorkspaceFileManager(CachingFileManager):
 
     def acquire(self, needs_lock: bool = True) -> typing.Any:
         self._check_process()
+        if self._serialized_worker:
+            raise RuntimeError(
+                "Serialized workspace readers support array selections only"
+            )
         if self._store is not None:
             if needs_lock:
-                with self.lock:
+                with self._store.lock:
                     return self._active_netcdf_file()
             return self._active_netcdf_file()
         return super().acquire(needs_lock)
@@ -437,9 +514,13 @@ class WorkspaceFileManager(CachingFileManager):
     @contextlib.contextmanager
     def acquire_context(self, needs_lock: bool = True) -> Iterator[typing.Any]:
         self._check_process()
+        if self._serialized_worker:
+            raise RuntimeError(
+                "Serialized workspace readers support array selections only"
+            )
         if self._store is not None:
             if needs_lock:
-                with self.lock:
+                with self._store.lock:
                     yield self._active_netcdf_file()
             else:
                 yield self._active_netcdf_file()
@@ -448,37 +529,54 @@ class WorkspaceFileManager(CachingFileManager):
             yield file
 
     def close(self, needs_lock: bool = True) -> None:
-        if self._store is None and self._process_id == os.getpid():
+        if (
+            self._store is None
+            and not self._serialized_worker
+            and self._process_id == os.getpid()
+        ):
             super().close(needs_lock)
 
     def __getstate__(self) -> typing.Any:
         self._check_process()
-        if self._store is not None:
-            raise TypeError(
-                "An open writable workspace cannot be sent to another process"
-            )
-        return super().__getstate__()
+        store = self._store
+        reader_path = self.reader_path if store is None else str(store.path)
+        workspace_path = self.workspace_path if store is None else reader_path
+        workspace_id = self._workspace_id if store is None else store.workspace_id
+        return (
+            "erlab-workspace-bounded-reader-v1",
+            workspace_path,
+            reader_path,
+            workspace_id,
+            self._object_id,
+            self._group_path,
+        )
 
     def __setstate__(self, state: typing.Any) -> None:
-        super().__setstate__(state)
+        (
+            marker,
+            self.workspace_path,
+            self.reader_path,
+            self._workspace_id,
+            self._object_id,
+            self._group_path,
+        ) = state
+        if marker != "erlab-workspace-bounded-reader-v1":
+            raise ValueError("Unsupported serialized workspace reader")
         self._process_id = os.getpid()
         self._store = None
-        self._object_id = None
-        self._group_path = None
         self._store_lease_released = True
         self._netcdf_file = None
         self._store_handle_generation = -1
-        self.workspace_path = os.fsdecode(self._args[0])
-        self.reader_path = self.workspace_path
-        self.lock = self._lock
+        self._serialized_worker = True
+        self.lock = SerializableLock(("erlab-workspace-reader", self.reader_path))
 
     def __dask_tokenize__(self) -> tuple[str, str, str | None, str | None]:
-        store_identity = (
-            None if self._store is None else f"{id(self._store)}:{self._store.path}"
-        )
+        store = self._store
+        store_identity = None if store is None else store.workspace_id
         return (
             type(self).__name__,
-            self.workspace_path,
+            (self._workspace_id if store is None else store.workspace_id)
+            or self.workspace_path,
             self._object_id or store_identity,
             self._group_path,
         )
@@ -502,8 +600,75 @@ class WorkspaceFileManager(CachingFileManager):
                     self._close_store_wrapper()
                     store.unregister_reader(self)
                     self._release_store_lease()
-        if hasattr(self, "_ref_counter"):
+        if not getattr(self, "_serialized_worker", False) and hasattr(
+            self, "_ref_counter"
+        ):
             self._base_del()
+
+
+class _WorkspaceBackendArray(BackendArray):
+    """Use bounded file handles after a workspace array is serialized."""
+
+    def __init__(
+        self,
+        variable_name: str,
+        datastore: _WorkspaceH5NetCDFStore,
+        *,
+        shape: tuple[int, ...],
+        dtype: np.dtype,
+    ) -> None:
+        self.variable_name = variable_name
+        self.datastore = datastore
+        self.shape = shape
+        self.dtype = dtype
+
+    def __getitem__(self, key: typing.Any) -> typing.Any:
+        return indexing.explicit_indexing_adapter(
+            key,
+            self.shape,
+            indexing.IndexingSupport.OUTER_1VECTOR,
+            self._getitem,
+        )
+
+    def _getitem(self, key: typing.Any) -> typing.Any:
+        manager = self.datastore._manager
+        if not isinstance(manager, WorkspaceFileManager):
+            raise TypeError("Workspace backend requires a WorkspaceFileManager")
+        if manager._serialized_worker:
+            return manager._read_bounded_variable(self.variable_name, key)
+        store = manager._store
+        if store is None:
+            with self.datastore.lock:
+                array = self.datastore._acquire(needs_lock=False).variables[
+                    self.variable_name
+                ]
+                return array[key]
+        with store.lock:
+            array = self.datastore._acquire(needs_lock=False).variables[
+                self.variable_name
+            ]
+            return array[key]
+
+
+class _WorkspaceH5NetCDFStore(H5NetCDFStore):
+    """Build workspace arrays with a process-safe read boundary."""
+
+    def open_store_variable(self, name: str, var: typing.Any) -> xr.Variable:
+        variable = super().open_store_variable(name, var)
+        data = indexing.LazilyIndexedArray(
+            _WorkspaceBackendArray(
+                name,
+                self,
+                shape=variable.shape,
+                dtype=variable.dtype,
+            )
+        )
+        return xr.Variable(
+            variable.dims,
+            data,
+            attrs=variable.attrs,
+            encoding=variable.encoding,
+        )
 
 
 def _iter_h5netcdf_group_paths(group: object, path: str = "/") -> Iterator[str]:
@@ -520,7 +685,7 @@ def _open_workspace_dataset_from_manager(
     *,
     chunks: typing.Any,
 ) -> xr.Dataset:
-    store = H5NetCDFStore(
+    store = _WorkspaceH5NetCDFStore(
         file_manager,
         group=group,
         mode="r",

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -2,29 +2,25 @@
 
 from __future__ import annotations
 
-import atexit
 import contextlib
+import json
 import os
 import pathlib
-import shutil
-import stat
-import tempfile
 import threading
 import typing
-import uuid
-import weakref
-from dataclasses import dataclass, field
 
 import h5netcdf
 import hdf5plugin
 import numpy as np
-import psutil
 import xarray as xr
 from xarray.backends import CachingFileManager, H5NetCDFStore
+from xarray.backends.common import ArrayWriter
 from xarray.backends.locks import SerializableLock
+from xarray.backends.writers import dump_to_store
 
 import erlab
 from erlab.interactive.imagetool import _serialization
+from erlab.interactive.imagetool.manager._workspace import _store as workspace_store
 
 if typing.TYPE_CHECKING:
     from collections.abc import Hashable, Iterable, Iterator, Mapping
@@ -38,7 +34,7 @@ else:
     h5py = _lazy.load("h5py")
 
 from erlab.interactive.imagetool.manager._workspace._format import (
-    _is_workspace_internal_group_name,
+    _WORKSPACE_MANIFEST_ATTR,
     _restore_workspace_serialized_attrs,
     _sanitize_workspace_attr_names,
     _workspace_file_is_workspace,
@@ -47,12 +43,6 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 
 _WORKSPACE_FILE_LOCKS: dict[str, threading.RLock] = {}
 _WORKSPACE_FILE_LOCKS_LOCK = threading.Lock()
-_WORKSPACE_READER_SNAPSHOTS: dict[tuple[object, ...], _WorkspaceReaderSnapshot] = {}
-_WORKSPACE_READER_SNAPSHOTS_BY_PATH: dict[str, _WorkspaceReaderSnapshot] = {}
-_WORKSPACE_READER_SNAPSHOTS_LOCK = threading.RLock()
-_WORKSPACE_READER_OWNER_PID = os.getpid()
-_WORKSPACE_READER_SESSION_ID = uuid.uuid4().hex
-_WORKSPACE_READER_STALE_CLEANUP_DONE = False
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
 _TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
 _SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
@@ -102,6 +92,27 @@ def _workspace_save_lock(path: str | os.PathLike[str]) -> threading.RLock:
     return _workspace_file_lock(path)
 
 
+@contextlib.contextmanager
+def _open_workspace_h5_file_for_read(
+    path: str | os.PathLike[str],
+) -> Iterator[typing.Any]:
+    """Open a workspace for a bounded raw HDF5 read.
+
+    An associated workspace has one manager-owned handle. Reuse that handle so
+    metadata and preview reads obey the same lock as lazy reads and saves.
+    """
+    active_store = workspace_store.WorkspaceStore.active(path)
+    if active_store is not None:
+        with active_store.lock:
+            active_store.require_current_path()
+            yield active_store.h5_file
+        return
+
+    ensure_workspace_hdf5_filters_registered()
+    with _workspace_file_lock(path), h5py.File(path, "r") as h5_file:
+        yield h5_file
+
+
 def _workspace_file_identity(
     path: str | os.PathLike[str],
 ) -> tuple[str, int, int, int, int]:
@@ -119,336 +130,6 @@ def _workspace_file_identity(
         stat_result.st_size,
         stat_result.st_mtime_ns,
     )
-
-
-def _workspace_reader_directory() -> pathlib.Path:
-    """Return the private directory for immutable workspace reader files."""
-    return pathlib.Path(tempfile.gettempdir()) / (
-        f"erlab-itws-readers-{os.getpid()}-{_WORKSPACE_READER_SESSION_ID}"
-    )
-
-
-def _workspace_process_is_running(process_id: int) -> bool:
-    try:
-        return psutil.pid_exists(process_id)
-    except (OSError, psutil.Error):
-        # Stale cleanup must not remove files when liveness is uncertain.
-        return True
-
-
-def _cleanup_stale_workspace_reader_directories() -> None:
-    """Remove private reader files left by terminated manager processes."""
-    global _WORKSPACE_READER_STALE_CLEANUP_DONE
-
-    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-        if _WORKSPACE_READER_STALE_CLEANUP_DONE:
-            return
-        _WORKSPACE_READER_STALE_CLEANUP_DONE = True
-    prefix = "erlab-itws-readers-"
-    try:
-        candidates = tuple(pathlib.Path(tempfile.gettempdir()).glob(f"{prefix}*"))
-    except OSError:
-        return
-    for directory in candidates:
-        try:
-            directory_stat = directory.lstat()
-            process_id_text = directory.name.removeprefix(prefix).split("-", 1)[0]
-            process_id = int(process_id_text)
-        except (OSError, ValueError):
-            continue
-        if stat.S_ISLNK(directory_stat.st_mode) or not stat.S_ISDIR(
-            directory_stat.st_mode
-        ):
-            continue
-        if hasattr(os, "getuid") and directory_stat.st_uid != os.getuid():
-            continue
-        if _workspace_process_is_running(process_id):
-            continue
-        try:
-            children = tuple(directory.iterdir())
-        except OSError:
-            continue
-        if any(
-            child.is_symlink()
-            or not child.is_file()
-            or not child.name.startswith("reader-")
-            or child.suffix != ".itws"
-            for child in children
-        ):
-            continue
-        for child in children:
-            with contextlib.suppress(OSError):
-                child.unlink()
-        with contextlib.suppress(OSError):
-            directory.rmdir()
-
-
-def _ensure_workspace_reader_directory() -> pathlib.Path:
-    _cleanup_stale_workspace_reader_directories()
-    directory = _workspace_reader_directory()
-    try:
-        directory.mkdir(mode=0o700)
-    except FileExistsError:
-        directory_stat = directory.lstat()
-        if stat.S_ISLNK(directory_stat.st_mode) or not stat.S_ISDIR(
-            directory_stat.st_mode
-        ):
-            raise OSError(
-                f"Workspace reader path is not a private directory: {directory}"
-            ) from None
-    return directory
-
-
-def _cleanup_workspace_reader_path(path: pathlib.Path) -> None:
-    with contextlib.suppress(OSError):
-        path.unlink()
-    with contextlib.suppress(OSError):
-        path.parent.rmdir()
-
-
-@dataclass
-class _WorkspaceReaderSnapshot:
-    """One immutable local copy used by live workspace readers."""
-
-    cache_key: tuple[object, ...]
-    workspace_path: str
-    path: str
-    identity: tuple[int, int, int, int]
-    owner_pid: int
-    lock: SerializableLock = field(default_factory=SerializableLock)
-    managers: weakref.WeakSet[WorkspaceFileManager] = field(
-        default_factory=weakref.WeakSet
-    )
-    manager_count: int = 0
-    retained_for_serialization: bool = False
-    disposed: bool = False
-
-
-def _create_workspace_reader_file(
-    source_path: str | os.PathLike[str], *, copy_only: bool
-) -> pathlib.Path:
-    """Create one immutable reader file from a stable source."""
-    source = pathlib.Path(source_path)
-    destination = _ensure_workspace_reader_directory() / (
-        f"reader-{os.getpid()}-{uuid.uuid4().hex}.itws"
-    )
-    try:
-        if copy_only:
-            shutil.copyfile(source, destination)
-        else:
-            try:
-                os.link(source, destination)
-            except OSError:
-                shutil.copyfile(source, destination)
-    except BaseException:
-        _cleanup_workspace_reader_path(destination)
-        raise
-    return destination
-
-
-def _register_workspace_reader_snapshot(
-    snapshot: _WorkspaceReaderSnapshot,
-) -> _WorkspaceReaderSnapshot:
-    _WORKSPACE_READER_SNAPSHOTS[snapshot.cache_key] = snapshot
-    normalized_path = _normalized_file_path(snapshot.path)
-    if normalized_path is None:
-        normalized_path = snapshot.path
-    _WORKSPACE_READER_SNAPSHOTS_BY_PATH[normalized_path] = snapshot
-    return snapshot
-
-
-def _workspace_reader_snapshot(
-    workspace_path: str | os.PathLike[str],
-) -> _WorkspaceReaderSnapshot:
-    """Return an immutable local copy of one published workspace generation."""
-    target = _normalized_file_path(workspace_path)
-    if target is None:
-        target = os.fsdecode(workspace_path)
-    with _workspace_save_lock(target):
-        source_identity = _workspace_file_identity(target)
-        if source_identity[1:] == (0, 0, 0, 0):
-            raise FileNotFoundError(target)
-        cache_key: tuple[object, ...] = ("workspace", *source_identity)
-        with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-            snapshot = _WORKSPACE_READER_SNAPSHOTS.get(cache_key)
-            if snapshot is not None and pathlib.Path(snapshot.path).exists():
-                return snapshot
-
-        reader_path = _create_workspace_reader_file(target, copy_only=True)
-        source_identity_after = _workspace_file_identity(target)
-        if source_identity_after != source_identity:
-            _cleanup_workspace_reader_path(reader_path)
-            raise RuntimeError(
-                "Workspace changed while its immutable reader copy was created: "
-                f"{target}"
-            )
-        try:
-            reader_file_identity = _workspace_file_identity(reader_path)
-            snapshot = _WorkspaceReaderSnapshot(
-                cache_key=cache_key,
-                workspace_path=target,
-                path=reader_file_identity[0],
-                identity=reader_file_identity[1:],
-                owner_pid=os.getpid(),
-            )
-            with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-                existing = _WORKSPACE_READER_SNAPSHOTS.get(cache_key)
-                if existing is not None and pathlib.Path(existing.path).exists():
-                    _cleanup_workspace_reader_path(reader_path)
-                    return existing
-                return _register_workspace_reader_snapshot(snapshot)
-        except BaseException:
-            _cleanup_workspace_reader_path(reader_path)
-            raise
-
-
-def _workspace_reader_snapshot_from_state(
-    workspace_path: str,
-    reader_path: str,
-    expected_identity: tuple[int, int, int, int],
-) -> _WorkspaceReaderSnapshot:
-    """Create or reuse a process-owned reader for serialized immutable data."""
-    normalized_reader_path = _normalized_file_path(reader_path)
-    if normalized_reader_path is None:
-        normalized_reader_path = os.fsdecode(reader_path)
-    cache_key: tuple[object, ...] = (
-        "serialized",
-        normalized_reader_path,
-        *expected_identity,
-    )
-    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-        owned = _WORKSPACE_READER_SNAPSHOTS_BY_PATH.get(normalized_reader_path)
-        if (
-            owned is not None
-            and owned.owner_pid == os.getpid()
-            and owned.identity == expected_identity
-            and pathlib.Path(owned.path).exists()
-        ):
-            return owned
-        existing = _WORKSPACE_READER_SNAPSHOTS.get(cache_key)
-        if existing is not None and pathlib.Path(existing.path).exists():
-            return existing
-
-    source_identity = _workspace_file_identity(normalized_reader_path)[1:]
-    if source_identity != expected_identity:
-        raise RuntimeError(
-            "Serialized workspace reader is no longer available: "
-            f"{normalized_reader_path}"
-        )
-    local_path = _create_workspace_reader_file(normalized_reader_path, copy_only=False)
-    if _workspace_file_identity(normalized_reader_path)[1:] != expected_identity:
-        _cleanup_workspace_reader_path(local_path)
-        raise RuntimeError(
-            "Serialized workspace reader changed while it was imported: "
-            f"{normalized_reader_path}"
-        )
-    try:
-        local_file_identity = _workspace_file_identity(local_path)
-        snapshot = _WorkspaceReaderSnapshot(
-            cache_key=cache_key,
-            workspace_path=workspace_path,
-            path=local_file_identity[0],
-            identity=local_file_identity[1:],
-            owner_pid=os.getpid(),
-        )
-        with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-            existing = _WORKSPACE_READER_SNAPSHOTS.get(cache_key)
-            if existing is not None and pathlib.Path(existing.path).exists():
-                _cleanup_workspace_reader_path(local_path)
-                return existing
-            return _register_workspace_reader_snapshot(snapshot)
-    except BaseException:
-        _cleanup_workspace_reader_path(local_path)
-        raise
-
-
-def _acquire_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> None:
-    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-        if snapshot.disposed or snapshot.owner_pid != os.getpid():
-            raise RuntimeError("Workspace reader belongs to another process")
-        snapshot.manager_count += 1
-
-
-def _dispose_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> None:
-    if snapshot.owner_pid != os.getpid():
-        return
-    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-        if snapshot.disposed:
-            return
-        snapshot.disposed = True
-        if _WORKSPACE_READER_SNAPSHOTS.get(snapshot.cache_key) is snapshot:
-            del _WORKSPACE_READER_SNAPSHOTS[snapshot.cache_key]
-        if _WORKSPACE_READER_SNAPSHOTS_BY_PATH.get(snapshot.path) is snapshot:
-            del _WORKSPACE_READER_SNAPSHOTS_BY_PATH[snapshot.path]
-    _cleanup_workspace_reader_path(pathlib.Path(snapshot.path))
-
-
-def _release_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> None:
-    if snapshot.owner_pid != os.getpid():
-        return
-    dispose = False
-    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-        if snapshot.disposed:
-            return
-        snapshot.manager_count -= 1
-        dispose = (
-            snapshot.manager_count == 0 and not snapshot.retained_for_serialization
-        )
-    if dispose:
-        _dispose_workspace_reader_snapshot(snapshot)
-
-
-def _export_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> None:
-    if snapshot.owner_pid != os.getpid():
-        raise RuntimeError(
-            "Workspace readers cannot be inherited across fork; use spawn"
-        )
-    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-        if snapshot.disposed or not pathlib.Path(snapshot.path).exists():
-            raise RuntimeError("Workspace reader is no longer available")
-        # Pickle bytes can be loaded later or more than once. Python does not report
-        # when all copies of those bytes are gone, so process cleanup is the first safe
-        # time to remove a serialized reader generation.
-        snapshot.retained_for_serialization = True
-
-
-def _cleanup_workspace_reader_snapshots() -> None:
-    if os.getpid() != _WORKSPACE_READER_OWNER_PID:
-        return
-    with _WORKSPACE_READER_SNAPSHOTS_LOCK:
-        snapshots = tuple(_WORKSPACE_READER_SNAPSHOTS.values())
-    for snapshot in snapshots:
-        for manager in tuple(snapshot.managers):
-            manager.close()
-        _dispose_workspace_reader_snapshot(snapshot)
-
-
-def _reset_workspace_reader_state_after_fork() -> None:
-    """Drop inherited registries without cleaning parent-owned reader files."""
-    global _WORKSPACE_FILE_LOCKS
-    global _WORKSPACE_FILE_LOCKS_LOCK
-    global _WORKSPACE_READER_SNAPSHOTS
-    global _WORKSPACE_READER_SNAPSHOTS_BY_PATH
-    global _WORKSPACE_READER_SNAPSHOTS_LOCK
-    global _WORKSPACE_READER_OWNER_PID
-    global _WORKSPACE_READER_SESSION_ID
-    global _WORKSPACE_READER_STALE_CLEANUP_DONE
-
-    _WORKSPACE_FILE_LOCKS = {}
-    _WORKSPACE_FILE_LOCKS_LOCK = threading.Lock()
-    _WORKSPACE_READER_SNAPSHOTS = {}
-    _WORKSPACE_READER_SNAPSHOTS_BY_PATH = {}
-    _WORKSPACE_READER_SNAPSHOTS_LOCK = threading.RLock()
-    _WORKSPACE_READER_OWNER_PID = os.getpid()
-    _WORKSPACE_READER_SESSION_ID = uuid.uuid4().hex
-    _WORKSPACE_READER_STALE_CLEANUP_DONE = False
-
-
-if hasattr(os, "register_at_fork"):
-    os.register_at_fork(after_in_child=_reset_workspace_reader_state_after_fork)
-
-
-atexit.register(_cleanup_workspace_reader_snapshots)
 
 
 def _xarray_source_path(value: object) -> str | None:
@@ -639,82 +320,185 @@ def workspace_dataset_encoding(
 
 
 class WorkspaceFileManager(CachingFileManager):
-    """xarray file manager for manager-owned workspace readers."""
+    """xarray file manager for one workspace payload.
+
+    Associated workspaces acquire the manager-owned HDF5 handle. Other files use
+    xarray's read-only file cache and do not create private workspace copies.
+    """
 
     _base_del = CachingFileManager.__del__
 
-    def __init__(self, path: str | os.PathLike[str]) -> None:
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        object_id: str | None = None,
+        group_path: str | None = None,
+    ) -> None:
+        self._store: workspace_store.WorkspaceStore | None = None
+        self._object_id: str | None = None
+        self._group_path = None if group_path is None else f"/{group_path.strip('/')}"
+        self._store_lease_released = True
+        self._netcdf_file: h5netcdf.File | None = None
+        self._store_handle_generation = -1
+        self.lock: typing.Any
         target = _normalized_file_path(path)
         if target is None:
             target = os.fsdecode(path)
-        self._initialize(_workspace_reader_snapshot(target))
-
-    def _initialize(self, snapshot: _WorkspaceReaderSnapshot) -> None:
-        """Initialize this manager from a process-owned immutable reader."""
-        self._snapshot = snapshot
         self._process_id = os.getpid()
-        self.workspace_path = snapshot.workspace_path
-        self.reader_path = snapshot.path
-        _acquire_workspace_reader_snapshot(snapshot)
-        try:
-            ensure_workspace_hdf5_filters_registered()
-            super().__init__(
-                h5netcdf.File,
-                snapshot.path,
-                mode="r",
-                kwargs={
-                    "invalid_netcdf": None,
-                    "phony_dims": "sort",
-                    "decode_vlen_strings": True,
-                },
-                lock=snapshot.lock,
-                # Readers for one immutable file can share a cached handle.
-                manager_id=("erlab-workspace-reader", *snapshot.identity, "r"),
-            )
-        except BaseException:
-            _release_workspace_reader_snapshot(snapshot)
-            raise
-        snapshot.managers.add(self)
-        self._snapshot_finalizer = weakref.finalize(
-            self, _release_workspace_reader_snapshot, snapshot
+        self.workspace_path = target
+        self.reader_path = target
+        self._store = workspace_store.WorkspaceStore.active(target)
+        self._object_id = object_id
+        if self._store is not None:
+            self.lock = self._store.lock
+            self._store.register_reader(self)
+            if object_id is not None:
+                self._store.acquire_object(object_id)
+                self._store_lease_released = False
+            return
+
+        ensure_workspace_hdf5_filters_registered()
+        self.lock = SerializableLock()
+        super().__init__(
+            h5netcdf.File,
+            target,
+            mode="r",
+            kwargs={
+                "invalid_netcdf": None,
+                "phony_dims": "sort",
+                "decode_vlen_strings": True,
+            },
+            lock=self.lock,
+            manager_id=(
+                "erlab-workspace-reader",
+                *_workspace_file_identity(target),
+                "r",
+            ),
         )
 
     def _check_process(self) -> None:
         if self._process_id != os.getpid():
             raise RuntimeError(
                 "Workspace readers cannot be inherited across fork; "
-                "pass the data through process serialization instead"
+                "use a same-process Dask scheduler"
             )
+
+    @property
+    def legacy_group_path(self) -> str | None:
+        """Return the group needed by a pre-generation lazy reader."""
+        if self._store is None or self._object_id is not None:
+            return None
+        first_component = (self._group_path or "/").strip("/").partition("/")[0]
+        if first_component.startswith("__itws_"):
+            return None
+        return self._group_path
+
+    def _active_netcdf_file(self) -> h5netcdf.File:
+        store = self._store
+        if store is None:
+            raise RuntimeError("Workspace has no active store")
+        if (
+            self._netcdf_file is None
+            or self._store_handle_generation != store.handle_generation
+        ):
+            if self._netcdf_file is not None:
+                with contextlib.suppress(Exception):
+                    self._netcdf_file.close()
+            self._netcdf_file = h5netcdf.File(
+                store.h5_file,
+                mode="r",
+                invalid_netcdf=True,
+                phony_dims="sort",
+                decode_vlen_strings=True,
+            )
+            self._store_handle_generation = store.handle_generation
+        return self._netcdf_file
+
+    def _close_store_wrapper(self) -> None:
+        netcdf_file = self._netcdf_file
+        self._netcdf_file = None
+        self._store_handle_generation = -1
+        if netcdf_file is not None:
+            netcdf_file.close()
 
     def acquire(self, needs_lock: bool = True) -> typing.Any:
         self._check_process()
+        if self._store is not None:
+            if needs_lock:
+                with self.lock:
+                    return self._active_netcdf_file()
+            return self._active_netcdf_file()
         return super().acquire(needs_lock)
 
-    def acquire_context(self, needs_lock: bool = True) -> typing.Any:
+    @contextlib.contextmanager
+    def acquire_context(self, needs_lock: bool = True) -> Iterator[typing.Any]:
         self._check_process()
-        return super().acquire_context(needs_lock)
+        if self._store is not None:
+            if needs_lock:
+                with self.lock:
+                    yield self._active_netcdf_file()
+            else:
+                yield self._active_netcdf_file()
+            return
+        with super().acquire_context(needs_lock) as file:
+            yield file
 
     def close(self, needs_lock: bool = True) -> None:
-        if self._process_id == os.getpid():
+        if self._store is None and self._process_id == os.getpid():
             super().close(needs_lock)
 
-    def __getstate__(self) -> tuple[str, str, tuple[int, int, int, int]]:
+    def __getstate__(self) -> typing.Any:
         self._check_process()
-        _export_workspace_reader_snapshot(self._snapshot)
-        return self.workspace_path, self.reader_path, self._snapshot.identity
+        if self._store is not None:
+            raise TypeError(
+                "An open writable workspace cannot be sent to another process"
+            )
+        return super().__getstate__()
 
-    def __setstate__(self, state: tuple[str, str, tuple[int, int, int, int]]) -> None:
-        workspace_path, reader_path, identity = state
-        self._initialize(
-            _workspace_reader_snapshot_from_state(workspace_path, reader_path, identity)
+    def __setstate__(self, state: typing.Any) -> None:
+        super().__setstate__(state)
+        self._process_id = os.getpid()
+        self._store = None
+        self._object_id = None
+        self._group_path = None
+        self._store_lease_released = True
+        self._netcdf_file = None
+        self._store_handle_generation = -1
+        self.workspace_path = os.fsdecode(self._args[0])
+        self.reader_path = self.workspace_path
+        self.lock = self._lock
+
+    def __dask_tokenize__(self) -> tuple[str, str, str | None, str | None]:
+        store_identity = (
+            None if self._store is None else f"{id(self._store)}:{self._store.path}"
+        )
+        return (
+            type(self).__name__,
+            self.workspace_path,
+            self._object_id or store_identity,
+            self._group_path,
         )
 
-    def __dask_tokenize__(
-        self,
-    ) -> tuple[str, str, tuple[int, int, int, int]]:
-        return type(self).__name__, self.workspace_path, self._snapshot.identity
+    def _release_store_lease(self) -> None:
+        store = getattr(self, "_store", None)
+        object_id = getattr(self, "_object_id", None)
+        if (
+            store is not None
+            and object_id is not None
+            and not getattr(self, "_store_lease_released", True)
+        ):
+            self._store_lease_released = True
+            store.release_object(object_id)
 
     def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            store = getattr(self, "_store", None)
+            if store is not None:
+                with store.lock:
+                    self._close_store_wrapper()
+                    store.unregister_reader(self)
+                    self._release_store_lease()
         if hasattr(self, "_ref_counter"):
             self._base_del()
 
@@ -737,7 +521,7 @@ def _open_workspace_dataset_from_manager(
         file_manager,
         group=group,
         mode="r",
-        lock=file_manager._snapshot.lock,
+        lock=file_manager.lock,
         autoclose=False,
     )
     if chunks is None:
@@ -759,8 +543,17 @@ def open_workspace_dataset(
     target = _normalized_file_path(path)
     if target is None:
         target = os.fsdecode(path)
+    group_parts = group.strip("/").split("/")
+    object_id = (
+        group_parts[1]
+        if len(group_parts) >= 2
+        and group_parts[0] == workspace_store._WORKSPACE_OBJECTS_GROUP
+        else None
+    )
     return _open_workspace_dataset_from_manager(
-        WorkspaceFileManager(target), group, chunks=chunks
+        WorkspaceFileManager(target, object_id=object_id, group_path=group),
+        group,
+        chunks=chunks,
     )
 
 
@@ -772,14 +565,17 @@ def open_workspace_datatree(
     if target is None:
         target = os.fsdecode(path)
     file_manager = WorkspaceFileManager(target)
-    with file_manager.acquire_context() as h5_file:
-        group_paths = tuple(_iter_h5netcdf_group_paths(h5_file))
+    try:
+        with file_manager.acquire_context() as h5_file:
+            group_paths = tuple(_iter_h5netcdf_group_paths(h5_file))
+    finally:
+        file_manager.close()
 
     groups: dict[str, xr.Dataset] = {}
     try:
         for group_path in group_paths:
-            groups[group_path] = _open_workspace_dataset_from_manager(
-                file_manager, group_path, chunks=chunks
+            groups[group_path] = open_workspace_dataset(
+                target, group_path, chunks=chunks
             )
         tree = xr.DataTree.from_dict(groups)
     except Exception:
@@ -829,66 +625,40 @@ def _read_workspace_root_attrs_h5py(
     fname: str | os.PathLike[str],
 ) -> dict[typing.Hashable, typing.Any]:
     ensure_workspace_hdf5_filters_registered()
-    with _workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
+    active_store = workspace_store.WorkspaceStore.active(fname)
+    if active_store is not None:
+        with active_store.lock:
+            attrs = _h5py_attrs_to_dict(active_store.h5_file.attrs)
+            if int(attrs.get("imagetool_workspace_schema_version", 1)) == 5:
+                attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(
+                    active_store.current_generation().manifest
+                )
+            return attrs
+
+    with _open_workspace_h5_file_for_read(fname) as h5_file:
         if not _workspace_file_is_workspace(h5_file):
             raise ValueError("Not a valid workspace file")
-        return _h5py_attrs_to_dict(h5_file.attrs)
-
-
-def _workspace_live_root_group_copy_groups(
-    fname: str | os.PathLike[str],
-) -> tuple[tuple[str, str, dict[str, typing.Any] | None], ...]:
-    ensure_workspace_hdf5_filters_registered()
-    with _workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
-        if not _workspace_file_is_workspace(h5_file):
-            raise ValueError("Not a valid workspace file")
-        return tuple(
-            (name, name, None)
-            for name, item in h5_file.items()
-            if isinstance(item, h5py.Group)
-            and not _is_workspace_internal_group_name(name)
-        )
-
-
-def _workspace_h5_object_storage_size(obj: typing.Any) -> int:
-    if isinstance(obj, h5py.Dataset):
-        return max(0, int(obj.id.get_storage_size()))
-    if isinstance(obj, h5py.Group):
-        return sum(_workspace_h5_object_storage_size(child) for child in obj.values())
-    return 0
-
-
-def _workspace_h5_paths_storage_size(
-    fname: str | os.PathLike[str],
-    paths: Iterable[str],
-) -> tuple[int, int]:
-    total = 0
-    existing_count = 0
-    ensure_workspace_hdf5_filters_registered()
-    with _workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
-        if not _workspace_file_is_workspace(h5_file):
-            raise ValueError("Not a valid workspace file")
-        for path in paths:
-            path = path.strip("/")
-            if path not in h5_file:
-                continue
-            existing_count += 1
-            total += _workspace_h5_object_storage_size(h5_file[path])
-    return total, existing_count
-
-
-def _workspace_live_h5_storage_size(fname: str | os.PathLike[str]) -> int:
-    total = 0
-    ensure_workspace_hdf5_filters_registered()
-    with _workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
-        if not _workspace_file_is_workspace(h5_file):
-            raise ValueError("Not a valid workspace file")
-        for name, item in h5_file.items():
-            if isinstance(item, h5py.Group) and not _is_workspace_internal_group_name(
-                name
-            ):
-                total += _workspace_h5_object_storage_size(item)
-    return total
+        attrs = _h5py_attrs_to_dict(h5_file.attrs)
+        if int(attrs.get("imagetool_workspace_schema_version", 1)) == 5:
+            generation_root = h5_file.get(workspace_store._WORKSPACE_GENERATIONS_GROUP)
+            if generation_root is None:
+                raise ValueError("Workspace has no committed generation")
+            for name in sorted(generation_root, reverse=True):
+                if (
+                    len(name) != workspace_store._WORKSPACE_GENERATION_WIDTH
+                    or not name.isdigit()
+                ):
+                    continue
+                with contextlib.suppress(Exception):
+                    attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(
+                        workspace_store.WorkspaceStore._read_manifest(
+                            generation_root[name]
+                        )
+                    )
+                    break
+            if _WORKSPACE_MANIFEST_ATTR not in attrs:
+                raise ValueError("Workspace has no valid committed generation")
+        return attrs
 
 
 def _workspace_h5py_dataset_storage_supported(dataset: typing.Any) -> bool:
@@ -998,67 +768,6 @@ def _workspace_h5py_create_kwargs(
     return kwargs
 
 
-def _workspace_h5py_filter_options(dataset: typing.Any) -> dict[int, tuple[int, ...]]:
-    create_plist = dataset.id.get_create_plist()
-    return {
-        create_plist.get_filter(index)[0]: tuple(create_plist.get_filter(index)[2])
-        for index in range(create_plist.get_nfilters())
-    }
-
-
-def _workspace_h5py_blosc2_options_match(
-    actual_options: tuple[int, ...], expected_options: tuple[int, ...]
-) -> bool:
-    if actual_options == expected_options:
-        return True
-    if len(actual_options) < 7 or len(expected_options) < 7:
-        return False
-    return actual_options[4:7] == expected_options[4:7]
-
-
-def _workspace_h5py_dataset_matches_encoding(
-    dataset: typing.Any,
-    encoding: Mapping[typing.Any, typing.Any],
-) -> bool:
-    filters = _workspace_h5py_filter_options(dataset)
-    expected_filter = encoding.get("compression")
-    if expected_filter is None:
-        return not filters
-    actual_options = filters.get(int(expected_filter))
-    if actual_options is None:
-        return False
-    expected_options = encoding.get("compression_opts")
-    if expected_options is None:
-        return True
-    expected_options = tuple(expected_options)
-    if int(expected_filter) == hdf5plugin.Blosc2.filter_id:
-        return _workspace_h5py_blosc2_options_match(actual_options, expected_options)
-    return actual_options == expected_options
-
-
-def _workspace_h5_group_matches_compression_mode(
-    h5_file: typing.Any,
-    group_path: str,
-    ds: xr.Dataset,
-    compression_mode: WorkspaceCompressionMode,
-) -> bool:
-    group_path = group_path.strip("/")
-    if group_path not in h5_file:
-        return False
-    group = h5_file[group_path]
-    encoding = workspace_dataset_encoding(ds, compression_mode=compression_mode)
-    for name in ds.data_vars:
-        dataset_name = str(name)
-        if dataset_name not in group:
-            return False
-        dataset = group[dataset_name]
-        if not _workspace_h5py_dataset_matches_encoding(
-            dataset, encoding.get(name, {})
-        ):
-            return False
-    return True
-
-
 def _workspace_h5py_attr_text(value: typing.Any) -> str | None:
     if isinstance(value, bytes):
         return value.decode()
@@ -1072,36 +781,6 @@ def _workspace_h5py_attr_text(value: typing.Any) -> str | None:
 
 def _workspace_h5py_dataset_is_dimension_scale(dataset: typing.Any) -> bool:
     return _workspace_h5py_attr_text(dataset.attrs.get("CLASS")) == "DIMENSION_SCALE"
-
-
-def _h5_group_matches_compression(
-    h5_file: typing.Any,
-    group_path: str,
-    compression_mode: WorkspaceCompressionMode,
-) -> bool:
-    group_path = group_path.strip("/")
-    if group_path not in h5_file:
-        return False
-    group = h5_file[group_path]
-    if not isinstance(group, h5py.Group):
-        return False
-    compression_encoding = _workspace_blosc2_encoding(compression_mode)
-    for item in group.values():
-        if not isinstance(item, h5py.Dataset):
-            continue
-        if _workspace_h5py_dataset_is_dimension_scale(item):
-            continue
-        encoding = {}
-        if (
-            compression_encoding
-            and item.dtype.kind in "iufc"
-            and int(item.size) * int(item.dtype.itemsize)
-            >= _WORKSPACE_COMPRESSION_MIN_BYTES
-        ):
-            encoding = compression_encoding
-        if not _workspace_h5py_dataset_matches_encoding(item, encoding):
-            return False
-    return True
 
 
 def _workspace_h5py_type_contains_reference(type_id: typing.Any) -> bool:
@@ -1339,7 +1018,7 @@ def _read_workspace_dataset_group_h5py(
         "_Netcdf4Dimid",
         "coordinates",
     )
-    with _workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
+    with _open_workspace_h5_file_for_read(fname) as h5_file:
         if group_path not in h5_file or not isinstance(h5_file[group_path], h5py.Group):
             return None
         group = h5_file[group_path]
@@ -1623,7 +1302,7 @@ def _write_workspace_independent_tool_items_h5py(
 
 
 def _write_workspace_dataset_group_h5py(
-    fname: str | os.PathLike[str],
+    target: str | os.PathLike[str] | typing.Any,
     group_path: str,
     ds: xr.Dataset,
     *,
@@ -1639,7 +1318,12 @@ def _write_workspace_dataset_group_h5py(
 
     ensure_workspace_hdf5_filters_registered()
     group_path = group_path.strip("/")
-    with h5py.File(fname, "a") as h5_file:
+    file_context = (
+        contextlib.nullcontext(target)
+        if isinstance(target, h5py.File)
+        else h5py.File(target, "a")
+    )
+    with file_context as h5_file:
         if group_path in h5_file:
             del h5_file[group_path]
         parent = _ensure_h5_parent_group(h5_file, group_path)
@@ -1758,7 +1442,7 @@ def _write_workspace_dataset_group_h5py(
 
 
 def _write_workspace_dataset_group_to_file(
-    fname: str | os.PathLike[str],
+    fname: str | os.PathLike[str] | typing.Any,
     group_path: str,
     ds: xr.Dataset,
     *,
@@ -1779,6 +1463,7 @@ def _write_workspace_dataset_group_to_file(
         ds = _serialization.encode_private_coords(ds, data_name)
     ds = _sanitize_workspace_attr_names(ds)
     stale_encoding_keys = {
+        "_FillValue",
         "chunksizes",
         "compression",
         "compression_opts",
@@ -1790,6 +1475,7 @@ def _write_workspace_dataset_group_to_file(
         "source",
     }
     for variable in ds.variables.values():
+        variable.attrs.pop("_FillValue", None)
         for key in stale_encoding_keys:
             variable.encoding.pop(key, None)
 
@@ -1803,11 +1489,49 @@ def _write_workspace_dataset_group_to_file(
             fname, group_path, ds, encoding=encoding
         ):
             return
-        ds.to_netcdf(
-            fname,
-            mode="a",
-            engine="h5netcdf",
+        netcdf_encoding = {
+            name: {**encoding.get(name, {}), "_FillValue": None}
+            for name in ds.variables
+        }
+        if not isinstance(fname, h5py.File):
+            ds.to_netcdf(
+                fname,
+                mode="a",
+                engine="h5netcdf",
+                group=f"/{group_path.strip('/')}",
+                invalid_netcdf=True,
+                encoding=netcdf_encoding,
+            )
+            return
+
+        netcdf_file = h5netcdf.File(fname, mode="a", invalid_netcdf=True)
+        active_store = workspace_store.WorkspaceStore.active(fname.filename)
+        store = H5NetCDFStore(
+            netcdf_file,
             group=f"/{group_path.strip('/')}",
-            invalid_netcdf=True,
-            encoding=encoding,
+            mode="a",
+            lock=(
+                active_store.lock
+                if active_store is not None
+                else _workspace_file_lock(fname.filename)
+            ),
+            autoclose=False,
         )
+        writer = ArrayWriter()
+        try:
+            dump_to_store(
+                ds,
+                store,
+                writer,
+                encoding=netcdf_encoding,
+                unlimited_dims=None,
+            )
+            # The active workspace handle belongs to this process. Use Dask
+            # threads so a default process-based client does not receive it.
+            writer.sync(
+                compute=True,
+                chunkmanager_store_kwargs={"scheduler": "threads"},
+            )
+            store.sync()
+        finally:
+            store.close()

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -17,7 +17,6 @@ import xarray as xr
 from xarray.backends import BackendArray, CachingFileManager, H5NetCDFStore
 from xarray.backends.common import ArrayWriter
 from xarray.backends.locks import SerializableLock
-from xarray.backends.writers import dump_to_store
 from xarray.core import indexing
 
 import erlab
@@ -1713,10 +1712,9 @@ def _write_workspace_dataset_group_to_file(
         )
         writer = ArrayWriter()
         try:
-            dump_to_store(
-                ds,
+            ds.dump_to_store(
                 store,
-                writer,
+                writer=writer,
                 encoding=netcdf_encoding,
                 unlimited_dims=None,
             )

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -220,7 +220,7 @@ class _WorkspaceReaderSnapshot:
         default_factory=weakref.WeakSet
     )
     manager_count: int = 0
-    exported: bool = False
+    retained_for_serialization: bool = False
     disposed: bool = False
 
 
@@ -391,7 +391,9 @@ def _release_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> No
         if snapshot.disposed:
             return
         snapshot.manager_count -= 1
-        dispose = snapshot.manager_count == 0 and not snapshot.exported
+        dispose = (
+            snapshot.manager_count == 0 and not snapshot.retained_for_serialization
+        )
     if dispose:
         _dispose_workspace_reader_snapshot(snapshot)
 
@@ -404,7 +406,10 @@ def _export_workspace_reader_snapshot(snapshot: _WorkspaceReaderSnapshot) -> Non
     with _WORKSPACE_READER_SNAPSHOTS_LOCK:
         if snapshot.disposed or not pathlib.Path(snapshot.path).exists():
             raise RuntimeError("Workspace reader is no longer available")
-        snapshot.exported = True
+        # Pickle bytes can be loaded later or more than once. Python does not report
+        # when all copies of those bytes are gone, so process cleanup is the first safe
+        # time to remove a serialized reader generation.
+        snapshot.retained_for_serialization = True
 
 
 def _cleanup_workspace_reader_snapshots() -> None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -104,8 +104,9 @@ def _open_workspace_h5_file_for_read(
     active_store = workspace_store.WorkspaceStore.active(path)
     if active_store is not None:
         with active_store.lock:
-            active_store.require_current_path()
-            yield active_store.h5_file
+            with contextlib.suppress(workspace_store.WorkspaceStoreConflictError):
+                active_store.require_current_path()
+            yield active_store.read_h5_file
         return
 
     ensure_workspace_hdf5_filters_registered()
@@ -408,7 +409,7 @@ class WorkspaceFileManager(CachingFileManager):
                 with contextlib.suppress(Exception):
                     self._netcdf_file.close()
             self._netcdf_file = h5netcdf.File(
-                store.h5_file,
+                store.read_h5_file,
                 mode="r",
                 invalid_netcdf=True,
                 phony_dims="sort",
@@ -630,7 +631,7 @@ def _read_workspace_root_attrs_h5py(
     active_store = workspace_store.WorkspaceStore.active(fname)
     if active_store is not None:
         with active_store.lock:
-            attrs = _h5py_attrs_to_dict(active_store.h5_file.attrs)
+            attrs = _h5py_attrs_to_dict(active_store.read_h5_file.attrs)
             if int(attrs.get("imagetool_workspace_schema_version", 1)) == 5:
                 attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(
                     active_store.current_generation().manifest

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -90,6 +90,10 @@ class _WorkspaceController:
         ) = None
         self._background_save_requested = False
         self._workspace_store: workspace_store.WorkspaceStore | None = None
+        self._imported_workspace_accesses: dict[
+            pathlib.Path, _WorkspaceDocumentAccess
+        ] = {}
+        self._imported_workspace_dependents: dict[pathlib.Path, set[str]] = {}
         self._workspace_gc_worker: workspace_saving._WorkspaceGcWorker | None = None
         self._workspace_gc_receiver: (
             workspace_saving._WorkspaceGcResultReceiver | None
@@ -527,6 +531,106 @@ class _WorkspaceController:
         self._manager._workspace_state.lock.unlock()
         self._manager._workspace_state.lock = None
 
+    def _release_imported_workspace_accesses(self) -> None:
+        """Release all source documents retained by imported lazy payloads."""
+        accesses = tuple(self._imported_workspace_accesses.values())
+        self._imported_workspace_accesses.clear()
+        self._imported_workspace_dependents.clear()
+        for access in accesses:
+            access.release()
+
+    @staticmethod
+    def _workspace_node_source_paths(
+        node: _ManagedWindowNode,
+    ) -> frozenset[pathlib.Path]:
+        """Return workspace paths directly referenced by one managed node."""
+        paths: set[pathlib.Path] = set()
+        pending = node.pending_workspace_payload
+        if pending is not None:
+            paths.add(pending[0].resolve())
+        if node.is_imagetool and node.imagetool is not None:
+            paths.update(
+                pathlib.Path(path).resolve()
+                for path in workspace_arrays.dataarray_source_paths(
+                    node.slicer_area._data
+                )
+            )
+        paths.update(
+            path.resolve() for path, _group in node._workspace_reference_datasets
+        )
+        return frozenset(paths)
+
+    def _retain_imported_workspace_access(
+        self,
+        access: _WorkspaceDocumentAccess,
+        candidate_uids: Collection[str],
+    ) -> None:
+        """Retain an imported source only when loaded nodes still read from it."""
+        path = access.path.resolve()
+        dependents = {
+            uid
+            for uid in candidate_uids
+            if (
+                (node := self._manager._tool_graph.nodes.get(uid)) is not None
+                and path in self._workspace_node_source_paths(node)
+            )
+        }
+        if not dependents:
+            return
+        self._imported_workspace_dependents.setdefault(path, set()).update(dependents)
+        if path in self._imported_workspace_accesses:
+            return
+        workspace_lock = access.take_lock()
+        if workspace_lock is not None:
+            self._imported_workspace_accesses[path] = _WorkspaceDocumentAccess(
+                path, workspace_lock
+            )
+
+    def _release_unused_imported_workspace_accesses(self) -> None:
+        """Release imported sources after all dependent payloads are rehomed."""
+        for path, access in tuple(self._imported_workspace_accesses.items()):
+            previous_dependents = self._imported_workspace_dependents.get(path, set())
+            dependents: set[str] = set()
+            for uid, node in self._manager._tool_graph.nodes.items():
+                source_paths = self._workspace_node_source_paths(node)
+                if path in source_paths:
+                    dependents.add(uid)
+                    continue
+                if (
+                    uid in previous_dependents
+                    and node.is_imagetool
+                    and node.imagetool is not None
+                    and node.slicer_area._data.chunks is not None
+                    and not source_paths
+                ):
+                    # Some Dask transformations discard xarray's source encoding.
+                    # Keep ownership until a save rebinds or materializes this node.
+                    dependents.add(uid)
+            if dependents:
+                self._imported_workspace_dependents[path] = dependents
+                continue
+            self._imported_workspace_accesses.pop(path, None)
+            self._imported_workspace_dependents.pop(path, None)
+            access.release()
+
+    def _take_imported_workspace_lock(
+        self, path: str | os.PathLike[str]
+    ) -> QtCore.QLockFile | None:
+        """Transfer a retained source lock to the associated workspace document."""
+        resolved = pathlib.Path(path).resolve()
+        access = self._imported_workspace_accesses.pop(resolved, None)
+        self._imported_workspace_dependents.pop(resolved, None)
+        return None if access is None else access.take_lock()
+
+    def _take_workspace_access_lock(
+        self, access: _WorkspaceDocumentAccess
+    ) -> QtCore.QLockFile | None:
+        """Transfer the lock that owns one workspace document."""
+        workspace_lock = access.take_lock()
+        if workspace_lock is None:
+            workspace_lock = self._take_imported_workspace_lock(access.path)
+        return workspace_lock
+
     def _current_workspace_document_path(self) -> pathlib.Path | None:
         path = self._manager._workspace_state.path
         if path is None or not workspace_format._workspace_path_is_itws(path):
@@ -538,7 +642,10 @@ class _WorkspaceController:
     ) -> _WorkspaceDocumentAccess:
         workspace_path = pathlib.Path(fname).resolve()
         workspace_lock = None
-        if workspace_path != self._manager._workspace_state.path:
+        if (
+            workspace_path != self._manager._workspace_state.path
+            and workspace_path not in self._imported_workspace_accesses
+        ):
             workspace_lock = workspace_storage._acquire_workspace_document_lock(
                 workspace_path
             )
@@ -1058,6 +1165,64 @@ class _WorkspaceController:
                 "rebound to the saved file."
             ) from exc
 
+    def _imported_workspace_backing_snapshot(
+        self,
+    ) -> dict[str, tuple[str, tuple[str, ...]]] | None:
+        """Capture data backing only when imported source ownership is active."""
+        if not self._imported_workspace_accesses:
+            return None
+        return self.loading._workspace_data_backing_snapshot()
+
+    def _rebind_imported_workspace_imagetools_after_save(
+        self,
+        workspace_path: str | os.PathLike[str],
+        backing_snapshot: Mapping[str, tuple[str, tuple[str, ...]]] | None,
+        *,
+        exclude_uids: Collection[str],
+    ) -> None:
+        """Move imported lazy readers to objects committed by the current save."""
+        if backing_snapshot is None:
+            self._release_unused_imported_workspace_accesses()
+            return
+        imported_uids: set[str] = set().union(
+            *self._imported_workspace_dependents.values()
+        )
+        dask_targets = {
+            uid
+            for uid, (kind, _source_paths) in backing_snapshot.items()
+            if kind == "dask" and uid in imported_uids and uid not in exclude_uids
+        }
+        file_lazy_targets = {
+            uid
+            for uid, (kind, _source_paths) in backing_snapshot.items()
+            if kind == "file_lazy" and uid in imported_uids and uid not in exclude_uids
+        }
+        targets = dask_targets | file_lazy_targets
+        live_snapshot = self._live_imagetool_rebind_snapshot(targets)
+        try:
+            if dask_targets:
+                self.loading._rebind_workspace_backed_imagetools(
+                    workspace_path,
+                    targets=dask_targets,
+                    chunks={},
+                    exclude_uids=exclude_uids,
+                )
+            if file_lazy_targets:
+                self.loading._rebind_workspace_backed_imagetools(
+                    workspace_path,
+                    targets=file_lazy_targets,
+                    chunks=None,
+                    exclude_uids=exclude_uids,
+                )
+        except Exception as exc:
+            with contextlib.suppress(Exception):
+                self._restore_live_imagetool_rebind_snapshot(live_snapshot)
+            raise _WorkspacePostSaveBindingError(
+                "Workspace file was saved, but imported lazy data could not be "
+                "rebound to the saved file."
+            ) from exc
+        self._release_unused_imported_workspace_accesses()
+
     def _active_managed_window(self) -> QtWidgets.QWidget | None:
         active_window = QtWidgets.QApplication.activeWindow()
         if not isinstance(active_window, QtWidgets.QWidget):
@@ -1264,7 +1429,10 @@ class _WorkspaceController:
         return self._mark_workspace_dirty(uid=uid, added=True, structure="Added window")
 
     def _mark_node_data_dirty(self, uid: str) -> bool:
-        return self._mark_workspace_dirty(uid=uid, data=True)
+        changed = self._mark_workspace_dirty(uid=uid, data=True)
+        if self._manager._workspace_state.loading_depth == 0:
+            self._release_unused_imported_workspace_accesses()
+        return changed
 
     def _mark_node_state_dirty(self, uid: str) -> bool:
         return self._mark_workspace_dirty(uid=uid, state=True)
@@ -1504,7 +1672,9 @@ class _WorkspaceController:
                     existing_access.path,
                     document_access=existing_access,
                 )
-            return str(existing_access.path), existing_access.take_lock()
+            return str(existing_access.path), self._take_workspace_access_lock(
+                existing_access
+            )
 
         with self._workspace_document_access_context(converted_fname) as access:
             with erlab.interactive.utils.wait_dialog(
@@ -1540,7 +1710,7 @@ class _WorkspaceController:
             associated_fname, associated_lock = converted
             schema_version = workspace_format._current_workspace_schema_version()
         elif workspace_access is not None:
-            associated_lock = workspace_access.take_lock()
+            associated_lock = self._take_workspace_access_lock(workspace_access)
 
         associated_store = None
         if schema_version >= workspace_format._WORKSPACE_LEGACY_SCHEMA_VERSION:
@@ -1864,6 +2034,7 @@ class _WorkspaceController:
         snapshot_elapsed: float,
         started_at: float,
         restore_focus: bool,
+        imported_backing_snapshot: Mapping[str, tuple[str, tuple[str, ...]]] | None,
     ) -> bool:
         total_elapsed = time.perf_counter() - started_at
         logger.debug(
@@ -1901,6 +2072,21 @@ class _WorkspaceController:
             snapshot,
             manifest=snapshot.generation_plan.manifest,
         )
+        post_save_uids = frozenset(
+            event.uid for event in post_save_events if event.uid is not None
+        )
+        try:
+            self._rebind_imported_workspace_imagetools_after_save(
+                workspace_path,
+                imported_backing_snapshot,
+                exclude_uids=post_save_uids,
+            )
+        except _WorkspacePostSaveBindingError:
+            self._mark_workspace_post_save_binding_refresh_failed()
+            self._show_workspace_post_save_binding_error(workspace_path)
+            if restore_focus:
+                self._restore_focus_after_workspace_save(origin)
+            return False
         if post_save_events:
             self._restore_workspace_dirty_events(post_save_events)
             message = "Workspace saved; new changes remain unsaved"
@@ -1931,6 +2117,8 @@ class _WorkspaceController:
         snapshot_elapsed: float,
         started_at: float,
         restore_focus: bool,
+        imported_backing_snapshot: Mapping[str, tuple[str, tuple[str, ...]]]
+        | None = None,
         on_finished: Callable[[bool], None] | None = None,
     ) -> None:
         try:
@@ -1944,6 +2132,7 @@ class _WorkspaceController:
                 snapshot_elapsed=snapshot_elapsed,
                 started_at=started_at,
                 restore_focus=restore_focus,
+                imported_backing_snapshot=imported_backing_snapshot,
             )
             queued = self._background_save_requested
             if (
@@ -1990,6 +2179,7 @@ class _WorkspaceController:
 
         origin = self._active_managed_window()
         document_id = self._manager._workspace_state.document_id
+        imported_backing_snapshot = self._imported_workspace_backing_snapshot()
         self._manager._status_bar.showMessage("Saving workspace...")
         started_at = time.perf_counter()
         snapshot: workspace_saving._WorkspaceSaveSnapshot | None = None
@@ -2038,6 +2228,7 @@ class _WorkspaceController:
                 snapshot_elapsed=snapshot_elapsed,
                 started_at=started_at,
                 restore_focus=restore_focus,
+                imported_backing_snapshot=imported_backing_snapshot,
                 on_finished=on_finished,
             ),
             on_start_error=_start_error,
@@ -2233,7 +2424,7 @@ class _WorkspaceController:
             saved_path = access.path
             self._set_workspace_path(
                 saved_path,
-                workspace_lock=access.take_lock(),
+                workspace_lock=self._take_workspace_access_lock(access),
                 store=new_store,
             )
             access = None
@@ -2255,6 +2446,7 @@ class _WorkspaceController:
                 if on_finished is not None:
                     on_finished(False)
                 return
+            self._release_unused_imported_workspace_accesses()
             self._drain_workspace_deferred_events()
             if post_save_events or has_new_dirty_generation:
                 self._restore_workspace_dirty_events(post_save_events)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -621,21 +621,48 @@ class _WorkspaceController:
         self,
         workspace_path: str | os.PathLike[str],
         *,
+        manifest: Mapping[str, typing.Any],
         exclude_uids: Collection[str] = frozenset(),
     ) -> None:
+        payload_paths = {
+            uid: payload_path
+            for uid, _kind, payload_path in (
+                workspace_format._workspace_manifest_payload_entries(manifest)
+            )
+        }
         for uid, node in self._manager._tool_graph.nodes.items():
             if uid in exclude_uids:
                 continue
             pending = node.pending_workspace_payload
             kind = node.pending_workspace_payload_kind
-            if pending is None or kind is None:
+            payload_path = payload_paths.get(uid)
+            if pending is None or kind is None or payload_path is None:
                 continue
             node.set_pending_workspace_payload(
                 kind,
                 workspace_path,
-                self.loading._workspace_payload_path_for_uid(workspace_path, node.uid),
+                payload_path,
                 payload_attrs=node.pending_workspace_payload_attrs,
             )
+
+    def _adopt_committed_workspace_generation(
+        self,
+        workspace_path: str | os.PathLike[str],
+        snapshot: workspace_saving._WorkspaceSaveSnapshot,
+        *,
+        manifest: Mapping[str, typing.Any],
+        exclude_uids: Collection[str] = frozenset(),
+    ) -> None:
+        """Apply one committed generation to live manager references."""
+        self._commit_saved_tool_data_references(snapshot)
+        self._repoint_saved_pending_workspace_payloads(
+            workspace_path,
+            manifest=manifest,
+            exclude_uids=exclude_uids,
+        )
+        self._manager._workspace_state.schema_version = (
+            workspace_format._current_workspace_schema_version()
+        )
 
     def _pending_workspace_payload_snapshot(
         self,
@@ -974,9 +1001,6 @@ class _WorkspaceController:
             )
             live_imagetool_snapshot = self._live_imagetool_rebind_snapshot(
                 dask_rebind_uids
-            )
-            self._repoint_saved_pending_workspace_payloads(
-                workspace_path, exclude_uids=skip_live_data_rebind_uids
             )
             if dask_rebind_uids:
                 self.loading._rebind_workspace_backed_imagetools(
@@ -1869,9 +1893,14 @@ class _WorkspaceController:
             self._manager._workspace_state.dirty_generation > snapshot.generation
             and self._manager.is_workspace_modified
         )
-        self._commit_saved_tool_data_references(snapshot)
-        self._manager._workspace_state.schema_version = (
-            workspace_format._current_workspace_schema_version()
+        post_save_uids = frozenset(
+            event.uid for event in post_save_events if event.uid is not None
+        )
+        self._adopt_committed_workspace_generation(
+            workspace_path,
+            snapshot,
+            manifest=snapshot.generation_plan.manifest,
+            exclude_uids=post_save_uids,
         )
         if post_save_events:
             self._restore_workspace_dirty_events(post_save_events)
@@ -2202,10 +2231,6 @@ class _WorkspaceController:
                     on_finished(False)
                 return
 
-            self._commit_saved_tool_data_references(snapshot)
-            self._manager._workspace_state.schema_version = (
-                workspace_format._current_workspace_schema_version()
-            )
             saved_path = access.path
             self._set_workspace_path(
                 saved_path,
@@ -2213,6 +2238,12 @@ class _WorkspaceController:
                 store=new_store,
             )
             access = None
+            self._adopt_committed_workspace_generation(
+                saved_path,
+                snapshot,
+                manifest=snapshot.generation_plan.manifest,
+                exclude_uids=post_save_uids,
+            )
             try:
                 self._refresh_workspace_payload_bindings_after_full_save(
                     saved_path,

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -1935,6 +1935,18 @@ class _WorkspaceController:
         self._workspace_gc_requested = True
         QtCore.QTimer.singleShot(0, self._start_workspace_gc)
 
+    def _default_dask_client_has_futures(self) -> bool:
+        """Return whether the manager's Dask client owns any Futures."""
+        client = self._manager._dask_menu.default_client
+        return client is not None and bool(client.futures)
+
+    def _release_finished_dask_reader_pins(
+        self, store: workspace_store.WorkspaceStore
+    ) -> None:
+        """Release serialized readers when no GUI-managed Future can use them."""
+        if store.has_serialized_readers and not self._default_dask_client_has_futures():
+            store.clear_serialized_reader_pins()
+
     def _start_workspace_gc(self) -> None:
         if (
             not self._workspace_gc_requested
@@ -1952,6 +1964,7 @@ class _WorkspaceController:
         ):
             self._workspace_gc_requested = False
             return
+        self._release_finished_dask_reader_pins(store)
         thread_pool = QtCore.QThreadPool.globalInstance()
         if thread_pool is None:
             return
@@ -2487,6 +2500,25 @@ class _WorkspaceController:
             on_start_error=_start_error,
         )
 
+    def _confirm_compaction_with_dask_futures(self, parent: QtWidgets.QWidget) -> bool:
+        """Confirm that compaction can invalidate serialized Dask readers."""
+        msg_box = QtWidgets.QMessageBox(parent)
+        msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        msg_box.setWindowTitle("Compact Workspace")
+        msg_box.setText("This workspace was sent to Dask workers.")
+        msg_box.setInformativeText(
+            "The connected Dask client still owns Futures. Compacting can remove "
+            "data that those Futures need for recomputation. Release the Futures "
+            "before you compact, or continue and invalidate their workspace readers."
+        )
+        cancel_button = msg_box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+        compact_button = msg_box.addButton(
+            "Compact Workspace", QtWidgets.QMessageBox.ButtonRole.DestructiveRole
+        )
+        msg_box.setDefaultButton(cancel_button)
+        msg_box.exec()
+        return msg_box.clickedButton() == compact_button
+
     def compact_workspace(self) -> bool:
         """Rewrite the current workspace with only reachable payload objects."""
         workspace_path = self._current_workspace_document_path()
@@ -2505,6 +2537,12 @@ class _WorkspaceController:
                 "The workspace file is not open. Reopen it and try again.",
             )
             return False
+        self._release_finished_dask_reader_pins(store)
+        if store.has_serialized_readers:
+            if not self._confirm_compaction_with_dask_futures(origin or self._manager):
+                self._restore_focus_after_workspace_save(origin)
+                return False
+            store.clear_serialized_reader_pins()
         try:
             with erlab.interactive.utils.wait_dialog(
                 origin or self._manager, "Compacting workspace..."
@@ -2519,6 +2557,7 @@ class _WorkspaceController:
                         workspace_path,
                         mark_clean=False,
                     )
+                self._release_finished_dask_reader_pins(store)
                 workspace_storage._compact_workspace_store(store)
             self._manager._status_bar.showMessage("Workspace compacted", 5000)
             self._mark_workspace_clean()

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -15,6 +15,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive._options.core
+import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._loading as workspace_loading
@@ -737,7 +738,7 @@ class _WorkspaceController:
                 return True
         return False
 
-    def _retarget_workspace_referenced_tool_data(
+    def _refresh_workspace_tool_data_after_full_save(
         self,
         old_workspace_path: str | os.PathLike[str] | None,
         workspace_path: str | os.PathLike[str],
@@ -745,6 +746,7 @@ class _WorkspaceController:
         exclude_data_uids: Collection[str],
         source_snapshot: list[tuple[xr.Variable, bool, typing.Any]],
     ) -> None:
+        """Rebind external Dask tool data and retarget saved references."""
         old_path = workspace_arrays._normalized_file_path(old_workspace_path)
         new_path = workspace_arrays._normalized_file_path(workspace_path)
         if new_path is None or old_path == new_path:
@@ -765,7 +767,6 @@ class _WorkspaceController:
                     node.is_imagetool
                     or tool is None
                     or not tool.can_save_and_load()
-                    or not node._workspace_reference_datasets
                     or node.uid in exclude_data_uids
                     or self._workspace_tool_references_include_uids(
                         node._workspace_tool_data_references,
@@ -774,52 +775,127 @@ class _WorkspaceController:
                     )
                 ):
                     continue
-                ds = tool.to_dataset()
                 original_data_items = {
                     name: data.copy(deep=False)
                     for name, data in tool._persistence_data_items().items()
                 }
+                rebind_names: set[str] = set()
+                retargets_current_workspace = False
+                for name, data in original_data_items.items():
+                    source_paths = workspace_arrays.dataarray_source_paths(data)
+                    if old_path is not None and old_path in source_paths:
+                        retargets_current_workspace = True
+                    uses_current_workspace_reader = (
+                        old_path is not None
+                        and bool(source_paths)
+                        and all(source_path == old_path for source_path in source_paths)
+                    )
+                    if data.chunks is not None and not uses_current_workspace_reader:
+                        rebind_names.add(name)
+                if (
+                    not node._workspace_reference_datasets
+                    and not rebind_names
+                    and not retargets_current_workspace
+                ):
+                    continue
+
+                restore_ds = tool.to_dataset()
                 data_items = {
                     name: data.copy(deep=False)
                     for name, data in original_data_items.items()
                 }
-                for data in data_items.values():
-                    workspace_arrays.set_workspace_xarray_sources(data, workspace_path)
                 original_reference_datasets = dict(node._workspace_reference_datasets)
                 restore_entries.append(
                     (
                         node,
                         tool,
-                        ds,
+                        restore_ds,
                         original_data_items,
                         original_reference_datasets,
                     )
                 )
-                with self._workspace_load_context(), tool._history_suppressed():
-                    tool._replace_persistence_data_items(data_items, ds)
-
-                reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] = {}
-                for (
-                    source_path,
-                    group_path,
-                ), reference_ds in node._workspace_reference_datasets.items():
-                    source_snapshot.extend(
-                        workspace_arrays._workspace_xarray_source_snapshot(reference_ds)
-                    )
-                    if old_path is None:
+                reference_datasets = dict(original_reference_datasets)
+                opened: xr.Dataset | None = None
+                try:
+                    replace_ds = restore_ds
+                    if rebind_names:
+                        opened = workspace_arrays.open_workspace_dataset(
+                            workspace_path,
+                            self.saving._workspace_payload_path(node.uid),
+                            chunks={},
+                        )
+                        replace_ds = workspace_format._restore_workspace_dataset_attrs(
+                            opened
+                        )
+                        replace_ds = imagetool_serialization.restore_private_coords(
+                            replace_ds, erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+                        )
+                        source_parent_data, reference_resolver = (
+                            self.loading._workspace_tool_restore_references(
+                                replace_ds,
+                                parent_target=node.parent_uid,
+                                owner_node=node,
+                                reference_datasets=reference_datasets,
+                            )
+                        )
+                        rebound_items = type(tool)._tool_data_items_from_dataset(
+                            replace_ds,
+                            source_parent_data=source_parent_data,
+                            reference_resolver=reference_resolver,
+                            variable_names=rebind_names,
+                        )
+                        for name in rebind_names:
+                            data_items[name] = rebound_items[name]
+                    for data in data_items.values():
                         workspace_arrays.set_workspace_xarray_sources(
-                            reference_ds, new_path
+                            data, workspace_path
                         )
-                    else:
-                        workspace_arrays.retarget_workspace_xarray_sources(
-                            reference_ds, old_path, new_path
+                    with self._workspace_load_context(), tool._history_suppressed():
+                        tool._replace_persistence_data_items(data_items, replace_ds)
+
+                    retargeted_reference_datasets: dict[
+                        tuple[pathlib.Path, str], xr.Dataset
+                    ] = {}
+                    for (
+                        source_path,
+                        group_path,
+                    ), reference_ds in reference_datasets.items():
+                        source_snapshot.extend(
+                            workspace_arrays._workspace_xarray_source_snapshot(
+                                reference_ds
+                            )
                         )
-                    if old_path is None or (
-                        workspace_arrays._normalized_file_path(source_path) == old_path
-                    ):
-                        source_path = pathlib.Path(new_path)
-                    reference_datasets[(source_path, group_path)] = reference_ds
-                node._replace_workspace_reference_datasets(reference_datasets)
+                        if old_path is None:
+                            workspace_arrays.set_workspace_xarray_sources(
+                                reference_ds, new_path
+                            )
+                        else:
+                            workspace_arrays.retarget_workspace_xarray_sources(
+                                reference_ds, old_path, new_path
+                            )
+                        if old_path is None or (
+                            workspace_arrays._normalized_file_path(source_path)
+                            == old_path
+                        ):
+                            source_path = pathlib.Path(new_path)
+                        retargeted_reference_datasets[(source_path, group_path)] = (
+                            reference_ds
+                        )
+                    node._replace_workspace_reference_datasets(
+                        retargeted_reference_datasets
+                    )
+                except Exception:
+                    original_dataset_ids = {
+                        id(dataset) for dataset in original_reference_datasets.values()
+                    }
+                    for dataset in reference_datasets.values():
+                        if id(dataset) not in original_dataset_ids:
+                            with contextlib.suppress(Exception):
+                                dataset.close()
+                    raise
+                finally:
+                    if opened is not None:
+                        opened.close()
         except Exception as exc:
             for (
                 restore_node,
@@ -905,7 +981,7 @@ class _WorkspaceController:
                             workspace_arrays.set_workspace_xarray_sources(
                                 node.slicer_area._data, workspace_path
                             )
-            self._retarget_workspace_referenced_tool_data(
+            self._refresh_workspace_tool_data_after_full_save(
                 old_workspace_path,
                 workspace_path,
                 exclude_data_uids=skip_live_data_rebind_uids,
@@ -1893,6 +1969,7 @@ class _WorkspaceController:
         started_at = time.perf_counter()
         try:
             access = self._workspace_document_access(fname)
+            expected_state = workspace_storage._workspace_publication_state(access.path)
             self._drain_workspace_deferred_events()
             generation = self._manager._workspace_state.dirty_generation
             self._manager._workspace_state.saving_depth += 1
@@ -1901,6 +1978,7 @@ class _WorkspaceController:
                 snapshot = self.saving._workspace_full_save_snapshot(
                     generation, fname=access.path
                 )
+                snapshot.expected_publication_state = expected_state
                 snapshot_elapsed = time.perf_counter() - snapshot_started_at
             finally:
                 self._manager._workspace_state.saving_depth -= 1

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -1935,18 +1935,6 @@ class _WorkspaceController:
         self._workspace_gc_requested = True
         QtCore.QTimer.singleShot(0, self._start_workspace_gc)
 
-    def _default_dask_client_has_futures(self) -> bool:
-        """Return whether the manager's Dask client owns any Futures."""
-        client = self._manager._dask_menu.default_client
-        return client is not None and bool(client.futures)
-
-    def _release_finished_dask_reader_pins(
-        self, store: workspace_store.WorkspaceStore
-    ) -> None:
-        """Release serialized readers when no GUI-managed Future can use them."""
-        if store.has_serialized_readers and not self._default_dask_client_has_futures():
-            store.clear_serialized_reader_pins()
-
     def _start_workspace_gc(self) -> None:
         if (
             not self._workspace_gc_requested
@@ -1964,7 +1952,6 @@ class _WorkspaceController:
         ):
             self._workspace_gc_requested = False
             return
-        self._release_finished_dask_reader_pins(store)
         thread_pool = QtCore.QThreadPool.globalInstance()
         if thread_pool is None:
             return
@@ -2500,16 +2487,18 @@ class _WorkspaceController:
             on_start_error=_start_error,
         )
 
-    def _confirm_compaction_with_dask_futures(self, parent: QtWidgets.QWidget) -> bool:
+    def _confirm_compaction_with_exported_readers(
+        self, parent: QtWidgets.QWidget
+    ) -> bool:
         """Confirm that compaction can invalidate serialized Dask readers."""
         msg_box = QtWidgets.QMessageBox(parent)
         msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
         msg_box.setWindowTitle("Compact Workspace")
         msg_box.setText("This workspace was sent to Dask workers.")
         msg_box.setInformativeText(
-            "The connected Dask client still owns Futures. Compacting can remove "
-            "data that those Futures need for recomputation. Release the Futures "
-            "before you compact, or continue and invalidate their workspace readers."
+            "Some Dask Futures can still need this data for retry or recomputation. "
+            "ImageTool Manager cannot determine when every client has released it. "
+            "Continue only if you no longer need those Futures."
         )
         cancel_button = msg_box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
         compact_button = msg_box.addButton(
@@ -2537,12 +2526,15 @@ class _WorkspaceController:
                 "The workspace file is not open. Reopen it and try again.",
             )
             return False
-        self._release_finished_dask_reader_pins(store)
-        if store.has_serialized_readers:
-            if not self._confirm_compaction_with_dask_futures(origin or self._manager):
-                self._restore_focus_after_workspace_save(origin)
-                return False
-            store.clear_serialized_reader_pins()
+        serialized_object_ids = store.serialized_object_ids
+        serialized_legacy_group_paths = store.serialized_legacy_group_paths
+        if (
+            serialized_object_ids or serialized_legacy_group_paths
+        ) and not self._confirm_compaction_with_exported_readers(
+            origin or self._manager
+        ):
+            self._restore_focus_after_workspace_save(origin)
+            return False
         try:
             with erlab.interactive.utils.wait_dialog(
                 origin or self._manager, "Compacting workspace..."
@@ -2557,8 +2549,17 @@ class _WorkspaceController:
                         workspace_path,
                         mark_clean=False,
                     )
-                self._release_finished_dask_reader_pins(store)
-                workspace_storage._compact_workspace_store(store)
+                workspace_storage._compact_workspace_store(
+                    store,
+                    discard_serialized_object_ids=serialized_object_ids,
+                    discard_serialized_legacy_group_paths=(
+                        serialized_legacy_group_paths
+                    ),
+                )
+            store.release_serialized_reader_pins(
+                object_ids=serialized_object_ids,
+                legacy_group_paths=serialized_legacy_group_paths,
+            )
             self._manager._status_bar.showMessage("Workspace compacted", 5000)
             self._mark_workspace_clean()
         except Exception as exc:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -10,6 +10,7 @@ import os
 import pathlib
 import time
 import typing
+import uuid
 
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -22,6 +23,7 @@ import erlab.interactive.imagetool.manager._workspace._loading as workspace_load
 import erlab.interactive.imagetool.manager._workspace._saving as workspace_saving
 import erlab.interactive.imagetool.manager._workspace._state as workspace_state
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.slicer
 import erlab.interactive.imagetool.viewer_linking
 from erlab.interactive.imagetool.manager import _desktop
@@ -87,7 +89,12 @@ class _WorkspaceController:
             workspace_saving._WorkspaceSaveResultReceiver | None
         ) = None
         self._background_save_requested = False
-        self._shutdown_compaction_attempted = False
+        self._workspace_store: workspace_store.WorkspaceStore | None = None
+        self._workspace_gc_worker: workspace_saving._WorkspaceGcWorker | None = None
+        self._workspace_gc_receiver: (
+            workspace_saving._WorkspaceGcResultReceiver | None
+        ) = None
+        self._workspace_gc_requested = False
 
     def _tool_data_reference_matches_current_snapshot(
         self, reference: Mapping[str, typing.Any]
@@ -134,10 +141,19 @@ class _WorkspaceController:
     def _commit_saved_tool_data_references(
         self, snapshot: workspace_saving._WorkspaceSaveSnapshot
     ) -> None:
-        for uid, references in snapshot.serialized_tool_data_references:
+        for uid, snapshot_token, references in snapshot.serialized_tool_data_references:
             node = self._manager._tool_graph.nodes.get(uid)
-            if node is not None and not node.is_imagetool:
-                node._set_workspace_tool_data_references(references)
+            if (
+                node is None
+                or node.is_imagetool
+                or node.snapshot_token != snapshot_token
+                or not all(
+                    self._tool_data_reference_matches_current_snapshot(reference)
+                    for reference in references.values()
+                )
+            ):
+                continue
+            node._set_workspace_tool_data_references(references)
 
     @staticmethod
     def _normalize_recent_workspace_paths(
@@ -503,6 +519,9 @@ class _WorkspaceController:
         self._workspace_window_state_applied = (window_file_path, title, modified)
 
     def _release_workspace_lock(self) -> None:
+        if self._workspace_store is not None:
+            self._workspace_store.close()
+            self._workspace_store = None
         if self._manager._workspace_state.lock is None:
             return
         self._manager._workspace_state.lock.unlock()
@@ -540,11 +559,16 @@ class _WorkspaceController:
         fname: str | os.PathLike[str] | None,
         *,
         workspace_lock: QtCore.QLockFile | None = None,
+        store: workspace_store.WorkspaceStore | None = None,
     ) -> None:
         workspace_path = None if fname is None else pathlib.Path(fname).resolve()
         if workspace_path == self._manager._workspace_state.path:
             if workspace_lock is not None:
                 workspace_lock.unlock()
+            if store is not None and store is not self._workspace_store:
+                if self._workspace_store is not None:
+                    self._workspace_store.close()
+                self._workspace_store = store
             self._update_workspace_window_title()
             self._refresh_manager_record()
             return
@@ -554,12 +578,13 @@ class _WorkspaceController:
                 "Changing the workspace path requires a pre-acquired document lock"
             )
         old_workspace_path = self._manager._workspace_state.path
+        if store is self._workspace_store:
+            self._workspace_store = None
         self._release_workspace_lock()
         self._manager._workspace_state.lock = workspace_lock
+        self._workspace_store = store
         self._manager._workspace_state.path = workspace_path
         self._manager._workspace_state.advance_document_identity()
-        self._manager._workspace_state.delta_save_count = 0
-        self._manager._workspace_state.reset_repack_estimate()
         if old_workspace_path is not None and workspace_path is not None:
             self._repoint_pending_workspace_payloads(old_workspace_path, workspace_path)
         if self._manager._workspace_state.path is not None:
@@ -593,9 +618,14 @@ class _WorkspaceController:
                 )
 
     def _repoint_saved_pending_workspace_payloads(
-        self, workspace_path: str | os.PathLike[str]
+        self,
+        workspace_path: str | os.PathLike[str],
+        *,
+        exclude_uids: Collection[str] = frozenset(),
     ) -> None:
-        for node in self._manager._tool_graph.nodes.values():
+        for uid, node in self._manager._tool_graph.nodes.items():
+            if uid in exclude_uids:
+                continue
             pending = node.pending_workspace_payload
             kind = node.pending_workspace_payload_kind
             if pending is None or kind is None:
@@ -603,7 +633,7 @@ class _WorkspaceController:
             node.set_pending_workspace_payload(
                 kind,
                 workspace_path,
-                self.saving._workspace_payload_path(node.uid),
+                self.loading._workspace_payload_path_for_uid(workspace_path, node.uid),
                 payload_attrs=node.pending_workspace_payload_attrs,
             )
 
@@ -821,7 +851,9 @@ class _WorkspaceController:
                     if rebind_names:
                         opened = workspace_arrays.open_workspace_dataset(
                             workspace_path,
-                            self.saving._workspace_payload_path(node.uid),
+                            self.loading._workspace_payload_path_for_uid(
+                                workspace_path, node.uid
+                            ),
                             chunks={},
                         )
                         replace_ds = workspace_format._restore_workspace_dataset_attrs(
@@ -943,7 +975,9 @@ class _WorkspaceController:
             live_imagetool_snapshot = self._live_imagetool_rebind_snapshot(
                 dask_rebind_uids
             )
-            self._repoint_saved_pending_workspace_payloads(workspace_path)
+            self._repoint_saved_pending_workspace_payloads(
+                workspace_path, exclude_uids=skip_live_data_rebind_uids
+            )
             if dask_rebind_uids:
                 self.loading._rebind_workspace_backed_imagetools(
                     workspace_path,
@@ -1424,7 +1458,7 @@ class _WorkspaceController:
         msg_box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Ok)
         msg_box.exec()
 
-    def _save_legacy_workspace_as_v4(
+    def _save_legacy_workspace_as_current(
         self,
         fname: str | os.PathLike[str],
         *,
@@ -1449,7 +1483,6 @@ class _WorkspaceController:
             ):
                 self.saving._save_workspace_document(
                     existing_access.path,
-                    force_full=True,
                     document_access=existing_access,
                 )
             return str(existing_access.path), existing_access.take_lock()
@@ -1460,7 +1493,6 @@ class _WorkspaceController:
             ):
                 self.saving._save_workspace_document(
                     access.path,
-                    force_full=True,
                     document_access=access,
                 )
             return str(access.path), access.take_lock()
@@ -1471,46 +1503,40 @@ class _WorkspaceController:
         schema_version: int,
         *,
         native: bool = True,
-        delta_save_count: int = 0,
-        estimated_obsolete_bytes: int = 0,
-        replacement_delta_count: int = 0,
-        repack_estimate_known: bool = True,
         workspace_access: _WorkspaceDocumentAccess | None = None,
         rebind_data: bool = True,
     ) -> None:
         associated_fname = fname
         associated_lock: QtCore.QLockFile | None = None
         if workspace_format._workspace_schema_requires_conversion(schema_version):
-            converted = self._save_legacy_workspace_as_v4(
+            converted = self._save_legacy_workspace_as_current(
                 fname, native=native, existing_access=workspace_access
             )
             if converted is None:
                 self._set_workspace_path(None)
-                self._manager._workspace_state.needs_full_save = True
                 self._mark_workspace_structure_dirty(
                     "Legacy workspace needs conversion"
                 )
                 return
             associated_fname, associated_lock = converted
-            delta_save_count = 0
-            estimated_obsolete_bytes = 0
-            replacement_delta_count = 0
-            repack_estimate_known = True
             schema_version = workspace_format._current_workspace_schema_version()
         elif workspace_access is not None:
             associated_lock = workspace_access.take_lock()
 
-        self._set_workspace_path(associated_fname, workspace_lock=associated_lock)
-        self._manager._workspace_state.delta_save_count = delta_save_count
-        self._manager._workspace_state.set_repack_estimate(
-            estimated_obsolete_bytes=estimated_obsolete_bytes,
-            replacement_delta_count=replacement_delta_count,
-            known=repack_estimate_known,
+        associated_store = None
+        if schema_version >= workspace_format._WORKSPACE_LEGACY_SCHEMA_VERSION:
+            associated_store = workspace_store.WorkspaceStore.active(associated_fname)
+            if associated_store is None:
+                associated_store = workspace_store.WorkspaceStore(associated_fname)
+            if schema_version == workspace_format._current_workspace_schema_version():
+                associated_store.clear_staging()
+
+        self._set_workspace_path(
+            associated_fname,
+            workspace_lock=associated_lock,
+            store=associated_store,
         )
         self._manager._workspace_state.schema_version = schema_version
-        self._manager._workspace_state.needs_full_save = (
-            workspace_format._workspace_schema_requires_full_save(schema_version)
-        )
         if rebind_data:
             self.loading._rebind_workspace_backed_imagetools(associated_fname)
         self._drain_workspace_restore_events()
@@ -1552,7 +1578,11 @@ class _WorkspaceController:
         state = self._manager._workspace_state
         if state.path is None:
             return self.save_as(native=native, on_finished=_offload_after_save)
-        if self._manager.is_workspace_modified or state.needs_full_save:
+        if (
+            self._manager.is_workspace_modified
+            or state.schema_version
+            < workspace_format._current_workspace_schema_version()
+        ):
             return self.save(native=native, on_finished=_offload_after_save)
         return self._offload_targets_to_current_workspace(offload_targets)
 
@@ -1573,14 +1603,17 @@ class _WorkspaceController:
                     targets=offload_targets,
                     chunks={},
                 )
-                workspace_storage._write_workspace_root_attrs_to_file(
+                self.saving._save_workspace_document(
                     workspace_path,
-                    self.saving._workspace_root_attrs_payload(
-                        delta_save_count=self._manager._workspace_state.delta_save_count
-                    ),
+                    mark_clean=False,
                 )
             self._manager._status_bar.showMessage("Data offloaded to workspace", 5000)
+            self._schedule_workspace_gc()
         except Exception:
+            logger.exception(
+                "Could not offload data to the current workspace",
+                extra={"suppress_ui_alert": True},
+            )
             self._manager._show_operation_error(
                 "Error while offloading to workspace",
                 "An error occurred while reconnecting data from the workspace file.",
@@ -1644,7 +1677,19 @@ class _WorkspaceController:
                 on_start_error()
             return False
 
-        worker = workspace_saving._WorkspaceSaveWorker(fname, snapshot)
+        target_path = pathlib.Path(fname).resolve()
+        store = (
+            self._workspace_store
+            if self._workspace_store is not None
+            and not self._workspace_store.closed
+            and self._workspace_store.path == target_path
+            else None
+        )
+        worker = workspace_saving._WorkspaceSaveWorker(
+            fname,
+            snapshot,
+            store=store,
+        )
         previous_action_states = self._set_workspace_save_actions_enabled(False)
 
         def _finish(
@@ -1694,6 +1739,76 @@ class _WorkspaceController:
             return False
         return True
 
+    def _schedule_workspace_gc(self) -> None:
+        """Schedule bounded cleanup after the current save has finished."""
+        self._workspace_gc_requested = True
+        QtCore.QTimer.singleShot(0, self._start_workspace_gc)
+
+    def _start_workspace_gc(self) -> None:
+        if (
+            not self._workspace_gc_requested
+            or self._workspace_gc_worker is not None
+            or self._manager._workspace_state.save_in_progress
+        ):
+            return
+        store = self._workspace_store
+        workspace_path = self._current_workspace_document_path()
+        if (
+            store is None
+            or store.closed
+            or workspace_path is None
+            or store.path != workspace_path
+        ):
+            self._workspace_gc_requested = False
+            return
+        thread_pool = QtCore.QThreadPool.globalInstance()
+        if thread_pool is None:
+            return
+
+        document_id = self._manager._workspace_state.document_id
+        worker = workspace_saving._WorkspaceGcWorker(store)
+
+        def _finish(more: bool, error: str | None) -> None:
+            receiver = self._workspace_gc_receiver
+            self._workspace_gc_receiver = None
+            self._workspace_gc_worker = None
+            if receiver is not None:
+                receiver.deleteLater()
+            if error is not None:
+                logger.warning(
+                    "Workspace cleanup failed:\n%s",
+                    error,
+                    extra={"suppress_ui_alert": True},
+                )
+                self._workspace_gc_requested = False
+                return
+            if self._manager._workspace_state.document_id != document_id:
+                self._workspace_gc_requested = False
+                return
+            self._workspace_gc_requested = more
+            if more:
+                QtCore.QTimer.singleShot(0, self._start_workspace_gc)
+
+        receiver = workspace_saving._WorkspaceGcResultReceiver(
+            _finish,
+            parent=self._manager,
+        )
+        worker.signals.finished.connect(receiver.finish)
+        self._workspace_gc_requested = False
+        self._workspace_gc_worker = worker
+        self._workspace_gc_receiver = receiver
+        try:
+            thread_pool.start(worker)
+        except Exception:
+            self._workspace_gc_worker = None
+            self._workspace_gc_receiver = None
+            receiver.deleteLater()
+            self._workspace_gc_requested = True
+            logger.exception(
+                "Could not start workspace cleanup",
+                extra={"suppress_ui_alert": True},
+            )
+
     def _show_workspace_post_save_binding_error(
         self, workspace_path: str | os.PathLike[str]
     ) -> None:
@@ -1706,7 +1821,6 @@ class _WorkspaceController:
         )
 
     def _mark_workspace_post_save_binding_refresh_failed(self) -> None:
-        self._manager._workspace_state.needs_full_save = True
         self._mark_workspace_structure_dirty(
             "Live workspace data references need refresh"
         )
@@ -1716,8 +1830,6 @@ class _WorkspaceController:
         *,
         document_id: str,
         workspace_path: pathlib.Path,
-        old_workspace_path: pathlib.Path | None,
-        backing_snapshot: Mapping[str, tuple[str, tuple[str, ...]]],
         snapshot: workspace_saving._WorkspaceSaveSnapshot,
         worker_elapsed: float,
         error: workspace_saving._WorkspaceSaveError | None,
@@ -1757,35 +1869,9 @@ class _WorkspaceController:
             self._manager._workspace_state.dirty_generation > snapshot.generation
             and self._manager.is_workspace_modified
         )
-        post_save_data_uids = frozenset(
-            event.uid
-            for event in post_save_events
-            if event.uid is not None and (event.data or event.added)
-        )
-        if snapshot.full_tree is not None:
-            try:
-                self._refresh_workspace_payload_bindings_after_full_save(
-                    workspace_path,
-                    backing_snapshot=backing_snapshot,
-                    old_workspace_path=old_workspace_path,
-                    skip_live_data_rebind_uids=post_save_data_uids,
-                )
-            except _WorkspacePostSaveBindingError:
-                self._mark_workspace_post_save_binding_refresh_failed()
-                self._show_workspace_post_save_binding_error(workspace_path)
-                if restore_focus:
-                    self._restore_focus_after_workspace_save(origin)
-                return False
-            self._manager._workspace_state.schema_version = (
-                workspace_format._current_workspace_schema_version()
-            )
         self._commit_saved_tool_data_references(snapshot)
-        self._manager._workspace_state.needs_full_save = False
-        self._manager._workspace_state.delta_save_count = snapshot.delta_save_count
-        self._manager._workspace_state.set_repack_estimate(
-            estimated_obsolete_bytes=snapshot.estimated_obsolete_bytes,
-            replacement_delta_count=snapshot.replacement_delta_count,
-            known=snapshot.repack_estimate_known,
+        self._manager._workspace_state.schema_version = (
+            workspace_format._current_workspace_schema_version()
         )
         if post_save_events:
             self._restore_workspace_dirty_events(post_save_events)
@@ -1810,8 +1896,6 @@ class _WorkspaceController:
         *,
         document_id: str,
         workspace_path: pathlib.Path,
-        old_workspace_path: pathlib.Path | None,
-        backing_snapshot: Mapping[str, tuple[str, tuple[str, ...]]],
         snapshot: workspace_saving._WorkspaceSaveSnapshot,
         worker_elapsed: float,
         error: workspace_saving._WorkspaceSaveError | None,
@@ -1825,8 +1909,6 @@ class _WorkspaceController:
             save_succeeded = self._finish_workspace_save_result(
                 document_id=document_id,
                 workspace_path=workspace_path,
-                old_workspace_path=old_workspace_path,
-                backing_snapshot=backing_snapshot,
                 snapshot=snapshot,
                 worker_elapsed=worker_elapsed,
                 error=error,
@@ -1843,6 +1925,8 @@ class _WorkspaceController:
                 and self._current_workspace_document_path() == workspace_path
             ):
                 QtCore.QTimer.singleShot(0, self.save)
+            elif save_succeeded:
+                self._schedule_workspace_gc()
             if on_finished is not None:
                 on_finished(save_succeeded)
         except Exception:
@@ -1878,8 +1962,6 @@ class _WorkspaceController:
 
         origin = self._active_managed_window()
         document_id = self._manager._workspace_state.document_id
-        old_workspace_path = workspace_path
-        backing_snapshot = self.loading._workspace_data_backing_snapshot()
         self._manager._status_bar.showMessage("Saving workspace...")
         started_at = time.perf_counter()
         snapshot: workspace_saving._WorkspaceSaveSnapshot | None = None
@@ -1921,8 +2003,6 @@ class _WorkspaceController:
             on_finished=lambda elapsed, error: self._finish_background_workspace_save(
                 document_id=document_id,
                 workspace_path=workspace_path,
-                old_workspace_path=old_workspace_path,
-                backing_snapshot=backing_snapshot,
                 snapshot=snapshot,
                 worker_elapsed=elapsed,
                 error=error,
@@ -1960,31 +2040,51 @@ class _WorkspaceController:
             if on_finished is not None:
                 on_finished(False)
             return False
+        if (
+            self._manager._workspace_state.path is not None
+            and pathlib.Path(fname).resolve() == self._manager._workspace_state.path
+        ):
+            return self.save(
+                native=native,
+                on_finished=on_finished,
+            )
         old_workspace_path = self._manager._workspace_state.path
         document_id = self._manager._workspace_state.document_id
         backing_snapshot = self.loading._workspace_data_backing_snapshot()
         access: _WorkspaceDocumentAccess | None = None
         snapshot: workspace_saving._WorkspaceSaveSnapshot | None = None
+        target_expected_state: workspace_storage._WorkspacePublicationState | None = (
+            None
+        )
+        worker_path: pathlib.Path | None = None
         self._manager._status_bar.showMessage("Saving workspace...")
         started_at = time.perf_counter()
         try:
             access = self._workspace_document_access(fname)
-            expected_state = workspace_storage._workspace_publication_state(access.path)
+            target_expected_state = workspace_storage._workspace_publication_state(
+                access.path
+            )
+            worker_path = access.path.with_name(
+                f".{access.path.name}.tmp-{uuid.uuid4().hex}"
+            )
             self._drain_workspace_deferred_events()
             generation = self._manager._workspace_state.dirty_generation
             self._manager._workspace_state.saving_depth += 1
             try:
                 snapshot_started_at = time.perf_counter()
-                snapshot = self.saving._workspace_full_save_snapshot(
-                    generation, fname=access.path
+                snapshot = self.saving._workspace_generation_save_snapshot(
+                    generation,
+                    fname=worker_path,
                 )
-                snapshot.expected_publication_state = expected_state
                 snapshot_elapsed = time.perf_counter() - snapshot_started_at
             finally:
                 self._manager._workspace_state.saving_depth -= 1
         except Exception:
             if snapshot is not None:
                 snapshot.close()
+            if worker_path is not None:
+                with contextlib.suppress(OSError):
+                    worker_path.unlink()
             if access is not None:
                 access.release()
             logger.exception(
@@ -2027,14 +2127,43 @@ class _WorkspaceController:
                     access.path,
                     extra={"suppress_ui_alert": True},
                 )
+                if worker_path is not None:
+                    with contextlib.suppress(OSError):
+                        worker_path.unlink()
                 access.release()
                 access = None
                 if on_finished is not None:
                     on_finished(False)
                 return
             if error is not None:
+                if worker_path is not None:
+                    with contextlib.suppress(OSError):
+                        worker_path.unlink()
                 self._manager._status_bar.clearMessage()
                 self._manager._show_workspace_save_worker_error(error)
+                access.release()
+                self._restore_focus_after_workspace_save(origin)
+                if on_finished is not None:
+                    on_finished(False)
+                return
+
+            if target_expected_state is None:  # pragma: no cover
+                raise RuntimeError("Save As publication state was not prepared")
+            try:
+                workspace_storage._replace_workspace_file(
+                    worker_path,
+                    access.path,
+                    expected_state=target_expected_state,
+                )
+            except Exception:
+                with contextlib.suppress(OSError):
+                    worker_path.unlink()
+                self._manager._status_bar.clearMessage()
+                self._manager._show_operation_error(
+                    "Error while saving workspace",
+                    "The new workspace was written, but it could not replace the "
+                    "selected destination.",
+                )
                 access.release()
                 self._restore_focus_after_workspace_save(origin)
                 if on_finished is not None:
@@ -2051,47 +2180,57 @@ class _WorkspaceController:
                 self._manager._workspace_state.dirty_generation > snapshot.generation
                 and self._manager.is_workspace_modified
             )
-            if post_save_events or has_new_dirty_generation:
-                access.release()
-                self._manager._status_bar.showMessage(
-                    "Workspace saved; new changes remain unsaved", 5000
+            post_save_uids = frozenset(
+                event.uid for event in post_save_events if event.uid is not None
+            )
+            old_store = self._workspace_store
+            try:
+                if old_store is not None:
+                    old_store.switch_path(access.path)
+                    new_store = old_store
+                else:
+                    new_store = workspace_store.WorkspaceStore(access.path)
+            except Exception:
+                logger.exception(
+                    "Could not open the saved workspace store",
+                    extra={"suppress_ui_alert": True},
                 )
+                self._show_workspace_post_save_binding_error(access.path)
+                access.release()
                 self._restore_focus_after_workspace_save(origin)
                 if on_finished is not None:
                     on_finished(False)
                 return
 
-            if snapshot.full_tree is not None:
-                try:
-                    self._refresh_workspace_payload_bindings_after_full_save(
-                        access.path,
-                        backing_snapshot=backing_snapshot,
-                        old_workspace_path=old_workspace_path,
-                    )
-                except _WorkspacePostSaveBindingError:
-                    self._show_workspace_post_save_binding_error(access.path)
-                    access.release()
-                    self._restore_focus_after_workspace_save(origin)
-                    if on_finished is not None:
-                        on_finished(False)
-                    return
-
             self._commit_saved_tool_data_references(snapshot)
-            self._manager._workspace_state.needs_full_save = False
-            self._manager._workspace_state.delta_save_count = snapshot.delta_save_count
-            self._manager._workspace_state.set_repack_estimate(
-                estimated_obsolete_bytes=snapshot.estimated_obsolete_bytes,
-                replacement_delta_count=snapshot.replacement_delta_count,
-                known=snapshot.repack_estimate_known,
-            )
             self._manager._workspace_state.schema_version = (
                 workspace_format._current_workspace_schema_version()
             )
             saved_path = access.path
-            self._set_workspace_path(saved_path, workspace_lock=access.take_lock())
+            self._set_workspace_path(
+                saved_path,
+                workspace_lock=access.take_lock(),
+                store=new_store,
+            )
             access = None
+            try:
+                self._refresh_workspace_payload_bindings_after_full_save(
+                    saved_path,
+                    backing_snapshot=backing_snapshot,
+                    old_workspace_path=old_workspace_path,
+                    skip_live_data_rebind_uids=post_save_uids,
+                )
+            except _WorkspacePostSaveBindingError:
+                self._show_workspace_post_save_binding_error(saved_path)
+                self._restore_focus_after_workspace_save(origin)
+                if on_finished is not None:
+                    on_finished(False)
+                return
             self._drain_workspace_deferred_events()
-            self._mark_workspace_clean()
+            if post_save_events or has_new_dirty_generation:
+                self._restore_workspace_dirty_events(post_save_events)
+            else:
+                self._mark_workspace_clean()
             self._record_recent_workspace(saved_path)
             message = (
                 f"Workspace saved in {total_elapsed:.1f} s"
@@ -2100,10 +2239,14 @@ class _WorkspaceController:
             )
             self._manager._status_bar.showMessage(message, 5000)
             self._restore_focus_after_workspace_save(origin)
+            self._schedule_workspace_gc()
             if on_finished is not None:
                 on_finished(True)
 
         def _start_error() -> None:
+            if worker_path is not None:
+                with contextlib.suppress(OSError):
+                    worker_path.unlink()
             if access is not None:
                 access.release()
             self._manager._status_bar.clearMessage()
@@ -2115,122 +2258,19 @@ class _WorkspaceController:
             if on_finished is not None:
                 on_finished(False)
 
+        if worker_path is None:  # pragma: no cover
+            snapshot.close()
+            access.release()
+            raise RuntimeError("Save As worker path was not prepared")
         return self._start_workspace_save_worker(
-            access.path,
+            worker_path,
             snapshot,
             on_finished=_finish_save_as,
             on_start_error=_start_error,
         )
 
-    def _compact_workspace_before_shutdown(
-        self, on_finished: Callable[[], None] | None = None
-    ) -> bool:
-        if (
-            self._manager._workspace_state.path is None
-            or self._manager._workspace_state.delta_save_count <= 0
-            or self._manager.is_workspace_modified
-            or self._manager._workspace_state.save_in_progress
-            or self._manager._workspace_state.loading_depth > 0
-            or self._shutdown_compaction_attempted
-        ):
-            return False
-        if not self.saving._workspace_should_repack_before_shutdown():
-            return False
-        try:
-            logger.debug("Compacting workspace before shutdown...")
-            self._shutdown_compaction_attempted = True
-            document_id = self._manager._workspace_state.document_id
-            self._drain_workspace_deferred_events()
-            generation = self._manager._workspace_state.dirty_generation
-            self._manager._workspace_state.saving_depth += 1
-            try:
-                snapshot = self.saving._workspace_file_repack_snapshot(generation)
-                if snapshot is None:
-                    return False
-            finally:
-                self._manager._workspace_state.saving_depth -= 1
-        except Exception:
-            logger.exception(
-                "Failed to compact workspace before shutdown",
-                extra={"suppress_ui_alert": True},
-            )
-            return False
-
-        def _finish_compaction(
-            _elapsed: float,
-            error: workspace_saving._WorkspaceSaveError | None,
-        ) -> None:
-            if self._manager._workspace_state.document_id != document_id:
-                logger.info(
-                    "Ignoring completed shutdown compaction for inactive document",
-                    extra={"suppress_ui_alert": True},
-                )
-                if on_finished is not None:
-                    on_finished()
-                return
-            if error is not None:
-                logger.error(
-                    "Failed to compact workspace before shutdown%s",
-                    f":\n{error.traceback_text}",
-                    extra={"suppress_ui_alert": True},
-                )
-            else:
-                self._manager._workspace_state.needs_full_save = False
-                self._manager._workspace_state.delta_save_count = 0
-                self._manager._workspace_state.reset_repack_estimate()
-                self._manager._workspace_state.schema_version = (
-                    workspace_format._current_workspace_schema_version()
-                )
-                workspace_path = self._manager._workspace_state.path
-                if workspace_path is not None:
-                    try:
-                        self._refresh_workspace_payload_bindings_after_full_save(
-                            workspace_path,
-                            old_workspace_path=workspace_path,
-                        )
-                    except _WorkspacePostSaveBindingError:
-                        logger.exception(
-                            "Workspace was compacted before shutdown, but live "
-                            "workspace data could not be rebound",
-                            extra={"suppress_ui_alert": True},
-                        )
-                        if on_finished is not None:
-                            on_finished()
-                        return
-                self._drain_workspace_deferred_events()
-                post_save_events = tuple(
-                    event
-                    for event in self._manager._workspace_state.dirty_events
-                    if event.generation > snapshot.generation
-                )
-                if post_save_events:
-                    self._restore_workspace_dirty_events(post_save_events)
-                else:
-                    self._mark_workspace_clean()
-            if on_finished is not None:
-                on_finished()
-
-        def _start_error() -> None:
-            logger.error(
-                "Failed to start workspace compaction before shutdown",
-                extra={"suppress_ui_alert": True},
-            )
-            if on_finished is not None:
-                on_finished()
-
-        workspace_path = self._manager._workspace_state.path
-        if workspace_path is None:
-            snapshot.close()
-            return False
-        return self._start_workspace_save_worker(
-            workspace_path,
-            snapshot,
-            on_finished=_finish_compaction,
-            on_start_error=_start_error,
-        )
-
     def compact_workspace(self) -> bool:
-        """Rewrite the current workspace file to remove unused space."""
+        """Rewrite the current workspace with only reachable payload objects."""
         workspace_path = self._current_workspace_document_path()
         if workspace_path is None:
             return self.save_as()
@@ -2241,33 +2281,34 @@ class _WorkspaceController:
             return False
 
         origin = self._active_managed_window()
-        old_workspace_path = workspace_path
-        backing_snapshot = self.loading._workspace_data_backing_snapshot()
+        store = self._workspace_store
+        if store is None or store.closed or store.path != workspace_path:
+            self._manager._show_operation_error(
+                "Error while compacting workspace",
+                "The workspace file is not open. Reopen it and try again.",
+            )
+            return False
         try:
             with erlab.interactive.utils.wait_dialog(
                 origin or self._manager, "Compacting workspace..."
             ):
-                self.saving._save_workspace_document(
-                    workspace_path,
-                    force_full=True,
-                    require_matching_compression=True,
-                    mark_clean=False,
-                )
-                self._refresh_workspace_payload_bindings_after_full_save(
-                    workspace_path,
-                    backing_snapshot=backing_snapshot,
-                    old_workspace_path=old_workspace_path,
-                )
-            self._manager._workspace_state.delta_save_count = 0
+                if (
+                    self._manager.is_workspace_modified
+                    or self._manager._workspace_state.schema_version
+                    < workspace_format._current_workspace_schema_version()
+                ):
+                    self.saving._save_workspace_document(
+                        workspace_path,
+                        mark_clean=False,
+                    )
+                workspace_storage._compact_workspace_store(store)
             self._manager._status_bar.showMessage("Workspace compacted", 5000)
-            self._manager._workspace_state.needs_full_save = False
             self._mark_workspace_clean()
-        except _WorkspacePostSaveBindingError:
-            self._mark_workspace_post_save_binding_refresh_failed()
-            self._show_workspace_post_save_binding_error(workspace_path)
-            self._restore_focus_after_workspace_save(origin)
-            return False
         except Exception:
+            logger.exception(
+                "Could not compact workspace",
+                extra={"suppress_ui_alert": True},
+            )
             self._manager._show_operation_error(
                 "Error while compacting workspace",
                 "An error occurred while compacting the workspace file.",
@@ -2276,7 +2317,6 @@ class _WorkspaceController:
             return False
 
         self._restore_focus_after_workspace_save(origin)
-        self._manager._workspace_state.reset_repack_estimate()
         return True
 
     def load(self, *, native: bool = True) -> bool:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -100,6 +100,19 @@ class _WorkspaceController:
         ) = None
         self._workspace_gc_requested = False
 
+    def _dask_client_has_live_futures(self) -> bool:
+        """Return whether a Dask client owns results that can need workspace data."""
+        try:
+            client = self._manager._dask_menu.default_client
+        except Exception:
+            return True
+        if client is None:
+            return False
+        try:
+            return bool(client.futures)
+        except Exception:
+            return True
+
     def _tool_data_reference_matches_current_snapshot(
         self, reference: Mapping[str, typing.Any]
     ) -> bool:
@@ -549,12 +562,9 @@ class _WorkspaceController:
         if pending is not None:
             paths.add(pending[0].resolve())
         if node.is_imagetool and node.imagetool is not None:
-            paths.update(
-                pathlib.Path(path).resolve()
-                for path in workspace_arrays.dataarray_source_paths(
-                    node.slicer_area._data
-                )
-            )
+            data_backing, source_paths = node.persistence_data_backing()
+            if data_backing in {"dask", "file_lazy"}:
+                paths.update(pathlib.Path(path).resolve() for path in source_paths)
         paths.update(
             path.resolve() for path, _group in node._workspace_reference_datasets
         )
@@ -1938,6 +1948,18 @@ class _WorkspaceController:
         self._workspace_gc_requested = True
         QtCore.QTimer.singleShot(0, self._start_workspace_gc)
 
+    def _resume_workspace_gc_after_dask(self) -> None:
+        """Wait without file access until Dask no longer owns workspace results."""
+        if not self._workspace_gc_requested or self._workspace_gc_worker is not None:
+            return
+        if (
+            self._manager._workspace_state.save_in_progress
+            or self._dask_client_has_live_futures()
+        ):
+            QtCore.QTimer.singleShot(1000, self._resume_workspace_gc_after_dask)
+            return
+        self._start_workspace_gc()
+
     def _start_workspace_gc(self) -> None:
         if (
             not self._workspace_gc_requested
@@ -1960,8 +1982,11 @@ class _WorkspaceController:
             return
 
         document_id = self._manager._workspace_state.document_id
+        object_gc_deferred = self._dask_client_has_live_futures()
         worker = workspace_saving._WorkspaceGcWorker(
             store,
+            delete_objects=not object_gc_deferred,
+            can_delete_objects=lambda: not self._dask_client_has_live_futures(),
             reader_closers=self.saving._workspace_reader_closers(workspace_path),
         )
 
@@ -1984,7 +2009,10 @@ class _WorkspaceController:
                 return
             self._workspace_gc_requested = more
             if more:
-                QtCore.QTimer.singleShot(0, self._start_workspace_gc)
+                if worker.object_gc_deferred:
+                    QtCore.QTimer.singleShot(1000, self._resume_workspace_gc_after_dask)
+                else:
+                    QtCore.QTimer.singleShot(0, self._start_workspace_gc)
 
         receiver = workspace_saving._WorkspaceGcResultReceiver(
             _finish,
@@ -2498,6 +2526,11 @@ class _WorkspaceController:
         if self._manager._workspace_state.save_in_progress:
             self._manager._status_bar.showMessage(
                 "Workspace save already in progress", 3000
+            )
+            return False
+        if self._dask_client_has_live_futures():
+            self._manager._status_bar.showMessage(
+                "Release Dask results before compacting the workspace", 5000
             )
             return False
 

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -2387,17 +2387,15 @@ class _WorkspaceController:
                 return
 
             self._drain_workspace_deferred_events()
-            post_save_events = tuple(
+            pre_rebind_post_save_events = tuple(
                 event
                 for event in self._manager._workspace_state.dirty_events
                 if event.generation > snapshot.generation
             )
-            has_new_dirty_generation = (
-                self._manager._workspace_state.dirty_generation > snapshot.generation
-                and self._manager.is_workspace_modified
-            )
             post_save_uids = frozenset(
-                event.uid for event in post_save_events if event.uid is not None
+                event.uid
+                for event in pre_rebind_post_save_events
+                if event.uid is not None
             )
             old_store = self._workspace_store
             try:
@@ -2445,6 +2443,15 @@ class _WorkspaceController:
                 return
             self._release_unused_imported_workspace_accesses()
             self._drain_workspace_deferred_events()
+            post_save_events = tuple(
+                event
+                for event in self._manager._workspace_state.dirty_events
+                if event.generation > snapshot.generation
+            )
+            has_new_dirty_generation = (
+                self._manager._workspace_state.dirty_generation > snapshot.generation
+                and self._manager.is_workspace_modified
+            )
             if post_save_events:
                 self._restore_workspace_dirty_events(post_save_events)
             elif not has_new_dirty_generation:
@@ -2529,12 +2536,12 @@ class _WorkspaceController:
                 "The workspace file is not open. Reopen it and try again.",
             )
             return False
-        serialized_object_ids = store.serialized_object_ids
-        serialized_legacy_group_paths = store.serialized_legacy_group_paths
+        serialized_reader_pins = store.serialized_reader_pin_snapshot()
         if (
-            serialized_object_ids or serialized_legacy_group_paths
-        ) and not self._confirm_compaction_with_exported_readers(
-            origin or self._manager
+            not serialized_reader_pins.empty
+            and not self._confirm_compaction_with_exported_readers(
+                origin or self._manager
+            )
         ):
             self._restore_focus_after_workspace_save(origin)
             return False
@@ -2554,15 +2561,9 @@ class _WorkspaceController:
                     )
                 workspace_storage._compact_workspace_store(
                     store,
-                    discard_serialized_object_ids=serialized_object_ids,
-                    discard_serialized_legacy_group_paths=(
-                        serialized_legacy_group_paths
-                    ),
+                    discard_serialized_reader_pins=serialized_reader_pins,
                 )
-            store.release_serialized_reader_pins(
-                object_ids=serialized_object_ids,
-                legacy_group_paths=serialized_legacy_group_paths,
-            )
+            store.release_serialized_reader_pins(serialized_reader_pins)
             self._manager._status_bar.showMessage("Workspace compacted", 5000)
             self._mark_workspace_clean()
         except Exception as exc:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -622,7 +622,6 @@ class _WorkspaceController:
         workspace_path: str | os.PathLike[str],
         *,
         manifest: Mapping[str, typing.Any],
-        exclude_uids: Collection[str] = frozenset(),
     ) -> None:
         payload_paths = {
             uid: payload_path
@@ -631,8 +630,6 @@ class _WorkspaceController:
             )
         }
         for uid, node in self._manager._tool_graph.nodes.items():
-            if uid in exclude_uids:
-                continue
             pending = node.pending_workspace_payload
             kind = node.pending_workspace_payload_kind
             payload_path = payload_paths.get(uid)
@@ -651,14 +648,12 @@ class _WorkspaceController:
         snapshot: workspace_saving._WorkspaceSaveSnapshot,
         *,
         manifest: Mapping[str, typing.Any],
-        exclude_uids: Collection[str] = frozenset(),
     ) -> None:
         """Apply one committed generation to live manager references."""
         self._commit_saved_tool_data_references(snapshot)
         self._repoint_saved_pending_workspace_payloads(
             workspace_path,
             manifest=manifest,
-            exclude_uids=exclude_uids,
         )
         self._manager._workspace_state.schema_version = (
             workspace_format._current_workspace_schema_version()
@@ -1893,14 +1888,10 @@ class _WorkspaceController:
             self._manager._workspace_state.dirty_generation > snapshot.generation
             and self._manager.is_workspace_modified
         )
-        post_save_uids = frozenset(
-            event.uid for event in post_save_events if event.uid is not None
-        )
         self._adopt_committed_workspace_generation(
             workspace_path,
             snapshot,
             manifest=snapshot.generation_plan.manifest,
-            exclude_uids=post_save_uids,
         )
         if post_save_events:
             self._restore_workspace_dirty_events(post_save_events)
@@ -2242,7 +2233,6 @@ class _WorkspaceController:
                 saved_path,
                 snapshot,
                 manifest=snapshot.generation_plan.manifest,
-                exclude_uids=post_save_uids,
             )
             try:
                 self._refresh_workspace_payload_bindings_after_full_save(
@@ -2335,14 +2325,24 @@ class _WorkspaceController:
                 workspace_storage._compact_workspace_store(store)
             self._manager._status_bar.showMessage("Workspace compacted", 5000)
             self._mark_workspace_clean()
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 "Could not compact workspace",
                 extra={"suppress_ui_alert": True},
             )
+            if isinstance(exc, workspace_store.WorkspaceStoreReopenError):
+                store.close()
+                if self._workspace_store is store:
+                    self._workspace_store = None
+                error_text = (
+                    "The compacted workspace was saved, but it could not be "
+                    "reopened. Close and reopen the workspace before you continue."
+                )
+            else:
+                error_text = "An error occurred while compacting the workspace file."
             self._manager._show_operation_error(
                 "Error while compacting workspace",
-                "An error occurred while compacting the workspace file.",
+                error_text,
             )
             self._restore_focus_after_workspace_save(origin)
             return False

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import copy
 import functools
 import logging
 import os
@@ -652,6 +653,72 @@ class _WorkspaceController:
                 payload_attrs=attrs,
             )
 
+    def _dask_rebind_uids_after_full_save(
+        self,
+        *,
+        backing_snapshot: Mapping[str, tuple[str, tuple[str, ...]]] | None,
+        old_workspace_path: str | os.PathLike[str] | None,
+        exclude_uids: Collection[str],
+    ) -> frozenset[str]:
+        """Return Dask nodes that still depend on data outside the document."""
+        if backing_snapshot is None:
+            return frozenset()
+        old_path = workspace_arrays._normalized_file_path(old_workspace_path)
+        rebind_uids: set[str] = set()
+        for uid, (kind, source_paths) in backing_snapshot.items():
+            node = self._manager._tool_graph.nodes.get(uid)
+            if (
+                kind != "dask"
+                or uid in exclude_uids
+                or node is None
+                or not node.is_imagetool
+                or node.imagetool is None
+                or node.pending_workspace_memory_payload is not None
+            ):
+                continue
+            uses_current_workspace_reader = (
+                old_path is not None
+                and bool(source_paths)
+                and all(source_path == old_path for source_path in source_paths)
+            )
+            if not uses_current_workspace_reader:
+                rebind_uids.add(uid)
+        return frozenset(rebind_uids)
+
+    def _live_imagetool_rebind_snapshot(
+        self, uids: Collection[str]
+    ) -> dict[str, tuple[_ManagedWindowNode, xr.DataArray, typing.Any, str]]:
+        snapshot: dict[
+            str, tuple[_ManagedWindowNode, xr.DataArray, typing.Any, str]
+        ] = {}
+        for uid in uids:
+            node = self._manager._tool_graph.nodes.get(uid)
+            if node is None or node.imagetool is None:
+                continue
+            snapshot[uid] = (
+                node,
+                node.slicer_area._data,
+                copy.deepcopy(node.slicer_area.state),
+                node.name,
+            )
+        return snapshot
+
+    def _restore_live_imagetool_rebind_snapshot(
+        self,
+        snapshot: Mapping[
+            str, tuple[_ManagedWindowNode, xr.DataArray, typing.Any, str]
+        ],
+    ) -> None:
+        if not snapshot:
+            return
+        with self._workspace_load_context():
+            for uid, (node, data, state, name) in snapshot.items():
+                if uid not in self._manager._tool_graph.nodes or node.imagetool is None:
+                    continue
+                node.slicer_area.set_data(data, auto_compute=False)
+                node.slicer_area.state = state
+                node._set_name(name, manual=False)
+
     @staticmethod
     def _workspace_tool_references_include_uids(
         references: Mapping[str, Mapping[str, typing.Any]],
@@ -787,9 +854,28 @@ class _WorkspaceController:
         skip_live_data_rebind_uids: Collection[str] = frozenset(),
     ) -> None:
         pending_snapshot = self._pending_workspace_payload_snapshot()
+        live_imagetool_snapshot: dict[
+            str, tuple[_ManagedWindowNode, xr.DataArray, typing.Any, str]
+        ] = {}
         source_snapshot: list[tuple[xr.Variable, bool, typing.Any]] = []
         try:
+            dask_rebind_uids = self._dask_rebind_uids_after_full_save(
+                backing_snapshot=backing_snapshot,
+                old_workspace_path=old_workspace_path,
+                exclude_uids=skip_live_data_rebind_uids,
+            )
+            live_imagetool_snapshot = self._live_imagetool_rebind_snapshot(
+                dask_rebind_uids
+            )
             self._repoint_saved_pending_workspace_payloads(workspace_path)
+            if dask_rebind_uids:
+                self.loading._rebind_workspace_backed_imagetools(
+                    workspace_path,
+                    targets=dask_rebind_uids,
+                    backing_snapshot=backing_snapshot,
+                    old_workspace_path=old_workspace_path,
+                    exclude_uids=skip_live_data_rebind_uids,
+                )
             old_path = workspace_arrays._normalized_file_path(old_workspace_path)
             for uid, node in self._manager._tool_graph.nodes.items():
                 if (
@@ -802,10 +888,13 @@ class _WorkspaceController:
                     backing = backing_snapshot.get(uid)
                     if backing is not None:
                         kind, source_paths = backing
-                        should_retarget = kind == "dask" or (
-                            kind == "file_lazy"
-                            and old_path is not None
-                            and old_path in source_paths
+                        should_retarget = uid not in dask_rebind_uids and (
+                            kind == "dask"
+                            or (
+                                kind == "file_lazy"
+                                and old_path is not None
+                                and old_path in source_paths
+                            )
                         )
                         if should_retarget:
                             source_snapshot.extend(
@@ -826,14 +915,18 @@ class _WorkspaceController:
             with contextlib.suppress(Exception):
                 self._restore_pending_workspace_payload_snapshot(pending_snapshot)
             workspace_arrays._restore_workspace_xarray_source_snapshot(source_snapshot)
+            with contextlib.suppress(Exception):
+                self._restore_live_imagetool_rebind_snapshot(live_imagetool_snapshot)
             raise
         except Exception as exc:
             with contextlib.suppress(Exception):
                 self._restore_pending_workspace_payload_snapshot(pending_snapshot)
             workspace_arrays._restore_workspace_xarray_source_snapshot(source_snapshot)
+            with contextlib.suppress(Exception):
+                self._restore_live_imagetool_rebind_snapshot(live_imagetool_snapshot)
             raise _WorkspacePostSaveBindingError(
-                "Workspace file was saved, but logical workspace references could "
-                "not be updated."
+                "Workspace file was saved, but live workspace data could not be "
+                "rebound to the saved file."
             ) from exc
 
     def _active_managed_window(self) -> QtWidgets.QWidget | None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -2445,16 +2445,19 @@ class _WorkspaceController:
                 return
             self._release_unused_imported_workspace_accesses()
             self._drain_workspace_deferred_events()
-            if post_save_events or has_new_dirty_generation:
+            if post_save_events:
                 self._restore_workspace_dirty_events(post_save_events)
-            else:
+            elif not has_new_dirty_generation:
                 self._mark_workspace_clean()
             self._record_recent_workspace(saved_path)
-            message = (
-                f"Workspace saved in {total_elapsed:.1f} s"
-                if total_elapsed >= _WORKSPACE_SAVE_WAIT_DIALOG_THRESHOLD_SECONDS
-                else "Workspace saved"
-            )
+            if post_save_events or has_new_dirty_generation:
+                message = "Workspace saved; new changes remain unsaved"
+            else:
+                message = (
+                    f"Workspace saved in {total_elapsed:.1f} s"
+                    if total_elapsed >= _WORKSPACE_SAVE_WAIT_DIALOG_THRESHOLD_SECONDS
+                    else "Workspace saved"
+                )
             self._manager._status_bar.showMessage(message, 5000)
             self._restore_focus_after_workspace_save(origin)
             self._schedule_workspace_gc()

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -100,19 +100,6 @@ class _WorkspaceController:
         ) = None
         self._workspace_gc_requested = False
 
-    def _dask_client_has_live_futures(self) -> bool:
-        """Return whether a Dask client owns results that can need workspace data."""
-        try:
-            client = self._manager._dask_menu.default_client
-        except Exception:
-            return True
-        if client is None:
-            return False
-        try:
-            return bool(client.futures)
-        except Exception:
-            return True
-
     def _tool_data_reference_matches_current_snapshot(
         self, reference: Mapping[str, typing.Any]
     ) -> bool:
@@ -1948,18 +1935,6 @@ class _WorkspaceController:
         self._workspace_gc_requested = True
         QtCore.QTimer.singleShot(0, self._start_workspace_gc)
 
-    def _resume_workspace_gc_after_dask(self) -> None:
-        """Wait without file access until Dask no longer owns workspace results."""
-        if not self._workspace_gc_requested or self._workspace_gc_worker is not None:
-            return
-        if (
-            self._manager._workspace_state.save_in_progress
-            or self._dask_client_has_live_futures()
-        ):
-            QtCore.QTimer.singleShot(1000, self._resume_workspace_gc_after_dask)
-            return
-        self._start_workspace_gc()
-
     def _start_workspace_gc(self) -> None:
         if (
             not self._workspace_gc_requested
@@ -1982,11 +1957,8 @@ class _WorkspaceController:
             return
 
         document_id = self._manager._workspace_state.document_id
-        object_gc_deferred = self._dask_client_has_live_futures()
         worker = workspace_saving._WorkspaceGcWorker(
             store,
-            delete_objects=not object_gc_deferred,
-            can_delete_objects=lambda: not self._dask_client_has_live_futures(),
             reader_closers=self.saving._workspace_reader_closers(workspace_path),
         )
 
@@ -2009,10 +1981,7 @@ class _WorkspaceController:
                 return
             self._workspace_gc_requested = more
             if more:
-                if worker.object_gc_deferred:
-                    QtCore.QTimer.singleShot(1000, self._resume_workspace_gc_after_dask)
-                else:
-                    QtCore.QTimer.singleShot(0, self._start_workspace_gc)
+                QtCore.QTimer.singleShot(0, self._start_workspace_gc)
 
         receiver = workspace_saving._WorkspaceGcResultReceiver(
             _finish,
@@ -2528,12 +2497,6 @@ class _WorkspaceController:
                 "Workspace save already in progress", 3000
             )
             return False
-        if self._dask_client_has_live_futures():
-            self._manager._status_bar.showMessage(
-                "Release Dask results before compacting the workspace", 5000
-            )
-            return False
-
         origin = self._active_managed_window()
         store = self._workspace_store
         if store is None or store.closed or store.path != workspace_path:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import contextlib
-import copy
 import functools
 import logging
 import os
@@ -23,7 +22,6 @@ import erlab.interactive.imagetool.manager._workspace._state as workspace_state
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.slicer
 import erlab.interactive.imagetool.viewer_linking
-from erlab.interactive.imagetool import _serialization
 from erlab.interactive.imagetool.manager import _desktop
 from erlab.interactive.imagetool.manager._widgets import (
     _RECENT_WORKSPACES_SETTINGS_KEY,
@@ -607,108 +605,6 @@ class _WorkspaceController:
                 payload_attrs=node.pending_workspace_payload_attrs,
             )
 
-    def _saved_tool_payload_dataset_for_rebind(
-        self,
-        workspace_path: str | os.PathLike[str],
-        node: _ManagedWindowNode,
-        reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset],
-    ) -> xr.Dataset:
-        payload_path = self.saving._workspace_payload_path(node.uid)
-        key = self.loading._workspace_reference_key(workspace_path, payload_path)
-        try:
-            opened = reference_datasets[key]
-        except KeyError:
-            opened = workspace_arrays.open_workspace_dataset(
-                workspace_path, payload_path, chunks={}
-            )
-            reference_datasets[key] = opened
-        ds = workspace_format._restore_workspace_dataset_attrs(opened.copy(deep=False))
-        return _serialization.restore_private_coords(
-            ds, erlab.interactive.utils._SAVED_TOOL_DATA_NAME
-        )
-
-    def _rebind_workspace_referenced_tool_data(
-        self,
-        workspace_path: str | os.PathLike[str],
-        *,
-        exclude_data_uids: Collection[str] = frozenset(),
-    ) -> None:
-        for node in self._manager._tool_graph.nodes.values():
-            tool = node.tool_window
-            if (
-                node.is_imagetool
-                or tool is None
-                or not tool.can_save_and_load()
-                or not node._workspace_reference_datasets
-                or node.uid in exclude_data_uids
-                or self._workspace_tool_references_include_uids(
-                    node._workspace_tool_data_references,
-                    exclude_data_uids,
-                    parent_uid=node.parent_uid,
-                )
-            ):
-                continue
-            reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] = {}
-            try:
-                with tool._save_tool_data_reference_context(
-                    self._manager._tool_graph.nodes,
-                    reference_validator=self._tool_data_reference_matches_current_data,
-                ):
-                    ds = tool.to_dataset()
-                references = type(tool)._saved_tool_data_references(ds)
-                if not references:
-                    ds = self._saved_tool_payload_dataset_for_rebind(
-                        workspace_path, node, reference_datasets
-                    )
-                    references = type(tool)._saved_tool_data_references(ds)
-                source_parent_data, tool_data_reference_resolver = (
-                    self.loading._workspace_tool_restore_references(
-                        ds,
-                        parent_target=node.parent_uid,
-                        owner_node=node,
-                        reference_datasets=reference_datasets,
-                        resolver_error_types=(Exception,),
-                        log_resolver_errors=True,
-                    )
-                )
-                data_items = type(tool)._tool_data_items_from_dataset(
-                    ds,
-                    source_parent_data=source_parent_data,
-                    reference_resolver=tool_data_reference_resolver,
-                )
-                with (
-                    self._workspace_load_context(),
-                    tool._history_suppressed(),
-                ):
-                    tool._replace_persistence_data_items(data_items, ds)
-                node._set_workspace_tool_data_references(references)
-                node._replace_workspace_reference_datasets(reference_datasets)
-                reference_datasets = {}
-            except Exception as exc:
-                self.loading._close_workspace_reference_datasets(reference_datasets)
-                raise _WorkspacePostSaveBindingError(
-                    "Workspace file was saved, but live ToolWindow data could not "
-                    f"be rebound for node {node.uid!r}."
-                ) from exc
-
-    @staticmethod
-    def _workspace_tool_references_include_uids(
-        references: Mapping[str, Mapping[str, typing.Any]],
-        uids: Collection[str],
-        *,
-        parent_uid: str | None,
-    ) -> bool:
-        if not uids:
-            return False
-        for reference in references.values():
-            kind = reference.get("kind")
-            if kind == "parent_source":
-                if parent_uid in uids:
-                    return True
-            elif kind == "manager_node" and reference.get("node_uid") in uids:
-                return True
-        return False
-
     def _pending_workspace_payload_snapshot(
         self,
     ) -> dict[
@@ -756,57 +652,131 @@ class _WorkspaceController:
                 payload_attrs=attrs,
             )
 
-    def _live_imagetool_rebind_snapshot(
-        self,
+    @staticmethod
+    def _workspace_tool_references_include_uids(
+        references: Mapping[str, Mapping[str, typing.Any]],
+        uids: Collection[str],
         *,
-        backing_snapshot: Mapping[str, tuple[str, tuple[str, ...]]] | None,
+        parent_uid: str | None,
+    ) -> bool:
+        if not uids:
+            return False
+        for reference in references.values():
+            kind = reference.get("kind")
+            if kind == "parent_source":
+                if parent_uid in uids:
+                    return True
+            elif kind == "manager_node" and reference.get("node_uid") in uids:
+                return True
+        return False
+
+    def _retarget_workspace_referenced_tool_data(
+        self,
         old_workspace_path: str | os.PathLike[str] | None,
-    ) -> dict[str, tuple[_ManagedWindowNode, xr.DataArray, typing.Any, str]]:
-        snapshot: dict[
-            str, tuple[_ManagedWindowNode, xr.DataArray, typing.Any, str]
-        ] = {}
+        workspace_path: str | os.PathLike[str],
+        *,
+        exclude_data_uids: Collection[str],
+        source_snapshot: list[tuple[xr.Variable, bool, typing.Any]],
+    ) -> None:
         old_path = workspace_arrays._normalized_file_path(old_workspace_path)
-        for uid, node in self._manager._tool_graph.nodes.items():
-            if (
-                not node.is_imagetool
-                or node.imagetool is None
-                or node.pending_workspace_memory_payload is not None
-            ):
-                continue
-            if backing_snapshot is not None:
-                backing = backing_snapshot.get(uid)
-                if backing is None:
-                    continue
-                kind, source_paths = backing
-                if kind == "memory":
-                    continue
-                if kind == "file_lazy" and (
-                    old_path is None or old_path not in source_paths
+        new_path = workspace_arrays._normalized_file_path(workspace_path)
+        if new_path is None or old_path == new_path:
+            return
+        restore_entries: list[
+            tuple[
+                _ManagedWindowNode,
+                typing.Any,
+                xr.Dataset,
+                dict[str, xr.DataArray],
+                dict[tuple[pathlib.Path, str], xr.Dataset],
+            ]
+        ] = []
+        try:
+            for node in self._manager._tool_graph.nodes.values():
+                tool = node.tool_window
+                if (
+                    node.is_imagetool
+                    or tool is None
+                    or not tool.can_save_and_load()
+                    or not node._workspace_reference_datasets
+                    or node.uid in exclude_data_uids
+                    or self._workspace_tool_references_include_uids(
+                        node._workspace_tool_data_references,
+                        exclude_data_uids,
+                        parent_uid=node.parent_uid,
+                    )
                 ):
                     continue
-            snapshot[uid] = (
-                node,
-                node.slicer_area._data,
-                copy.deepcopy(node.slicer_area.state),
-                node.name,
-            )
-        return snapshot
+                ds = tool.to_dataset()
+                original_data_items = {
+                    name: data.copy(deep=False)
+                    for name, data in tool._persistence_data_items().items()
+                }
+                data_items = {
+                    name: data.copy(deep=False)
+                    for name, data in original_data_items.items()
+                }
+                for data in data_items.values():
+                    workspace_arrays.set_workspace_xarray_sources(data, workspace_path)
+                original_reference_datasets = dict(node._workspace_reference_datasets)
+                restore_entries.append(
+                    (
+                        node,
+                        tool,
+                        ds,
+                        original_data_items,
+                        original_reference_datasets,
+                    )
+                )
+                with self._workspace_load_context(), tool._history_suppressed():
+                    tool._replace_persistence_data_items(data_items, ds)
 
-    def _restore_live_imagetool_rebind_snapshot(
-        self,
-        snapshot: Mapping[
-            str, tuple[_ManagedWindowNode, xr.DataArray, typing.Any, str]
-        ],
-    ) -> None:
-        if not snapshot:
-            return
-        with self._workspace_load_context():
-            for uid, (node, data, state, name) in snapshot.items():
-                if uid not in self._manager._tool_graph.nodes or node.imagetool is None:
-                    continue
-                node.slicer_area.set_data(data, auto_compute=False)
-                node.slicer_area.state = state
-                node._set_name(name, manual=False)
+                reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] = {}
+                for (
+                    source_path,
+                    group_path,
+                ), reference_ds in node._workspace_reference_datasets.items():
+                    source_snapshot.extend(
+                        workspace_arrays._workspace_xarray_source_snapshot(reference_ds)
+                    )
+                    if old_path is None:
+                        workspace_arrays.set_workspace_xarray_sources(
+                            reference_ds, new_path
+                        )
+                    else:
+                        workspace_arrays.retarget_workspace_xarray_sources(
+                            reference_ds, old_path, new_path
+                        )
+                    if old_path is None or (
+                        workspace_arrays._normalized_file_path(source_path) == old_path
+                    ):
+                        source_path = pathlib.Path(new_path)
+                    reference_datasets[(source_path, group_path)] = reference_ds
+                node._replace_workspace_reference_datasets(reference_datasets)
+        except Exception as exc:
+            for (
+                restore_node,
+                restore_tool,
+                restore_ds,
+                restore_data_items,
+                restore_reference_datasets,
+            ) in reversed(restore_entries):
+                with contextlib.suppress(Exception):
+                    restore_node._replace_workspace_reference_datasets(
+                        restore_reference_datasets
+                    )
+                with (
+                    contextlib.suppress(Exception),
+                    self._workspace_load_context(),
+                    restore_tool._history_suppressed(),
+                ):
+                    restore_tool._replace_persistence_data_items(
+                        restore_data_items, restore_ds
+                    )
+            raise _WorkspacePostSaveBindingError(
+                "Workspace file was saved, but live ToolWindow references could "
+                "not be updated."
+            ) from exc
 
     def _refresh_workspace_payload_bindings_after_full_save(
         self,
@@ -817,35 +787,53 @@ class _WorkspaceController:
         skip_live_data_rebind_uids: Collection[str] = frozenset(),
     ) -> None:
         pending_snapshot = self._pending_workspace_payload_snapshot()
-        live_imagetool_snapshot = self._live_imagetool_rebind_snapshot(
-            backing_snapshot=backing_snapshot,
-            old_workspace_path=old_workspace_path,
-        )
+        source_snapshot: list[tuple[xr.Variable, bool, typing.Any]] = []
         try:
             self._repoint_saved_pending_workspace_payloads(workspace_path)
-            self.loading._rebind_workspace_backed_imagetools(
+            old_path = workspace_arrays._normalized_file_path(old_workspace_path)
+            for uid, node in self._manager._tool_graph.nodes.items():
+                if (
+                    uid not in skip_live_data_rebind_uids
+                    and node.is_imagetool
+                    and node.imagetool is not None
+                    and node.pending_workspace_memory_payload is None
+                    and backing_snapshot is not None
+                ):
+                    backing = backing_snapshot.get(uid)
+                    if backing is not None:
+                        kind, source_paths = backing
+                        should_retarget = kind == "dask" or (
+                            kind == "file_lazy"
+                            and old_path is not None
+                            and old_path in source_paths
+                        )
+                        if should_retarget:
+                            source_snapshot.extend(
+                                workspace_arrays._workspace_xarray_source_snapshot(
+                                    node.slicer_area._data
+                                )
+                            )
+                            workspace_arrays.set_workspace_xarray_sources(
+                                node.slicer_area._data, workspace_path
+                            )
+            self._retarget_workspace_referenced_tool_data(
+                old_workspace_path,
                 workspace_path,
-                backing_snapshot=backing_snapshot,
-                old_workspace_path=old_workspace_path,
-                exclude_uids=skip_live_data_rebind_uids,
-            )
-            self._rebind_workspace_referenced_tool_data(
-                workspace_path, exclude_data_uids=skip_live_data_rebind_uids
+                exclude_data_uids=skip_live_data_rebind_uids,
+                source_snapshot=source_snapshot,
             )
         except _WorkspacePostSaveBindingError:
             with contextlib.suppress(Exception):
                 self._restore_pending_workspace_payload_snapshot(pending_snapshot)
-            with contextlib.suppress(Exception):
-                self._restore_live_imagetool_rebind_snapshot(live_imagetool_snapshot)
+            workspace_arrays._restore_workspace_xarray_source_snapshot(source_snapshot)
             raise
         except Exception as exc:
             with contextlib.suppress(Exception):
                 self._restore_pending_workspace_payload_snapshot(pending_snapshot)
-            with contextlib.suppress(Exception):
-                self._restore_live_imagetool_rebind_snapshot(live_imagetool_snapshot)
+            workspace_arrays._restore_workspace_xarray_source_snapshot(source_snapshot)
             raise _WorkspacePostSaveBindingError(
-                "Workspace file was saved, but live workspace data could not be "
-                "rebound to the saved file."
+                "Workspace file was saved, but logical workspace references could "
+                "not be updated."
             ) from exc
 
     def _active_managed_window(self) -> QtWidgets.QWidget | None:
@@ -2026,7 +2014,8 @@ class _WorkspaceController:
                 if workspace_path is not None:
                     try:
                         self._refresh_workspace_payload_bindings_after_full_save(
-                            workspace_path
+                            workspace_path,
+                            old_workspace_path=workspace_path,
                         )
                     except _WorkspacePostSaveBindingError:
                         logger.exception(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -1708,6 +1708,7 @@ class _WorkspaceController:
             fname,
             snapshot,
             store=store,
+            reader_closers=self.saving._workspace_reader_closers(target_path),
         )
         previous_action_states = self._set_workspace_save_actions_enabled(False)
 
@@ -1738,8 +1739,12 @@ class _WorkspaceController:
 
         receiver = workspace_saving._WorkspaceSaveResultReceiver(
             callback=_finish,
+            waiting_callback=lambda: self._manager._status_bar.showMessage(
+                "Waiting for active workspace computations..."
+            ),
             parent=self._manager,
         )
+        worker.signals.waiting.connect(receiver.wait)
         worker.signals.finished.connect(receiver.finish)
         self._manager._workspace_state.save_in_progress = True
         self._background_save_worker = worker
@@ -1785,7 +1790,10 @@ class _WorkspaceController:
             return
 
         document_id = self._manager._workspace_state.document_id
-        worker = workspace_saving._WorkspaceGcWorker(store)
+        worker = workspace_saving._WorkspaceGcWorker(
+            store,
+            reader_closers=self.saving._workspace_reader_closers(workspace_path),
+        )
 
         def _finish(more: bool, error: str | None) -> None:
             receiver = self._workspace_gc_receiver
@@ -2313,6 +2321,7 @@ class _WorkspaceController:
             with erlab.interactive.utils.wait_dialog(
                 origin or self._manager, "Compacting workspace..."
             ):
+                self.saving._close_workspace_idle_readers(workspace_path)
                 if (
                     self._manager.is_workspace_modified
                     or self._manager._workspace_state.schema_version

--- a/src/erlab/interactive/imagetool/manager/_workspace/_format.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_format.py
@@ -19,7 +19,7 @@ import typing
 import numpy as np
 import pydantic
 
-import erlab
+from erlab.interactive.imagetool import _serialization
 
 if typing.TYPE_CHECKING:
     import os
@@ -29,7 +29,8 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_WORKSPACE_SCHEMA_VERSION = 4
+_WORKSPACE_SCHEMA_VERSION = 5
+_WORKSPACE_MANIFEST_SCHEMA_VERSION = 4
 _WORKSPACE_LEGACY_SCHEMA_VERSION = 3
 _WORKSPACE_MANIFEST_ATTR = "imagetool_workspace_manifest"
 _WORKSPACE_TRANSACTION_PROTOCOL = "recoverable-delta-v1"
@@ -114,15 +115,33 @@ def _workspace_manifest_payload_entries(
     for entry in _iter_workspace_manifest_node_entries(manifest):
         uid = entry.get("uid")
         kind = entry.get("kind")
-        path = entry.get("path")
+        path = entry.get("payload_path")
+        if not isinstance(path, str):
+            node_path = entry.get("path")
+            path = (
+                f"{node_path}/{kind}"
+                if isinstance(node_path, str) and isinstance(kind, str)
+                else None
+            )
         if (
             isinstance(uid, str)
             and isinstance(kind, str)
             and kind in {"imagetool", "tool"}
             and isinstance(path, str)
         ):
-            entries.append((uid, kind, f"{path}/{kind}"))
+            entries.append((uid, kind, path))
     return entries
+
+
+def _workspace_manifest_payload_path(
+    manifest: Mapping[str, typing.Any] | None,
+    uid: str,
+) -> str | None:
+    """Return the immutable payload path for one manifest node."""
+    for entry_uid, _kind, payload_path in _workspace_manifest_payload_entries(manifest):
+        if entry_uid == uid:
+            return payload_path
+    return None
 
 
 def _decode_workspace_attr_text(value: object) -> str | None:
@@ -134,105 +153,14 @@ def _decode_workspace_attr_text(value: object) -> str | None:
     return None
 
 
-def _workspace_delta_save_count_from_attrs(
-    attrs: Mapping[typing.Any, typing.Any],
-) -> int:
-    value = _workspace_manifest_from_attrs(attrs).get("delta_save_count", 0)
-    with contextlib.suppress(TypeError, ValueError):
-        return max(0, int(value))
-    return 0
-
-
-def _workspace_manifest_nonnegative_int(
-    manifest: Mapping[str, typing.Any], key: str
-) -> int:
-    value = manifest.get(key, 0)
-    with contextlib.suppress(TypeError, ValueError):
-        return max(0, int(value))
-    return 0
-
-
-def _workspace_manifest_repack_estimate(
-    manifest: Mapping[str, typing.Any] | None,
-    *,
-    delta_save_count: int,
-) -> tuple[int, int, bool]:
-    if delta_save_count <= 0:
-        return 0, 0, True
-    if manifest is None:
-        return 0, 0, False
-    has_estimate = (
-        "estimated_obsolete_bytes" in manifest and "replacement_delta_count" in manifest
-    )
-    return (
-        _workspace_manifest_nonnegative_int(manifest, "estimated_obsolete_bytes"),
-        _workspace_manifest_nonnegative_int(manifest, "replacement_delta_count"),
-        has_estimate,
-    )
-
-
 def _workspace_file_metadata_from_attrs(
     attrs: Mapping[typing.Any, typing.Any],
-) -> tuple[int, int, dict[str, typing.Any] | None]:
+) -> tuple[int, dict[str, typing.Any] | None]:
     schema_version = int(attrs.get("imagetool_workspace_schema_version", 1))
     manifest = None
-    if schema_version >= _WORKSPACE_SCHEMA_VERSION:
+    if schema_version >= _WORKSPACE_MANIFEST_SCHEMA_VERSION:
         manifest = _workspace_manifest_from_attrs(attrs) or None
-    return schema_version, _workspace_delta_save_count_from_attrs(attrs), manifest
-
-
-def _compacted_workspace_root_attrs(
-    attrs: Mapping[typing.Any, typing.Any],
-) -> dict[str, typing.Any]:
-    schema_version, _delta_save_count, manifest = _workspace_file_metadata_from_attrs(
-        attrs
-    )
-    if schema_version != _WORKSPACE_SCHEMA_VERSION or manifest is None:
-        raise ValueError(
-            "File-level workspace repack requires current workspace schema"
-        )
-    compacted_manifest = dict(manifest)
-    compacted_manifest["schema_version"] = _WORKSPACE_SCHEMA_VERSION
-    compacted_manifest["erlab_version"] = erlab.__version__
-    compacted_manifest.pop("delta_save_count", None)
-    compacted_manifest.pop("transaction_protocol", None)
-    compacted_manifest.pop("estimated_obsolete_bytes", None)
-    compacted_manifest.pop("replacement_delta_count", None)
-
-    root_attrs = {str(key): value for key, value in attrs.items()}
-    root_attrs["imagetool_workspace_schema_version"] = _WORKSPACE_SCHEMA_VERSION
-    root_attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(compacted_manifest)
-    root_attrs["erlab_version"] = erlab.__version__
-    return root_attrs
-
-
-def _workspace_root_attrs_with_repack_estimate(
-    attrs: Mapping[typing.Any, typing.Any],
-    *,
-    estimated_obsolete_bytes: int,
-    replacement_delta_count: int,
-    repack_estimate_known: bool = True,
-) -> dict[str, typing.Any]:
-    schema_version, delta_save_count, manifest = _workspace_file_metadata_from_attrs(
-        attrs
-    )
-    if schema_version != _WORKSPACE_SCHEMA_VERSION or manifest is None:
-        return {str(key): value for key, value in attrs.items()}
-    updated_manifest = dict(manifest)
-    if delta_save_count > 0 and repack_estimate_known:
-        updated_manifest["estimated_obsolete_bytes"] = max(
-            0, int(estimated_obsolete_bytes)
-        )
-        updated_manifest["replacement_delta_count"] = max(
-            0, int(replacement_delta_count)
-        )
-    else:
-        updated_manifest.pop("estimated_obsolete_bytes", None)
-        updated_manifest.pop("replacement_delta_count", None)
-
-    root_attrs = {str(key): value for key, value in attrs.items()}
-    root_attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(updated_manifest)
-    return root_attrs
+    return schema_version, manifest
 
 
 def _current_workspace_schema_version() -> int:
@@ -260,17 +188,10 @@ def _workspace_schema_requires_conversion(schema_version: int) -> bool:
     return schema_version < _WORKSPACE_LEGACY_SCHEMA_VERSION
 
 
-def _workspace_schema_requires_full_save(schema_version: int) -> bool:
-    return (
-        _WORKSPACE_LEGACY_SCHEMA_VERSION <= schema_version < _WORKSPACE_SCHEMA_VERSION
-    )
-
-
-def _workspace_root_attrs_payload(
+def _workspace_manifest_payload(
     *,
     root_order: Iterable[typing.Any],
     nodes: Iterable[Mapping[str, typing.Any]],
-    delta_save_count: int,
     erlab_version: str,
     workspace_link_id: str | None = None,
     manager_layout: Mapping[str, typing.Any] | None = None,
@@ -278,9 +199,6 @@ def _workspace_root_attrs_payload(
     standalone_apps: Mapping[str, typing.Any] | None = None,
     option_overrides: Mapping[str, typing.Any] | None = None,
     acquisition_context: Mapping[str, typing.Any] | None = None,
-    estimated_obsolete_bytes: int = 0,
-    replacement_delta_count: int = 0,
-    repack_estimate_known: bool = True,
 ) -> dict[str, typing.Any]:
     manifest: dict[str, typing.Any] = {
         "schema_version": _WORKSPACE_SCHEMA_VERSION,
@@ -308,28 +226,55 @@ def _workspace_root_attrs_payload(
     if acquisition_context is not None:
         # Context defaults are workspace-scoped and independent of loader choices.
         manifest["acquisition_context"] = dict(acquisition_context)
-    if delta_save_count > 0:
-        # Marks files written through the recoverable in-place delta-save protocol.
-        manifest["transaction_protocol"] = _WORKSPACE_TRANSACTION_PROTOCOL
-        manifest["delta_save_count"] = int(delta_save_count)
-        if repack_estimate_known:
-            manifest["estimated_obsolete_bytes"] = max(0, int(estimated_obsolete_bytes))
-            manifest["replacement_delta_count"] = max(0, int(replacement_delta_count))
-    return {
-        "imagetool_workspace_schema_version": _WORKSPACE_SCHEMA_VERSION,
-        _WORKSPACE_MANIFEST_ATTR: json.dumps(manifest),
-        "erlab_version": erlab_version,
-    }
+    return manifest
 
 
 def _is_workspace_internal_group_name(name: typing.Any) -> bool:
     return str(name).startswith(
         (
+            "__itws_objects",
+            "__itws_staging",
+            "__itws_generations",
             _WORKSPACE_PENDING_GROUP_PREFIX,
             _WORKSPACE_BACKUP_GROUP_PREFIX,
             _WORKSPACE_TRANSACTION_GROUP_PREFIX,
         )
     )
+
+
+def _workspace_manifest_attrs(
+    attrs: Mapping[typing.Any, typing.Any],
+) -> list[list[dict[str, typing.Any]]]:
+    """Encode dataset attributes for storage inside a JSON manifest."""
+    encoded: list[list[dict[str, typing.Any]]] = []
+    for key, value in attrs.items():
+        try:
+            encoded.append(
+                [_workspace_encode_attr_key(key), _workspace_encode_attr_value(value)]
+            )
+        except TypeError:
+            logger.warning(
+                "Dropping workspace attribute %r with unsupported value type %s",
+                key,
+                type(value).__name__,
+            )
+    return encoded
+
+
+def _restore_workspace_manifest_attrs(
+    payload: object,
+) -> dict[typing.Hashable, typing.Any]:
+    """Decode dataset attributes stored in a generation manifest."""
+    if not isinstance(payload, list):
+        raise TypeError("Workspace manifest attributes must be a list")
+    attrs: dict[typing.Hashable, typing.Any] = {}
+    for item in payload:
+        if not isinstance(item, list) or len(item) != 2:
+            raise TypeError("Workspace manifest attribute entry is invalid")
+        attrs[_workspace_decode_attr_key(item[0])] = _workspace_decode_attr_value(
+            item[1]
+        )
+    return attrs
 
 
 def _workspace_root_keys(
@@ -687,4 +632,4 @@ def _restore_workspace_dataset_attrs(ds: xr.Dataset) -> xr.Dataset:
     restored.attrs = _restore_workspace_serialized_attrs(restored.attrs)
     for variable in restored.variables.values():
         variable.attrs = _restore_workspace_serialized_attrs(variable.attrs)
-    return restored
+    return _serialization.restore_private_coords(restored)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -2322,7 +2322,8 @@ class _WorkspaceLoader:
             access: _WorkspaceDocumentAccess, loaded: bool
         ) -> bool:
             finished = self._finish_workspace_file_load(loaded)
-            if finished and not associate:
+            source_is_associated = self._manager._workspace_state.path == access.path
+            if finished and not source_is_associated:
                 candidate_uids = (
                     frozenset(self._manager._tool_graph.nodes)
                     if replace
@@ -2391,7 +2392,9 @@ class _WorkspaceLoader:
                                     workspace_access=access,
                                     rebind_data=False,
                                 )
-                                store_adopted = True
+                                store_adopted = (
+                                    self._controller._workspace_store is load_store
+                                )
                                 if replace:
                                     self._restore_workspace_option_overrides(manifest)
                                     self._restore_workspace_loader_state(
@@ -2452,7 +2455,9 @@ class _WorkspaceLoader:
                             native=native,
                             workspace_access=access,
                         )
-                        fallback_store_adopted = True
+                        fallback_store_adopted = (
+                            self._controller._workspace_store is fallback_store
+                        )
                         if replace:
                             self._restore_workspace_option_overrides(manifest)
                             self._restore_workspace_loader_state(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -65,6 +65,7 @@ if typing.TYPE_CHECKING:
     import h5py
 
     from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
+    from erlab.interactive.imagetool.manager._widgets import _WorkspaceDocumentAccess
     from erlab.interactive.imagetool.manager._workspace._controller import (
         _WorkspaceController,
     )
@@ -2315,6 +2316,23 @@ class _WorkspaceLoader:
         self._skipped_workspace_nodes = []
         profiler = _WorkspaceLoadProfiler(fname)
         schema_version = 1
+        nodes_before_load = frozenset(self._manager._tool_graph.nodes)
+
+        def _retain_imported_source(
+            access: _WorkspaceDocumentAccess, loaded: bool
+        ) -> bool:
+            finished = self._finish_workspace_file_load(loaded)
+            if finished and not associate:
+                candidate_uids = (
+                    frozenset(self._manager._tool_graph.nodes)
+                    if replace
+                    else frozenset(self._manager._tool_graph.nodes) - nodes_before_load
+                )
+                self._controller._retain_imported_workspace_access(
+                    access, candidate_uids
+                )
+            return finished
+
         try:
             with self._controller._workspace_document_access_context(fname) as access:
                 with profiler.stage("metadata read"):
@@ -2379,7 +2397,7 @@ class _WorkspaceLoader:
                                     self._restore_workspace_loader_state(
                                         manifest, apply_explorer=False
                                     )
-                            return self._finish_workspace_file_load(loaded)
+                            return _retain_imported_source(access, loaded)
                         finally:
                             if (
                                 owns_load_store
@@ -2440,7 +2458,7 @@ class _WorkspaceLoader:
                             self._restore_workspace_loader_state(
                                 manifest, apply_explorer=False
                             )
-                    return self._finish_workspace_file_load(loaded)
+                    return _retain_imported_source(access, loaded)
                 finally:
                     if (
                         owns_fallback_store
@@ -2449,5 +2467,6 @@ class _WorkspaceLoader:
                     ):
                         fallback_store.close()
         finally:
+            self._controller._release_unused_imported_workspace_accesses()
             self._missing_workspace_colormaps = previous_missing_colormaps
             self._skipped_workspace_nodes = previous_skipped_nodes

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -22,6 +22,7 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._pending as workspace_pending
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.slicer
 import erlab.interactive.imagetool.viewer_linking
 from erlab.interactive import _qt_state
@@ -189,7 +190,7 @@ def _workspace_payload_window_visible_h5py(
     *,
     default: bool = True,
 ) -> bool | None:
-    with workspace_arrays._workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
+    with workspace_arrays._open_workspace_h5_file_for_read(fname) as h5_file:
         obj = h5_file.get(payload_path.strip("/"))
         if not isinstance(obj, h5py.Group):
             return None
@@ -203,7 +204,7 @@ def _workspace_payload_attrs_h5py(
     fname: str | os.PathLike[str],
     payload_path: str,
 ) -> dict[typing.Hashable, typing.Any] | None:
-    with workspace_arrays._workspace_file_lock(fname), h5py.File(fname, "r") as h5_file:
+    with workspace_arrays._open_workspace_h5_file_for_read(fname) as h5_file:
         obj = h5_file.get(payload_path.strip("/"))
         if not isinstance(obj, h5py.Group):
             return None
@@ -472,7 +473,7 @@ class _WorkspaceLoader:
         )
         if workspace_path is None:
             return None
-        payload_path = self._controller.saving._workspace_payload_path(node.uid)
+        payload_path = self._workspace_payload_path_for_uid(workspace_path, node.uid)
         opened = self._workspace_imagetool_reference_dataset_at(
             workspace_path,
             payload_path,
@@ -749,7 +750,7 @@ class _WorkspaceLoader:
     def _workspace_file_can_restore_replace_backup(self, path: pathlib.Path) -> bool:
         try:
             root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(path)
-            schema_version, _delta_save_count, manifest = (
+            schema_version, manifest = (
                 workspace_format._workspace_file_metadata_from_attrs(root_attrs)
             )
         except Exception:
@@ -1542,14 +1543,27 @@ class _WorkspaceLoader:
         def _load_dataset(
             payload_path: str, *, entry: Mapping[str, typing.Any], imagetool: bool
         ) -> tuple[xr.Dataset, tuple[str | os.PathLike[str], str] | None]:
+            manifest_attrs = entry.get("payload_attrs")
+            current_attrs = (
+                workspace_format._restore_workspace_manifest_attrs(manifest_attrs)
+                if manifest_attrs is not None
+                else None
+            )
+            prefix = "itool" if imagetool else "tool"
+            if current_attrs is None:
+                window_visible = _workspace_payload_window_visible_h5py(
+                    fname, payload_path, prefix
+                )
+            else:
+                window_visible = _workspace_dataset_window_visible(
+                    xr.Dataset(attrs=current_attrs), prefix
+                )
             if imagetool and entry.get("data_backing") == "dask":
                 return _load_xarray_dataset(payload_path, chunks={}, load=False), None
             if (
                 imagetool
                 and entry.get("data_backing") == "memory"
-                and not _workspace_payload_window_visible_h5py(
-                    fname, payload_path, "itool"
-                )
+                and not window_visible
             ):
                 try:
                     ds = self._read_workspace_imagetool_payload_dataset(
@@ -1562,11 +1576,8 @@ class _WorkspaceLoader:
                         exc_info=True,
                     )
                 else:
-                    if not _workspace_dataset_window_visible(ds, "itool"):
-                        return ds, (fname, payload_path)
-            if not imagetool and not _workspace_payload_window_visible_h5py(
-                fname, payload_path, "tool"
-            ):
+                    return ds, (fname, payload_path)
+            if not imagetool and not window_visible:
                 try:
                     attrs = _workspace_payload_attrs_h5py(fname, payload_path)
                 except Exception:
@@ -1605,10 +1616,18 @@ class _WorkspaceLoader:
             entry = entries_by_path[path]
             kind = typing.cast("str", entry["kind"])
             is_imagetool = kind == "imagetool"
-            payload_path = f"{path}/{'imagetool' if is_imagetool else 'tool'}"
+            payload_path = entry.get("payload_path")
+            if not isinstance(payload_path, str):
+                payload_path = f"{path}/{'imagetool' if is_imagetool else 'tool'}"
             with profiler.stage("payload read"):
                 ds, pending_payload = _load_dataset(
                     payload_path, entry=entry, imagetool=is_imagetool
+                )
+            manifest_attrs = entry.get("payload_attrs")
+            if manifest_attrs is not None:
+                ds = ds.copy(deep=False)
+                ds.attrs = workspace_format._restore_workspace_manifest_attrs(
+                    manifest_attrs
                 )
             if is_imagetool:
                 target = self._load_workspace_imagetool_dataset(
@@ -1748,7 +1767,7 @@ class _WorkspaceLoader:
             self._manager.remove_all_tools()
             self._controller._drain_workspace_restore_events()
             root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(path)
-            schema_version, _delta_save_count, manifest = (
+            schema_version, manifest = (
                 workspace_format._workspace_file_metadata_from_attrs(root_attrs)
             )
             if (
@@ -1801,7 +1820,7 @@ class _WorkspaceLoader:
             if not self._is_datatree_workspace(tree):
                 raise ValueError("Not a valid workspace file")
 
-            schema_version, _delta_save_count, manifest = (
+            schema_version, manifest = (
                 workspace_format._workspace_file_metadata_from_attrs(tree.attrs)
             )
             match schema_version:
@@ -2137,9 +2156,10 @@ class _WorkspaceLoader:
         chunks: typing.Any,
     ) -> xr.DataArray:
         ds = workspace_arrays.open_workspace_dataset(
-            fname, self._controller.saving._workspace_payload_path(uid), chunks=chunks
+            fname, self._workspace_payload_path_for_uid(fname, uid), chunks=chunks
         )
         try:
+            ds = workspace_format._restore_workspace_dataset_attrs(ds)
             data_name: Hashable
             if _ITOOL_DATA_NAME in ds.data_vars:
                 data_name = _ITOOL_DATA_NAME
@@ -2150,6 +2170,31 @@ class _WorkspaceLoader:
             return ds[data_name].rename(name).copy(deep=False)
         finally:
             ds.close()
+
+    def _workspace_payload_path_for_uid(
+        self,
+        fname: str | os.PathLike[str],
+        uid: str,
+    ) -> str:
+        manifest = None
+        store = getattr(self._controller, "_workspace_store", None)
+        if (
+            store is not None
+            and not store.closed
+            and store.path == pathlib.Path(fname).resolve()
+        ):
+            with contextlib.suppress(Exception):
+                manifest = store.current_generation().manifest
+        if manifest is None:
+            with contextlib.suppress(Exception):
+                attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
+                _schema, manifest = (
+                    workspace_format._workspace_file_metadata_from_attrs(attrs)
+                )
+        payload_path = workspace_format._workspace_manifest_payload_path(manifest, uid)
+        if payload_path is not None:
+            return payload_path
+        return self._controller.saving._workspace_payload_path(uid)
 
     def _workspace_data_backing_snapshot(
         self,
@@ -2269,6 +2314,7 @@ class _WorkspaceLoader:
         self._missing_workspace_colormaps = []
         self._skipped_workspace_nodes = []
         profiler = _WorkspaceLoadProfiler(fname)
+        schema_version = 1
         try:
             with self._controller._workspace_document_access_context(fname) as access:
                 with profiler.stage("metadata read"):
@@ -2278,7 +2324,7 @@ class _WorkspaceLoader:
                         root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(
                             access.path
                         )
-                        schema_version, delta_save_count, manifest = (
+                        schema_version, manifest = (
                             workspace_format._workspace_file_metadata_from_attrs(
                                 root_attrs
                             )
@@ -2288,95 +2334,120 @@ class _WorkspaceLoader:
                         == workspace_format._current_workspace_schema_version()
                         and manifest is not None
                     ):
-                        selected_paths: set[str] | None = None
-                        if select:
-                            with profiler.stage("selection dialog setup"):
-                                dialog = _ChooseFromWorkspaceManifestDialog(
-                                    self._manager, manifest
-                                )
-                            if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
-                                return self._finish_workspace_file_load(False)
-                            selected_paths = dialog.selected_paths()
-                        loaded = self._from_h5py_workspace_file(
-                            access.path,
-                            manifest,
-                            replace=replace,
-                            mark_dirty=mark_dirty,
-                            selected_paths=selected_paths,
-                            profiler=profiler,
-                        )
-                        if loaded and associate:
-                            (
-                                estimated_obsolete_bytes,
-                                replacement_delta_count,
-                                repack_estimate_known,
-                            ) = workspace_format._workspace_manifest_repack_estimate(
-                                manifest,
-                                delta_save_count=delta_save_count,
+                        load_store = None
+                        owns_load_store = False
+                        store_adopted = False
+                        if associate:
+                            load_store = workspace_store.WorkspaceStore.active(
+                                access.path
                             )
-                            self._controller._associate_loaded_workspace_file(
+                            if load_store is None:
+                                load_store = workspace_store.WorkspaceStore(access.path)
+                                owns_load_store = True
+                        try:
+                            selected_paths: set[str] | None = None
+                            if select:
+                                with profiler.stage("selection dialog setup"):
+                                    dialog = _ChooseFromWorkspaceManifestDialog(
+                                        self._manager, manifest
+                                    )
+                                if (
+                                    dialog.exec()
+                                    != QtWidgets.QDialog.DialogCode.Accepted
+                                ):
+                                    return self._finish_workspace_file_load(False)
+                                selected_paths = dialog.selected_paths()
+                            loaded = self._from_h5py_workspace_file(
                                 access.path,
-                                schema_version,
-                                native=native,
-                                delta_save_count=delta_save_count,
-                                estimated_obsolete_bytes=estimated_obsolete_bytes,
-                                replacement_delta_count=replacement_delta_count,
-                                repack_estimate_known=repack_estimate_known,
-                                workspace_access=access,
-                                rebind_data=False,
+                                manifest,
+                                replace=replace,
+                                mark_dirty=mark_dirty,
+                                selected_paths=selected_paths,
+                                profiler=profiler,
                             )
-                            if replace:
-                                self._restore_workspace_option_overrides(manifest)
-                                self._restore_workspace_loader_state(
-                                    manifest, apply_explorer=False
+                            if loaded and associate:
+                                self._controller._associate_loaded_workspace_file(
+                                    access.path,
+                                    schema_version,
+                                    native=native,
+                                    workspace_access=access,
+                                    rebind_data=False,
                                 )
-                        return self._finish_workspace_file_load(loaded)
+                                store_adopted = True
+                                if replace:
+                                    self._restore_workspace_option_overrides(manifest)
+                                    self._restore_workspace_loader_state(
+                                        manifest, apply_explorer=False
+                                    )
+                            return self._finish_workspace_file_load(loaded)
+                        finally:
+                            if (
+                                owns_load_store
+                                and not store_adopted
+                                and load_store is not None
+                            ):
+                                load_store.close()
                 except Exception:
+                    if (
+                        schema_version
+                        == workspace_format._current_workspace_schema_version()
+                    ):
+                        raise
                     logger.debug(
                         "Failed h5py workspace load path; falling back to DataTree",
                         exc_info=True,
                     )
-                with profiler.stage("metadata read"):
-                    tree = workspace_arrays.open_workspace_datatree(
-                        access.path, chunks=None
-                    )
-                    schema_version, delta_save_count, manifest = (
-                        workspace_format._workspace_file_metadata_from_attrs(tree.attrs)
-                    )
-                loaded = self._from_datatree(
-                    tree,
-                    replace=replace,
-                    mark_dirty=mark_dirty,
-                    select=select,
-                    workspace_file_path=access.path,
-                    profiler=profiler,
-                )
-                if loaded and associate:
-                    (
-                        estimated_obsolete_bytes,
-                        replacement_delta_count,
-                        repack_estimate_known,
-                    ) = workspace_format._workspace_manifest_repack_estimate(
-                        manifest,
-                        delta_save_count=delta_save_count,
-                    )
-                    self._controller._associate_loaded_workspace_file(
-                        access.path,
-                        schema_version,
-                        native=native,
-                        delta_save_count=delta_save_count,
-                        estimated_obsolete_bytes=estimated_obsolete_bytes,
-                        replacement_delta_count=replacement_delta_count,
-                        repack_estimate_known=repack_estimate_known,
-                        workspace_access=access,
-                        rebind_data=False,
-                    )
-                    if replace:
-                        self._restore_workspace_option_overrides(manifest)
-                        self._restore_workspace_loader_state(
-                            manifest, apply_explorer=False
+                fallback_store = None
+                owns_fallback_store = False
+                fallback_store_adopted = False
+                if (
+                    associate
+                    and schema_version
+                    >= workspace_format._WORKSPACE_LEGACY_SCHEMA_VERSION
+                ):
+                    fallback_store = workspace_store.WorkspaceStore.active(access.path)
+                    if fallback_store is None:
+                        fallback_store = workspace_store.WorkspaceStore(access.path)
+                        owns_fallback_store = True
+                try:
+                    with profiler.stage("metadata read"):
+                        tree = workspace_arrays.open_workspace_datatree(
+                            access.path, chunks=None
                         )
-                return self._finish_workspace_file_load(loaded)
+                        schema_version, manifest = (
+                            workspace_format._workspace_file_metadata_from_attrs(
+                                tree.attrs
+                            )
+                        )
+                    loaded = self._from_datatree(
+                        tree,
+                        replace=replace,
+                        mark_dirty=mark_dirty,
+                        select=select,
+                        workspace_file_path=access.path,
+                        profiler=profiler,
+                    )
+                    if loaded and associate:
+                        self._controller._associate_loaded_workspace_file(
+                            access.path,
+                            schema_version,
+                            native=native,
+                            workspace_access=access,
+                        )
+                        fallback_store_adopted = True
+                        if replace:
+                            self._restore_workspace_option_overrides(manifest)
+                            self._restore_workspace_loader_state(
+                                manifest, apply_explorer=False
+                            )
+                    return self._finish_workspace_file_load(loaded)
+                finally:
+                    if (
+                        owns_fallback_store
+                        and not fallback_store_adopted
+                        and fallback_store is not None
+                    ):
+                        fallback_store.close()
         finally:
             self._missing_workspace_colormaps = previous_missing_colormaps
             self._skipped_workspace_nodes = previous_skipped_nodes

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -1483,7 +1483,7 @@ class _WorkspaceLoader:
             if not isinstance(path, str) or kind not in {"imagetool", "tool"}:
                 continue
             entries_by_path[path] = entry
-        if not entries_by_path:
+        if nodes and not entries_by_path:
             raise ValueError("Workspace manifest has no loadable nodes")
 
         root_paths: list[str] = []
@@ -1501,7 +1501,7 @@ class _WorkspaceLoader:
             for path in entries_by_path
             if path.startswith("figures/") and path.count("/") == 1
         ]
-        if not root_paths and not figure_paths:
+        if entries_by_path and not root_paths and not figure_paths:
             raise ValueError("Workspace manifest has no loadable root nodes")
 
         loaded_targets_by_uid: dict[str, int | str] = {}

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -1019,6 +1019,7 @@ class _PendingWorkspacePayloads:
                     node.update_title()
                     self._loader._sync_materialized_workspace_link_group(node)
                 node._notify_change(_ManagedNodeChange.ROW | _ManagedNodeChange.INFO)
+                self._controller._release_unused_imported_workspace_accesses()
                 return True
         except Exception:
             logger.exception(
@@ -1126,6 +1127,7 @@ class _PendingWorkspacePayloads:
             return False
         else:
             node._notify_change(_ManagedNodeChange.ROW | _ManagedNodeChange.INFO)
+            self._controller._release_unused_imported_workspace_accesses()
             return True
 
     def _has_pending_workspace_linked_slicers(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -535,10 +535,9 @@ class _PendingWorkspacePayloads:
         attrs = node.pending_workspace_payload_attrs
         workspace_path, payload_path = pending
         try:
-            with (
-                workspace_arrays._workspace_file_lock(workspace_path),
-                h5py.File(workspace_path, "r") as h5_file,
-            ):
+            with workspace_arrays._open_workspace_h5_file_for_read(
+                workspace_path
+            ) as h5_file:
                 group = h5_file.get(payload_path.strip("/"))
                 if not isinstance(group, h5py.Group):
                     return None
@@ -632,10 +631,9 @@ class _PendingWorkspacePayloads:
         attrs = node.pending_workspace_payload_attrs
         workspace_path, payload_path = pending
         try:
-            with (
-                workspace_arrays._workspace_file_lock(workspace_path),
-                h5py.File(workspace_path, "r") as h5_file,
-            ):
+            with workspace_arrays._open_workspace_h5_file_for_read(
+                workspace_path
+            ) as h5_file:
                 group = h5_file.get(payload_path.strip("/"))
                 if not isinstance(group, h5py.Group):
                     return None

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -77,6 +77,9 @@ class _WorkspaceSaveSnapshot:
     serialized_tool_data_references: tuple[
         tuple[str, dict[str, dict[str, typing.Any]]], ...
     ] = ()
+    expected_publication_state: workspace_storage._WorkspacePublicationState | None = (
+        None
+    )
 
     def close(self) -> None:
         if self.full_tree is not None:
@@ -122,6 +125,8 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
         snapshot: _WorkspaceSaveSnapshot,
     ) -> None:
         super().__init__()
+        if snapshot.expected_publication_state is None:
+            raise ValueError("Background save snapshot is not bound to its destination")
         self.signals = _WorkspaceSaveWorkerSignals()
         self._fname = fname
         self._snapshot = snapshot
@@ -139,6 +144,7 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
                     copy_groups=self._snapshot.copy_groups,
                     copy_group_sources=self._snapshot.copy_group_sources,
                     compression_mode=self._snapshot.compression_mode,
+                    expected_state=self._snapshot.expected_publication_state,
                 )
             elif self._snapshot.full_tree is None:
                 workspace_storage._write_workspace_transaction_file(
@@ -147,6 +153,7 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
                     self._snapshot.attr_updates,
                     self._snapshot.root_attrs,
                     compression_mode=self._snapshot.compression_mode,
+                    expected_state=self._snapshot.expected_publication_state,
                 )
             else:
                 workspace_storage._write_full_workspace_tree_file(
@@ -157,6 +164,7 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
                     copy_groups=self._snapshot.copy_groups,
                     copy_group_sources=self._snapshot.copy_group_sources,
                     compression_mode=self._snapshot.compression_mode,
+                    expected_state=self._snapshot.expected_publication_state,
                 )
         except workspace_storage._WorkspaceBackingFileNotFoundError as exc:
             error = _WorkspaceSaveError(
@@ -1070,12 +1078,14 @@ class _WorkspaceSaver:
         reuse_unchanged_groups: bool = True,
         require_matching_compression: bool = False,
     ) -> None:
+        expected_state = workspace_storage._workspace_publication_state(fname)
         snapshot = self._workspace_full_save_snapshot(
             self._manager._workspace_state.dirty_generation,
             fname=fname,
             reuse_unchanged_groups=reuse_unchanged_groups,
             require_matching_compression=require_matching_compression,
         )
+        snapshot.expected_publication_state = expected_state
         try:
             workspace_storage._write_full_workspace_tree_file(
                 fname,
@@ -1085,6 +1095,7 @@ class _WorkspaceSaver:
                 copy_groups=snapshot.copy_groups,
                 copy_group_sources=snapshot.copy_group_sources,
                 compression_mode=snapshot.compression_mode,
+                expected_state=snapshot.expected_publication_state,
             )
             self._controller._commit_saved_tool_data_references(snapshot)
         finally:
@@ -1164,12 +1175,14 @@ class _WorkspaceSaver:
         )
 
     def _save_workspace_delta(self, fname: str | os.PathLike[str]) -> None:
+        expected_state = workspace_storage._workspace_publication_state(fname)
         delta_save_count = self._manager._workspace_state.delta_save_count + 1
         snapshot = self._workspace_delta_save_snapshot(
             self._manager._workspace_state.dirty_generation,
             self._workspace_root_attrs_payload(delta_save_count=delta_save_count),
             delta_save_count,
         )
+        snapshot.expected_publication_state = expected_state
         try:
             workspace_storage._write_workspace_transaction_file(
                 fname,
@@ -1177,6 +1190,7 @@ class _WorkspaceSaver:
                 snapshot.attr_updates,
                 snapshot.root_attrs,
                 compression_mode=snapshot.compression_mode,
+                expected_state=snapshot.expected_publication_state,
             )
             self._controller._commit_saved_tool_data_references(snapshot)
             self._manager._workspace_state.delta_save_count = snapshot.delta_save_count
@@ -1562,27 +1576,31 @@ class _WorkspaceSaver:
     def _workspace_save_snapshot(
         self, fname: str | os.PathLike[str]
     ) -> _WorkspaceSaveSnapshot:
+        expected_state = workspace_storage._workspace_publication_state(fname)
         self._controller._drain_workspace_deferred_events()
         generation = self._manager._workspace_state.dirty_generation
         self._manager._workspace_state.saving_depth += 1
         try:
             if self._workspace_requires_full_save(fname):
-                return self._workspace_full_save_snapshot(generation)
-            if self._workspace_layout_only_modified():
+                snapshot = self._workspace_full_save_snapshot(generation)
+            elif self._workspace_layout_only_modified():
                 delta_save_count = self._manager._workspace_state.delta_save_count
                 root_attrs = self._workspace_root_attrs_payload(
                     delta_save_count=delta_save_count
                 )
-                return self._workspace_delta_save_snapshot(
+                snapshot = self._workspace_delta_save_snapshot(
                     generation, root_attrs, delta_save_count
                 )
-            delta_save_count = self._manager._workspace_state.delta_save_count + 1
-            root_attrs = self._workspace_root_attrs_payload(
-                delta_save_count=delta_save_count
-            )
-            return self._workspace_delta_save_snapshot(
-                generation, root_attrs, delta_save_count
-            )
+            else:
+                delta_save_count = self._manager._workspace_state.delta_save_count + 1
+                root_attrs = self._workspace_root_attrs_payload(
+                    delta_save_count=delta_save_count
+                )
+                snapshot = self._workspace_delta_save_snapshot(
+                    generation, root_attrs, delta_save_count
+                )
+            snapshot.expected_publication_state = expected_state
+            return snapshot
         finally:
             self._manager._workspace_state.saving_depth -= 1
 
@@ -1659,8 +1677,8 @@ class _WorkspaceSaver:
         if workspace_storage._workspace_path_is_likely_network_path(workspace_path):
             return None
         try:
-            root_attrs, copy_groups = workspace_storage._workspace_file_repack_payload(
-                workspace_path
+            root_attrs, copy_groups, expected_state = (
+                workspace_storage._workspace_file_repack_payload(workspace_path)
             )
         except Exception:
             logger.debug(
@@ -1676,6 +1694,7 @@ class _WorkspaceSaver:
             file_repack=True,
             copy_source=str(workspace_path),
             copy_groups=copy_groups,
+            expected_publication_state=expected_state,
         )
 
     def _workspace_should_repack_before_shutdown(self) -> bool:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -87,6 +87,8 @@ class _WorkspaceSaveSnapshot:
 class _WorkspaceSaveError:
     traceback_text: str
     missing_source_path: str | None = None
+    publication_conflict_path: str | None = None
+    access_denied_path: str | None = None
 
 
 class _WorkspaceSaveWorkerSignals(QtCore.QObject):
@@ -160,6 +162,16 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
             error = _WorkspaceSaveError(
                 traceback_text=traceback.format_exc(),
                 missing_source_path=exc.source_path,
+            )
+        except workspace_storage._WorkspacePublicationConflictError as exc:
+            error = _WorkspaceSaveError(
+                traceback_text=traceback.format_exc(),
+                publication_conflict_path=exc.path,
+            )
+        except PermissionError as exc:
+            error = _WorkspaceSaveError(
+                traceback_text=traceback.format_exc(),
+                access_denied_path=os.fsdecode(exc.filename or self._fname),
             )
         except Exception:
             error = _WorkspaceSaveError(traceback_text=traceback.format_exc())
@@ -1737,10 +1749,13 @@ class _WorkspaceSaver:
             (uid, kind): payload_path for uid, kind, payload_path in manifest_entries
         }
         copy_groups: list[tuple[str, str, dict[str, typing.Any] | None]] = []
-        context = contextlib.nullcontext(None)
-        if require_matching_compression and compression_mode is not None:
-            context = h5py.File(workspace_path, "r")
-        with context as h5_file:
+        with contextlib.ExitStack() as stack:
+            h5_file = None
+            if require_matching_compression and compression_mode is not None:
+                stack.enter_context(
+                    workspace_arrays._workspace_file_lock(workspace_path)
+                )
+                h5_file = stack.enter_context(h5py.File(workspace_path, "r"))
             for uid, node in self._manager._tool_graph.nodes.items():
                 if (
                     uid in self._manager._workspace_state.dirty_data

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -664,14 +664,15 @@ class _WorkspaceSaver:
                     create=not pathlib.Path(fname).exists(),
                 )
                 owned_store = True
-            workspace_storage._write_workspace_generation(
+            committed_generation = workspace_storage._write_workspace_generation(
                 target_store,
                 snapshot.generation_plan,
                 compression_mode=snapshot.compression_mode,
             )
-            self._controller._commit_saved_tool_data_references(snapshot)
-            self._manager._workspace_state.schema_version = (
-                workspace_format._current_workspace_schema_version()
+            self._controller._adopt_committed_workspace_generation(
+                fname,
+                snapshot,
+                manifest=committed_generation.manifest,
             )
         finally:
             if snapshot is not None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import collections
 import contextlib
 import json
 import logging
@@ -11,6 +10,7 @@ import pathlib
 import time
 import traceback
 import typing
+import uuid
 from dataclasses import dataclass
 
 import xarray as xr
@@ -20,6 +20,7 @@ import erlab
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 from erlab.interactive import _qt_state
 from erlab.interactive.imagetool._load_source import _serialize_loader_kwargs
 from erlab.interactive.imagetool.manager._widgets import (
@@ -31,9 +32,7 @@ from erlab.interactive.imagetool.manager._wrapper import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, Iterable, Mapping
-
-    import h5py
+    from collections.abc import Callable, Iterable, Mapping
 
     from erlab.interactive._options.schema import WorkspaceCompressionMode
     from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
@@ -41,49 +40,30 @@ if typing.TYPE_CHECKING:
     from erlab.interactive.imagetool.manager._workspace._controller import (
         _WorkspaceController,
     )
-else:
-    import lazy_loader as _lazy
-
-    h5py = _lazy.load("h5py")
-
 from erlab.interactive.imagetool.manager._workspace._format import (
     _require_itws_workspace_path,
 )
 
 logger = logging.getLogger(__name__)
 _WORKSPACE_SAVE_SUFFIX_ERROR = "ImageTool workspace documents must be saved as .itws"
-_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES = 128 * 1024 * 1024
-_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO = 0.10
 
 
 @dataclass
 class _WorkspaceSaveSnapshot:
     generation: int
-    root_attrs: dict[str, typing.Any]
-    delta_save_count: int
-    estimated_obsolete_bytes: int = 0
-    replacement_delta_count: int = 0
-    repack_estimate_known: bool = True
-    compression_mode: WorkspaceCompressionMode = "zstd1"
-    file_repack: bool = False
-    full_tree: xr.DataTree | None = None
-    copy_source: str | None = None
-    copy_groups: tuple[workspace_storage._WorkspaceCopyGroup, ...] = ()
-    copy_group_sources: tuple[workspace_storage._WorkspaceCopyGroupWithSource, ...] = ()
-    rewrite_groups: tuple[tuple[str, dict[str, xr.Dataset]], ...] = ()
-    attr_updates: tuple[
-        tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]], ...
-    ] = ()
+    generation_plan: workspace_storage._WorkspaceGenerationPlan
+    compression_mode: WorkspaceCompressionMode
     serialized_tool_data_references: tuple[
-        tuple[str, dict[str, dict[str, typing.Any]]], ...
+        tuple[str, str, dict[str, dict[str, typing.Any]]], ...
     ] = ()
-    expected_publication_state: workspace_storage._WorkspacePublicationState | None = (
-        None
-    )
 
     def close(self) -> None:
-        if self.full_tree is not None:
-            self.full_tree.close()
+        closed: set[int] = set()
+        for item in self.generation_plan.objects:
+            if item.dataset is None or id(item.dataset) in closed:
+                continue
+            closed.add(id(item.dataset))
+            item.dataset.close()
 
 
 @dataclass(frozen=True)
@@ -123,49 +103,38 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
         self,
         fname: str | os.PathLike[str],
         snapshot: _WorkspaceSaveSnapshot,
+        *,
+        store: workspace_store.WorkspaceStore | None = None,
     ) -> None:
         super().__init__()
-        if snapshot.expected_publication_state is None:
-            raise ValueError("Background save snapshot is not bound to its destination")
         self.signals = _WorkspaceSaveWorkerSignals()
         self._fname = fname
         self._snapshot = snapshot
+        self._store = store
 
     def run(self) -> None:
         start_time = time.perf_counter()
         error: _WorkspaceSaveError | None = None
         try:
-            if self._snapshot.file_repack:
-                workspace_storage._write_full_workspace_tree_file(
+            owned_store = False
+            target_store = self._store
+            if target_store is None:
+                target_store = workspace_store.WorkspaceStore.active(self._fname)
+            if target_store is None:
+                target_store = workspace_store.WorkspaceStore(
                     self._fname,
-                    None,
-                    self._snapshot.root_attrs,
-                    copy_source=self._snapshot.copy_source,
-                    copy_groups=self._snapshot.copy_groups,
-                    copy_group_sources=self._snapshot.copy_group_sources,
-                    compression_mode=self._snapshot.compression_mode,
-                    expected_state=self._snapshot.expected_publication_state,
+                    create=not pathlib.Path(self._fname).exists(),
                 )
-            elif self._snapshot.full_tree is None:
-                workspace_storage._write_workspace_transaction_file(
-                    self._fname,
-                    self._snapshot.rewrite_groups,
-                    self._snapshot.attr_updates,
-                    self._snapshot.root_attrs,
+                owned_store = True
+            try:
+                workspace_storage._write_workspace_generation(
+                    target_store,
+                    self._snapshot.generation_plan,
                     compression_mode=self._snapshot.compression_mode,
-                    expected_state=self._snapshot.expected_publication_state,
                 )
-            else:
-                workspace_storage._write_full_workspace_tree_file(
-                    self._fname,
-                    self._snapshot.full_tree,
-                    self._snapshot.root_attrs,
-                    copy_source=self._snapshot.copy_source,
-                    copy_groups=self._snapshot.copy_groups,
-                    copy_group_sources=self._snapshot.copy_group_sources,
-                    compression_mode=self._snapshot.compression_mode,
-                    expected_state=self._snapshot.expected_publication_state,
-                )
+            finally:
+                if owned_store:
+                    target_store.close()
         except workspace_storage._WorkspaceBackingFileNotFoundError as exc:
             error = _WorkspaceSaveError(
                 traceback_text=traceback.format_exc(),
@@ -175,6 +144,11 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
             error = _WorkspaceSaveError(
                 traceback_text=traceback.format_exc(),
                 publication_conflict_path=exc.path,
+            )
+        except workspace_store.WorkspaceStoreConflictError:
+            error = _WorkspaceSaveError(
+                traceback_text=traceback.format_exc(),
+                publication_conflict_path=os.fsdecode(self._fname),
             )
         except PermissionError as exc:
             error = _WorkspaceSaveError(
@@ -189,6 +163,43 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
         self.signals.finished.emit(time.perf_counter() - start_time, error)
 
 
+class _WorkspaceGcWorkerSignals(QtCore.QObject):
+    finished = QtCore.Signal(bool, object)
+
+
+class _WorkspaceGcResultReceiver(QtCore.QObject):
+    def __init__(
+        self,
+        callback: Callable[[bool, str | None], None],
+        *,
+        parent: QtCore.QObject,
+    ) -> None:
+        super().__init__(parent)
+        self._callback = callback
+
+    @QtCore.Slot(bool, object)
+    def finish(self, more: bool, error: str | None) -> None:
+        self._callback(more, error)
+
+
+class _WorkspaceGcWorker(QtCore.QRunnable):
+    """Unlink at most one obsolete payload object outside the save path."""
+
+    def __init__(self, store: workspace_store.WorkspaceStore) -> None:
+        super().__init__()
+        self.signals = _WorkspaceGcWorkerSignals()
+        self._store = store
+
+    def run(self) -> None:
+        more = False
+        error: str | None = None
+        try:
+            more = self._store.collect_garbage(max_objects=1)
+        except Exception:
+            error = traceback.format_exc()
+        self.signals.finished.emit(more, error)
+
+
 class _WorkspaceSaver:
     """Serialize and snapshot workspace state for one manager."""
 
@@ -201,52 +212,28 @@ class _WorkspaceSaver:
     @staticmethod
     def _serialized_tool_data_references(
         datasets: Iterable[xr.Dataset],
-    ) -> tuple[tuple[str, dict[str, dict[str, typing.Any]]], ...]:
-        references_by_uid: dict[str, dict[str, dict[str, typing.Any]]] = {}
+    ) -> tuple[tuple[str, str, dict[str, dict[str, typing.Any]]], ...]:
+        references_by_uid: dict[str, tuple[str, dict[str, dict[str, typing.Any]]]] = {}
         for ds in datasets:
             if ds.attrs.get("manager_node_kind") != "tool":
                 continue
             uid = ds.attrs.get("manager_node_uid")
-            if not isinstance(uid, str) or not uid:
+            snapshot_token = ds.attrs.get("manager_node_snapshot_token")
+            if (
+                not isinstance(uid, str)
+                or not uid
+                or not isinstance(snapshot_token, str)
+                or not snapshot_token
+            ):
                 continue
             references_by_uid[uid] = (
-                erlab.interactive.utils.ToolWindow._saved_tool_data_references(ds)
+                snapshot_token,
+                erlab.interactive.utils.ToolWindow._saved_tool_data_references(ds),
             )
-        return tuple(sorted(references_by_uid.items()))
-
-    @classmethod
-    def _serialized_tool_data_references_from_tree(
-        cls,
-        tree: xr.DataTree,
-        *,
-        exclude_payload_paths: Iterable[str] = (),
-    ) -> tuple[tuple[str, dict[str, dict[str, typing.Any]]], ...]:
-        excluded = {path.strip("/") for path in exclude_payload_paths}
-        return cls._serialized_tool_data_references(
-            node.to_dataset(inherit=False)
-            for node in tree.subtree
-            if node.path.strip("/") not in excluded
+        return tuple(
+            (uid, snapshot_token, references)
+            for uid, (snapshot_token, references) in sorted(references_by_uid.items())
         )
-
-    @classmethod
-    def _serialized_tool_data_references_from_delta(
-        cls,
-        rewrite_groups: Iterable[tuple[str, dict[str, xr.Dataset]]],
-        attr_updates: Iterable[
-            tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
-        ],
-    ) -> tuple[tuple[str, dict[str, dict[str, typing.Any]]], ...]:
-        datasets = [
-            ds
-            for _group_path, constructor in rewrite_groups
-            for ds in constructor.values()
-        ]
-        datasets.extend(
-            ds
-            for _payload_path, _attrs, (_node_path, constructor) in attr_updates
-            for ds in constructor.values()
-        )
-        return cls._serialized_tool_data_references(datasets)
 
     def _annotate_workspace_dataset(
         self,
@@ -491,27 +478,10 @@ class _WorkspaceSaver:
                 _append(uid)
         return entries
 
-    def _workspace_root_attrs_payload(
-        self,
-        *,
-        delta_save_count: int | None = None,
-        estimated_obsolete_bytes: int | None = None,
-        replacement_delta_count: int | None = None,
-        repack_estimate_known: bool | None = None,
-    ) -> dict[str, typing.Any]:
-        state = self._manager._workspace_state
-        if delta_save_count is None:
-            delta_save_count = state.delta_save_count
-        if estimated_obsolete_bytes is None:
-            estimated_obsolete_bytes = state.estimated_obsolete_bytes
-        if replacement_delta_count is None:
-            replacement_delta_count = state.replacement_delta_count
-        if repack_estimate_known is None:
-            repack_estimate_known = state.repack_estimate_known
-        return workspace_format._workspace_root_attrs_payload(
+    def _workspace_manifest(self) -> dict[str, typing.Any]:
+        return workspace_format._workspace_manifest_payload(
             root_order=self._workspace_root_indices(),
             nodes=self._workspace_node_manifest_entries(),
-            delta_save_count=delta_save_count,
             erlab_version=str(erlab.__version__),
             workspace_link_id=self._manager._workspace_state.link_id,
             manager_layout=self._workspace_layout_snapshot(),
@@ -519,9 +489,6 @@ class _WorkspaceSaver:
             standalone_apps=self._workspace_standalone_apps_snapshot(),
             option_overrides=self._workspace_option_overrides_snapshot(),
             acquisition_context=(self._manager._acquisition_context.state_payload()),
-            estimated_obsolete_bytes=estimated_obsolete_bytes,
-            replacement_delta_count=replacement_delta_count,
-            repack_estimate_known=repack_estimate_known,
         )
 
     def _workspace_compression_mode(self) -> WorkspaceCompressionMode:
@@ -625,519 +592,6 @@ class _WorkspaceSaver:
             mode="json", exclude_none=True
         )
 
-    def _workspace_datatree_for_payload_uids(self, uids: Iterable[str]) -> xr.DataTree:
-        constructor: dict[str, xr.Dataset] = {}
-        for uid in sorted(set(uids), key=self._workspace_node_path):
-            node = self._manager._tool_graph.nodes.get(uid)
-            if node is None:
-                continue
-            self._serialize_workspace_node(
-                constructor,
-                node,
-                self._workspace_node_path(uid),
-                include_children=False,
-            )
-        tree = xr.DataTree.from_dict(constructor)
-        workspace_format._set_legacy_workspace_schema(tree.attrs)
-        return tree
-
-    def _serialize_workspace_node_for_full_save_fallback(
-        self,
-        constructor: dict[str, xr.Dataset],
-        node: _ImageToolWrapper | _ManagedWindowNode,
-        path: str,
-        copy_group_sources: list[tuple[str, str, str, dict[str, typing.Any] | None]],
-        *,
-        include_children: bool,
-        pending_copy_allowed: Callable[[tuple[str | os.PathLike[str], str]], bool],
-    ) -> None:
-        pending_payload = node.pending_workspace_payload
-        pending_kind = node.pending_workspace_payload_kind
-        if (
-            pending_payload is not None
-            and pending_kind is not None
-            and node.uid not in self._manager._workspace_state.dirty_data
-            and (
-                pending_kind != "tool"
-                or self._pending_workspace_tool_references_available(node)
-            )
-            and pending_copy_allowed(pending_payload)
-        ):
-            source_file, source_path = pending_payload
-            copy_group_sources.append(
-                (
-                    os.fsdecode(source_file),
-                    source_path,
-                    f"{path}/{pending_kind}",
-                    self._pending_workspace_payload_attrs_for_save(node),
-                )
-            )
-        else:
-            self._serialize_workspace_node(
-                constructor,
-                node,
-                path,
-                include_children=False,
-            )
-
-        if not include_children:
-            return
-        for child_uid in node._childtool_indices:
-            child = self._manager._child_node(child_uid)
-            self._serialize_workspace_node_for_full_save_fallback(
-                constructor,
-                child,
-                f"{path}/childtools/{child_uid}",
-                copy_group_sources,
-                include_children=True,
-                pending_copy_allowed=pending_copy_allowed,
-            )
-
-    def _workspace_full_save_fallback_tree(
-        self,
-        *,
-        require_matching_compression: bool,
-        compression_mode: WorkspaceCompressionMode,
-    ) -> tuple[
-        xr.DataTree,
-        tuple[tuple[str, str, str, dict[str, typing.Any] | None], ...],
-    ]:
-        constructor: dict[str, xr.Dataset] = {}
-        copy_group_sources: list[
-            tuple[str, str, str, dict[str, typing.Any] | None]
-        ] = []
-        with contextlib.ExitStack() as stack:
-            pending_compression_cache: dict[tuple[str, str], bool] = {}
-            pending_compression_files: dict[str, typing.Any] = {}
-
-            def _pending_copy_allowed(
-                pending_payload: tuple[str | os.PathLike[str], str],
-            ) -> bool:
-                if not require_matching_compression:
-                    return True
-                source_file, source_path = pending_payload
-                source_key = os.fsdecode(source_file)
-                source_path = source_path.strip("/")
-                cache_key = (source_key, source_path)
-                if cache_key in pending_compression_cache:
-                    return pending_compression_cache[cache_key]
-                try:
-                    h5_file = pending_compression_files.get(source_key)
-                    if h5_file is None:
-                        workspace_arrays.ensure_workspace_hdf5_filters_registered()
-                        stack.enter_context(
-                            workspace_arrays._workspace_file_lock(source_key)
-                        )
-                        h5_file = stack.enter_context(h5py.File(source_key, "r"))
-                        pending_compression_files[source_key] = h5_file
-                    matches = workspace_arrays._h5_group_matches_compression(
-                        h5_file,
-                        source_path,
-                        compression_mode,
-                    )
-                except Exception:
-                    logger.debug(
-                        "Cannot verify pending workspace payload compression",
-                        exc_info=True,
-                    )
-                    matches = False
-                pending_compression_cache[cache_key] = matches
-                return matches
-
-            for index in self._workspace_root_indices():
-                self._serialize_workspace_node_for_full_save_fallback(
-                    constructor,
-                    self._manager._tool_graph.root_wrappers[index],
-                    str(index),
-                    copy_group_sources,
-                    include_children=True,
-                    pending_copy_allowed=_pending_copy_allowed,
-                )
-            for uid in list(self._manager._tool_graph.figure_uids):
-                node = self._manager._tool_graph.nodes.get(uid)
-                if not isinstance(node, _ManagedWindowNode):
-                    continue
-                self._serialize_workspace_node_for_full_save_fallback(
-                    constructor,
-                    node,
-                    f"figures/{uid}",
-                    copy_group_sources,
-                    include_children=False,
-                    pending_copy_allowed=_pending_copy_allowed,
-                )
-        tree = xr.DataTree.from_dict(constructor)
-        workspace_format._set_legacy_workspace_schema(tree.attrs)
-        return tree, tuple(copy_group_sources)
-
-    def _workspace_full_save_source_identities(
-        self,
-    ) -> tuple[pathlib.Path, dict[tuple[str, str], str]] | None:
-        workspace_path = self._manager._workspace_state.path
-        if workspace_path is None:
-            return None
-        workspace_path = pathlib.Path(workspace_path)
-        if (
-            self._manager._workspace_state.schema_version
-            != workspace_format._current_workspace_schema_version()
-            or not workspace_path.exists()
-        ):
-            return None
-
-        try:
-            root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(
-                workspace_path
-            )
-        except Exception:
-            return None
-        schema_version, _delta_save_count, manifest = (
-            workspace_format._workspace_file_metadata_from_attrs(root_attrs)
-        )
-        if (
-            schema_version != workspace_format._current_workspace_schema_version()
-            or manifest is None
-        ):
-            return None
-
-        manifest_entries = workspace_format._workspace_manifest_payload_entries(
-            manifest
-        )
-        identities = {
-            (uid, kind): payload_path for uid, kind, payload_path in manifest_entries
-        }
-        if not identities:
-            return None
-        return workspace_path, identities
-
-    def _workspace_full_save_manifest_entries(
-        self, root_attrs: Mapping[str, typing.Any]
-    ) -> list[tuple[str, str, str]]:
-        manifest = workspace_format._workspace_manifest_from_attrs(
-            typing.cast("Mapping[Hashable, typing.Any]", root_attrs)
-        )
-        return workspace_format._workspace_manifest_payload_entries(manifest)
-
-    def _workspace_full_save_dirty_payload_uids(self) -> set[str]:
-        state = self._manager._workspace_state
-        serialize_uids: set[str] = set()
-        for uid in state.dirty_added | state.dirty_data:
-            if uid not in self._manager._tool_graph.nodes:
-                continue
-            serialize_uids.add(uid)
-            serialize_uids.update(self._manager._iter_descendant_uids(uid))
-        serialize_uids.update(
-            uid for uid in state.dirty_state if uid in self._manager._tool_graph.nodes
-        )
-        serialize_uids.update(
-            self._workspace_stale_reference_rewrite_uids(
-                frozenset(self._manager._tool_graph.nodes)
-            )
-        )
-        return serialize_uids
-
-    def _workspace_full_save_manifest_first_snapshot(
-        self,
-        generation: int,
-        fname: str | os.PathLike[str],
-        root_attrs: dict[str, typing.Any],
-        *,
-        compression_mode: WorkspaceCompressionMode,
-        require_matching_compression: bool,
-    ) -> _WorkspaceSaveSnapshot | None:
-        if workspace_storage._workspace_path_is_likely_network_path(fname):
-            return None
-        source = self._workspace_full_save_source_identities()
-        if source is None:
-            return None
-        workspace_path, identities = source
-
-        copy_groups: list[tuple[str, str, dict[str, typing.Any] | None]] = []
-        copy_group_sources: list[
-            tuple[str, str, str, dict[str, typing.Any] | None]
-        ] = []
-        serialize_uids = self._workspace_full_save_dirty_payload_uids()
-        reason_counts: collections.Counter[str] = collections.Counter()
-        copied_bytes = 0
-        serialized_existing_bytes = 0
-        plan_started_at = time.perf_counter()
-        try:
-            workspace_arrays.ensure_workspace_hdf5_filters_registered()
-            with contextlib.ExitStack() as stack:
-                stack.enter_context(
-                    workspace_arrays._workspace_file_lock(workspace_path)
-                )
-                h5_file = stack.enter_context(h5py.File(workspace_path, "r"))
-                pending_compression_cache: dict[tuple[str, str], bool] = {}
-                pending_compression_files: dict[str, typing.Any] = {}
-
-                def _pending_copy_allowed(
-                    pending_payload: tuple[str | os.PathLike[str], str],
-                ) -> bool:
-                    if not require_matching_compression:
-                        return True
-                    source_file, source_path = pending_payload
-                    source_key = os.fsdecode(source_file)
-                    source_path = source_path.strip("/")
-                    cache_key = (source_key, source_path)
-                    if cache_key in pending_compression_cache:
-                        return pending_compression_cache[cache_key]
-                    try:
-                        pending_h5_file = pending_compression_files.get(source_key)
-                        if pending_h5_file is None:
-                            stack.enter_context(
-                                workspace_arrays._workspace_file_lock(source_key)
-                            )
-                            pending_h5_file = stack.enter_context(
-                                h5py.File(source_key, "r")
-                            )
-                            pending_compression_files[source_key] = pending_h5_file
-                        matches = workspace_arrays._h5_group_matches_compression(
-                            pending_h5_file,
-                            source_path,
-                            compression_mode,
-                        )
-                    except Exception:
-                        logger.debug(
-                            "Cannot verify pending workspace payload compression",
-                            exc_info=True,
-                        )
-                        matches = False
-                    pending_compression_cache[cache_key] = matches
-                    return matches
-
-                for (
-                    uid,
-                    kind,
-                    payload_path,
-                ) in self._workspace_full_save_manifest_entries(root_attrs):
-                    node = self._manager._tool_graph.nodes.get(uid)
-                    if node is None:
-                        reason_counts["missing_node"] += 1
-                        continue
-                    if not node.is_imagetool:
-                        if node.pending_workspace_tool_payload is not None:
-                            if not self._pending_workspace_tool_references_available(
-                                node
-                            ):
-                                serialize_uids.add(uid)
-                                reason_counts["stale_tool_reference"] += 1
-                        else:
-                            tool = node.tool_window
-                            if tool is None or not tool.can_save_and_load():
-                                reason_counts["unsupported_tool"] += 1
-                                continue
-                    pending_payload = node.pending_workspace_payload
-                    if (
-                        pending_payload is not None
-                        and node.pending_workspace_payload_kind == kind
-                        and uid not in self._manager._workspace_state.dirty_data
-                        and (
-                            kind != "tool"
-                            or self._pending_workspace_tool_references_available(node)
-                        )
-                    ):
-                        source_path_for_pending = identities.get((uid, kind))
-                        pending_workspace_path, pending_payload_path = pending_payload
-                        pending_source_matches = (
-                            source_path_for_pending is not None
-                            and workspace_arrays._normalized_file_path(
-                                pending_workspace_path
-                            )
-                            == workspace_arrays._normalized_file_path(workspace_path)
-                            and pending_payload_path
-                            == source_path_for_pending.strip("/")
-                        )
-                        pending_external_copy = (
-                            uid in self._manager._workspace_state.dirty_added
-                            or not pending_source_matches
-                        )
-                        if pending_external_copy:
-                            if _pending_copy_allowed(pending_payload):
-                                pending_source_file, pending_source_path = (
-                                    pending_payload
-                                )
-                                copy_group_sources.append(
-                                    (
-                                        os.fsdecode(pending_source_file),
-                                        pending_source_path,
-                                        payload_path,
-                                        self._pending_workspace_payload_attrs_for_save(
-                                            node
-                                        ),
-                                    )
-                                )
-                                serialize_uids.discard(uid)
-                                reason_counts["pending_external"] += 1
-                                continue
-                            serialize_uids.add(uid)
-                            reason_counts["pending_compression_mismatch"] += 1
-                            continue
-                    source_path = identities.get((uid, kind))
-                    if source_path is None or source_path != payload_path:
-                        serialize_uids.add(uid)
-                        reason_counts[
-                            "missing_source" if source_path is None else "moved"
-                        ] += 1
-                        continue
-                    source_group = h5_file.get(source_path)
-                    if not isinstance(source_group, h5py.Group):
-                        serialize_uids.add(uid)
-                        reason_counts["missing_source_group"] += 1
-                        continue
-                    source_storage_size = (
-                        workspace_arrays._workspace_h5_object_storage_size(source_group)
-                    )
-                    compression_mismatch = (
-                        require_matching_compression
-                        and not workspace_arrays._h5_group_matches_compression(
-                            h5_file, source_path, compression_mode
-                        )
-                    )
-                    pending_payload = node.pending_workspace_payload
-                    pending_source_matches = False
-                    if pending_payload is not None:
-                        pending_workspace_path, pending_payload_path = pending_payload
-                        pending_source_matches = workspace_arrays._normalized_file_path(
-                            pending_workspace_path
-                        ) == workspace_arrays._normalized_file_path(
-                            workspace_path
-                        ) and pending_payload_path == source_path.strip("/")
-                    if compression_mismatch:
-                        serialize_uids.add(uid)
-                        reason_counts["compression_mismatch"] += 1
-                        serialized_existing_bytes += source_storage_size
-                        continue
-                    if (
-                        pending_source_matches
-                        and uid in self._manager._workspace_state.dirty_state
-                        and uid not in self._manager._workspace_state.dirty_data
-                        and uid not in self._manager._workspace_state.dirty_added
-                    ):
-                        serialize_uids.discard(uid)
-                        update = self._workspace_attr_update_snapshot(uid)
-                        copy_groups.append(
-                            (
-                                source_path,
-                                payload_path,
-                                None if update is None else update[1],
-                            )
-                        )
-                        reason_counts["pending_dirty_state"] += 1
-                        copied_bytes += source_storage_size
-                        continue
-                    if uid in serialize_uids:
-                        state = self._manager._workspace_state
-                        if uid in state.dirty_added:
-                            reason_counts["dirty_added"] += 1
-                        elif uid in state.dirty_data:
-                            reason_counts["dirty_data"] += 1
-                        elif uid in state.dirty_state:
-                            reason_counts["dirty_state"] += 1
-                        else:
-                            reason_counts["dirty_descendant"] += 1
-                        serialized_existing_bytes += source_storage_size
-                        continue
-                    copy_groups.append((source_path, payload_path, None))
-                    copied_bytes += source_storage_size
-        except Exception:
-            logger.debug(
-                "Falling back to DataTree full-save snapshot",
-                exc_info=True,
-            )
-            return None
-
-        tree = self._workspace_datatree_for_payload_uids(serialize_uids)
-        logger.debug(
-            "Workspace manifest-first full-save plan: copied %d groups "
-            "(%.1f MiB), serialized %d existing groups (%.1f MiB), "
-            "reasons=%s, planning %.3f s",
-            len(copy_groups),
-            copied_bytes / 1024**2,
-            len(serialize_uids),
-            serialized_existing_bytes / 1024**2,
-            dict(reason_counts),
-            time.perf_counter() - plan_started_at,
-        )
-        return _WorkspaceSaveSnapshot(
-            generation=generation,
-            root_attrs=root_attrs,
-            delta_save_count=0,
-            compression_mode=compression_mode,
-            full_tree=tree,
-            copy_source=str(workspace_path),
-            copy_groups=tuple(copy_groups),
-            copy_group_sources=tuple(copy_group_sources),
-            serialized_tool_data_references=(
-                self._serialized_tool_data_references_from_tree(tree)
-            ),
-        )
-
-    def _write_full_workspace_file(
-        self,
-        fname: str | os.PathLike[str],
-        *,
-        reuse_unchanged_groups: bool = True,
-        require_matching_compression: bool = False,
-    ) -> None:
-        expected_state = workspace_storage._workspace_publication_state(fname)
-        snapshot = self._workspace_full_save_snapshot(
-            self._manager._workspace_state.dirty_generation,
-            fname=fname,
-            reuse_unchanged_groups=reuse_unchanged_groups,
-            require_matching_compression=require_matching_compression,
-        )
-        snapshot.expected_publication_state = expected_state
-        try:
-            workspace_storage._write_full_workspace_tree_file(
-                fname,
-                snapshot.full_tree,
-                snapshot.root_attrs,
-                copy_source=snapshot.copy_source,
-                copy_groups=snapshot.copy_groups,
-                copy_group_sources=snapshot.copy_group_sources,
-                compression_mode=snapshot.compression_mode,
-                expected_state=snapshot.expected_publication_state,
-            )
-            self._controller._commit_saved_tool_data_references(snapshot)
-        finally:
-            snapshot.close()
-
-    def _workspace_highest_dirty_data_roots(self) -> list[str]:
-        dirty_existing = [
-            uid
-            for uid in self._manager._workspace_state.dirty_data
-            if uid in self._manager._tool_graph.nodes
-        ]
-        dirty_set = set(dirty_existing)
-        roots: list[str] = []
-        for uid in sorted(
-            dirty_existing, key=lambda value: self._workspace_node_path(value)
-        ):
-            node = self._manager._tool_graph.nodes[uid]
-            parent_uid = node.parent_uid
-            has_dirty_ancestor = False
-            while parent_uid is not None:
-                if parent_uid in dirty_set:
-                    has_dirty_ancestor = True
-                    break
-                parent_uid = self._manager._tool_graph.nodes[parent_uid].parent_uid
-            if not has_dirty_ancestor:
-                roots.append(uid)
-        return roots
-
-    @classmethod
-    def _workspace_manifest_node_uids(
-        cls, root_attrs: Mapping[str, typing.Any]
-    ) -> frozenset[str]:
-        manifest = workspace_format._workspace_manifest_from_attrs(
-            typing.cast("Mapping[Hashable, typing.Any]", root_attrs)
-        )
-        uids: set[str] = set()
-        for node in workspace_format._iter_workspace_manifest_node_entries(manifest):
-            uid = node.get("uid")
-            if uid is not None:
-                uids.add(str(uid))
-        return frozenset(uids)
-
     def _workspace_stale_reference_rewrite_uids(
         self, available_uids: frozenset[str]
     ) -> list[str]:
@@ -1174,53 +628,20 @@ class _WorkspaceSaver:
             for reference in references
         )
 
-    def _save_workspace_delta(self, fname: str | os.PathLike[str]) -> None:
-        expected_state = workspace_storage._workspace_publication_state(fname)
-        delta_save_count = self._manager._workspace_state.delta_save_count + 1
-        snapshot = self._workspace_delta_save_snapshot(
-            self._manager._workspace_state.dirty_generation,
-            self._workspace_root_attrs_payload(delta_save_count=delta_save_count),
-            delta_save_count,
-        )
-        snapshot.expected_publication_state = expected_state
-        try:
-            workspace_storage._write_workspace_transaction_file(
-                fname,
-                snapshot.rewrite_groups,
-                snapshot.attr_updates,
-                snapshot.root_attrs,
-                compression_mode=snapshot.compression_mode,
-                expected_state=snapshot.expected_publication_state,
-            )
-            self._controller._commit_saved_tool_data_references(snapshot)
-            self._manager._workspace_state.delta_save_count = snapshot.delta_save_count
-            self._manager._workspace_state.set_repack_estimate(
-                estimated_obsolete_bytes=snapshot.estimated_obsolete_bytes,
-                replacement_delta_count=snapshot.replacement_delta_count,
-                known=snapshot.repack_estimate_known,
-            )
-        finally:
-            snapshot.close()
-
     def _save_workspace_document(
         self,
         fname: str | os.PathLike[str],
         *,
-        force_full: bool = False,
         document_access: _WorkspaceDocumentAccess | None = None,
-        reuse_unchanged_groups: bool = True,
-        require_matching_compression: bool = False,
         mark_clean: bool = True,
     ) -> None:
         if document_access is None:
             _require_itws_workspace_path(fname, _WORKSPACE_SAVE_SUFFIX_ERROR)
+            self._controller._drain_workspace_deferred_events()
             with self._controller._workspace_document_access_context(fname) as access:
                 self._save_workspace_document(
                     access.path,
-                    force_full=force_full,
                     document_access=access,
-                    reuse_unchanged_groups=reuse_unchanged_groups,
-                    require_matching_compression=require_matching_compression,
                     mark_clean=mark_clean,
                 )
             return
@@ -1228,65 +649,38 @@ class _WorkspaceSaver:
         fname = document_access.path
         _require_itws_workspace_path(fname, _WORKSPACE_SAVE_SUFFIX_ERROR)
         self._manager._workspace_state.saving_depth += 1
+        snapshot: _WorkspaceSaveSnapshot | None = None
+        target_store: workspace_store.WorkspaceStore | None = None
+        owned_store = False
         try:
-            workspace_storage._recover_workspace_transactions(fname)
-            requires_full_save = force_full or self._workspace_requires_full_save(fname)
-            if requires_full_save:
-                self._write_full_workspace_file(
+            snapshot = self._workspace_generation_save_snapshot(
+                self._manager._workspace_state.dirty_generation,
+                fname=fname,
+            )
+            target_store = workspace_store.WorkspaceStore.active(fname)
+            if target_store is None:
+                target_store = workspace_store.WorkspaceStore(
                     fname,
-                    reuse_unchanged_groups=reuse_unchanged_groups,
-                    require_matching_compression=require_matching_compression,
+                    create=not pathlib.Path(fname).exists(),
                 )
-                self._manager._workspace_state.delta_save_count = 0
-                self._manager._workspace_state.reset_repack_estimate()
-                self._manager._workspace_state.schema_version = (
-                    workspace_format._current_workspace_schema_version()
-                )
-            else:
-                self._save_workspace_delta(fname)
+                owned_store = True
+            workspace_storage._write_workspace_generation(
+                target_store,
+                snapshot.generation_plan,
+                compression_mode=snapshot.compression_mode,
+            )
+            self._controller._commit_saved_tool_data_references(snapshot)
+            self._manager._workspace_state.schema_version = (
+                workspace_format._current_workspace_schema_version()
+            )
         finally:
+            if snapshot is not None:
+                snapshot.close()
+            if owned_store and target_store is not None:
+                target_store.close()
             self._manager._workspace_state.saving_depth -= 1
         if mark_clean:
-            self._manager._workspace_state.needs_full_save = False
             self._controller._mark_workspace_clean()
-
-    def _workspace_requires_full_save(self, fname: str | os.PathLike[str]) -> bool:
-        return workspace_storage._workspace_requires_full_save(
-            fname,
-            needs_full_save=self._manager._workspace_state.needs_full_save,
-            schema_version=self._manager._workspace_state.schema_version,
-            structure_modified=self._manager._workspace_state.structure_modified,
-            has_dirty_added=bool(self._manager._workspace_state.dirty_added),
-            has_dirty_removed=bool(self._manager._workspace_state.dirty_removed),
-        )
-
-    def _workspace_has_non_layout_modifications(self) -> bool:
-        state = self._manager._workspace_state
-        return (
-            state.structure_modified
-            or bool(state.dirty_added)
-            or bool(state.dirty_data)
-            or bool(state.dirty_state)
-            or bool(state.dirty_removed)
-        )
-
-    def _workspace_layout_only_modified(self) -> bool:
-        return (
-            self._manager._workspace_state.layout_modified
-            or self._manager._workspace_state.options_modified
-            or self._manager._workspace_state.context_modified
-        ) and not self._workspace_has_non_layout_modifications()
-
-    def _workspace_rewrite_group_snapshot(
-        self, uid: str
-    ) -> tuple[str, dict[str, xr.Dataset]]:
-        constructor: dict[str, xr.Dataset] = {}
-        node = self._manager._tool_graph.nodes[uid]
-        node_path = self._workspace_node_path(uid)
-        self._serialize_workspace_node(
-            constructor, node, node_path, include_children=True
-        )
-        return node_path, constructor
 
     @staticmethod
     def _pending_workspace_node_attrs(
@@ -1479,351 +873,232 @@ class _WorkspaceSaver:
                 return False
         return True
 
-    def _workspace_attr_update_snapshot(
-        self, uid: str
-    ) -> tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]] | None:
-        constructor: dict[str, xr.Dataset] = {}
-        node = self._manager._tool_graph.nodes[uid]
-        node_path = self._workspace_node_path(uid)
-        payload_path = self._workspace_payload_path(uid)
-        pending_attrs = self._pending_workspace_payload_attrs_for_save(node)
-        if pending_attrs is not None:
-            return (
-                payload_path,
-                pending_attrs,
-                (node_path, constructor),
-            )
-        self._serialize_workspace_node(
-            constructor,
-            node,
-            node_path,
-            include_children=False,
-        )
-        ds = constructor.get(payload_path)
-        if ds is None:
-            return None
-        return payload_path, dict(ds.attrs), (node_path, constructor)
-
-    def _workspace_delta_save_snapshot(
-        self,
-        generation: int,
-        root_attrs: dict[str, typing.Any],
-        delta_save_count: int,
-    ) -> _WorkspaceSaveSnapshot:
-        state = self._manager._workspace_state
-        rewrite_groups: list[tuple[str, dict[str, xr.Dataset]]] = []
-        rewritten_uids: set[str] = set()
-        for uid in self._workspace_highest_dirty_data_roots():
-            rewrite_groups.append(self._workspace_rewrite_group_snapshot(uid))
-            rewritten_uids.add(uid)
-            rewritten_uids.update(self._manager._iter_descendant_uids(uid))
-
-        manifest_uids = self._workspace_manifest_node_uids(root_attrs)
-        for uid in self._workspace_stale_reference_rewrite_uids(manifest_uids):
-            if uid in rewritten_uids:
-                continue
-            rewrite_groups.append(self._workspace_rewrite_group_snapshot(uid))
-            rewritten_uids.add(uid)
-            rewritten_uids.update(self._manager._iter_descendant_uids(uid))
-
-        attr_updates: list[
-            tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
-        ] = []
-        for uid in sorted(self._manager._workspace_state.dirty_state - rewritten_uids):
-            if uid not in self._manager._tool_graph.nodes:
-                continue
-            update = self._workspace_attr_update_snapshot(uid)
-            if update is not None:
-                attr_updates.append(update)
-
-        estimated_obsolete_bytes = state.estimated_obsolete_bytes
-        replacement_delta_count = state.replacement_delta_count
-        repack_estimate_known = state.repack_estimate_known
-        if repack_estimate_known and rewrite_groups and state.path is not None:
-            old_bytes, replaced_group_count = (
-                workspace_arrays._workspace_h5_paths_storage_size(
-                    state.path,
-                    (group_path for group_path, _constructor in rewrite_groups),
-                )
-            )
-            estimated_obsolete_bytes += old_bytes
-            if replaced_group_count > 0:
-                replacement_delta_count += 1
-        root_attrs = workspace_format._workspace_root_attrs_with_repack_estimate(
-            root_attrs,
-            estimated_obsolete_bytes=estimated_obsolete_bytes,
-            replacement_delta_count=replacement_delta_count,
-            repack_estimate_known=repack_estimate_known,
-        )
-
-        return _WorkspaceSaveSnapshot(
-            generation=generation,
-            root_attrs=root_attrs,
-            delta_save_count=delta_save_count,
-            estimated_obsolete_bytes=estimated_obsolete_bytes,
-            replacement_delta_count=replacement_delta_count,
-            repack_estimate_known=repack_estimate_known,
-            compression_mode=self._workspace_compression_mode(),
-            rewrite_groups=tuple(rewrite_groups),
-            attr_updates=tuple(attr_updates),
-            serialized_tool_data_references=(
-                self._serialized_tool_data_references_from_delta(
-                    rewrite_groups, attr_updates
-                )
-            ),
-        )
-
     def _workspace_save_snapshot(
         self, fname: str | os.PathLike[str]
     ) -> _WorkspaceSaveSnapshot:
-        expected_state = workspace_storage._workspace_publication_state(fname)
         self._controller._drain_workspace_deferred_events()
         generation = self._manager._workspace_state.dirty_generation
         self._manager._workspace_state.saving_depth += 1
         try:
-            if self._workspace_requires_full_save(fname):
-                snapshot = self._workspace_full_save_snapshot(generation)
-            elif self._workspace_layout_only_modified():
-                delta_save_count = self._manager._workspace_state.delta_save_count
-                root_attrs = self._workspace_root_attrs_payload(
-                    delta_save_count=delta_save_count
-                )
-                snapshot = self._workspace_delta_save_snapshot(
-                    generation, root_attrs, delta_save_count
-                )
-            else:
-                delta_save_count = self._manager._workspace_state.delta_save_count + 1
-                root_attrs = self._workspace_root_attrs_payload(
-                    delta_save_count=delta_save_count
-                )
-                snapshot = self._workspace_delta_save_snapshot(
-                    generation, root_attrs, delta_save_count
-                )
-            snapshot.expected_publication_state = expected_state
-            return snapshot
+            return self._workspace_generation_save_snapshot(generation, fname=fname)
         finally:
             self._manager._workspace_state.saving_depth -= 1
 
-    def _workspace_full_save_snapshot(
+    def _workspace_generation_save_snapshot(
         self,
         generation: int,
         *,
-        fname: str | os.PathLike[str] | None = None,
-        reuse_unchanged_groups: bool = True,
-        require_matching_compression: bool = False,
+        fname: str | os.PathLike[str],
     ) -> _WorkspaceSaveSnapshot:
-        compression_mode = self._workspace_compression_mode()
-        root_attrs = self._workspace_root_attrs_payload(delta_save_count=0)
-        if fname is None:
-            fname = self._manager._workspace_state.path
-        target_drops_copy_groups = (
-            fname is not None
-            and workspace_storage._workspace_path_is_likely_network_path(fname)
-        )
-        if (
-            reuse_unchanged_groups
-            and fname is not None
-            and not target_drops_copy_groups
-        ):
-            snapshot = self._workspace_full_save_manifest_first_snapshot(
-                generation,
-                fname,
-                root_attrs,
-                compression_mode=compression_mode,
-                require_matching_compression=require_matching_compression,
-            )
-            if snapshot is not None:
-                return snapshot
-
-        tree, pending_copy_groups = self._workspace_full_save_fallback_tree(
-            require_matching_compression=require_matching_compression,
-            compression_mode=compression_mode,
-        )
-        if reuse_unchanged_groups and not target_drops_copy_groups:
-            copy_source, copy_groups = self._workspace_full_save_copy_groups(
-                tree,
-                compression_mode=compression_mode,
-                require_matching_compression=require_matching_compression,
-            )
-        else:
-            copy_source, copy_groups = None, ()
-        return _WorkspaceSaveSnapshot(
-            generation=generation,
-            root_attrs=root_attrs,
-            delta_save_count=0,
-            compression_mode=compression_mode,
-            full_tree=tree,
-            copy_source=copy_source,
-            copy_groups=copy_groups,
-            copy_group_sources=pending_copy_groups,
-            serialized_tool_data_references=(
-                self._serialized_tool_data_references_from_tree(
-                    tree,
-                    exclude_payload_paths=(
-                        destination_path
-                        for _source_path, destination_path, attrs in copy_groups
-                        if attrs is None
-                    ),
+        """Capture one immutable generation without copying unchanged payloads."""
+        source_store = getattr(self._controller, "_workspace_store", None)
+        current_manifest: dict[str, typing.Any] | None = None
+        if source_store is not None and not source_store.closed:
+            with contextlib.suppress(Exception):
+                current_manifest = source_store.current_generation().manifest
+        if current_manifest is None and self._manager._workspace_state.path is not None:
+            with contextlib.suppress(Exception):
+                root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(
+                    self._manager._workspace_state.path
                 )
-            ),
-        )
-
-    def _workspace_file_repack_snapshot(
-        self, generation: int
-    ) -> _WorkspaceSaveSnapshot | None:
-        workspace_path = self._manager._workspace_state.path
-        if workspace_path is None:
-            return None
-        if workspace_storage._workspace_path_is_likely_network_path(workspace_path):
-            return None
-        try:
-            root_attrs, copy_groups, expected_state = (
-                workspace_storage._workspace_file_repack_payload(workspace_path)
-            )
-        except Exception:
-            logger.debug(
-                "Skipping shutdown compaction; file-level repack snapshot failed",
-                exc_info=True,
-            )
-            return None
-        return _WorkspaceSaveSnapshot(
-            generation=generation,
-            root_attrs=root_attrs,
-            delta_save_count=0,
-            compression_mode=self._workspace_compression_mode(),
-            file_repack=True,
-            copy_source=str(workspace_path),
-            copy_groups=copy_groups,
-            expected_publication_state=expected_state,
-        )
-
-    def _workspace_should_repack_before_shutdown(self) -> bool:
-        workspace_path = self._manager._workspace_state.path
-        if workspace_path is None:
-            return False
-        state = self._manager._workspace_state
-        if state.repack_estimate_known:
-            if state.replacement_delta_count <= 0:
-                return False
-            estimated_obsolete_bytes = state.estimated_obsolete_bytes
-        else:
-            try:
-                estimated_obsolete_bytes = (
-                    workspace_storage._workspace_obsolete_estimate(workspace_path)
+                schema_version, manifest = (
+                    workspace_format._workspace_file_metadata_from_attrs(root_attrs)
                 )
-            except Exception:
-                logger.debug(
-                    "Failed to estimate workspace repack benefit before shutdown",
-                    exc_info=True,
-                )
-                return False
-        try:
-            file_size = pathlib.Path(workspace_path).stat().st_size
-        except OSError:
-            return False
-        if file_size <= 0:
-            return False
-        return (
-            estimated_obsolete_bytes >= _WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES
-            and estimated_obsolete_bytes / file_size
-            >= _WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO
-        )
-
-    def _workspace_full_save_copy_groups(
-        self,
-        tree: xr.DataTree,
-        *,
-        compression_mode: WorkspaceCompressionMode | None = None,
-        require_matching_compression: bool = True,
-    ) -> tuple[str | None, tuple[tuple[str, str, dict[str, typing.Any] | None], ...]]:
-        if self._manager._workspace_state.path is None:
-            return None, ()
-        workspace_path = pathlib.Path(self._manager._workspace_state.path)
-        if (
-            self._manager._workspace_state.schema_version
-            != workspace_format._current_workspace_schema_version()
-            or not workspace_path.exists()
-        ):
-            return None, ()
-
-        try:
-            root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(
-                workspace_path
-            )
-        except Exception:
-            return None, ()
-        schema_version, _delta_save_count, manifest = (
-            workspace_format._workspace_file_metadata_from_attrs(root_attrs)
-        )
-        if (
-            schema_version != workspace_format._current_workspace_schema_version()
-            or manifest is None
-        ):
-            return None, ()
-
-        manifest_entries = workspace_format._workspace_manifest_payload_entries(
-            manifest
-        )
-        identities = {
-            (uid, kind): payload_path for uid, kind, payload_path in manifest_entries
-        }
-        copy_groups: list[tuple[str, str, dict[str, typing.Any] | None]] = []
-        with contextlib.ExitStack() as stack:
-            h5_file = None
-            if require_matching_compression and compression_mode is not None:
-                stack.enter_context(
-                    workspace_arrays._workspace_file_lock(workspace_path)
-                )
-                h5_file = stack.enter_context(h5py.File(workspace_path, "r"))
-            for uid, node in self._manager._tool_graph.nodes.items():
                 if (
-                    uid in self._manager._workspace_state.dirty_data
-                    or uid in self._manager._workspace_state.dirty_added
+                    schema_version
+                    == workspace_format._current_workspace_schema_version()
                 ):
-                    continue
-                if not node.is_imagetool:
-                    if node.pending_workspace_tool_payload is not None:
-                        if not self._pending_workspace_tool_references_available(node):
+                    current_manifest = manifest
+
+        previous_entries: dict[str, Mapping[str, typing.Any]] = {}
+        if current_manifest is not None:
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                current_manifest
+            ):
+                uid = entry.get("uid")
+                if isinstance(uid, str):
+                    previous_entries[uid] = entry
+
+        manifest = self._workspace_manifest()
+        base_entries = [
+            dict(entry)
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                manifest
+            )
+        ]
+        available_uids = frozenset(
+            str(entry["uid"]) for entry in base_entries if "uid" in entry
+        )
+        stale_reference_uids = set(
+            self._workspace_stale_reference_rewrite_uids(available_uids)
+        )
+        dirty_data = (
+            self._manager._workspace_state.dirty_data
+            | self._manager._workspace_state.dirty_added
+            | stale_reference_uids
+        )
+        dirty_state = self._manager._workspace_state.dirty_state
+        source_workspace_path = self._manager._workspace_state.path
+
+        object_writes: dict[str, workspace_storage._WorkspaceObjectWrite] = {}
+        final_entries: list[dict[str, typing.Any]] = []
+        serialized_datasets: list[xr.Dataset] = []
+
+        def _serialize(uid: str) -> xr.Dataset | None:
+            node = self._manager._tool_graph.nodes.get(uid)
+            if node is None:
+                return None
+            constructor: dict[str, xr.Dataset] = {}
+            self._serialize_workspace_node(
+                constructor,
+                node,
+                self._workspace_node_path(uid),
+                include_children=False,
+            )
+            return constructor.get(self._workspace_payload_path(uid))
+
+        for entry in base_entries:
+            uid = str(entry["uid"])
+            node = self._manager._tool_graph.nodes.get(uid)
+            if node is None:
+                continue
+            kind = typing.cast("typing.Literal['imagetool', 'tool']", entry["kind"])
+            previous = previous_entries.get(uid)
+            previous_object_id = (
+                previous.get("payload_object_id") if previous is not None else None
+            )
+            can_reuse_object = (
+                isinstance(previous_object_id, str)
+                and bool(previous_object_id)
+                and uid not in dirty_data
+            )
+
+            dataset: xr.Dataset | None = None
+            attrs_payload = (
+                previous.get("payload_attrs") if previous is not None else None
+            )
+            needs_current_attrs = (
+                attrs_payload is None or uid in dirty_state or uid in dirty_data
+            )
+            if needs_current_attrs:
+                pending_attrs = (
+                    self._pending_workspace_payload_attrs_for_save(node)
+                    if uid not in self._manager._workspace_state.dirty_data
+                    else None
+                )
+                if pending_attrs is not None:
+                    attrs_payload = workspace_format._workspace_manifest_attrs(
+                        pending_attrs
+                    )
+                else:
+                    dataset = _serialize(uid)
+                    if dataset is None:
+                        if not can_reuse_object:
                             continue
                     else:
-                        tool = node.tool_window
-                        if tool is None or not tool.can_save_and_load():
-                            continue
-                        if not self._workspace_tool_references_match_current_snapshots(
-                            node._workspace_tool_data_references.values()
-                        ):
-                            continue
-                kind = "imagetool" if node.is_imagetool else "tool"
-                source_path = identities.get((uid, kind))
-                if source_path is None:
-                    continue
-                payload_path = self._workspace_payload_path(uid)
-                try:
-                    payload_tree = typing.cast("xr.DataTree", tree[payload_path])
-                except KeyError:
-                    continue
-                payload_ds = payload_tree.to_dataset(inherit=False)
-                compression_matches = (
-                    h5_file is None
-                    or compression_mode is None
-                    or workspace_arrays._workspace_h5_group_matches_compression_mode(
-                        h5_file,
-                        source_path,
-                        payload_ds,
-                        compression_mode,
+                        attrs_payload = workspace_format._workspace_manifest_attrs(
+                            dataset.attrs
+                        )
+                        serialized_datasets.append(dataset)
+            if attrs_payload is not None:
+                entry["payload_attrs"] = attrs_payload
+
+            if can_reuse_object:
+                object_id = typing.cast("str", previous_object_id)
+                previous_entry = typing.cast("Mapping[str, typing.Any]", previous)
+                source_path = previous_entry.get("payload_path")
+                if not isinstance(source_path, str):
+                    source_path = workspace_store.WorkspaceStore.object_path(object_id)
+                if source_workspace_path is not None and object_id not in object_writes:
+                    object_writes[object_id] = workspace_storage._WorkspaceObjectWrite(
+                        object_id,
+                        source_file=str(source_workspace_path),
+                        source_path=source_path,
+                    )
+                if dataset is not None:
+                    dataset.close()
+            else:
+                object_id = uuid.uuid4().hex
+                pending_payload = node.pending_workspace_payload
+                pending_kind = node.pending_workspace_payload_kind
+                use_pending = (
+                    dataset is None
+                    and pending_payload is not None
+                    and pending_kind == kind
+                    and uid not in self._manager._workspace_state.dirty_data
+                    and (
+                        kind != "tool"
+                        or self._pending_workspace_tool_references_available(node)
                     )
                 )
-                if (
-                    require_matching_compression
-                    and compression_mode is not None
-                    and not compression_matches
-                ):
-                    continue
-                attrs = None
-                if (
-                    uid in self._manager._workspace_state.dirty_state
-                    or source_path != payload_path
-                ):
-                    attrs = dict(payload_ds.attrs)
-                copy_groups.append((source_path, payload_path, attrs))
-        return str(workspace_path), tuple(copy_groups)
+                if use_pending:
+                    pending_file, pending_path = typing.cast(
+                        "tuple[str | os.PathLike[str], str]", pending_payload
+                    )
+                    object_writes[object_id] = workspace_storage._WorkspaceObjectWrite(
+                        object_id,
+                        source_file=os.fsdecode(pending_file),
+                        source_path=pending_path,
+                    )
+                else:
+                    if dataset is None:
+                        dataset = _serialize(uid)
+                        if dataset is None:
+                            continue
+                    if all(existing is not dataset for existing in serialized_datasets):
+                        serialized_datasets.append(dataset)
+                    entry["payload_attrs"] = workspace_format._workspace_manifest_attrs(
+                        dataset.attrs
+                    )
+                    object_writes[object_id] = workspace_storage._WorkspaceObjectWrite(
+                        object_id,
+                        dataset=dataset,
+                    )
+
+            entry["payload_object_id"] = object_id
+            entry["payload_path"] = workspace_store.WorkspaceStore.object_path(
+                object_id
+            )
+            final_entries.append(entry)
+
+        manifest["nodes"] = final_entries
+        manifest["schema_version"] = (
+            workspace_format._current_workspace_schema_version()
+        )
+        manifest["storage_model"] = "immutable-generations-v1"
+        manifest.pop("transaction_protocol", None)
+        preserved_groups: tuple[workspace_storage._WorkspaceGroupCopy, ...] = ()
+        if (
+            source_store is not None
+            and pathlib.Path(fname).resolve() != source_store.path
+        ):
+            source_path = str(source_store.path)
+            for object_id in source_store.leased_object_ids:
+                object_writes.setdefault(
+                    object_id,
+                    workspace_storage._WorkspaceObjectWrite(
+                        object_id,
+                        source_file=source_path,
+                        source_path=source_store.object_path(object_id),
+                    ),
+                )
+            preserved_groups = tuple(
+                workspace_storage._WorkspaceGroupCopy(
+                    source_file=source_path,
+                    source_path=group_path,
+                    target_path=group_path,
+                )
+                for group_path in sorted(source_store.leased_legacy_group_paths)
+            )
+        return _WorkspaceSaveSnapshot(
+            generation=generation,
+            generation_plan=workspace_storage._WorkspaceGenerationPlan(
+                manifest=manifest,
+                objects=tuple(object_writes.values()),
+                preserved_groups=preserved_groups,
+            ),
+            compression_mode=self._workspace_compression_mode(),
+            serialized_tool_data_references=(
+                self._serialized_tool_data_references(serialized_datasets)
+            ),
+        )

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -208,30 +208,12 @@ class _WorkspaceGcWorker(QtCore.QRunnable):
         self,
         store: workspace_store.WorkspaceStore,
         *,
-        delete_objects: bool = True,
-        can_delete_objects: Callable[[], bool] | None = None,
         reader_closers: tuple[Callable[[], None], ...] = (),
     ) -> None:
         super().__init__()
         self.signals = _WorkspaceGcWorkerSignals()
         self._store = store
-        self._delete_objects = delete_objects
-        self._can_delete_objects = can_delete_objects
-        self._object_gc_deferred = not delete_objects
         self._reader_closers = reader_closers
-
-    @property
-    def object_gc_deferred(self) -> bool:
-        """Return whether this run kept obsolete payload objects."""
-        return self._object_gc_deferred
-
-    def _object_deletion_allowed(self) -> bool:
-        allowed = self._delete_objects and (
-            self._can_delete_objects is None or self._can_delete_objects()
-        )
-        if not allowed:
-            self._object_gc_deferred = True
-        return allowed
 
     def _handle_contention(self) -> None:
         for closer in self._reader_closers:
@@ -243,8 +225,6 @@ class _WorkspaceGcWorker(QtCore.QRunnable):
         try:
             more = self._store.collect_garbage(
                 max_objects=1,
-                delete_objects=self._delete_objects,
-                can_delete_objects=self._object_deletion_allowed,
                 on_contention=self._handle_contention,
             )
         except Exception:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -208,12 +208,30 @@ class _WorkspaceGcWorker(QtCore.QRunnable):
         self,
         store: workspace_store.WorkspaceStore,
         *,
+        delete_objects: bool = True,
+        can_delete_objects: Callable[[], bool] | None = None,
         reader_closers: tuple[Callable[[], None], ...] = (),
     ) -> None:
         super().__init__()
         self.signals = _WorkspaceGcWorkerSignals()
         self._store = store
+        self._delete_objects = delete_objects
+        self._can_delete_objects = can_delete_objects
+        self._object_gc_deferred = not delete_objects
         self._reader_closers = reader_closers
+
+    @property
+    def object_gc_deferred(self) -> bool:
+        """Return whether this run kept obsolete payload objects."""
+        return self._object_gc_deferred
+
+    def _object_deletion_allowed(self) -> bool:
+        allowed = self._delete_objects and (
+            self._can_delete_objects is None or self._can_delete_objects()
+        )
+        if not allowed:
+            self._object_gc_deferred = True
+        return allowed
 
     def _handle_contention(self) -> None:
         for closer in self._reader_closers:
@@ -225,6 +243,8 @@ class _WorkspaceGcWorker(QtCore.QRunnable):
         try:
             more = self._store.collect_garbage(
                 max_objects=1,
+                delete_objects=self._delete_objects,
+                can_delete_objects=self._object_deletion_allowed,
                 on_contention=self._handle_contention,
             )
         except Exception:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -75,6 +75,7 @@ class _WorkspaceSaveError:
 
 
 class _WorkspaceSaveWorkerSignals(QtCore.QObject):
+    waiting = QtCore.Signal()
     finished = QtCore.Signal(float, object)
 
 
@@ -83,10 +84,17 @@ class _WorkspaceSaveResultReceiver(QtCore.QObject):
         self,
         *,
         callback: Callable[[float, _WorkspaceSaveError | None], None] | None = None,
+        waiting_callback: Callable[[], None] | None = None,
         parent: QtCore.QObject | None = None,
     ) -> None:
         super().__init__(parent)
         self._callback = callback
+        self._waiting_callback = waiting_callback
+
+    @QtCore.Slot()
+    def wait(self) -> None:
+        if self._waiting_callback is not None:
+            self._waiting_callback()
 
     @QtCore.Slot(float, object)
     def finish(
@@ -105,12 +113,22 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
         snapshot: _WorkspaceSaveSnapshot,
         *,
         store: workspace_store.WorkspaceStore | None = None,
+        reader_closers: tuple[Callable[[], None], ...] = (),
     ) -> None:
         super().__init__()
         self.signals = _WorkspaceSaveWorkerSignals()
         self._fname = fname
         self._snapshot = snapshot
         self._store = store
+        self._reader_closers = reader_closers
+        self._waiting_reported = False
+
+    def _handle_contention(self) -> None:
+        for closer in self._reader_closers:
+            closer()
+        if not self._waiting_reported:
+            self._waiting_reported = True
+            self.signals.waiting.emit()
 
     def run(self) -> None:
         start_time = time.perf_counter()
@@ -131,6 +149,7 @@ class _WorkspaceSaveWorker(QtCore.QRunnable):
                     target_store,
                     self._snapshot.generation_plan,
                     compression_mode=self._snapshot.compression_mode,
+                    on_contention=self._handle_contention,
                 )
             finally:
                 if owned_store:
@@ -185,16 +204,29 @@ class _WorkspaceGcResultReceiver(QtCore.QObject):
 class _WorkspaceGcWorker(QtCore.QRunnable):
     """Unlink at most one obsolete payload object outside the save path."""
 
-    def __init__(self, store: workspace_store.WorkspaceStore) -> None:
+    def __init__(
+        self,
+        store: workspace_store.WorkspaceStore,
+        *,
+        reader_closers: tuple[Callable[[], None], ...] = (),
+    ) -> None:
         super().__init__()
         self.signals = _WorkspaceGcWorkerSignals()
         self._store = store
+        self._reader_closers = reader_closers
+
+    def _handle_contention(self) -> None:
+        for closer in self._reader_closers:
+            closer()
 
     def run(self) -> None:
         more = False
         error: str | None = None
         try:
-            more = self._store.collect_garbage(max_objects=1)
+            more = self._store.collect_garbage(
+                max_objects=1,
+                on_contention=self._handle_contention,
+            )
         except Exception:
             error = traceback.format_exc()
         self.signals.finished.emit(more, error)
@@ -208,6 +240,33 @@ class _WorkspaceSaver:
     ) -> None:
         self._manager = manager
         self._controller = controller
+
+    def _workspace_reader_closers(
+        self, fname: str | os.PathLike[str]
+    ) -> tuple[Callable[[], None], ...]:
+        """Return reusable closers for displayed data from one workspace."""
+        target = workspace_arrays._normalized_file_path(fname)
+        if target is None:
+            return ()
+        closers: list[Callable[[], None]] = []
+        seen: set[int] = set()
+        for node in self._manager._tool_graph.nodes.values():
+            if node.imagetool is None:
+                continue
+            if target not in workspace_arrays.dataarray_source_paths(
+                node.slicer_area._data
+            ):
+                continue
+            closer = node.slicer_area._data_resource_close_callback()
+            if closer is None or id(closer) in seen:
+                continue
+            seen.add(id(closer))
+            closers.append(closer)
+        return tuple(closers)
+
+    def _close_workspace_idle_readers(self, fname: str | os.PathLike[str]) -> None:
+        for closer in self._workspace_reader_closers(fname):
+            closer()
 
     @staticmethod
     def _serialized_tool_data_references(
@@ -657,6 +716,7 @@ class _WorkspaceSaver:
                 self._manager._workspace_state.dirty_generation,
                 fname=fname,
             )
+            self._close_workspace_idle_readers(fname)
             target_store = workspace_store.WorkspaceStore.active(fname)
             if target_store is None:
                 target_store = workspace_store.WorkspaceStore(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_state.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_state.py
@@ -34,6 +34,9 @@ class _WorkspaceDirtyEvent:
     added: bool = False
     removed: str | None = None
     structure: str | None = None
+    layout: bool = False
+    options: bool = False
+    context: bool = False
 
 
 class _WorkspaceStateSnapshot(typing.TypedDict):
@@ -123,6 +126,15 @@ class _ManagerWorkspaceState:
             self.structure_reasons.append(event.structure)
             self.structure_modified = True
             dirty_changed = True
+        if event.layout and not self.layout_modified:
+            self.layout_modified = True
+            dirty_changed = True
+        if event.options and not self.options_modified:
+            self.options_modified = True
+            dirty_changed = True
+        if event.context and not self.context_modified:
+            self.context_modified = True
+            dirty_changed = True
         return dirty_changed
 
     def mark_dirty(self, event: _WorkspaceDirtyEvent) -> bool:
@@ -133,6 +145,9 @@ class _ManagerWorkspaceState:
                 event.uid is not None
                 or event.removed is not None
                 or event.structure is not None
+                or event.layout
+                or event.options
+                or event.context
             )
         ):
             self.dirty_generation = event.generation
@@ -141,34 +156,28 @@ class _ManagerWorkspaceState:
         return False
 
     def mark_layout_dirty(self) -> bool:
-        if self.layout_modified:
-            if self.save_in_progress:
-                self.dirty_generation += 1
-                return True
-            return False
-        self.layout_modified = True
-        self.dirty_generation += 1
-        return True
+        return self.mark_dirty(
+            _WorkspaceDirtyEvent(
+                generation=self.dirty_generation + 1,
+                layout=True,
+            )
+        )
 
     def mark_options_dirty(self) -> bool:
-        if self.options_modified:
-            if self.save_in_progress:
-                self.dirty_generation += 1
-                return True
-            return False
-        self.options_modified = True
-        self.dirty_generation += 1
-        return True
+        return self.mark_dirty(
+            _WorkspaceDirtyEvent(
+                generation=self.dirty_generation + 1,
+                options=True,
+            )
+        )
 
     def mark_context_dirty(self) -> bool:
-        if self.context_modified:
-            if self.save_in_progress:
-                self.dirty_generation += 1
-                return True
-            return False
-        self.context_modified = True
-        self.dirty_generation += 1
-        return True
+        return self.mark_dirty(
+            _WorkspaceDirtyEvent(
+                generation=self.dirty_generation + 1,
+                context=True,
+            )
+        )
 
     def mark_clean(self) -> None:
         self.structure_modified = False

--- a/src/erlab/interactive/imagetool/manager/_workspace/_state.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_state.py
@@ -40,7 +40,6 @@ class _WorkspaceStateSnapshot(typing.TypedDict):
     path: pathlib.Path | None
     document_id: str
     link_id: str
-    needs_full_save: bool
     node_uid_counter: int
     structure_modified: bool
     dirty_added: frozenset[str]
@@ -56,10 +55,6 @@ class _WorkspaceStateSnapshot(typing.TypedDict):
     metadata_editor_layout: dict[str, typing.Any]
     dirty_generation: int
     dirty_events: tuple[_WorkspaceDirtyEvent, ...]
-    delta_save_count: int
-    estimated_obsolete_bytes: int
-    replacement_delta_count: int
-    repack_estimate_known: bool
     schema_version: int
 
 
@@ -84,14 +79,9 @@ class _ManagerWorkspaceState:
         self.context_modified: bool = False
         self.acquisition_context: dict[str, typing.Any] = {}
         self.metadata_editor_layout: dict[str, typing.Any] = {}
-        self.needs_full_save: bool = False
         self.dirty_generation: int = 0
         self.dirty_events: list[_WorkspaceDirtyEvent] = []
         self.save_in_progress: bool = False
-        self.delta_save_count: int = 0
-        self.estimated_obsolete_bytes: int = 0
-        self.replacement_delta_count: int = 0
-        self.repack_estimate_known: bool = True
         self.schema_version: int = _current_workspace_schema_version()
         self.lock: QtCore.QLockFile | None = None
         self.closing_document: bool = False
@@ -192,22 +182,6 @@ class _ManagerWorkspaceState:
         self.structure_reasons.clear()
         self.dirty_events.clear()
 
-    def reset_repack_estimate(self) -> None:
-        self.estimated_obsolete_bytes = 0
-        self.replacement_delta_count = 0
-        self.repack_estimate_known = True
-
-    def set_repack_estimate(
-        self,
-        *,
-        estimated_obsolete_bytes: int,
-        replacement_delta_count: int,
-        known: bool = True,
-    ) -> None:
-        self.estimated_obsolete_bytes = max(0, int(estimated_obsolete_bytes))
-        self.replacement_delta_count = max(0, int(replacement_delta_count))
-        self.repack_estimate_known = known
-
     def advance_document_identity(self) -> None:
         self.document_id = uuid.uuid4().hex
 
@@ -224,7 +198,6 @@ class _ManagerWorkspaceState:
             "path": self.path,
             "document_id": self.document_id,
             "link_id": self.link_id,
-            "needs_full_save": self.needs_full_save,
             "node_uid_counter": node_uid_counter,
             "structure_modified": self.structure_modified,
             "dirty_added": frozenset(self.dirty_added),
@@ -240,10 +213,6 @@ class _ManagerWorkspaceState:
             "metadata_editor_layout": copy.deepcopy(self.metadata_editor_layout),
             "dirty_generation": self.dirty_generation,
             "dirty_events": tuple(self.dirty_events),
-            "delta_save_count": self.delta_save_count,
-            "estimated_obsolete_bytes": self.estimated_obsolete_bytes,
-            "replacement_delta_count": self.replacement_delta_count,
-            "repack_estimate_known": self.repack_estimate_known,
             "schema_version": self.schema_version,
         }
 
@@ -251,7 +220,6 @@ class _ManagerWorkspaceState:
         self.path = snapshot["path"]
         self.document_id = snapshot["document_id"]
         self.link_id = snapshot["link_id"]
-        self.needs_full_save = snapshot["needs_full_save"]
         self.structure_modified = snapshot["structure_modified"]
         self.dirty_added = set(snapshot["dirty_added"])
         self.dirty_data = set(snapshot["dirty_data"])
@@ -266,9 +234,5 @@ class _ManagerWorkspaceState:
         self.metadata_editor_layout = copy.deepcopy(snapshot["metadata_editor_layout"])
         self.dirty_generation = snapshot["dirty_generation"]
         self.dirty_events = list(snapshot["dirty_events"])
-        self.delta_save_count = snapshot["delta_save_count"]
-        self.estimated_obsolete_bytes = snapshot["estimated_obsolete_bytes"]
-        self.replacement_delta_count = snapshot["replacement_delta_count"]
-        self.repack_estimate_known = snapshot["repack_estimate_known"]
         self.schema_version = snapshot["schema_version"]
         return self.dirty_added | self.dirty_data | self.dirty_state

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -81,7 +81,7 @@ def _workspace_generation_copy_source(
     active_store = workspace_store.WorkspaceStore.active(path)
     if active_store is not None:
         with active_store.lock:
-            yield active_store.h5_file
+            yield active_store.read_h5_file
         return
     workspace_arrays.ensure_workspace_hdf5_filters_registered()
     with workspace_arrays._workspace_file_lock(path), h5py.File(path, "r") as h5_file:
@@ -258,13 +258,23 @@ def _compact_workspace_store(store: workspace_store.WorkspaceStore) -> None:
                     )
                 compacted.flush(durable=True)
 
-            store.replace_from(
-                prepared_path,
-                lambda source, destination: _replace_workspace_file(
+            expected_identity = expected_state[1:3]
+
+            def _publish_compacted_workspace(
+                source: pathlib.Path, destination: pathlib.Path
+            ) -> None:
+                closed_state = _workspace_publication_state(destination)
+                if not closed_state[0] or closed_state[1:3] != expected_identity:
+                    raise _WorkspacePublicationConflictError(destination)
+                _replace_workspace_file(
                     source,
                     destination,
-                    expected_state=_workspace_publication_state(destination),
-                ),
+                    expected_state=closed_state,
+                )
+
+            store.replace_from(
+                prepared_path,
+                _publish_compacted_workspace,
                 before_close=lambda: _require_workspace_publication_state(
                     workspace_path, expected_state
                 ),

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -129,7 +129,7 @@ def _write_workspace_generation(
     compression_mode: WorkspaceCompressionMode,
 ) -> workspace_store._WorkspaceGeneration:
     """Write new immutable objects and publish one generation."""
-    with target_store.write_lock:
+    with target_store.write_session():
         created_object_ids: list[str] = []
         try:
             with target_store.lock:
@@ -211,9 +211,14 @@ def _compact_workspace_store(store: workspace_store.WorkspaceStore) -> None:
             legacy_group_paths = store.leased_legacy_group_paths
             expected_state = _workspace_publication_state(workspace_path)
 
-            with workspace_store.WorkspaceStore(
-                prepared_path, create=True
-            ) as compacted:
+            with (
+                workspace_store.WorkspaceStore(
+                    prepared_path,
+                    create=True,
+                    workspace_id=store.workspace_id,
+                ) as compacted,
+                compacted.write_session(),
+            ):
                 with compacted.lock:
                     for group_path in sorted(legacy_group_paths):
                         copied = workspace_arrays._copy_workspace_h5_group_to_open_file(
@@ -627,7 +632,13 @@ def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
             return
         if not _workspace_path_is_itws(fname):
             return
-        with h5py.File(fname, "a") as h5_file:
+        active_store = workspace_store.WorkspaceStore.active(fname)
+        file_context = (
+            active_store.write_session()
+            if active_store is not None
+            else h5py.File(fname, "a")
+        )
+        with file_context as h5_file:
             if not _workspace_file_is_workspace(h5_file):
                 return
             for name in list(h5_file):

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -27,7 +27,7 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Collection, Iterator, Mapping
+    from collections.abc import Callable, Iterator, Mapping
 
     import h5py
     import xarray as xr
@@ -196,8 +196,9 @@ def _write_workspace_generation(
 def _compact_workspace_store(
     store: workspace_store.WorkspaceStore,
     *,
-    discard_serialized_object_ids: Collection[str] = (),
-    discard_serialized_legacy_group_paths: Collection[str] = (),
+    discard_serialized_reader_pins: (
+        workspace_store._SerializedReaderPinSnapshot | None
+    ) = None,
 ) -> None:
     """Rewrite a workspace while omitting confirmed obsolete reader pins."""
     workspace_path = store.path
@@ -214,13 +215,21 @@ def _compact_workspace_store(
             baseline_manifest.pop("repack_estimate_known", None)
             object_ids = set(store.manifest_object_ids(baseline_manifest))
             object_ids.update(store.leased_object_ids)
+            serialized_pins = store.serialized_reader_pin_snapshot()
+            discarded_pins = (
+                discard_serialized_reader_pins
+                or workspace_store._SerializedReaderPinSnapshot({}, {})
+            )
             object_ids.update(
-                store.serialized_object_ids - set(discard_serialized_object_ids)
+                object_id
+                for object_id, version in serialized_pins.object_versions.items()
+                if version > discarded_pins.object_versions.get(object_id, -1)
             )
-            legacy_group_paths = store.leased_legacy_group_paths | (
-                store.serialized_legacy_group_paths
-                - set(discard_serialized_legacy_group_paths)
-            )
+            legacy_group_paths = store.leased_legacy_group_paths | {
+                group_path
+                for group_path, version in serialized_pins.legacy_group_versions.items()
+                if version > discarded_pins.legacy_group_versions.get(group_path, -1)
+            }
             expected_state = _workspace_publication_state(workspace_path)
 
             with (

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -1,4 +1,4 @@
-"""Low-level storage, locking, and transaction mechanics for workspaces."""
+"""Immutable workspace generations and legacy transaction recovery."""
 
 from __future__ import annotations
 
@@ -8,10 +8,8 @@ import errno
 import json
 import os
 import pathlib
-import shutil
 import stat
 import sys
-import tempfile
 import time
 import typing
 import uuid
@@ -19,21 +17,18 @@ from dataclasses import dataclass
 
 from qtpy import QtCore
 
-import erlab
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 from erlab.interactive.imagetool.manager._workspace._format import (
     _WORKSPACE_BACKUP_GROUP_PREFIX,
     _WORKSPACE_PENDING_GROUP_PREFIX,
-    _WORKSPACE_SCHEMA_VERSION,
     _WORKSPACE_TRANSACTION_GROUP_PREFIX,
-    _WORKSPACE_TRANSACTION_PROTOCOL,
-    _compacted_workspace_root_attrs,
     _workspace_file_is_workspace,
     _workspace_path_is_itws,
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Mapping
+    from collections.abc import Iterator, Mapping
 
     import h5py
     import xarray as xr
@@ -45,10 +40,225 @@ else:
     h5py = _lazy.load("h5py")
 
 
-_WorkspaceCopyGroup: typing.TypeAlias = tuple[str, str, dict[str, typing.Any] | None]
-_WorkspaceCopyGroupWithSource: typing.TypeAlias = tuple[
-    str, str, str, dict[str, typing.Any] | None
-]
+@dataclass(frozen=True)
+class _WorkspaceObjectWrite:
+    """One immutable payload object required by a generation."""
+
+    object_id: str
+    dataset: xr.Dataset | None = None
+    source_file: str | None = None
+    source_path: str | None = None
+
+
+@dataclass(frozen=True)
+class _WorkspaceGroupCopy:
+    """One live old-format group that a new document must preserve."""
+
+    source_file: str
+    source_path: str
+    target_path: str
+
+
+@dataclass(frozen=True)
+class _WorkspaceGenerationPlan:
+    """A complete manifest and the new objects that it references."""
+
+    manifest: dict[str, typing.Any]
+    objects: tuple[_WorkspaceObjectWrite, ...]
+    preserved_groups: tuple[_WorkspaceGroupCopy, ...] = ()
+
+
+@contextlib.contextmanager
+def _workspace_generation_copy_source(
+    path: str | os.PathLike[str],
+) -> Iterator[typing.Any]:
+    active_store = workspace_store.WorkspaceStore.active(path)
+    if active_store is not None:
+        with active_store.lock:
+            yield active_store.h5_file
+        return
+    workspace_arrays.ensure_workspace_hdf5_filters_registered()
+    with workspace_arrays._workspace_file_lock(path), h5py.File(path, "r") as h5_file:
+        yield h5_file
+
+
+def _copy_workspace_group(
+    target_store: workspace_store.WorkspaceStore,
+    *,
+    source_file: str,
+    source_path: str,
+    target_path: str,
+) -> None:
+    try:
+        with (
+            _workspace_generation_copy_source(source_file) as source_h5_file,
+            target_store.lock,
+        ):
+            copied = workspace_arrays._copy_workspace_h5_group_to_open_file(
+                source_h5_file,
+                target_store.h5_file,
+                source_path,
+                target_path,
+                None,
+            )
+    except Exception as exc:
+        with target_store.lock:
+            workspace_arrays._delete_h5_path(target_store.h5_file, target_path)
+            target_store.h5_file.flush()
+        if isinstance(exc, FileNotFoundError):
+            raise _WorkspaceBackingFileNotFoundError(source_file) from exc
+        raise
+    if not copied:
+        with target_store.lock:
+            workspace_arrays._delete_h5_path(target_store.h5_file, target_path)
+            target_store.h5_file.flush()
+        raise KeyError(
+            f"Workspace payload group {source_path!r} is missing from {source_file!r}"
+        )
+
+
+def _write_workspace_generation(
+    target_store: workspace_store.WorkspaceStore,
+    plan: _WorkspaceGenerationPlan,
+    *,
+    compression_mode: WorkspaceCompressionMode,
+) -> workspace_store._WorkspaceGeneration:
+    """Write new immutable objects and publish one generation."""
+    with target_store.write_lock:
+        with target_store.lock:
+            target_store.require_current_path()
+        for item in plan.preserved_groups:
+            with target_store.lock:
+                if item.target_path.strip("/") in target_store.h5_file:
+                    continue
+            _copy_workspace_group(
+                target_store,
+                source_file=item.source_file,
+                source_path=item.source_path,
+                target_path=item.target_path,
+            )
+        for item in plan.objects:
+            target_path = target_store.object_path(item.object_id)
+            with target_store.lock:
+                if target_path.strip("/") in target_store.h5_file:
+                    continue
+            if item.dataset is not None:
+                try:
+                    if workspace_arrays._workspace_dataset_can_write_h5py(item.dataset):
+                        with target_store.lock:
+                            workspace_arrays._write_workspace_dataset_group_to_file(
+                                target_store.h5_file,
+                                target_path,
+                                item.dataset,
+                                compression_mode=compression_mode,
+                            )
+                    else:
+                        workspace_arrays._write_workspace_dataset_group_to_file(
+                            target_store.h5_file,
+                            target_path,
+                            item.dataset,
+                            compression_mode=compression_mode,
+                        )
+                except Exception:
+                    with target_store.lock:
+                        workspace_arrays._delete_h5_path(
+                            target_store.h5_file, target_path
+                        )
+                        target_store.h5_file.flush()
+                    raise
+                continue
+            if item.source_file is None or item.source_path is None:
+                raise ValueError(f"Workspace object {item.object_id!r} has no source")
+            _copy_workspace_group(
+                target_store,
+                source_file=item.source_file,
+                source_path=item.source_path,
+                target_path=target_path,
+            )
+        return target_store.publish(plan.manifest)
+
+
+def _compact_workspace_store(store: workspace_store.WorkspaceStore) -> None:
+    """Rewrite an open workspace with only its current and leased objects."""
+    workspace_path = store.path
+    prepared_path = workspace_path.with_name(
+        f".{workspace_path.name}.compact-{uuid.uuid4().hex}"
+    )
+    try:
+        with store.write_lock, store.lock:
+            current = store.current_generation()
+            baseline_manifest = dict(current.manifest)
+            baseline_manifest.pop("delta_save_count", None)
+            baseline_manifest.pop("estimated_obsolete_bytes", None)
+            baseline_manifest.pop("replacement_delta_count", None)
+            baseline_manifest.pop("repack_estimate_known", None)
+            object_ids = set(store.manifest_object_ids(baseline_manifest))
+            object_ids.update(store.leased_object_ids)
+            legacy_group_paths = store.leased_legacy_group_paths
+            expected_state = _workspace_publication_state(workspace_path)
+
+            with workspace_store.WorkspaceStore(
+                prepared_path, create=True
+            ) as compacted:
+                with compacted.lock:
+                    for group_path in sorted(legacy_group_paths):
+                        copied = workspace_arrays._copy_workspace_h5_group_to_open_file(
+                            store.h5_file,
+                            compacted.h5_file,
+                            group_path,
+                            group_path,
+                            None,
+                        )
+                        if not copied:
+                            raise KeyError(
+                                f"Workspace payload group {group_path!r} is missing"
+                            )
+                    for object_id in sorted(object_ids):
+                        object_path = store.object_path(object_id)
+                        copied = workspace_arrays._copy_workspace_h5_group_to_open_file(
+                            store.h5_file,
+                            compacted.h5_file,
+                            object_path,
+                            object_path,
+                            None,
+                        )
+                        if not copied:
+                            raise KeyError(f"Workspace object {object_id!r} is missing")
+                compacted.publish(baseline_manifest)
+                compacted.publish(baseline_manifest)
+                generations = compacted.generations()
+                if (
+                    len(generations) != 2
+                    or generations[0].manifest != generations[1].manifest
+                ):
+                    raise RuntimeError(
+                        "Compacted workspace baseline generations do not match"
+                    )
+                if any(
+                    compacted.object_path(object_id).strip("/") not in compacted.h5_file
+                    for object_id in object_ids
+                ):
+                    raise RuntimeError(
+                        "Compacted workspace is missing a payload object"
+                    )
+                compacted.flush(durable=True)
+
+            store.replace_from(
+                prepared_path,
+                lambda source, destination: _replace_workspace_file(
+                    source,
+                    destination,
+                    expected_state=_workspace_publication_state(destination),
+                ),
+                before_close=lambda: _require_workspace_publication_state(
+                    workspace_path, expected_state
+                ),
+            )
+    finally:
+        with contextlib.suppress(OSError):
+            prepared_path.unlink()
+
+
 _WorkspacePublicationState: typing.TypeAlias = tuple[bool, int, int, int, int, int]
 _WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
 
@@ -107,12 +317,15 @@ def _replace_workspace_file(
     source: str | os.PathLike[str],
     destination: str | os.PathLike[str],
     *,
-    expected_state: _WorkspacePublicationState,
+    expected_state: _WorkspacePublicationState | None,
 ) -> None:
     """Publish a prepared workspace with bounded Windows sharing retries."""
     retry_delays = iter(_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS)
     while True:
-        if _workspace_publication_state(destination) != expected_state:
+        if (
+            expected_state is not None
+            and _workspace_publication_state(destination) != expected_state
+        ):
             raise _WorkspacePublicationConflictError(destination)
         try:
             os.replace(source, destination)
@@ -126,6 +339,13 @@ def _replace_workspace_file(
             time.sleep(delay)
         else:
             return
+
+
+def _require_workspace_publication_state(
+    path: str | os.PathLike[str], expected_state: _WorkspacePublicationState
+) -> None:
+    if _workspace_publication_state(path) != expected_state:
+        raise _WorkspacePublicationConflictError(path)
 
 
 @dataclass(frozen=True)
@@ -245,83 +465,6 @@ def _acquire_workspace_document_lock(
         )
     _hide_workspace_lock_file(lock_path)
     return lock
-
-
-def _workspace_path_is_unc(path: str | os.PathLike[str]) -> bool:
-    path_str = os.fsdecode(path)
-    return path_str.startswith(("\\\\", "//"))
-
-
-def _workspace_path_is_likely_cloud_path(path: str | os.PathLike[str]) -> bool:
-    cloud_markers = {
-        "com~apple~clouddocs",
-        "dropbox",
-        "google drive",
-        "icloud drive",
-        "icloud~com~apple~clouddocs",
-        "mobile documents",
-        "onedrive",
-        "one drive",
-    }
-    try:
-        parts = pathlib.Path(path).resolve().parts
-    except OSError:
-        parts = pathlib.Path(path).absolute().parts
-    normalized_parts = {part.casefold().replace("-", " ") for part in parts}
-    return any(marker in part for part in normalized_parts for marker in cloud_markers)
-
-
-def _workspace_path_is_likely_network_path(path: str | os.PathLike[str]) -> bool:
-    if _workspace_path_is_unc(path):
-        return True
-    try:
-        resolved = pathlib.Path(path).resolve()
-    except OSError:
-        resolved = pathlib.Path(path).absolute()
-    parts = resolved.parts
-    if sys.platform == "darwin" and len(parts) > 2 and parts[1] == "Volumes":
-        return True
-    return len(parts) > 1 and parts[1] in {"net", "nfs", "smb"}
-
-
-def _workspace_path_is_high_risk(path: str | os.PathLike[str]) -> bool:
-    return _workspace_path_is_likely_network_path(
-        path
-    ) or _workspace_path_is_likely_cloud_path(path)
-
-
-def _workspace_use_incremental_enabled() -> bool:
-    return bool(erlab.interactive.options.model.io.workspace.use_incremental)
-
-
-def _workspace_incremental_save_on_remote_enabled() -> bool:
-    return bool(erlab.interactive.options.model.io.workspace.incremental_save_on_remote)
-
-
-def _workspace_requires_full_save(
-    fname: str | os.PathLike[str],
-    *,
-    needs_full_save: bool,
-    schema_version: int,
-    structure_modified: bool,
-    has_dirty_added: bool,
-    has_dirty_removed: bool,
-) -> bool:
-    if not _workspace_use_incremental_enabled():
-        return True
-    if (
-        not _workspace_incremental_save_on_remote_enabled()
-        and _workspace_path_is_high_risk(fname)
-    ):
-        return True
-    return (
-        needs_full_save
-        or not pathlib.Path(fname).exists()
-        or schema_version != _WORKSPACE_SCHEMA_VERSION
-        or structure_modified
-        or has_dirty_added
-        or has_dirty_removed
-    )
 
 
 def _workspace_txn_attr_target(h5_file, target_path: str):
@@ -473,491 +616,3 @@ def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
                     _recover_open_workspace_transaction(h5_file, name)
             _cleanup_orphan_workspace_internal_groups(h5_file)
             h5_file.flush()
-
-
-def _write_root_attrs_to_open_workspace_file(
-    h5_file,
-    attrs: Mapping[str, typing.Any],
-    *,
-    replace: bool = False,
-) -> None:
-    if replace:
-        for key in list(h5_file.attrs):
-            del h5_file.attrs[key]
-    for key, value in attrs.items():
-        h5_file.attrs[key] = value
-
-
-def _write_workspace_root_attrs_to_file(
-    fname: str | os.PathLike[str],
-    attrs: Mapping[str, typing.Any],
-    *,
-    replace: bool = False,
-) -> None:
-    with (
-        workspace_arrays._workspace_save_lock(fname),
-        _open_workspace_h5_file_for_update(fname) as h5_file,
-    ):
-        _write_root_attrs_to_open_workspace_file(h5_file, attrs, replace=replace)
-
-
-def _workspace_obsolete_estimate(
-    fname: str | os.PathLike[str],
-) -> int:
-    try:
-        file_size = pathlib.Path(fname).stat().st_size
-    except OSError:
-        return 0
-    live_storage_size = workspace_arrays._workspace_live_h5_storage_size(fname)
-    return max(0, int(file_size) - live_storage_size)
-
-
-def _workspace_file_repack_payload(
-    fname: str | os.PathLike[str],
-) -> tuple[
-    dict[str, typing.Any],
-    tuple[tuple[str, str, dict[str, typing.Any] | None], ...],
-    _WorkspacePublicationState,
-]:
-    with workspace_arrays._workspace_save_lock(fname):
-        _recover_workspace_transactions(fname)
-        expected_state = _workspace_publication_state(fname)
-        root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
-        copy_groups = workspace_arrays._workspace_live_root_group_copy_groups(fname)
-        if _workspace_publication_state(fname) != expected_state:
-            raise _WorkspacePublicationConflictError(fname)
-        return (
-            _compacted_workspace_root_attrs(root_attrs),
-            copy_groups,
-            expected_state,
-        )
-
-
-def _write_workspace_constructor_groups_to_pending(
-    fname: str | os.PathLike[str],
-    constructor: Mapping[str, xr.Dataset],
-    group_path: str,
-    pending_path: str,
-    *,
-    compression_mode: WorkspaceCompressionMode | None = None,
-) -> None:
-    target_group_path = group_path.strip("/")
-    pending_path = pending_path.strip("/")
-    for constructor_group_path, ds in sorted(
-        constructor.items(), key=lambda item: item[0].count("/")
-    ):
-        source_group_path = constructor_group_path.strip("/")
-        if source_group_path != target_group_path and not source_group_path.startswith(
-            f"{target_group_path}/"
-        ):
-            continue
-        relative_path = source_group_path.removeprefix(target_group_path).strip("/")
-        pending_group_path = (
-            pending_path if not relative_path else f"{pending_path}/{relative_path}"
-        )
-        workspace_arrays._write_workspace_dataset_group_to_file(
-            fname,
-            pending_group_path,
-            ds,
-            lock_path=fname,
-            compression_mode=compression_mode,
-        )
-
-
-def _path_is_at_or_under(path: str, root_path: str) -> bool:
-    path = path.strip("/")
-    root_path = root_path.strip("/")
-    return path == root_path or path.startswith(f"{root_path}/")
-
-
-def _move_h5_path(h5_file, source_path: str, destination_path: str) -> None:
-    workspace_arrays._ensure_h5_parent_group(h5_file, destination_path)
-    h5_file.move(source_path.strip("/"), destination_path.strip("/"))
-
-
-def _set_workspace_transaction_status(h5_file, txn_path: str, status: str) -> None:
-    h5_file[txn_path].attrs["status"] = status
-    h5_file.flush()
-
-
-def _prepare_workspace_transaction(
-    fname: str | os.PathLike[str],
-    txn_path: str,
-    pending_root: str,
-    backup_root: str,
-    rewrite_map: dict[str, tuple[str, dict[str, xr.Dataset]]],
-    attr_updates: tuple[
-        tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]], ...
-    ],
-    root_attrs: Mapping[str, typing.Any],
-) -> tuple[
-    list[dict[str, typing.Any]],
-    list[tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]],
-]:
-    attr_updates_to_write: list[
-        tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
-    ] = []
-    with _open_workspace_h5_file_for_update(fname) as h5_file:
-        txn_group = h5_file.create_group(txn_path)
-        txn_group.attrs["protocol"] = _WORKSPACE_TRANSACTION_PROTOCOL
-        txn_group.attrs["status"] = "preparing"
-        txn_group.attrs["pending_root"] = pending_root
-        txn_group.attrs["backup_root"] = backup_root
-
-        attr_backup_index = 0
-        for payload_path, attrs, fallback in attr_updates:
-            attr_path = payload_path.strip("/")
-            if any(
-                _path_is_at_or_under(attr_path, rewrite_path)
-                for rewrite_path in rewrite_map
-            ):
-                continue
-            if attr_path in h5_file:
-                _write_workspace_attr_backup(
-                    txn_group,
-                    attr_backup_index,
-                    payload_path,
-                    h5_file[attr_path].attrs,
-                )
-                attr_backup_index += 1
-                attr_updates_to_write.append((payload_path, attrs, fallback))
-            else:
-                fallback_path = fallback[0].strip("/")
-                if not any(
-                    _path_is_at_or_under(fallback_path, rewrite_path)
-                    for rewrite_path in rewrite_map
-                ):
-                    rewrite_map[fallback_path] = fallback
-
-        _write_workspace_attr_backup(txn_group, attr_backup_index, "/", h5_file.attrs)
-
-        group_operations: list[dict[str, typing.Any]] = []
-        for group_path in sorted(rewrite_map):
-            pending_path = f"{pending_root}/{group_path}"
-            backup_path = f"{backup_root}/{group_path}"
-            group_operations.append(
-                {
-                    "group_path": group_path,
-                    "pending_path": pending_path,
-                    "backup_path": backup_path,
-                    "old_exists": workspace_arrays._h5_path_exists(h5_file, group_path),
-                }
-            )
-        txn_group.attrs["operations"] = json.dumps(
-            {"group_replacements": group_operations}
-        )
-        h5_file.flush()
-    return group_operations, attr_updates_to_write
-
-
-def _write_workspace_transaction_pending_groups(
-    fname: str | os.PathLike[str],
-    rewrite_map: Mapping[str, tuple[str, dict[str, xr.Dataset]]],
-    pending_root: str,
-    *,
-    compression_mode: WorkspaceCompressionMode | None = None,
-) -> None:
-    try:
-        for group_path, (rewrite_group_path, constructor) in sorted(
-            rewrite_map.items()
-        ):
-            pending_group_path = f"{pending_root}/{group_path}"
-            _write_workspace_constructor_groups_to_pending(
-                fname,
-                constructor,
-                rewrite_group_path,
-                pending_group_path,
-                compression_mode=compression_mode,
-            )
-    except Exception:
-        with _open_workspace_h5_file_for_update(fname) as h5_file:
-            workspace_arrays._delete_h5_path(h5_file, pending_root)
-            h5_file.flush()
-        raise
-
-
-def _commit_workspace_transaction(
-    fname: str | os.PathLike[str],
-    txn_path: str,
-    group_operations: Iterable[Mapping[str, typing.Any]],
-    attr_updates: Iterable[
-        tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
-    ],
-    root_attrs: Mapping[str, typing.Any],
-) -> None:
-    with _open_workspace_h5_file_for_update(fname) as h5_file:
-        _set_workspace_transaction_status(h5_file, txn_path, "committing")
-        for operation in group_operations:
-            group_path = typing.cast("str", operation["group_path"])
-            pending_path = typing.cast("str", operation["pending_path"])
-            backup_path = typing.cast("str", operation["backup_path"])
-            if not workspace_arrays._h5_path_exists(h5_file, pending_path):
-                raise KeyError(
-                    f"Workspace pending group {pending_path!r} was not written"
-                )
-            if workspace_arrays._h5_path_exists(h5_file, group_path):
-                _move_h5_path(h5_file, group_path, backup_path)
-            _move_h5_path(h5_file, pending_path, group_path)
-
-        for payload_path, attrs, _fallback in attr_updates:
-            target_attrs = _workspace_txn_attr_target(h5_file, payload_path)
-            if target_attrs is not None:
-                workspace_arrays._replace_h5_attrs(target_attrs, attrs)
-
-        _write_root_attrs_to_open_workspace_file(h5_file, root_attrs)
-        _set_workspace_transaction_status(h5_file, txn_path, "committed")
-
-
-def _write_workspace_transaction_file(
-    fname: str | os.PathLike[str],
-    rewrite_groups: Iterable[tuple[str, dict[str, xr.Dataset]]],
-    attr_updates: Iterable[
-        tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
-    ],
-    root_attrs: Mapping[str, typing.Any],
-    *,
-    compression_mode: WorkspaceCompressionMode | None = None,
-    expected_state: _WorkspacePublicationState | None = None,
-) -> None:
-    with workspace_arrays._workspace_save_lock(fname):
-        _write_workspace_transaction_file_locked(
-            fname,
-            rewrite_groups,
-            attr_updates,
-            root_attrs,
-            compression_mode=compression_mode,
-            expected_state=expected_state,
-        )
-
-
-def _write_workspace_transaction_file_locked(
-    fname: str | os.PathLike[str],
-    rewrite_groups: Iterable[tuple[str, dict[str, xr.Dataset]]],
-    attr_updates: Iterable[
-        tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
-    ],
-    root_attrs: Mapping[str, typing.Any],
-    *,
-    compression_mode: WorkspaceCompressionMode | None = None,
-    expected_state: _WorkspacePublicationState | None = None,
-) -> None:
-    if (
-        expected_state is not None
-        and _workspace_publication_state(fname) != expected_state
-    ):
-        raise _WorkspacePublicationConflictError(fname)
-    _recover_workspace_transactions(fname)
-    rewrite_map = {
-        group_path.strip("/"): (group_path, constructor)
-        for group_path, constructor in rewrite_groups
-    }
-    attr_updates_tuple = tuple(attr_updates)
-    txn_id = uuid.uuid4().hex
-    txn_path = f"{_WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
-    pending_root = f"{_WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
-    backup_root = f"{_WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
-    group_operations, attr_updates_to_write = _prepare_workspace_transaction(
-        fname,
-        txn_path,
-        pending_root,
-        backup_root,
-        rewrite_map,
-        attr_updates_tuple,
-        root_attrs,
-    )
-    try:
-        _write_workspace_transaction_pending_groups(
-            fname,
-            rewrite_map,
-            pending_root,
-            compression_mode=compression_mode,
-        )
-        _commit_workspace_transaction(
-            fname,
-            txn_path,
-            group_operations,
-            attr_updates_to_write,
-            root_attrs,
-        )
-    except Exception:
-        _recover_workspace_transactions(fname)
-        raise
-    _recover_workspace_transactions(fname)
-
-
-def _write_full_workspace_tree_file(
-    fname: str | os.PathLike[str],
-    tree: xr.DataTree | None,
-    root_attrs: Mapping[str, typing.Any],
-    *,
-    copy_source: str | os.PathLike[str] | None = None,
-    copy_groups: Iterable[_WorkspaceCopyGroup] = (),
-    copy_group_sources: Iterable[_WorkspaceCopyGroupWithSource] = (),
-    compression_mode: WorkspaceCompressionMode | None = None,
-    expected_state: _WorkspacePublicationState | None = None,
-) -> None:
-    with workspace_arrays._workspace_save_lock(fname):
-        _write_full_workspace_tree_file_locked(
-            fname,
-            tree,
-            root_attrs,
-            copy_source=copy_source,
-            copy_groups=copy_groups,
-            copy_group_sources=copy_group_sources,
-            compression_mode=compression_mode,
-            expected_state=expected_state,
-        )
-
-
-def _write_full_workspace_tree_file_locked(
-    fname: str | os.PathLike[str],
-    tree: xr.DataTree | None,
-    root_attrs: Mapping[str, typing.Any],
-    *,
-    copy_source: str | os.PathLike[str] | None = None,
-    copy_groups: Iterable[_WorkspaceCopyGroup] = (),
-    copy_group_sources: Iterable[_WorkspaceCopyGroupWithSource] = (),
-    compression_mode: WorkspaceCompressionMode | None = None,
-    expected_state: _WorkspacePublicationState | None = None,
-) -> None:
-    fname = os.fsdecode(fname)
-    current_state = _workspace_publication_state(fname)
-    if expected_state is None:
-        expected_state = current_state
-    elif current_state != expected_state:
-        raise _WorkspacePublicationConflictError(fname)
-    use_scratch = _workspace_path_is_high_risk(fname)
-    tmp_dir: tempfile.TemporaryDirectory[str] | None = None
-    destination_tmp: str | None = None
-    if use_scratch:
-        tmp_dir = tempfile.TemporaryDirectory(prefix="erlab-itws-")
-        tmp_fname = str(pathlib.Path(tmp_dir.name) / pathlib.Path(fname).name)
-    else:
-        tmp_fname = f"{fname}.tmp-{uuid.uuid4().hex}"
-    try:
-        copied_paths: set[str] = set()
-        workspace_arrays.ensure_workspace_hdf5_filters_registered()
-        copy_groups_tuple = tuple(copy_groups)
-        copy_group_sources_tuple = tuple(
-            (os.fsdecode(source_file), source_path, destination_path, attrs)
-            for source_file, source_path, destination_path, attrs in copy_group_sources
-        )
-        if use_scratch and _workspace_path_is_likely_network_path(fname):
-            if tree is None and copy_source is not None and copy_groups_tuple:
-                raise ValueError(
-                    "File-level workspace repack cannot run when HDF5 group "
-                    "copy reuse is disabled"
-                )
-            copy_source = None
-            copy_groups_tuple = ()
-
-        copy_jobs_by_source: dict[
-            str, list[tuple[str, str, dict[str, typing.Any] | None, bool]]
-        ] = {}
-        if copy_source is not None and copy_groups_tuple:
-            copy_jobs_by_source[os.fsdecode(copy_source)] = [
-                (source_path, destination_path, attrs, False)
-                for source_path, destination_path, attrs in copy_groups_tuple
-            ]
-        for (
-            source_file,
-            source_path,
-            destination_path,
-            attrs,
-        ) in copy_group_sources_tuple:
-            copy_jobs_by_source.setdefault(source_file, []).append(
-                (source_path, destination_path, attrs, True)
-            )
-
-        with h5py.File(tmp_fname, "w") as tmp_file:
-            _write_root_attrs_to_open_workspace_file(tmp_file, root_attrs, replace=True)
-
-        for source_fname, copy_jobs in copy_jobs_by_source.items():
-            with workspace_arrays._workspace_file_lock(source_fname):
-                try:
-                    source_file = h5py.File(source_fname, "r")
-                except FileNotFoundError as exc:
-                    raise _WorkspaceBackingFileNotFoundError(source_fname) from exc
-                with source_file, h5py.File(tmp_fname, "a") as tmp_file:
-                    for source_path, destination_path, attrs, required in copy_jobs:
-                        destination_path = destination_path.strip("/")
-                        if workspace_arrays._copy_workspace_h5_group_to_open_file(
-                            source_file,
-                            tmp_file,
-                            source_path,
-                            destination_path,
-                            attrs,
-                        ):
-                            copied_paths.add(destination_path)
-                        elif required:
-                            raise ValueError(
-                                "Required workspace payload group "
-                                f"{source_path!r} was not found in {source_fname!r}"
-                            )
-
-        if tree is not None:
-            for node in sorted(tree.subtree, key=lambda value: value.path.count("/")):
-                group_path = node.path.strip("/")
-                if not group_path or group_path in copied_paths:
-                    continue
-                ds = node.to_dataset(inherit=False)
-                if ds.variables or ds.attrs:
-                    workspace_arrays._write_workspace_dataset_group_to_file(
-                        tmp_fname,
-                        group_path,
-                        ds,
-                        compression_mode=compression_mode,
-                    )
-
-        _validate_workspace_h5_file(tmp_fname)
-        _fsync_file(tmp_fname)
-        if use_scratch:
-            try:
-                _replace_workspace_file(tmp_fname, fname, expected_state=expected_state)
-            except OSError as err:
-                if err.errno != errno.EXDEV:
-                    raise
-                destination_tmp = f"{fname}.tmp-{uuid.uuid4().hex}"
-                shutil.copyfile(tmp_fname, destination_tmp)
-                _fsync_file(destination_tmp)
-                _replace_workspace_file(
-                    destination_tmp, fname, expected_state=expected_state
-                )
-            _fsync_parent_directory(fname)
-        else:
-            _replace_workspace_file(tmp_fname, fname, expected_state=expected_state)
-            _fsync_parent_directory(fname)
-    finally:
-        with contextlib.suppress(FileNotFoundError):
-            os.remove(tmp_fname)
-        if destination_tmp is not None:
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(destination_tmp)
-        if tmp_dir is not None:
-            tmp_dir.cleanup()
-
-
-def _validate_workspace_h5_file(fname: str | os.PathLike[str]) -> None:
-    with h5py.File(fname, "r") as h5_file:
-        if not _workspace_file_is_workspace(h5_file):
-            raise ValueError(f"Temporary workspace file is not valid: {fname}")
-
-
-def _fsync_file(fname: str | os.PathLike[str]) -> None:
-    with contextlib.suppress(OSError):
-        fd = os.open(fname, os.O_RDONLY)
-        try:
-            os.fsync(fd)
-        finally:
-            os.close(fd)
-
-
-def _fsync_parent_directory(fname: str | os.PathLike[str]) -> None:
-    if os.name != "posix":
-        return
-    with contextlib.suppress(OSError):
-        fd = os.open(pathlib.Path(fname).parent, os.O_RDONLY)
-        try:
-            os.fsync(fd)
-        finally:
-            os.close(fd)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -27,7 +27,7 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Mapping
+    from collections.abc import Callable, Collection, Iterator, Mapping
 
     import h5py
     import xarray as xr
@@ -193,8 +193,13 @@ def _write_workspace_generation(
             raise
 
 
-def _compact_workspace_store(store: workspace_store.WorkspaceStore) -> None:
-    """Rewrite an open workspace with only its current and leased objects."""
+def _compact_workspace_store(
+    store: workspace_store.WorkspaceStore,
+    *,
+    discard_serialized_object_ids: Collection[str] = (),
+    discard_serialized_legacy_group_paths: Collection[str] = (),
+) -> None:
+    """Rewrite a workspace while omitting confirmed obsolete reader pins."""
     workspace_path = store.path
     prepared_path = workspace_path.with_name(
         f".{workspace_path.name}.compact-{uuid.uuid4().hex}"
@@ -209,9 +214,12 @@ def _compact_workspace_store(store: workspace_store.WorkspaceStore) -> None:
             baseline_manifest.pop("repack_estimate_known", None)
             object_ids = set(store.manifest_object_ids(baseline_manifest))
             object_ids.update(store.leased_object_ids)
-            object_ids.update(store.serialized_object_ids)
-            legacy_group_paths = (
-                store.leased_legacy_group_paths | store.serialized_legacy_group_paths
+            object_ids.update(
+                store.serialized_object_ids - set(discard_serialized_object_ids)
+            )
+            legacy_group_paths = store.leased_legacy_group_paths | (
+                store.serialized_legacy_group_paths
+                - set(discard_serialized_legacy_group_paths)
             )
             expected_state = _workspace_publication_state(workspace_path)
 

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -27,7 +27,7 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
+    from collections.abc import Callable, Iterator, Mapping
 
     import h5py
     import xarray as xr
@@ -79,8 +79,8 @@ def _workspace_generation_copy_source(
 ) -> Iterator[typing.Any]:
     active_store = workspace_store.WorkspaceStore.active(path)
     if active_store is not None:
-        with active_store.lock:
-            yield active_store.read_h5_file
+        with active_store.read_session() as h5_file:
+            yield h5_file
         return
     workspace_arrays.ensure_workspace_hdf5_filters_registered()
     with workspace_arrays._workspace_file_lock(path), h5py.File(path, "r") as h5_file:
@@ -127,9 +127,10 @@ def _write_workspace_generation(
     plan: _WorkspaceGenerationPlan,
     *,
     compression_mode: WorkspaceCompressionMode,
+    on_contention: Callable[[], None] | None = None,
 ) -> workspace_store._WorkspaceGeneration:
     """Write new immutable objects and publish one generation."""
-    with target_store.write_session():
+    with target_store.write_session(on_contention=on_contention):
         created_object_ids: list[str] = []
         try:
             with target_store.lock:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -68,6 +68,12 @@ class _WorkspaceGenerationPlan:
     preserved_groups: tuple[_WorkspaceGroupCopy, ...] = ()
 
 
+def _workspace_object_copy_source(item: _WorkspaceObjectWrite) -> tuple[str, str]:
+    if item.source_file is None or item.source_path is None:
+        raise ValueError(f"Workspace object {item.object_id!r} has no source")
+    return item.source_file, item.source_path
+
+
 @contextlib.contextmanager
 def _workspace_generation_copy_source(
     path: str | os.PathLike[str],
@@ -125,25 +131,27 @@ def _write_workspace_generation(
 ) -> workspace_store._WorkspaceGeneration:
     """Write new immutable objects and publish one generation."""
     with target_store.write_lock:
-        with target_store.lock:
-            target_store.require_current_path()
-        for item in plan.preserved_groups:
+        created_object_ids: list[str] = []
+        try:
             with target_store.lock:
-                if item.target_path.strip("/") in target_store.h5_file:
-                    continue
-            _copy_workspace_group(
-                target_store,
-                source_file=item.source_file,
-                source_path=item.source_path,
-                target_path=item.target_path,
-            )
-        for item in plan.objects:
-            target_path = target_store.object_path(item.object_id)
-            with target_store.lock:
-                if target_path.strip("/") in target_store.h5_file:
-                    continue
-            if item.dataset is not None:
-                try:
+                target_store.require_current_path()
+            for item in plan.preserved_groups:
+                with target_store.lock:
+                    if item.target_path.strip("/") in target_store.h5_file:
+                        continue
+                _copy_workspace_group(
+                    target_store,
+                    source_file=item.source_file,
+                    source_path=item.source_path,
+                    target_path=item.target_path,
+                )
+            for item in plan.objects:
+                target_path = target_store.object_path(item.object_id)
+                with target_store.lock:
+                    if target_path.strip("/") in target_store.h5_file:
+                        continue
+                created_object_ids.append(item.object_id)
+                if item.dataset is not None:
                     if workspace_arrays._workspace_dataset_can_write_h5py(item.dataset):
                         with target_store.lock:
                             workspace_arrays._write_workspace_dataset_group_to_file(
@@ -159,23 +167,30 @@ def _write_workspace_generation(
                             item.dataset,
                             compression_mode=compression_mode,
                         )
-                except Exception:
-                    with target_store.lock:
+                    continue
+                source_file, source_path = _workspace_object_copy_source(item)
+                _copy_workspace_group(
+                    target_store,
+                    source_file=source_file,
+                    source_path=source_path,
+                    target_path=target_path,
+                )
+            return target_store.publish(plan.manifest)
+        except Exception:
+            with contextlib.suppress(Exception), target_store.lock:
+                referenced_object_ids: set[str] = set()
+                for generation in target_store.generations():
+                    referenced_object_ids.update(
+                        target_store.manifest_object_ids(generation.manifest)
+                    )
+                for object_id in created_object_ids:
+                    if object_id not in referenced_object_ids:
                         workspace_arrays._delete_h5_path(
-                            target_store.h5_file, target_path
+                            target_store.h5_file,
+                            target_store.object_path(object_id),
                         )
-                        target_store.h5_file.flush()
-                    raise
-                continue
-            if item.source_file is None or item.source_path is None:
-                raise ValueError(f"Workspace object {item.object_id!r} has no source")
-            _copy_workspace_group(
-                target_store,
-                source_file=item.source_file,
-                source_path=item.source_path,
-                target_path=target_path,
-            )
-        return target_store.publish(plan.manifest)
+                target_store.h5_file.flush()
+            raise
 
 
 def _compact_workspace_store(store: workspace_store.WorkspaceStore) -> None:
@@ -275,7 +290,7 @@ class _WorkspaceBackingFileNotFoundError(FileNotFoundError):
         )
 
 
-class _WorkspacePublicationConflictError(RuntimeError):
+class _WorkspacePublicationConflictError(workspace_store.WorkspaceStoreConflictError):
     """A published workspace changed while a save was in progress."""
 
     def __init__(self, path: str | os.PathLike[str]) -> None:
@@ -338,7 +353,20 @@ def _replace_workspace_file(
                 raise exc from None
             time.sleep(delay)
         else:
+            _fsync_parent_directory(destination)
             return
+
+
+def _fsync_parent_directory(path: str | os.PathLike[str]) -> None:
+    """Ask POSIX to persist a completed directory entry replacement."""
+    if os.name != "posix":
+        return
+    with contextlib.suppress(OSError):
+        file_descriptor = os.open(pathlib.Path(path).parent, os.O_RDONLY)
+        try:
+            os.fsync(file_descriptor)
+        finally:
+            os.close(file_descriptor)
 
 
 def _require_workspace_publication_state(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -10,7 +10,6 @@ import os
 import pathlib
 import stat
 import sys
-import time
 import typing
 import uuid
 from dataclasses import dataclass
@@ -280,12 +279,12 @@ def _compact_workspace_store(store: workspace_store.WorkspaceStore) -> None:
                 ),
             )
     finally:
-        with contextlib.suppress(OSError):
-            prepared_path.unlink()
+        if store.recovery_path != prepared_path:
+            with contextlib.suppress(OSError):
+                prepared_path.unlink()
 
 
 _WorkspacePublicationState: typing.TypeAlias = tuple[bool, int, int, int, int, int]
-_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
 
 
 class _WorkspaceBackingFileNotFoundError(FileNotFoundError):
@@ -329,42 +328,24 @@ def _workspace_publication_state(
     )
 
 
-def _is_retryable_windows_workspace_replace_error(exc: PermissionError) -> bool:
-    if os.name != "nt":
-        return False
-    winerror = getattr(exc, "winerror", None)
-    if winerror is not None:
-        return winerror in {5, 32}
-    return exc.errno in {errno.EACCES, errno.EPERM}
-
-
 def _replace_workspace_file(
     source: str | os.PathLike[str],
     destination: str | os.PathLike[str],
     *,
     expected_state: _WorkspacePublicationState | None,
 ) -> None:
-    """Publish a prepared workspace with bounded Windows sharing retries."""
-    retry_delays = iter(_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS)
-    while True:
+    """Publish a prepared workspace with bounded file-access retries."""
+
+    def _replace() -> None:
         if (
             expected_state is not None
             and _workspace_publication_state(destination) != expected_state
         ):
             raise _WorkspacePublicationConflictError(destination)
-        try:
-            os.replace(source, destination)
-        except PermissionError as exc:
-            if not _is_retryable_windows_workspace_replace_error(exc):
-                raise
-            try:
-                delay = next(retry_delays)
-            except StopIteration:
-                raise exc from None
-            time.sleep(delay)
-        else:
-            _fsync_parent_directory(destination)
-            return
+        os.replace(source, destination)
+
+    workspace_store._retry_file_access(_replace)
+    _fsync_parent_directory(destination)
 
 
 def _fsync_parent_directory(path: str | os.PathLike[str]) -> None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -209,7 +209,10 @@ def _compact_workspace_store(store: workspace_store.WorkspaceStore) -> None:
             baseline_manifest.pop("repack_estimate_known", None)
             object_ids = set(store.manifest_object_ids(baseline_manifest))
             object_ids.update(store.leased_object_ids)
-            legacy_group_paths = store.leased_legacy_group_paths
+            object_ids.update(store.serialized_object_ids)
+            legacy_group_paths = (
+                store.leased_legacy_group_paths | store.serialized_legacy_group_paths
+            )
             expected_state = _workspace_publication_state(workspace_path)
 
             with (

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -12,6 +12,7 @@ import shutil
 import stat
 import sys
 import tempfile
+import time
 import typing
 import uuid
 from dataclasses import dataclass
@@ -48,6 +49,7 @@ _WorkspaceCopyGroup: typing.TypeAlias = tuple[str, str, dict[str, typing.Any] | 
 _WorkspaceCopyGroupWithSource: typing.TypeAlias = tuple[
     str, str, str, dict[str, typing.Any] | None
 ]
+_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
 
 
 class _WorkspaceBackingFileNotFoundError(FileNotFoundError):
@@ -60,6 +62,69 @@ class _WorkspaceBackingFileNotFoundError(FileNotFoundError):
             "Workspace backing file is missing",
             self.source_path,
         )
+
+
+class _WorkspacePublicationConflictError(RuntimeError):
+    """A published workspace changed while a save was in progress."""
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self.path = os.fsdecode(path)
+        super().__init__(
+            "Workspace changed outside ImageTool Manager while it was being saved: "
+            f"{self.path}"
+        )
+
+
+def _workspace_publication_state(
+    path: str | os.PathLike[str],
+) -> tuple[bool, int, int, int, int, int]:
+    """Return the state used to detect an external document replacement."""
+    try:
+        stat_result = os.stat(path)
+    except FileNotFoundError:
+        return False, 0, 0, 0, 0, 0
+    return (
+        True,
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+    )
+
+
+def _is_retryable_windows_workspace_replace_error(exc: PermissionError) -> bool:
+    if os.name != "nt":
+        return False
+    winerror = getattr(exc, "winerror", None)
+    if winerror is not None:
+        return winerror in {5, 32}
+    return exc.errno in {errno.EACCES, errno.EPERM}
+
+
+def _replace_workspace_file(
+    source: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    *,
+    expected_state: tuple[bool, int, int, int, int, int],
+) -> None:
+    """Publish a prepared workspace with bounded Windows sharing retries."""
+    retry_delays = iter(_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS)
+    while True:
+        if _workspace_publication_state(destination) != expected_state:
+            raise _WorkspacePublicationConflictError(destination)
+        try:
+            os.replace(source, destination)
+        except PermissionError as exc:
+            if not _is_retryable_windows_workspace_replace_error(exc):
+                raise
+            try:
+                delay = next(retry_delays)
+            except StopIteration:
+                raise exc from None
+            time.sleep(delay)
+        else:
+            return
 
 
 @dataclass(frozen=True)
@@ -394,18 +459,19 @@ def _cleanup_orphan_workspace_internal_groups(h5_file) -> None:
 
 
 def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
-    if not pathlib.Path(fname).exists():
-        return
-    if not _workspace_path_is_itws(fname):
-        return
-    with workspace_arrays._workspace_file_lock(fname), h5py.File(fname, "a") as h5_file:
-        if not _workspace_file_is_workspace(h5_file):
+    with workspace_arrays._workspace_save_lock(fname):
+        if not pathlib.Path(fname).exists():
             return
-        for name in list(h5_file):
-            if name.startswith(_WORKSPACE_TRANSACTION_GROUP_PREFIX):
-                _recover_open_workspace_transaction(h5_file, name)
-        _cleanup_orphan_workspace_internal_groups(h5_file)
-        h5_file.flush()
+        if not _workspace_path_is_itws(fname):
+            return
+        with h5py.File(fname, "a") as h5_file:
+            if not _workspace_file_is_workspace(h5_file):
+                return
+            for name in list(h5_file):
+                if name.startswith(_WORKSPACE_TRANSACTION_GROUP_PREFIX):
+                    _recover_open_workspace_transaction(h5_file, name)
+            _cleanup_orphan_workspace_internal_groups(h5_file)
+            h5_file.flush()
 
 
 def _write_root_attrs_to_open_workspace_file(
@@ -427,7 +493,10 @@ def _write_workspace_root_attrs_to_file(
     *,
     replace: bool = False,
 ) -> None:
-    with _open_workspace_h5_file_for_update(fname) as h5_file:
+    with (
+        workspace_arrays._workspace_save_lock(fname),
+        _open_workspace_h5_file_for_update(fname) as h5_file,
+    ):
         _write_root_attrs_to_open_workspace_file(h5_file, attrs, replace=replace)
 
 
@@ -447,12 +516,13 @@ def _workspace_file_repack_payload(
 ) -> tuple[
     dict[str, typing.Any], tuple[tuple[str, str, dict[str, typing.Any] | None], ...]
 ]:
-    _recover_workspace_transactions(fname)
-    root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
-    return (
-        _compacted_workspace_root_attrs(root_attrs),
-        workspace_arrays._workspace_live_root_group_copy_groups(fname),
-    )
+    with workspace_arrays._workspace_save_lock(fname):
+        _recover_workspace_transactions(fname)
+        root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
+        return (
+            _compacted_workspace_root_attrs(root_attrs),
+            workspace_arrays._workspace_live_root_group_copy_groups(fname),
+        )
 
 
 def _write_workspace_constructor_groups_to_pending(
@@ -640,6 +710,26 @@ def _write_workspace_transaction_file(
     *,
     compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
+    with workspace_arrays._workspace_save_lock(fname):
+        _write_workspace_transaction_file_locked(
+            fname,
+            rewrite_groups,
+            attr_updates,
+            root_attrs,
+            compression_mode=compression_mode,
+        )
+
+
+def _write_workspace_transaction_file_locked(
+    fname: str | os.PathLike[str],
+    rewrite_groups: Iterable[tuple[str, dict[str, xr.Dataset]]],
+    attr_updates: Iterable[
+        tuple[str, dict[str, typing.Any], tuple[str, dict[str, xr.Dataset]]]
+    ],
+    root_attrs: Mapping[str, typing.Any],
+    *,
+    compression_mode: WorkspaceCompressionMode | None = None,
+) -> None:
     _recover_workspace_transactions(fname)
     rewrite_map = {
         group_path.strip("/"): (group_path, constructor)
@@ -689,7 +779,30 @@ def _write_full_workspace_tree_file(
     copy_group_sources: Iterable[_WorkspaceCopyGroupWithSource] = (),
     compression_mode: WorkspaceCompressionMode | None = None,
 ) -> None:
+    with workspace_arrays._workspace_save_lock(fname):
+        _write_full_workspace_tree_file_locked(
+            fname,
+            tree,
+            root_attrs,
+            copy_source=copy_source,
+            copy_groups=copy_groups,
+            copy_group_sources=copy_group_sources,
+            compression_mode=compression_mode,
+        )
+
+
+def _write_full_workspace_tree_file_locked(
+    fname: str | os.PathLike[str],
+    tree: xr.DataTree | None,
+    root_attrs: Mapping[str, typing.Any],
+    *,
+    copy_source: str | os.PathLike[str] | None = None,
+    copy_groups: Iterable[_WorkspaceCopyGroup] = (),
+    copy_group_sources: Iterable[_WorkspaceCopyGroupWithSource] = (),
+    compression_mode: WorkspaceCompressionMode | None = None,
+) -> None:
     fname = os.fsdecode(fname)
+    expected_state = _workspace_publication_state(fname)
     use_scratch = _workspace_path_is_high_risk(fname)
     tmp_dir: tempfile.TemporaryDirectory[str] | None = None
     destination_tmp: str | None = None
@@ -777,17 +890,19 @@ def _write_full_workspace_tree_file(
         _fsync_file(tmp_fname)
         if use_scratch:
             try:
-                os.replace(tmp_fname, fname)
+                _replace_workspace_file(tmp_fname, fname, expected_state=expected_state)
             except OSError as err:
                 if err.errno != errno.EXDEV:
                     raise
                 destination_tmp = f"{fname}.tmp-{uuid.uuid4().hex}"
                 shutil.copyfile(tmp_fname, destination_tmp)
                 _fsync_file(destination_tmp)
-                os.replace(destination_tmp, fname)
+                _replace_workspace_file(
+                    destination_tmp, fname, expected_state=expected_state
+                )
             _fsync_parent_directory(fname)
         else:
-            os.replace(tmp_fname, fname)
+            _replace_workspace_file(tmp_fname, fname, expected_state=expected_state)
             _fsync_parent_directory(fname)
     finally:
         with contextlib.suppress(FileNotFoundError):

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -49,6 +49,7 @@ _WorkspaceCopyGroup: typing.TypeAlias = tuple[str, str, dict[str, typing.Any] | 
 _WorkspaceCopyGroupWithSource: typing.TypeAlias = tuple[
     str, str, str, dict[str, typing.Any] | None
 ]
+_WorkspacePublicationState: typing.TypeAlias = tuple[bool, int, int, int, int, int]
 _WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
 
 
@@ -77,7 +78,7 @@ class _WorkspacePublicationConflictError(RuntimeError):
 
 def _workspace_publication_state(
     path: str | os.PathLike[str],
-) -> tuple[bool, int, int, int, int, int]:
+) -> _WorkspacePublicationState:
     """Return the state used to detect an external document replacement."""
     try:
         stat_result = os.stat(path)
@@ -106,7 +107,7 @@ def _replace_workspace_file(
     source: str | os.PathLike[str],
     destination: str | os.PathLike[str],
     *,
-    expected_state: tuple[bool, int, int, int, int, int],
+    expected_state: _WorkspacePublicationState,
 ) -> None:
     """Publish a prepared workspace with bounded Windows sharing retries."""
     retry_delays = iter(_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS)
@@ -514,14 +515,21 @@ def _workspace_obsolete_estimate(
 def _workspace_file_repack_payload(
     fname: str | os.PathLike[str],
 ) -> tuple[
-    dict[str, typing.Any], tuple[tuple[str, str, dict[str, typing.Any] | None], ...]
+    dict[str, typing.Any],
+    tuple[tuple[str, str, dict[str, typing.Any] | None], ...],
+    _WorkspacePublicationState,
 ]:
     with workspace_arrays._workspace_save_lock(fname):
         _recover_workspace_transactions(fname)
+        expected_state = _workspace_publication_state(fname)
         root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
+        copy_groups = workspace_arrays._workspace_live_root_group_copy_groups(fname)
+        if _workspace_publication_state(fname) != expected_state:
+            raise _WorkspacePublicationConflictError(fname)
         return (
             _compacted_workspace_root_attrs(root_attrs),
-            workspace_arrays._workspace_live_root_group_copy_groups(fname),
+            copy_groups,
+            expected_state,
         )
 
 
@@ -709,6 +717,7 @@ def _write_workspace_transaction_file(
     root_attrs: Mapping[str, typing.Any],
     *,
     compression_mode: WorkspaceCompressionMode | None = None,
+    expected_state: _WorkspacePublicationState | None = None,
 ) -> None:
     with workspace_arrays._workspace_save_lock(fname):
         _write_workspace_transaction_file_locked(
@@ -717,6 +726,7 @@ def _write_workspace_transaction_file(
             attr_updates,
             root_attrs,
             compression_mode=compression_mode,
+            expected_state=expected_state,
         )
 
 
@@ -729,7 +739,13 @@ def _write_workspace_transaction_file_locked(
     root_attrs: Mapping[str, typing.Any],
     *,
     compression_mode: WorkspaceCompressionMode | None = None,
+    expected_state: _WorkspacePublicationState | None = None,
 ) -> None:
+    if (
+        expected_state is not None
+        and _workspace_publication_state(fname) != expected_state
+    ):
+        raise _WorkspacePublicationConflictError(fname)
     _recover_workspace_transactions(fname)
     rewrite_map = {
         group_path.strip("/"): (group_path, constructor)
@@ -778,6 +794,7 @@ def _write_full_workspace_tree_file(
     copy_groups: Iterable[_WorkspaceCopyGroup] = (),
     copy_group_sources: Iterable[_WorkspaceCopyGroupWithSource] = (),
     compression_mode: WorkspaceCompressionMode | None = None,
+    expected_state: _WorkspacePublicationState | None = None,
 ) -> None:
     with workspace_arrays._workspace_save_lock(fname):
         _write_full_workspace_tree_file_locked(
@@ -788,6 +805,7 @@ def _write_full_workspace_tree_file(
             copy_groups=copy_groups,
             copy_group_sources=copy_group_sources,
             compression_mode=compression_mode,
+            expected_state=expected_state,
         )
 
 
@@ -800,9 +818,14 @@ def _write_full_workspace_tree_file_locked(
     copy_groups: Iterable[_WorkspaceCopyGroup] = (),
     copy_group_sources: Iterable[_WorkspaceCopyGroupWithSource] = (),
     compression_mode: WorkspaceCompressionMode | None = None,
+    expected_state: _WorkspacePublicationState | None = None,
 ) -> None:
     fname = os.fsdecode(fname)
-    expected_state = _workspace_publication_state(fname)
+    current_state = _workspace_publication_state(fname)
+    if expected_state is None:
+        expected_state = current_state
+    elif current_state != expected_state:
+        raise _WorkspacePublicationConflictError(fname)
     use_scratch = _workspace_path_is_high_risk(fname)
     tmp_dir: tempfile.TemporaryDirectory[str] | None = None
     destination_tmp: str | None = None

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import json
 import os
 import pathlib
 import threading
+import time
 import typing
 import uuid
 import weakref
@@ -31,6 +33,37 @@ _WORKSPACE_STAGING_GROUP = "__itws_staging"
 _WORKSPACE_GENERATIONS_GROUP = "__itws_generations"
 _WORKSPACE_MANIFEST_DATASET = "manifest"
 _WORKSPACE_GENERATION_WIDTH = 20
+_FILE_ACCESS_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
+_RETRYABLE_FILE_ACCESS_ERRNOS = frozenset(
+    {
+        errno.EACCES,
+        errno.EAGAIN,
+        errno.EBUSY,
+        errno.EPERM,
+        getattr(errno, "ETXTBSY", errno.EBUSY),
+    }
+)
+
+
+def _is_retryable_file_access_error(exc: OSError) -> bool:
+    """Return whether a file access failure can be temporary."""
+    return exc.errno in _RETRYABLE_FILE_ACCESS_ERRNOS
+
+
+def _retry_file_access(operation: Callable[[], typing.Any]) -> typing.Any:
+    """Run one file operation with bounded retries for temporary access errors."""
+    retry_delays = iter(_FILE_ACCESS_RETRY_DELAYS)
+    while True:
+        try:
+            return operation()
+        except OSError as exc:
+            if not _is_retryable_file_access_error(exc):
+                raise
+            try:
+                delay = next(retry_delays)
+            except StopIteration:
+                raise exc from None
+            time.sleep(delay)
 
 
 @dataclass(frozen=True)
@@ -43,6 +76,10 @@ class _WorkspaceGeneration:
 
 class WorkspaceStoreConflictError(RuntimeError):
     """The path no longer identifies the file opened by the store."""
+
+
+class WorkspaceStoreReopenError(RuntimeError):
+    """A replaced workspace could not be reopened."""
 
 
 class WorkspaceStore:
@@ -134,6 +171,12 @@ class WorkspaceStore:
     def handle_generation(self) -> int:
         """Return a value that changes each time the HDF5 handle reopens."""
         return self._handle_generation
+
+    @property
+    def recovery_path(self) -> pathlib.Path | None:
+        """Return the temporary document retained for read-only recovery."""
+        with self._lock:
+            return self._recovery_path
 
     def _register(self) -> None:
         key = self._key(self._path)
@@ -282,6 +325,18 @@ class WorkspaceStore:
             self._close_handle()
             self._open(create=False)
 
+    def _reopen_after_file_operation(self) -> None:
+        """Reopen the document after a file operation released its handle."""
+
+        def _reopen() -> None:
+            try:
+                self._open(create=False)
+            except Exception:
+                self._close_handle()
+                raise
+
+        _retry_file_access(_reopen)
+
     def replace_from(
         self,
         prepared_path: str | os.PathLike[str],
@@ -327,10 +382,22 @@ class WorkspaceStore:
                 except WorkspaceStoreConflictError as conflict:
                     self._mark_conflicted()
                     raise conflict from exc
-                self._open(create=False)
+                try:
+                    self._reopen_after_file_operation()
+                except Exception:
+                    try:
+                        self._use_recovery_source(source)
+                    except Exception:
+                        self._mark_conflicted()
                 raise
             else:
-                self._open(create=False)
+                try:
+                    self._reopen_after_file_operation()
+                except Exception as exc:
+                    raise WorkspaceStoreReopenError(
+                        "Workspace was replaced but could not be reopened: "
+                        f"{self._path}"
+                    ) from exc
 
     def acquire_object(self, object_id: str) -> None:
         """Keep a payload object reachable while a lazy array uses it."""

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -1,4 +1,4 @@
-"""Long-lived HDF5 storage for one ImageTool Manager workspace."""
+"""Document lifetime and HDF5 access for ImageTool Manager workspaces."""
 
 from __future__ import annotations
 
@@ -33,6 +33,7 @@ _WORKSPACE_STAGING_GROUP = "__itws_staging"
 _WORKSPACE_GENERATIONS_GROUP = "__itws_generations"
 _WORKSPACE_MANIFEST_DATASET = "manifest"
 _WORKSPACE_GENERATION_WIDTH = 20
+_WORKSPACE_ID_ATTR = "imagetool_workspace_id"
 _FILE_ACCESS_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
 _RETRYABLE_FILE_ACCESS_ERRNOS = frozenset(
     {
@@ -83,10 +84,13 @@ class WorkspaceStoreReopenError(RuntimeError):
 
 
 class WorkspaceStore:
-    """Own the HDF5 handle used by one open workspace document.
+    """Own the lifetime and access policy for one workspace document.
 
     Payload objects are immutable. A generation becomes visible only after its
-    completed staging group moves into the generations group.
+    completed staging group moves into the generations group. The store keeps a
+    read-only handle while the document is idle. A bounded write session closes
+    that handle, opens the document for writing, and closes the writable handle
+    before it returns.
     """
 
     _active: weakref.WeakValueDictionary[str, WorkspaceStore] = (
@@ -94,7 +98,15 @@ class WorkspaceStore:
     )
     _active_lock = threading.RLock()
 
-    def __init__(self, path: str | os.PathLike[str], *, create: bool = False) -> None:
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        create: bool = False,
+        workspace_id: str | None = None,
+    ) -> None:
+        if not create and workspace_id is not None:
+            raise ValueError("workspace_id is valid only when create is true")
         self._path = pathlib.Path(path).resolve()
         self._lock = threading.RLock()
         self._write_lock = threading.RLock()
@@ -103,10 +115,12 @@ class WorkspaceStore:
         self._state: typing.Literal["open", "conflicted", "closed"] = "closed"
         self._handle_generation = 0
         self._h5_file: typing.Any = None
+        self._write_depth = 0
+        self._workspace_id = ""
         self._path_identity: tuple[int, int] | None = None
         self._recovery_path: pathlib.Path | None = None
         try:
-            self._open(create=create)
+            self._open(create=create, workspace_id=workspace_id)
             self._register()
         except Exception:
             self._close_handle()
@@ -151,21 +165,29 @@ class WorkspaceStore:
 
     @property
     def h5_file(self) -> typing.Any:
-        """Return the writable document handle."""
+        """Return the current document handle.
+
+        The handle is read-only outside :meth:`write_session`.
+        """
         if self.conflicted:
             raise WorkspaceStoreConflictError(
                 f"Workspace store no longer owns its path: {self._path}"
             )
         if self.closed:
             raise RuntimeError("Workspace store is closed")
-        return self._h5_file
+        return self._ensure_read_handle()
 
     @property
     def read_h5_file(self) -> typing.Any:
         """Return the readable session handle, including during recovery."""
-        if self.closed or self._h5_file is None:
+        if self.closed:
             raise RuntimeError("Workspace store has no readable handle")
-        return self._h5_file
+        return self._ensure_read_handle()
+
+    @property
+    def workspace_id(self) -> str:
+        """Return the stable identity stored inside this workspace file."""
+        return self._workspace_id
 
     @property
     def handle_generation(self) -> int:
@@ -195,31 +217,54 @@ class WorkspaceStore:
             if self._active.get(key) is self:
                 self._active.pop(key, None)
 
-    def _open(self, *, create: bool) -> None:
+    @staticmethod
+    def _ensure_workspace_id(h5_file: typing.Any, preferred: str | None = None) -> str:
+        workspace_id = preferred or h5_file.attrs.get(_WORKSPACE_ID_ATTR)
+        if isinstance(workspace_id, bytes):
+            workspace_id = workspace_id.decode()
+        if not isinstance(workspace_id, str) or not workspace_id:
+            workspace_id = uuid.uuid4().hex
+        if h5_file.attrs.get(_WORKSPACE_ID_ATTR) != workspace_id:
+            h5_file.attrs[_WORKSPACE_ID_ATTR] = workspace_id
+            h5_file.flush()
+        return workspace_id
+
+    def _open(self, *, create: bool, workspace_id: str | None = None) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         if create:
-            self._h5_file = h5py.File(
+            h5_file = h5py.File(
                 self._path,
                 "w",
                 libver="latest",
                 fs_strategy="fsm",
                 fs_persist=True,
             )
-            self._h5_file.attrs["imagetool_workspace_schema_version"] = 5
-            self._h5_file.attrs["erlab_version"] = str(erlab.__version__)
-            self._h5_file.require_group(_WORKSPACE_OBJECTS_GROUP)
-            self._h5_file.require_group(_WORKSPACE_STAGING_GROUP)
-            self._h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
-            self._h5_file.flush()
+            self._workspace_id = self._ensure_workspace_id(h5_file, workspace_id)
+            h5_file.attrs["imagetool_workspace_schema_version"] = 5
+            h5_file.attrs["erlab_version"] = str(erlab.__version__)
+            h5_file.require_group(_WORKSPACE_OBJECTS_GROUP)
+            h5_file.require_group(_WORKSPACE_STAGING_GROUP)
+            h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
+            h5_file.flush()
+            h5_file.close()
         else:
-            self._h5_file = h5py.File(self._path, "r+")
-        self._handle_generation += 1
+            with h5py.File(self._path, "r+") as h5_file:
+                self._workspace_id = self._ensure_workspace_id(h5_file)
+        self._h5_file = None
         path_stat = self._path.stat()
         self._path_identity = (path_stat.st_dev, path_stat.st_ino)
         self._recovery_path = None
         self._state = "open"
 
-    def _close_handle(self) -> None:
+    def _ensure_read_handle(self) -> typing.Any:
+        if self._h5_file is None:
+            source = self._recovery_path or self._path
+            self._h5_file = _retry_file_access(lambda: h5py.File(source, "r"))
+            self._handle_generation += 1
+        return self._h5_file
+
+    def _release_handle(self) -> None:
+        """Release the current HDF5 handle without closing the store."""
         for reader in tuple(self._readers):
             with contextlib.suppress(Exception):
                 reader._close_store_wrapper()
@@ -228,6 +273,40 @@ class WorkspaceStore:
         if h5_file is not None:
             with contextlib.suppress(Exception):
                 h5_file.close()
+        self._handle_generation += 1
+
+    @contextlib.contextmanager
+    def write_session(self) -> typing.Iterator[typing.Any]:
+        """Yield the only writable handle for one bounded document operation."""
+        with self._write_lock:
+            with self._lock:
+                self.require_current_path()
+                outermost = self._write_depth == 0
+                if outermost:
+                    self._release_handle()
+                    self._h5_file = _retry_file_access(
+                        lambda: h5py.File(self._path, "r+")
+                    )
+                    self._handle_generation += 1
+                self._write_depth += 1
+            try:
+                yield self._h5_file
+            finally:
+                with self._lock:
+                    self._write_depth -= 1
+                    if outermost:
+                        self._release_handle()
+
+    @contextlib.contextmanager
+    def computation_session(self) -> typing.Iterator[None]:
+        """Keep saves and file replacement out of one Dask computation."""
+        with self._write_lock:
+            with self._lock:
+                self.require_current_path()
+            yield
+
+    def _close_handle(self) -> None:
+        self._release_handle()
         recovery_path = self._recovery_path
         self._recovery_path = None
         if recovery_path is not None:
@@ -291,29 +370,25 @@ class WorkspaceStore:
     def switch_path(self, path: str | os.PathLike[str]) -> None:
         """Open *path* through this store without invalidating store references."""
         new_path = pathlib.Path(path).resolve()
-        with self._write_lock, self._lock:
-            new_h5_file = h5py.File(new_path, "r+")
-            with contextlib.ExitStack() as cleanup:
-                cleanup.callback(new_h5_file.close)
-                new_stat = new_path.stat()
-                new_identity = (new_stat.st_dev, new_stat.st_ino)
-                with self._active_lock:
-                    existing = self._active.get(self._key(new_path))
-                    if existing is not None and existing is not self:
-                        raise RuntimeError(
-                            f"Workspace already has an active store: {new_path}"
-                        )
-                    old_path = self._path
-                    self._unregister(old_path)
-                    self._close_handle()
-                    self._path = new_path
-                    self._h5_file = new_h5_file
-                    new_h5_file = None
-                    self._handle_generation += 1
-                    self._path_identity = new_identity
-                    self._state = "open"
-                    self._active[self._key(new_path)] = self
-                    cleanup.pop_all()
+        with self._write_lock, self._lock, h5py.File(new_path, "r+") as new_h5_file:
+            new_stat = new_path.stat()
+            new_identity = (new_stat.st_dev, new_stat.st_ino)
+            workspace_id = self._ensure_workspace_id(new_h5_file)
+            with self._active_lock:
+                existing = self._active.get(self._key(new_path))
+                if existing is not None and existing is not self:
+                    raise RuntimeError(
+                        f"Workspace already has an active store: {new_path}"
+                    )
+                old_path = self._path
+                self._unregister(old_path)
+                self._close_handle()
+                self._path = new_path
+                self._workspace_id = workspace_id
+                self._path_identity = new_identity
+                self._recovery_path = None
+                self._state = "open"
+                self._active[self._key(new_path)] = self
 
     def reopen(self) -> None:
         """Close and reopen the current file through the same store object."""
@@ -366,7 +441,7 @@ class WorkspaceStore:
             path_identity = self._path_identity
             if path_identity is None:
                 raise RuntimeError("Workspace store has no path identity")
-            self._close_handle()
+            self._release_handle()
             try:
                 self._require_path_identity(path_identity)
                 replace(source, self._path)
@@ -532,8 +607,7 @@ class WorkspaceStore:
 
     def publish(self, manifest: Mapping[str, typing.Any]) -> _WorkspaceGeneration:
         """Publish one completed manifest as the newest generation."""
-        with self._write_lock, self._lock:
-            self.require_current_path()
+        with self.write_session():
             generation_root = self.h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
             existing_sequences = [
                 int(name)
@@ -600,8 +674,7 @@ class WorkspaceStore:
         """
         if max_objects < 1:
             raise ValueError("max_objects must be positive")
-        with self._write_lock, self._lock:
-            self.require_current_path()
+        with self.write_session():
             generations = self.generations()
             retained = generations[-2:]
             retained_names = {
@@ -627,7 +700,7 @@ class WorkspaceStore:
 
     def clear_staging(self) -> None:
         """Remove unpublished staging groups left by interrupted saves."""
-        with self._write_lock, self._lock:
+        with self.write_session():
             staging_root = self.h5_file.require_group(_WORKSPACE_STAGING_GROUP)
             for name in list(staging_root):
                 del staging_root[name]

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -63,7 +63,7 @@ class WorkspaceStore:
         self._write_lock = threading.RLock()
         self._object_leases: dict[str, int] = {}
         self._readers: weakref.WeakSet[typing.Any] = weakref.WeakSet()
-        self._closed = True
+        self._state: typing.Literal["open", "conflicted", "closed"] = "closed"
         self._handle_generation = 0
         self._h5_file: typing.Any = None
         self._path_identity: tuple[int, int] | None = None
@@ -83,9 +83,10 @@ class WorkspaceStore:
         """Return the store that owns *path*, if this process has one."""
         with cls._active_lock:
             store = cls._active.get(cls._key(path))
-        if store is None or store.closed:
+        if store is None:
             return None
-        return store
+        with store.lock:
+            return None if store.closed else store
 
     @property
     def path(self) -> pathlib.Path:
@@ -102,11 +103,21 @@ class WorkspaceStore:
 
     @property
     def closed(self) -> bool:
-        return self._closed
+        """Return whether this store released ownership of its path."""
+        return self._state == "closed"
+
+    @property
+    def conflicted(self) -> bool:
+        """Return whether the workspace path changed outside this store."""
+        return self._state == "conflicted"
 
     @property
     def h5_file(self) -> typing.Any:
-        if self._closed:
+        if self.conflicted:
+            raise WorkspaceStoreConflictError(
+                f"Workspace store no longer owns its path: {self._path}"
+            )
+        if self.closed:
             raise RuntimeError("Workspace store is closed")
         return self._h5_file
 
@@ -119,7 +130,7 @@ class WorkspaceStore:
         key = self._key(self._path)
         with self._active_lock:
             existing = self._active.get(key)
-            if existing is not None and existing is not self and not existing.closed:
+            if existing is not None and existing is not self:
                 self._close_handle()
                 raise RuntimeError(
                     f"Workspace already has an active store: {self._path}"
@@ -153,7 +164,7 @@ class WorkspaceStore:
         self._handle_generation += 1
         path_stat = self._path.stat()
         self._path_identity = (path_stat.st_dev, path_stat.st_ino)
-        self._closed = False
+        self._state = "open"
 
     def _close_handle(self) -> None:
         for reader in tuple(self._readers):
@@ -164,20 +175,42 @@ class WorkspaceStore:
         if h5_file is not None:
             with contextlib.suppress(Exception):
                 h5_file.close()
-        self._closed = True
+        self._state = "closed"
 
-    def require_current_path(self) -> None:
-        """Fail if the open handle is no longer the file at ``path``."""
+    def _mark_conflicted(self) -> None:
+        """Close the handle and quarantine this path until explicit recovery."""
+        if self._h5_file is not None:
+            self._close_handle()
+        self._state = "conflicted"
+
+    def _require_path_identity(self, expected: tuple[int, int]) -> None:
         try:
             path_stat = self._path.stat()
         except OSError as exc:
             raise WorkspaceStoreConflictError(
                 f"Open workspace path is no longer available: {self._path}"
             ) from exc
-        if (path_stat.st_dev, path_stat.st_ino) != self._path_identity:
+        if (path_stat.st_dev, path_stat.st_ino) != expected:
             raise WorkspaceStoreConflictError(
                 f"Open workspace path now identifies another file: {self._path}"
             )
+
+    def require_current_path(self) -> None:
+        """Fail if the open handle is no longer the file at ``path``."""
+        if self.conflicted:
+            raise WorkspaceStoreConflictError(
+                f"Workspace store no longer owns its path: {self._path}"
+            )
+        if self.closed:
+            raise RuntimeError("Workspace store is closed")
+        path_identity = self._path_identity
+        if path_identity is None:
+            raise RuntimeError("Workspace store has no path identity")
+        try:
+            self._require_path_identity(path_identity)
+        except WorkspaceStoreConflictError:
+            self._mark_conflicted()
+            raise
 
     def close(self) -> None:
         """Close the document handle and remove this store from the registry."""
@@ -190,6 +223,7 @@ class WorkspaceStore:
         new_path = pathlib.Path(path).resolve()
         with self._write_lock, self._lock:
             old_path = self._path
+            old_conflicted = self.conflicted
             self._unregister(old_path)
             self._close_handle()
             self._path = new_path
@@ -197,14 +231,23 @@ class WorkspaceStore:
                 self._open(create=False)
                 self._register()
             except Exception:
+                self._close_handle()
                 self._path = old_path
-                self._open(create=False)
-                self._register()
+                if old_conflicted:
+                    self._state = "conflicted"
+                    self._register()
+                else:
+                    self._open(create=False)
+                    self._register()
                 raise
 
     def reopen(self) -> None:
         """Close and reopen the current file through the same store object."""
         with self._write_lock, self._lock:
+            if self.conflicted:
+                raise WorkspaceStoreConflictError(
+                    f"Workspace store no longer owns its path: {self._path}"
+                )
             self._close_handle()
             self._open(create=False)
 
@@ -222,23 +265,37 @@ class WorkspaceStore:
         """
         source = pathlib.Path(prepared_path).resolve()
         with self._write_lock, self._lock:
+            if self.conflicted:
+                raise WorkspaceStoreConflictError(
+                    f"Workspace store no longer owns its path: {self._path}"
+                )
+            if self.closed:
+                raise RuntimeError("Workspace store is closed")
             if before_close is not None:
-                before_close()
+                try:
+                    before_close()
+                except WorkspaceStoreConflictError:
+                    self._mark_conflicted()
+                    raise
             path_identity = self._path_identity
+            if path_identity is None:
+                raise RuntimeError("Workspace store has no path identity")
             self._close_handle()
             try:
-                try:
-                    path_stat = self._path.stat()
-                except OSError as exc:
-                    raise WorkspaceStoreConflictError(
-                        f"Open workspace path is no longer available: {self._path}"
-                    ) from exc
-                if (path_stat.st_dev, path_stat.st_ino) != path_identity:
-                    raise WorkspaceStoreConflictError(
-                        f"Open workspace path now identifies another file: {self._path}"
-                    )
+                self._require_path_identity(path_identity)
                 replace(source, self._path)
-            finally:
+            except WorkspaceStoreConflictError:
+                self._mark_conflicted()
+                raise
+            except Exception as exc:
+                try:
+                    self._require_path_identity(path_identity)
+                except WorkspaceStoreConflictError as conflict:
+                    self._mark_conflicted()
+                    raise conflict from exc
+                self._open(create=False)
+                raise
+            else:
                 self._open(create=False)
 
     def acquire_object(self, object_id: str) -> None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -20,7 +20,7 @@ from typing import Self
 import erlab
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping
+    from collections.abc import Callable, Mapping
 
     import h5py
 else:
@@ -145,6 +145,8 @@ def _wait_for_hdf5_access(
         except OSError as exc:
             if after_failed_attempt is not None:
                 after_failed_attempt()
+            if _is_hdf5_file_lock_unavailable_error(exc):
+                raise
             if not _is_hdf5_file_contention_error(exc):
                 raise
             if on_wait is not None:
@@ -164,12 +166,36 @@ class _WorkspaceGeneration:
     manifest: dict[str, typing.Any]
 
 
+@dataclass(frozen=True)
+class _SerializedReaderPinSnapshot:
+    """Versioned reader pins captured at one instant."""
+
+    object_versions: dict[str, int]
+    legacy_group_versions: dict[str, int]
+
+    @property
+    def object_ids(self) -> frozenset[str]:
+        return frozenset(self.object_versions)
+
+    @property
+    def legacy_group_paths(self) -> frozenset[str]:
+        return frozenset(self.legacy_group_versions)
+
+    @property
+    def empty(self) -> bool:
+        return not self.object_versions and not self.legacy_group_versions
+
+
 class WorkspaceStoreConflictError(RuntimeError):
     """The path no longer identifies the file opened by the store."""
 
 
 class WorkspaceStoreReopenError(RuntimeError):
     """A replaced workspace could not be reopened."""
+
+
+class WorkspaceReaderUnavailableError(RuntimeError):
+    """A workspace reader no longer has a payload that it can export."""
 
 
 class WorkspaceStore:
@@ -186,8 +212,9 @@ class WorkspaceStore:
         weakref.WeakValueDictionary()
     )
     _pending_readers: typing.ClassVar[dict[str, weakref.WeakSet[typing.Any]]] = {}
-    _serialized_object_pins: typing.ClassVar[dict[str, set[str]]] = {}
-    _serialized_legacy_group_pins: typing.ClassVar[dict[str, set[str]]] = {}
+    _serialized_object_pins: typing.ClassVar[dict[str, dict[str, int]]] = {}
+    _serialized_legacy_group_pins: typing.ClassVar[dict[str, dict[str, int]]] = {}
+    _serialized_pin_version = 0
     _active_lock = threading.RLock()
     _fork_stores: tuple[WorkspaceStore, ...] = ()
 
@@ -255,12 +282,14 @@ class WorkspaceStore:
         """
         key = cls._serialization_key(workspace_id, path)
         with cls._active_lock:
+            cls._serialized_pin_version += 1
+            version = cls._serialized_pin_version
             if object_id is not None:
-                cls._serialized_object_pins.setdefault(key, set()).add(object_id)
+                cls._serialized_object_pins.setdefault(key, {})[object_id] = version
             if legacy_group_path is not None:
-                cls._serialized_legacy_group_pins.setdefault(key, set()).add(
+                cls._serialized_legacy_group_pins.setdefault(key, {})[
                     legacy_group_path
-                )
+                ] = version
 
     @classmethod
     def active(cls, path: str | os.PathLike[str]) -> WorkspaceStore | None:
@@ -915,6 +944,42 @@ class WorkspaceStore:
         with self._lock:
             self._readers.add(reader)
 
+    def pin_serialized_reader_reference(
+        self,
+        *,
+        object_id: str | None,
+        legacy_group_path: str | None,
+    ) -> None:
+        """Pin one exported reader without racing workspace compaction."""
+        with self._lock:
+            if self.closed or self.conflicted:
+                raise WorkspaceReaderUnavailableError(
+                    "The workspace changed before its Dask reader was exported"
+                )
+            with self.read_session() as h5_file:
+                if (
+                    object_id is not None
+                    and self.object_path(object_id).strip("/") not in h5_file
+                ):
+                    raise WorkspaceReaderUnavailableError(
+                        "The workspace payload was compacted before its Dask reader "
+                        "was exported"
+                    )
+                if (
+                    legacy_group_path is not None
+                    and legacy_group_path.strip("/") not in h5_file
+                ):
+                    raise WorkspaceReaderUnavailableError(
+                        "The workspace payload was compacted before its Dask reader "
+                        "was exported"
+                    )
+            self.pin_serialized_reader(
+                workspace_id=self.workspace_id,
+                path=self.path,
+                object_id=object_id,
+                legacy_group_path=legacy_group_path,
+            )
+
     def unregister_reader(self, reader: object) -> None:
         """Remove a reader that no longer uses this store."""
         with self._lock:
@@ -943,20 +1008,35 @@ class WorkspaceStore:
     @property
     def serialized_object_ids(self) -> frozenset[str]:
         """Return objects pinned by readers serialized in this process."""
-        with self._active_lock:
-            object_ids: set[str] = set()
-            for key in self._serialization_keys():
-                object_ids.update(self._serialized_object_pins.get(key, ()))
-            return frozenset(object_ids)
+        return self.serialized_reader_pin_snapshot().object_ids
 
     @property
     def serialized_legacy_group_paths(self) -> frozenset[str]:
         """Return old-format groups pinned by serialized readers."""
+        return self.serialized_reader_pin_snapshot().legacy_group_paths
+
+    def serialized_reader_pin_snapshot(self) -> _SerializedReaderPinSnapshot:
+        """Return the newest pin version for each exported reader target."""
         with self._active_lock:
-            group_paths: set[str] = set()
+            object_versions: dict[str, int] = {}
+            legacy_group_versions: dict[str, int] = {}
             for key in self._serialization_keys():
-                group_paths.update(self._serialized_legacy_group_pins.get(key, ()))
-            return frozenset(group_paths)
+                for object_id, version in self._serialized_object_pins.get(
+                    key, {}
+                ).items():
+                    object_versions[object_id] = max(
+                        version, object_versions.get(object_id, -1)
+                    )
+                for group_path, version in self._serialized_legacy_group_pins.get(
+                    key, {}
+                ).items():
+                    legacy_group_versions[group_path] = max(
+                        version, legacy_group_versions.get(group_path, -1)
+                    )
+            return _SerializedReaderPinSnapshot(
+                object_versions=object_versions,
+                legacy_group_versions=legacy_group_versions,
+            )
 
     @property
     def has_serialized_readers(self) -> bool:
@@ -977,24 +1057,38 @@ class WorkspaceStore:
 
     def release_serialized_reader_pins(
         self,
-        *,
-        object_ids: Iterable[str] = (),
-        legacy_group_paths: Iterable[str] = (),
+        snapshot: _SerializedReaderPinSnapshot,
     ) -> None:
         """Release a confirmed snapshot of serialized reader pins."""
-        released_object_ids = frozenset(object_ids)
-        released_group_paths = frozenset(legacy_group_paths)
         with self._active_lock:
             for key in self._serialization_keys():
-                pinned_object_ids = self._serialized_object_pins.get(key)
-                if pinned_object_ids is not None:
-                    pinned_object_ids.difference_update(released_object_ids)
-                    if not pinned_object_ids:
+                pinned_objects = self._serialized_object_pins.get(key)
+                if pinned_objects is not None:
+                    for (
+                        object_id,
+                        confirmed_version,
+                    ) in snapshot.object_versions.items():
+                        current_version = pinned_objects.get(object_id)
+                        if (
+                            current_version is not None
+                            and current_version <= confirmed_version
+                        ):
+                            pinned_objects.pop(object_id, None)
+                    if not pinned_objects:
                         self._serialized_object_pins.pop(key, None)
-                pinned_group_paths = self._serialized_legacy_group_pins.get(key)
-                if pinned_group_paths is not None:
-                    pinned_group_paths.difference_update(released_group_paths)
-                    if not pinned_group_paths:
+                pinned_groups = self._serialized_legacy_group_pins.get(key)
+                if pinned_groups is not None:
+                    for (
+                        group_path,
+                        confirmed_version,
+                    ) in snapshot.legacy_group_versions.items():
+                        current_version = pinned_groups.get(group_path)
+                        if (
+                            current_version is not None
+                            and current_version <= confirmed_version
+                        ):
+                            pinned_groups.pop(group_path, None)
+                    if not pinned_groups:
                         self._serialized_legacy_group_pins.pop(key, None)
 
     @property

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -248,9 +248,10 @@ class WorkspaceStore:
     ) -> None:
         """Keep data reachable after a reader is sent to another process.
 
-        Dask does not provide a release callback that works for every scheduler.
-        These small pins therefore last for this Python process. They do not block
-        saves. They only defer reclamation of the referenced data.
+        Dask does not provide a release callback for a serialized task graph. The
+        controller clears these small pins when its client no longer owns Futures.
+        The pins do not block saves. They only defer reclamation of the referenced
+        data.
         """
         key = cls._serialization_key(workspace_id, path)
         with cls._active_lock:
@@ -956,6 +957,23 @@ class WorkspaceStore:
             for key in self._serialization_keys():
                 group_paths.update(self._serialized_legacy_group_pins.get(key, ()))
             return frozenset(group_paths)
+
+    @property
+    def has_serialized_readers(self) -> bool:
+        """Return whether this workspace has data pinned after serialization."""
+        with self._active_lock:
+            return any(
+                self._serialized_object_pins.get(key)
+                or self._serialized_legacy_group_pins.get(key)
+                for key in self._serialization_keys()
+            )
+
+    def clear_serialized_reader_pins(self) -> None:
+        """Release data pinned when this workspace's readers were serialized."""
+        with self._active_lock:
+            for key in self._serialization_keys():
+                self._serialized_object_pins.pop(key, None)
+                self._serialized_legacy_group_pins.pop(key, None)
 
     @property
     def leased_legacy_group_paths(self) -> frozenset[str]:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -20,7 +20,7 @@ from typing import Self
 import erlab
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
 
     import h5py
 else:
@@ -248,10 +248,10 @@ class WorkspaceStore:
     ) -> None:
         """Keep data reachable after a reader is sent to another process.
 
-        Dask does not provide a release callback for a serialized task graph. The
-        controller clears these small pins when its client no longer owns Futures.
-        The pins do not block saves. They only defer reclamation of the referenced
-        data.
+        Dask does not provide a reliable release callback for every client and
+        scheduler. These small pins therefore remain until the user confirms
+        workspace compaction. They do not block saves. They only defer reclamation
+        of the referenced data.
         """
         key = cls._serialization_key(workspace_id, path)
         with cls._active_lock:
@@ -974,6 +974,28 @@ class WorkspaceStore:
             for key in self._serialization_keys():
                 self._serialized_object_pins.pop(key, None)
                 self._serialized_legacy_group_pins.pop(key, None)
+
+    def release_serialized_reader_pins(
+        self,
+        *,
+        object_ids: Iterable[str] = (),
+        legacy_group_paths: Iterable[str] = (),
+    ) -> None:
+        """Release a confirmed snapshot of serialized reader pins."""
+        released_object_ids = frozenset(object_ids)
+        released_group_paths = frozenset(legacy_group_paths)
+        with self._active_lock:
+            for key in self._serialization_keys():
+                pinned_object_ids = self._serialized_object_pins.get(key)
+                if pinned_object_ids is not None:
+                    pinned_object_ids.difference_update(released_object_ids)
+                    if not pinned_object_ids:
+                        self._serialized_object_pins.pop(key, None)
+                pinned_group_paths = self._serialized_legacy_group_pins.get(key)
+                if pinned_group_paths is not None:
+                    pinned_group_paths.difference_update(released_group_paths)
+                    if not pinned_group_paths:
+                        self._serialized_legacy_group_pins.pop(key, None)
 
     @property
     def leased_legacy_group_paths(self) -> frozenset[str]:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -186,6 +186,8 @@ class WorkspaceStore:
         weakref.WeakValueDictionary()
     )
     _pending_readers: typing.ClassVar[dict[str, weakref.WeakSet[typing.Any]]] = {}
+    _serialized_object_pins: typing.ClassVar[dict[str, set[str]]] = {}
+    _serialized_legacy_group_pins: typing.ClassVar[dict[str, set[str]]] = {}
     _active_lock = threading.RLock()
     _fork_stores: tuple[WorkspaceStore, ...] = ()
 
@@ -226,6 +228,38 @@ class WorkspaceStore:
     @staticmethod
     def _key(path: str | os.PathLike[str]) -> str:
         return os.path.normcase(str(pathlib.Path(path).resolve()))
+
+    @classmethod
+    def _serialization_key(
+        cls,
+        workspace_id: str | None,
+        path: str | os.PathLike[str],
+    ) -> str:
+        return f"{cls._key(path)}\0{workspace_id or ''}"
+
+    @classmethod
+    def pin_serialized_reader(
+        cls,
+        *,
+        workspace_id: str | None,
+        path: str | os.PathLike[str],
+        object_id: str | None,
+        legacy_group_path: str | None,
+    ) -> None:
+        """Keep data reachable after a reader is sent to another process.
+
+        Dask does not provide a release callback that works for every scheduler.
+        These small pins therefore last for this Python process. They do not block
+        saves. They only defer reclamation of the referenced data.
+        """
+        key = cls._serialization_key(workspace_id, path)
+        with cls._active_lock:
+            if object_id is not None:
+                cls._serialized_object_pins.setdefault(key, set()).add(object_id)
+            if legacy_group_path is not None:
+                cls._serialized_legacy_group_pins.setdefault(key, set()).add(
+                    legacy_group_path
+                )
 
     @classmethod
     def active(cls, path: str | os.PathLike[str]) -> WorkspaceStore | None:
@@ -899,6 +933,30 @@ class WorkspaceStore:
         with self._lock:
             return frozenset(self._object_leases)
 
+    def _serialization_keys(self) -> tuple[str, ...]:
+        path_key = self._serialization_key(None, self._path)
+        if self._workspace_id is None:
+            return (path_key,)
+        return (self._serialization_key(self._workspace_id, self._path), path_key)
+
+    @property
+    def serialized_object_ids(self) -> frozenset[str]:
+        """Return objects pinned by readers serialized in this process."""
+        with self._active_lock:
+            object_ids: set[str] = set()
+            for key in self._serialization_keys():
+                object_ids.update(self._serialized_object_pins.get(key, ()))
+            return frozenset(object_ids)
+
+    @property
+    def serialized_legacy_group_paths(self) -> frozenset[str]:
+        """Return old-format groups pinned by serialized readers."""
+        with self._active_lock:
+            group_paths: set[str] = set()
+            for key in self._serialization_keys():
+                group_paths.update(self._serialized_legacy_group_pins.get(key, ()))
+            return frozenset(group_paths)
+
     @property
     def leased_legacy_group_paths(self) -> frozenset[str]:
         """Return old-format payload groups that still have lazy readers."""
@@ -1068,8 +1126,6 @@ class WorkspaceStore:
         self,
         *,
         max_objects: int = 1,
-        delete_objects: bool = True,
-        can_delete_objects: Callable[[], bool] | None = None,
         on_contention: Callable[[], None] | None = None,
     ) -> bool:
         """Retire old generations and unlink a bounded number of dead objects.
@@ -1091,21 +1147,13 @@ class WorkspaceStore:
                     continue
                 del generation_root[name]
 
-            deletion_allowed = delete_objects and (
-                can_delete_objects is None or can_delete_objects()
-            )
             reachable = set(self._object_leases)
+            reachable.update(self.serialized_object_ids)
             for generation in retained:
                 reachable.update(self.manifest_object_ids(generation.manifest))
 
             object_root = self.h5_file.require_group(_WORKSPACE_OBJECTS_GROUP)
             obsolete = [name for name in object_root if name not in reachable]
-            deletion_allowed = deletion_allowed and (
-                can_delete_objects is None or can_delete_objects()
-            )
-            if not deletion_allowed:
-                self.h5_file.flush()
-                return bool(obsolete)
             remove_count = len(obsolete) if not self._locking_supported else max_objects
             for name in obsolete[:remove_count]:
                 del object_root[name]

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -212,7 +212,7 @@ class WorkspaceStore:
         self._write_opening = False
         self._write_target_path: pathlib.Path | None = None
         self._locking_supported = True
-        self._workspace_id = ""
+        self._workspace_id: str | None = None
         self._path_identity: tuple[int, int] | None = None
         self._recovery_path: pathlib.Path | None = None
         try:
@@ -378,8 +378,8 @@ class WorkspaceStore:
         return self._ensure_read_handle()
 
     @property
-    def workspace_id(self) -> str:
-        """Return the stable identity stored inside this workspace file."""
+    def workspace_id(self) -> str | None:
+        """Return the stored identity, or ``None`` before first publication."""
         return self._workspace_id
 
     @property
@@ -469,15 +469,12 @@ class WorkspaceStore:
             h5_file.close()
         else:
             with self._open_with_lock_detection("r") as h5_file:
-                self._workspace_id = self._workspace_id_from_file(h5_file) or ""
+                self._workspace_id = self._workspace_id_from_file(h5_file)
         self._h5_file = None
         path_stat = self._path.stat()
         self._path_identity = (path_stat.st_dev, path_stat.st_ino)
         self._recovery_path = None
         self._state = "open"
-        if not self._workspace_id:
-            with self.write_session() as h5_file:
-                self._workspace_id = self._ensure_workspace_id(h5_file, workspace_id)
 
     def _ensure_read_handle(self) -> typing.Any:
         if self._h5_file is None:
@@ -997,6 +994,8 @@ class WorkspaceStore:
     def publish(self, manifest: Mapping[str, typing.Any]) -> _WorkspaceGeneration:
         """Publish one completed manifest as the newest generation."""
         with self.write_session():
+            if self._workspace_id is None:
+                self._workspace_id = self._ensure_workspace_id(self.h5_file)
             generation_root = self.h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
             existing_sequences = [
                 int(name)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -67,6 +67,7 @@ class WorkspaceStore:
         self._handle_generation = 0
         self._h5_file: typing.Any = None
         self._path_identity: tuple[int, int] | None = None
+        self._recovery_path: pathlib.Path | None = None
         try:
             self._open(create=create)
             self._register()
@@ -113,12 +114,20 @@ class WorkspaceStore:
 
     @property
     def h5_file(self) -> typing.Any:
+        """Return the writable document handle."""
         if self.conflicted:
             raise WorkspaceStoreConflictError(
                 f"Workspace store no longer owns its path: {self._path}"
             )
         if self.closed:
             raise RuntimeError("Workspace store is closed")
+        return self._h5_file
+
+    @property
+    def read_h5_file(self) -> typing.Any:
+        """Return the readable session handle, including during recovery."""
+        if self.closed or self._h5_file is None:
+            raise RuntimeError("Workspace store has no readable handle")
         return self._h5_file
 
     @property
@@ -164,6 +173,7 @@ class WorkspaceStore:
         self._handle_generation += 1
         path_stat = self._path.stat()
         self._path_identity = (path_stat.st_dev, path_stat.st_ino)
+        self._recovery_path = None
         self._state = "open"
 
     def _close_handle(self) -> None:
@@ -175,12 +185,29 @@ class WorkspaceStore:
         if h5_file is not None:
             with contextlib.suppress(Exception):
                 h5_file.close()
+        recovery_path = self._recovery_path
+        self._recovery_path = None
+        if recovery_path is not None:
+            with contextlib.suppress(OSError):
+                recovery_path.unlink()
         self._state = "closed"
 
     def _mark_conflicted(self) -> None:
-        """Close the handle and quarantine this path until explicit recovery."""
-        if self._h5_file is not None:
-            self._close_handle()
+        """Quarantine writes while retaining readable session data."""
+        self._state = "conflicted"
+
+    def _use_recovery_source(self, path: pathlib.Path) -> None:
+        """Use a prepared document as the read-only source after a conflict."""
+        self._close_handle()
+        try:
+            self._h5_file = h5py.File(path, "r")
+        except Exception:
+            self._h5_file = None
+            self._state = "conflicted"
+            raise
+        self._handle_generation += 1
+        self._path_identity = None
+        self._recovery_path = path
         self._state = "conflicted"
 
     def _require_path_identity(self, expected: tuple[int, int]) -> None:
@@ -222,24 +249,28 @@ class WorkspaceStore:
         """Open *path* through this store without invalidating store references."""
         new_path = pathlib.Path(path).resolve()
         with self._write_lock, self._lock:
-            old_path = self._path
-            old_conflicted = self.conflicted
-            self._unregister(old_path)
-            self._close_handle()
-            self._path = new_path
-            try:
-                self._open(create=False)
-                self._register()
-            except Exception:
-                self._close_handle()
-                self._path = old_path
-                if old_conflicted:
-                    self._state = "conflicted"
-                    self._register()
-                else:
-                    self._open(create=False)
-                    self._register()
-                raise
+            new_h5_file = h5py.File(new_path, "r+")
+            with contextlib.ExitStack() as cleanup:
+                cleanup.callback(new_h5_file.close)
+                new_stat = new_path.stat()
+                new_identity = (new_stat.st_dev, new_stat.st_ino)
+                with self._active_lock:
+                    existing = self._active.get(self._key(new_path))
+                    if existing is not None and existing is not self:
+                        raise RuntimeError(
+                            f"Workspace already has an active store: {new_path}"
+                        )
+                    old_path = self._path
+                    self._unregister(old_path)
+                    self._close_handle()
+                    self._path = new_path
+                    self._h5_file = new_h5_file
+                    new_h5_file = None
+                    self._handle_generation += 1
+                    self._path_identity = new_identity
+                    self._state = "open"
+                    self._active[self._key(new_path)] = self
+                    cleanup.pop_all()
 
     def reopen(self) -> None:
         """Close and reopen the current file through the same store object."""
@@ -285,7 +316,10 @@ class WorkspaceStore:
                 self._require_path_identity(path_identity)
                 replace(source, self._path)
             except WorkspaceStoreConflictError:
-                self._mark_conflicted()
+                try:
+                    self._use_recovery_source(source)
+                except Exception:
+                    self._mark_conflicted()
                 raise
             except Exception as exc:
                 try:
@@ -336,14 +370,14 @@ class WorkspaceStore:
                 for reader in self._readers
                 if (path := reader.legacy_group_path) not in {None, "/"}
             }
+            h5_file = self.read_h5_file
             return frozenset(
                 path
                 for path in paths
-                if path.strip("/") in self.h5_file
-                and isinstance(self.h5_file[path], h5py.Group)
+                if path.strip("/") in h5_file
+                and isinstance(h5_file[path], h5py.Group)
                 and any(
-                    isinstance(item, h5py.Dataset)
-                    for item in self.h5_file[path].values()
+                    isinstance(item, h5py.Dataset) for item in h5_file[path].values()
                 )
             )
 
@@ -409,7 +443,7 @@ class WorkspaceStore:
     def generations(self) -> tuple[_WorkspaceGeneration, ...]:
         """Return all valid committed generations in ascending order."""
         with self._lock:
-            root = self.h5_file.get(_WORKSPACE_GENERATIONS_GROUP)
+            root = self.read_h5_file.get(_WORKSPACE_GENERATIONS_GROUP)
             if root is None:
                 return ()
             generations: list[_WorkspaceGeneration] = []

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import pathlib
+import shutil
 import threading
 import time
 import typing
@@ -35,6 +36,7 @@ _WORKSPACE_MANIFEST_DATASET = "manifest"
 _WORKSPACE_GENERATION_WIDTH = 20
 _WORKSPACE_ID_ATTR = "imagetool_workspace_id"
 _FILE_ACCESS_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
+_HDF5_CONTENTION_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
 _RETRYABLE_FILE_ACCESS_ERRNOS = frozenset(
     {
         errno.EACCES,
@@ -44,6 +46,21 @@ _RETRYABLE_FILE_ACCESS_ERRNOS = frozenset(
         getattr(errno, "ETXTBSY", errno.EBUSY),
     }
 )
+_HDF5_CONTENTION_ERRNOS = frozenset(
+    {
+        errno.EAGAIN,
+        errno.EBUSY,
+        getattr(errno, "EWOULDBLOCK", errno.EAGAIN),
+        getattr(errno, "ETXTBSY", errno.EBUSY),
+    }
+)
+_HDF5_LOCK_UNAVAILABLE_ERRNOS = frozenset(
+    {
+        errno.ENOSYS,
+        getattr(errno, "ENOTSUP", errno.ENOSYS),
+        getattr(errno, "EOPNOTSUPP", errno.ENOSYS),
+    }
+)
 
 
 def _is_retryable_file_access_error(exc: OSError) -> bool:
@@ -51,19 +68,91 @@ def _is_retryable_file_access_error(exc: OSError) -> bool:
     return exc.errno in _RETRYABLE_FILE_ACCESS_ERRNOS
 
 
-def _retry_file_access(operation: Callable[[], typing.Any]) -> typing.Any:
+def _retry_file_access(
+    operation: Callable[[], typing.Any],
+    *,
+    on_wait: Callable[[], None] | None = None,
+) -> typing.Any:
     """Run one file operation with bounded retries for temporary access errors."""
     retry_delays = iter(_FILE_ACCESS_RETRY_DELAYS)
+    waiting = False
     while True:
         try:
             return operation()
         except OSError as exc:
             if not _is_retryable_file_access_error(exc):
                 raise
+            if not waiting:
+                waiting = True
+                if on_wait is not None:
+                    on_wait()
             try:
                 delay = next(retry_delays)
             except StopIteration:
                 raise exc from None
+            time.sleep(delay)
+
+
+def _is_hdf5_file_contention_error(exc: OSError) -> bool:
+    """Return whether another HDF5 reader or writer blocked an open."""
+    if exc.errno in _HDF5_CONTENTION_ERRNOS:
+        return True
+    if getattr(exc, "winerror", None) in {32, 33}:
+        return True
+    message = str(exc).lower()
+    return any(
+        marker in message
+        for marker in (
+            "file is already open for read-only",
+            "file is already open for write",
+            "unable to lock file",
+            "resource temporarily unavailable",
+            "sharing violation",
+            "lock violation",
+        )
+    )
+
+
+def _is_hdf5_file_lock_unavailable_error(exc: OSError) -> bool:
+    """Return whether the filesystem rejected required HDF5 locking."""
+    if exc.errno in _HDF5_LOCK_UNAVAILABLE_ERRNOS:
+        return True
+    message = str(exc).lower()
+    return "lock" in message and any(
+        marker in message
+        for marker in (
+            "function not implemented",
+            "not supported",
+            "locking is disabled",
+        )
+    )
+
+
+def _wait_for_hdf5_access(
+    operation: Callable[[], typing.Any],
+    *,
+    on_wait: Callable[[], None] | None = None,
+    before_attempt: Callable[[], None] | None = None,
+    after_failed_attempt: Callable[[], None] | None = None,
+) -> typing.Any:
+    """Wait until a conflicting HDF5 reader or writer releases the file."""
+    delay_index = 0
+    while True:
+        if before_attempt is not None:
+            before_attempt()
+        try:
+            return operation()
+        except OSError as exc:
+            if after_failed_attempt is not None:
+                after_failed_attempt()
+            if not _is_hdf5_file_contention_error(exc):
+                raise
+            if on_wait is not None:
+                on_wait()
+            delay = _HDF5_CONTENTION_RETRY_DELAYS[
+                min(delay_index, len(_HDF5_CONTENTION_RETRY_DELAYS) - 1)
+            ]
+            delay_index += 1
             time.sleep(delay)
 
 
@@ -96,7 +185,9 @@ class WorkspaceStore:
     _active: weakref.WeakValueDictionary[str, WorkspaceStore] = (
         weakref.WeakValueDictionary()
     )
+    _pending_readers: typing.ClassVar[dict[str, weakref.WeakSet[typing.Any]]] = {}
     _active_lock = threading.RLock()
+    _fork_stores: tuple[WorkspaceStore, ...] = ()
 
     def __init__(
         self,
@@ -109,6 +200,7 @@ class WorkspaceStore:
             raise ValueError("workspace_id is valid only when create is true")
         self._path = pathlib.Path(path).resolve()
         self._lock = threading.RLock()
+        self._access_condition = threading.Condition(self._lock)
         self._write_lock = threading.RLock()
         self._object_leases: dict[str, int] = {}
         self._readers: weakref.WeakSet[typing.Any] = weakref.WeakSet()
@@ -116,10 +208,15 @@ class WorkspaceStore:
         self._handle_generation = 0
         self._h5_file: typing.Any = None
         self._write_depth = 0
+        self._write_pending = False
+        self._write_opening = False
+        self._write_target_path: pathlib.Path | None = None
+        self._locking_supported = True
         self._workspace_id = ""
         self._path_identity: tuple[int, int] | None = None
         self._recovery_path: pathlib.Path | None = None
         try:
+            self._close_pending_reader_caches()
             self._open(create=create, workspace_id=workspace_id)
             self._register()
         except Exception:
@@ -140,6 +237,92 @@ class WorkspaceStore:
         with store.lock:
             return None if store.closed else store
 
+    def _close_pending_reader_caches(self) -> None:
+        """Release local caches before this store opens their shared path."""
+        with self._active_lock:
+            readers = tuple(self._pending_readers.get(self._key(self._path), ()))
+        for reader in readers:
+            reader.close()
+
+    @classmethod
+    def register_path_reader(
+        cls,
+        path: str | os.PathLike[str],
+        reader: typing.Any,
+    ) -> WorkspaceStore | None:
+        """Register a reader and return the active store for its path."""
+        key = cls._key(path)
+        with cls._active_lock:
+            store = cls._active.get(key)
+            if store is None or store.closed:
+                cls._pending_readers.setdefault(key, weakref.WeakSet()).add(reader)
+                return None
+        store.register_reader(reader)
+        return store
+
+    @classmethod
+    def unregister_path_reader(
+        cls,
+        path: str | os.PathLike[str],
+        reader: typing.Any,
+    ) -> None:
+        """Remove a reader that is not attached to an active store."""
+        key = cls._key(path)
+        with cls._active_lock:
+            readers = cls._pending_readers.get(key)
+            if readers is None:
+                return
+            readers.discard(reader)
+            if not readers:
+                cls._pending_readers.pop(key, None)
+
+    @classmethod
+    def _before_fork(cls) -> None:
+        """Close inherited HDF5 handles before a process forks."""
+        with cls._active_lock:
+            stores = tuple(
+                sorted(
+                    (store for store in cls._active.values() if not store.closed),
+                    key=lambda store: str(store.path),
+                )
+            )
+        acquired: list[WorkspaceStore] = []
+        try:
+            for store in stores:
+                store._write_lock.acquire()
+                store._lock.acquire()
+                acquired.append(store)
+            for store in stores:
+                store._release_handle()
+        except Exception:
+            for store in reversed(acquired):
+                store._lock.release()
+                store._write_lock.release()
+            raise
+        cls._fork_stores = stores
+
+    @classmethod
+    def _after_fork_parent(cls) -> None:
+        for store in reversed(cls._fork_stores):
+            store._lock.release()
+            store._write_lock.release()
+        cls._fork_stores = ()
+
+    @classmethod
+    def _after_fork_child(cls) -> None:
+        for store in cls._fork_stores:
+            store._h5_file = None
+            store._state = "closed"
+            store._lock = threading.RLock()
+            store._access_condition = threading.Condition(store._lock)
+            store._write_lock = threading.RLock()
+            store._write_pending = False
+            store._write_opening = False
+        cls._active = weakref.WeakValueDictionary()
+        cls._pending_readers = {}
+        cls._active_lock = threading.RLock()
+        cls._fork_stores = ()
+
     @property
     def path(self) -> pathlib.Path:
         return self._path
@@ -152,6 +335,16 @@ class WorkspaceStore:
     def write_lock(self) -> threading.RLock:
         """Serialize complete saves and maintenance operations."""
         return self._write_lock
+
+    @property
+    def locking_supported(self) -> bool:
+        """Return whether required HDF5 locks work for this workspace path."""
+        return self._locking_supported
+
+    @property
+    def write_in_progress(self) -> bool:
+        """Return whether this store is waiting to write or is writing."""
+        return self._write_pending or self._write_depth > 0
 
     @property
     def closed(self) -> bool:
@@ -210,6 +403,9 @@ class WorkspaceStore:
                     f"Workspace already has an active store: {self._path}"
                 )
             self._active[key] = self
+            pending_readers = tuple(self._pending_readers.pop(key, ()))
+        for reader in pending_readers:
+            reader._attach_store(self)
 
     def _unregister(self, path: pathlib.Path | None = None) -> None:
         key = self._key(self._path if path is None else path)
@@ -229,11 +425,35 @@ class WorkspaceStore:
             h5_file.flush()
         return workspace_id
 
+    @staticmethod
+    def _workspace_id_from_file(h5_file: typing.Any) -> str | None:
+        workspace_id = h5_file.attrs.get(_WORKSPACE_ID_ATTR)
+        if isinstance(workspace_id, bytes):
+            workspace_id = workspace_id.decode()
+        if isinstance(workspace_id, str) and workspace_id:
+            return workspace_id
+        return None
+
+    def _open_with_lock_detection(
+        self,
+        mode: str,
+        **kwargs: typing.Any,
+    ) -> typing.Any:
+        try:
+            return _wait_for_hdf5_access(
+                lambda: h5py.File(self._path, mode, locking=True, **kwargs)
+            )
+        except OSError as exc:
+            if not _is_hdf5_file_lock_unavailable_error(exc):
+                raise
+        self._locking_supported = False
+        return h5py.File(self._path, mode, locking=False, **kwargs)
+
     def _open(self, *, create: bool, workspace_id: str | None = None) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._locking_supported = True
         if create:
-            h5_file = h5py.File(
-                self._path,
+            h5_file = self._open_with_lock_detection(
                 "w",
                 libver="latest",
                 fs_strategy="fsm",
@@ -248,18 +468,27 @@ class WorkspaceStore:
             h5_file.flush()
             h5_file.close()
         else:
-            with h5py.File(self._path, "r+") as h5_file:
-                self._workspace_id = self._ensure_workspace_id(h5_file)
+            with self._open_with_lock_detection("r") as h5_file:
+                self._workspace_id = self._workspace_id_from_file(h5_file) or ""
         self._h5_file = None
         path_stat = self._path.stat()
         self._path_identity = (path_stat.st_dev, path_stat.st_ino)
         self._recovery_path = None
         self._state = "open"
+        if not self._workspace_id:
+            with self.write_session() as h5_file:
+                self._workspace_id = self._ensure_workspace_id(h5_file, workspace_id)
 
     def _ensure_read_handle(self) -> typing.Any:
         if self._h5_file is None:
             source = self._recovery_path or self._path
-            self._h5_file = _retry_file_access(lambda: h5py.File(source, "r"))
+            self._h5_file = _wait_for_hdf5_access(
+                lambda: h5py.File(
+                    source,
+                    "r",
+                    locking="best-effort",
+                )
+            )
             self._handle_generation += 1
         return self._h5_file
 
@@ -275,35 +504,160 @@ class WorkspaceStore:
                 h5_file.close()
         self._handle_generation += 1
 
+    def _prepare_copy_on_write(self) -> pathlib.Path:
+        target = self._path.with_name(f".{self._path.name}.write-{uuid.uuid4().hex}")
+        shutil.copy2(self._path, target)
+        return target
+
+    def _publish_copy_on_write(
+        self,
+        source: pathlib.Path,
+        expected_state: tuple[int, int, int, int],
+        *,
+        on_contention: Callable[[], None] | None,
+    ) -> None:
+        def _replace() -> None:
+            self._require_path_state(expected_state)
+            os.replace(source, self._path)
+
+        _retry_file_access(_replace, on_wait=on_contention)
+        path_stat = self._path.stat()
+        self._path_identity = (path_stat.st_dev, path_stat.st_ino)
+        if os.name == "posix":
+            with contextlib.suppress(OSError):
+                file_descriptor = os.open(self._path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(file_descriptor)
+                finally:
+                    os.close(file_descriptor)
+
     @contextlib.contextmanager
-    def write_session(self) -> typing.Iterator[typing.Any]:
+    def read_session(self) -> typing.Iterator[typing.Any]:
+        """Yield the shared handle when no writer is changing its open mode."""
+        with self._access_condition:
+            while self._write_opening:
+                self._access_condition.wait()
+            if self.closed:
+                raise RuntimeError("Workspace store is closed")
+            yield self.read_h5_file
+
+    @contextlib.contextmanager
+    def write_session(
+        self,
+        *,
+        on_contention: Callable[[], None] | None = None,
+    ) -> typing.Iterator[typing.Any]:
         """Yield the only writable handle for one bounded document operation."""
         with self._write_lock:
-            with self._lock:
+            copy_on_write_path: pathlib.Path | None = None
+            expected_path_state: tuple[int, int, int, int] | None = None
+            succeeded = False
+            with self._access_condition:
                 self.require_current_path()
                 outermost = self._write_depth == 0
                 if outermost:
-                    self._release_handle()
-                    self._h5_file = _retry_file_access(
-                        lambda: h5py.File(self._path, "r+")
-                    )
+                    self._write_pending = True
+                    path_identity = self._path_identity
+                    if not self._locking_supported and path_identity is None:
+                        self._write_pending = False
+                        self._access_condition.notify_all()
+                        raise RuntimeError("Workspace store has no path identity")
+                else:
+                    self._write_depth += 1
+
+            if outermost:
+
+                def _begin_open_attempt() -> None:
+                    with self._access_condition:
+                        self._release_handle()
+                        self._write_opening = True
+
+                def _end_failed_open_attempt() -> None:
+                    with self._access_condition:
+                        self._write_opening = False
+                        self._access_condition.notify_all()
+
+                try:
+                    if self._locking_supported:
+                        h5_file = _wait_for_hdf5_access(
+                            lambda: h5py.File(
+                                self._path,
+                                "r+",
+                                locking="best-effort",
+                            ),
+                            on_wait=on_contention,
+                            before_attempt=_begin_open_attempt,
+                            after_failed_attempt=_end_failed_open_attempt,
+                        )
+                    else:
+                        with self._access_condition:
+                            self._release_handle()
+                            self._write_opening = True
+                        path_stat = self._path.stat()
+                        expected_path_state = (
+                            path_stat.st_dev,
+                            path_stat.st_ino,
+                            path_stat.st_size,
+                            path_stat.st_mtime_ns,
+                        )
+                        copy_on_write_path = self._prepare_copy_on_write()
+                        h5_file = h5py.File(
+                            copy_on_write_path,
+                            "r+",
+                            locking=False,
+                        )
+                except BaseException:
+                    with self._access_condition:
+                        self._write_target_path = None
+                        self._write_pending = False
+                        self._write_opening = False
+                        self._access_condition.notify_all()
+                    if copy_on_write_path is not None:
+                        with contextlib.suppress(OSError):
+                            copy_on_write_path.unlink()
+                    raise
+                with self._access_condition:
+                    self._h5_file = h5_file
+                    self._write_target_path = copy_on_write_path
                     self._handle_generation += 1
-                self._write_depth += 1
+                    self._write_depth = 1
+                    self._write_opening = False
+                    self._access_condition.notify_all()
             try:
                 yield self._h5_file
+                succeeded = True
             finally:
-                with self._lock:
-                    self._write_depth -= 1
-                    if outermost:
-                        self._release_handle()
-
-    @contextlib.contextmanager
-    def computation_session(self) -> typing.Iterator[None]:
-        """Keep saves and file replacement out of one Dask computation."""
-        with self._write_lock:
-            with self._lock:
-                self.require_current_path()
-            yield
+                if not outermost:
+                    with self._lock:
+                        self._write_depth -= 1
+                else:
+                    try:
+                        with self._lock:
+                            self._write_depth = 0
+                            try:
+                                if succeeded and copy_on_write_path is not None:
+                                    self.flush(durable=True)
+                            finally:
+                                self._release_handle()
+                                self._write_target_path = None
+                        if (
+                            succeeded
+                            and copy_on_write_path is not None
+                            and expected_path_state is not None
+                        ):
+                            self._publish_copy_on_write(
+                                copy_on_write_path,
+                                expected_path_state,
+                                on_contention=on_contention,
+                            )
+                    finally:
+                        with self._access_condition:
+                            self._write_pending = False
+                            self._write_opening = False
+                            self._access_condition.notify_all()
+                        if copy_on_write_path is not None:
+                            with contextlib.suppress(OSError):
+                                copy_on_write_path.unlink()
 
     def _close_handle(self) -> None:
         self._release_handle()
@@ -322,7 +676,11 @@ class WorkspaceStore:
         """Use a prepared document as the read-only source after a conflict."""
         self._close_handle()
         try:
-            self._h5_file = h5py.File(path, "r")
+            self._h5_file = h5py.File(
+                path,
+                "r",
+                locking="best-effort",
+            )
         except Exception:
             self._h5_file = None
             self._state = "conflicted"
@@ -342,6 +700,25 @@ class WorkspaceStore:
         if (path_stat.st_dev, path_stat.st_ino) != expected:
             raise WorkspaceStoreConflictError(
                 f"Open workspace path now identifies another file: {self._path}"
+            )
+
+    def _require_path_state(self, expected: tuple[int, int, int, int]) -> None:
+        """Fail if an unlocked copy-on-write source changed before publication."""
+        try:
+            path_stat = self._path.stat()
+        except OSError as exc:
+            raise WorkspaceStoreConflictError(
+                f"Open workspace path is no longer available: {self._path}"
+            ) from exc
+        current = (
+            path_stat.st_dev,
+            path_stat.st_ino,
+            path_stat.st_size,
+            path_stat.st_mtime_ns,
+        )
+        if current != expected:
+            raise WorkspaceStoreConflictError(
+                f"Open workspace changed during save: {self._path}"
             )
 
     def require_current_path(self) -> None:
@@ -370,10 +747,22 @@ class WorkspaceStore:
     def switch_path(self, path: str | os.PathLike[str]) -> None:
         """Open *path* through this store without invalidating store references."""
         new_path = pathlib.Path(path).resolve()
-        with self._write_lock, self._lock, h5py.File(new_path, "r+") as new_h5_file:
+        locking_supported = True
+        try:
+            new_h5_file = _wait_for_hdf5_access(
+                lambda: h5py.File(new_path, "r", locking=True)
+            )
+        except OSError as exc:
+            if not _is_hdf5_file_lock_unavailable_error(exc):
+                raise
+            locking_supported = False
+            new_h5_file = h5py.File(new_path, "r", locking=False)
+        with self._write_lock, self._lock, new_h5_file:
             new_stat = new_path.stat()
             new_identity = (new_stat.st_dev, new_stat.st_ino)
-            workspace_id = self._ensure_workspace_id(new_h5_file)
+            workspace_id = self._workspace_id_from_file(new_h5_file)
+            if workspace_id is None:
+                raise ValueError("Workspace file has no stable identity")
             with self._active_lock:
                 existing = self._active.get(self._key(new_path))
                 if existing is not None and existing is not self:
@@ -385,6 +774,7 @@ class WorkspaceStore:
                 self._close_handle()
                 self._path = new_path
                 self._workspace_id = workspace_id
+                self._locking_supported = locking_supported
                 self._path_identity = new_identity
                 self._recovery_path = None
                 self._state = "open"
@@ -506,13 +896,12 @@ class WorkspaceStore:
     @property
     def leased_legacy_group_paths(self) -> frozenset[str]:
         """Return old-format payload groups that still have lazy readers."""
-        with self._lock:
+        with self.read_session() as h5_file:
             paths = {
                 path
                 for reader in self._readers
                 if (path := reader.legacy_group_path) not in {None, "/"}
             }
-            h5_file = self.read_h5_file
             return frozenset(
                 path
                 for path in paths
@@ -584,8 +973,8 @@ class WorkspaceStore:
 
     def generations(self) -> tuple[_WorkspaceGeneration, ...]:
         """Return all valid committed generations in ascending order."""
-        with self._lock:
-            root = self.read_h5_file.get(_WORKSPACE_GENERATIONS_GROUP)
+        with self.read_session() as h5_file:
+            root = h5_file.get(_WORKSPACE_GENERATIONS_GROUP)
             if root is None:
                 return ()
             generations: list[_WorkspaceGeneration] = []
@@ -667,14 +1056,19 @@ class WorkspaceStore:
                 object_ids.add(object_id)
         return frozenset(object_ids)
 
-    def collect_garbage(self, *, max_objects: int = 1) -> bool:
+    def collect_garbage(
+        self,
+        *,
+        max_objects: int = 1,
+        on_contention: Callable[[], None] | None = None,
+    ) -> bool:
         """Retire old generations and unlink a bounded number of dead objects.
 
         Returns ``True`` when more obsolete objects remain.
         """
         if max_objects < 1:
             raise ValueError("max_objects must be positive")
-        with self.write_session():
+        with self.write_session(on_contention=on_contention):
             generations = self.generations()
             retained = generations[-2:]
             retained_names = {
@@ -693,13 +1087,18 @@ class WorkspaceStore:
 
             object_root = self.h5_file.require_group(_WORKSPACE_OBJECTS_GROUP)
             obsolete = [name for name in object_root if name not in reachable]
-            for name in obsolete[:max_objects]:
+            remove_count = len(obsolete) if not self._locking_supported else max_objects
+            for name in obsolete[:remove_count]:
                 del object_root[name]
             self.h5_file.flush()
-            return len(obsolete) > max_objects
+            return len(obsolete) > remove_count
 
     def clear_staging(self) -> None:
         """Remove unpublished staging groups left by interrupted saves."""
+        with self.read_session() as h5_file:
+            staging_root = h5_file.get(_WORKSPACE_STAGING_GROUP)
+            if staging_root is None or not staging_root:
+                return
         with self.write_session():
             staging_root = self.h5_file.require_group(_WORKSPACE_STAGING_GROUP)
             for name in list(staging_root):
@@ -711,3 +1110,11 @@ class WorkspaceStore:
 
     def __exit__(self, *_args: object) -> None:
         self.close()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(
+        before=WorkspaceStore._before_fork,
+        after_in_parent=WorkspaceStore._after_fork_parent,
+        after_in_child=WorkspaceStore._after_fork_child,
+    )

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -642,11 +642,20 @@ class WorkspaceStore:
                             and copy_on_write_path is not None
                             and expected_path_state is not None
                         ):
-                            self._publish_copy_on_write(
-                                copy_on_write_path,
-                                expected_path_state,
-                                on_contention=on_contention,
-                            )
+                            try:
+                                self._publish_copy_on_write(
+                                    copy_on_write_path,
+                                    expected_path_state,
+                                    on_contention=on_contention,
+                                )
+                            except WorkspaceStoreConflictError:
+                                try:
+                                    self._use_recovery_source(copy_on_write_path)
+                                except Exception:
+                                    self._mark_conflicted()
+                                else:
+                                    copy_on_write_path = None
+                                raise
                     finally:
                         with self._access_condition:
                             self._write_pending = False
@@ -1059,6 +1068,8 @@ class WorkspaceStore:
         self,
         *,
         max_objects: int = 1,
+        delete_objects: bool = True,
+        can_delete_objects: Callable[[], bool] | None = None,
         on_contention: Callable[[], None] | None = None,
     ) -> bool:
         """Retire old generations and unlink a bounded number of dead objects.
@@ -1080,12 +1091,21 @@ class WorkspaceStore:
                     continue
                 del generation_root[name]
 
+            deletion_allowed = delete_objects and (
+                can_delete_objects is None or can_delete_objects()
+            )
             reachable = set(self._object_leases)
             for generation in retained:
                 reachable.update(self.manifest_object_ids(generation.manifest))
 
             object_root = self.h5_file.require_group(_WORKSPACE_OBJECTS_GROUP)
             obsolete = [name for name in object_root if name not in reachable]
+            deletion_allowed = deletion_allowed and (
+                can_delete_objects is None or can_delete_objects()
+            )
+            if not deletion_allowed:
+                self.h5_file.flush()
+                return bool(obsolete)
             remove_count = len(obsolete) if not self._locking_supported else max_objects
             for name in obsolete[:remove_count]:
                 del object_root[name]

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -1,0 +1,482 @@
+"""Long-lived HDF5 storage for one ImageTool Manager workspace."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import pathlib
+import threading
+import typing
+import uuid
+import weakref
+from dataclasses import dataclass
+from typing import Self
+
+import erlab
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    import h5py
+else:
+    import lazy_loader as _lazy
+
+    h5py = _lazy.load("h5py")
+
+
+_WORKSPACE_OBJECTS_GROUP = "__itws_objects"
+_WORKSPACE_STAGING_GROUP = "__itws_staging"
+_WORKSPACE_GENERATIONS_GROUP = "__itws_generations"
+_WORKSPACE_MANIFEST_DATASET = "manifest"
+_WORKSPACE_GENERATION_WIDTH = 20
+
+
+@dataclass(frozen=True)
+class _WorkspaceGeneration:
+    """One validated committed workspace generation."""
+
+    sequence: int
+    manifest: dict[str, typing.Any]
+
+
+class WorkspaceStoreConflictError(RuntimeError):
+    """The path no longer identifies the file opened by the store."""
+
+
+class WorkspaceStore:
+    """Own the HDF5 handle used by one open workspace document.
+
+    Payload objects are immutable. A generation becomes visible only after its
+    completed staging group moves into the generations group.
+    """
+
+    _active: weakref.WeakValueDictionary[str, WorkspaceStore] = (
+        weakref.WeakValueDictionary()
+    )
+    _active_lock = threading.RLock()
+
+    def __init__(self, path: str | os.PathLike[str], *, create: bool = False) -> None:
+        self._path = pathlib.Path(path).resolve()
+        self._lock = threading.RLock()
+        self._write_lock = threading.RLock()
+        self._object_leases: dict[str, int] = {}
+        self._readers: weakref.WeakSet[typing.Any] = weakref.WeakSet()
+        self._closed = True
+        self._handle_generation = 0
+        self._h5_file: typing.Any = None
+        self._path_identity: tuple[int, int] | None = None
+        try:
+            self._open(create=create)
+            self._register()
+        except Exception:
+            self._close_handle()
+            raise
+
+    @staticmethod
+    def _key(path: str | os.PathLike[str]) -> str:
+        return os.path.normcase(str(pathlib.Path(path).resolve()))
+
+    @classmethod
+    def active(cls, path: str | os.PathLike[str]) -> WorkspaceStore | None:
+        """Return the store that owns *path*, if this process has one."""
+        with cls._active_lock:
+            store = cls._active.get(cls._key(path))
+        if store is None or store.closed:
+            return None
+        return store
+
+    @property
+    def path(self) -> pathlib.Path:
+        return self._path
+
+    @property
+    def lock(self) -> threading.RLock:
+        return self._lock
+
+    @property
+    def write_lock(self) -> threading.RLock:
+        """Serialize complete saves and maintenance operations."""
+        return self._write_lock
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def h5_file(self) -> typing.Any:
+        if self._closed:
+            raise RuntimeError("Workspace store is closed")
+        return self._h5_file
+
+    @property
+    def handle_generation(self) -> int:
+        """Return a value that changes each time the HDF5 handle reopens."""
+        return self._handle_generation
+
+    def _register(self) -> None:
+        key = self._key(self._path)
+        with self._active_lock:
+            existing = self._active.get(key)
+            if existing is not None and existing is not self and not existing.closed:
+                self._close_handle()
+                raise RuntimeError(
+                    f"Workspace already has an active store: {self._path}"
+                )
+            self._active[key] = self
+
+    def _unregister(self, path: pathlib.Path | None = None) -> None:
+        key = self._key(self._path if path is None else path)
+        with self._active_lock:
+            if self._active.get(key) is self:
+                self._active.pop(key, None)
+
+    def _open(self, *, create: bool) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        if create:
+            self._h5_file = h5py.File(
+                self._path,
+                "w",
+                libver="latest",
+                fs_strategy="fsm",
+                fs_persist=True,
+            )
+            self._h5_file.attrs["imagetool_workspace_schema_version"] = 5
+            self._h5_file.attrs["erlab_version"] = str(erlab.__version__)
+            self._h5_file.require_group(_WORKSPACE_OBJECTS_GROUP)
+            self._h5_file.require_group(_WORKSPACE_STAGING_GROUP)
+            self._h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
+            self._h5_file.flush()
+        else:
+            self._h5_file = h5py.File(self._path, "r+")
+        self._handle_generation += 1
+        path_stat = self._path.stat()
+        self._path_identity = (path_stat.st_dev, path_stat.st_ino)
+        self._closed = False
+
+    def _close_handle(self) -> None:
+        for reader in tuple(self._readers):
+            with contextlib.suppress(Exception):
+                reader._close_store_wrapper()
+        h5_file = self._h5_file
+        self._h5_file = None
+        if h5_file is not None:
+            with contextlib.suppress(Exception):
+                h5_file.close()
+        self._closed = True
+
+    def require_current_path(self) -> None:
+        """Fail if the open handle is no longer the file at ``path``."""
+        try:
+            path_stat = self._path.stat()
+        except OSError as exc:
+            raise WorkspaceStoreConflictError(
+                f"Open workspace path is no longer available: {self._path}"
+            ) from exc
+        if (path_stat.st_dev, path_stat.st_ino) != self._path_identity:
+            raise WorkspaceStoreConflictError(
+                f"Open workspace path now identifies another file: {self._path}"
+            )
+
+    def close(self) -> None:
+        """Close the document handle and remove this store from the registry."""
+        with self._write_lock, self._lock:
+            self._unregister()
+            self._close_handle()
+
+    def switch_path(self, path: str | os.PathLike[str]) -> None:
+        """Open *path* through this store without invalidating store references."""
+        new_path = pathlib.Path(path).resolve()
+        with self._write_lock, self._lock:
+            old_path = self._path
+            self._unregister(old_path)
+            self._close_handle()
+            self._path = new_path
+            try:
+                self._open(create=False)
+                self._register()
+            except Exception:
+                self._path = old_path
+                self._open(create=False)
+                self._register()
+                raise
+
+    def reopen(self) -> None:
+        """Close and reopen the current file through the same store object."""
+        with self._write_lock, self._lock:
+            self._close_handle()
+            self._open(create=False)
+
+    def replace_from(
+        self,
+        prepared_path: str | os.PathLike[str],
+        replace: Callable[[pathlib.Path, pathlib.Path], None],
+        *,
+        before_close: Callable[[], None] | None = None,
+    ) -> None:
+        """Replace this document while its HDF5 handle is closed.
+
+        The store object stays stable, so existing lazy arrays use the reopened
+        file after the replacement.
+        """
+        source = pathlib.Path(prepared_path).resolve()
+        with self._write_lock, self._lock:
+            if before_close is not None:
+                before_close()
+            path_identity = self._path_identity
+            self._close_handle()
+            try:
+                try:
+                    path_stat = self._path.stat()
+                except OSError as exc:
+                    raise WorkspaceStoreConflictError(
+                        f"Open workspace path is no longer available: {self._path}"
+                    ) from exc
+                if (path_stat.st_dev, path_stat.st_ino) != path_identity:
+                    raise WorkspaceStoreConflictError(
+                        f"Open workspace path now identifies another file: {self._path}"
+                    )
+                replace(source, self._path)
+            finally:
+                self._open(create=False)
+
+    def acquire_object(self, object_id: str) -> None:
+        """Keep a payload object reachable while a lazy array uses it."""
+        with self._lock:
+            self._object_leases[object_id] = self._object_leases.get(object_id, 0) + 1
+
+    def register_reader(self, reader: object) -> None:
+        """Register a lazy reader that must refresh when this store reopens."""
+        with self._lock:
+            self._readers.add(reader)
+
+    def unregister_reader(self, reader: object) -> None:
+        """Remove a reader that no longer uses this store."""
+        with self._lock:
+            self._readers.discard(reader)
+
+    def release_object(self, object_id: str) -> None:
+        """Release one lazy-array reference to a payload object."""
+        with self._lock:
+            count = self._object_leases.get(object_id, 0)
+            if count <= 1:
+                self._object_leases.pop(object_id, None)
+            else:
+                self._object_leases[object_id] = count - 1
+
+    @property
+    def leased_object_ids(self) -> frozenset[str]:
+        with self._lock:
+            return frozenset(self._object_leases)
+
+    @property
+    def leased_legacy_group_paths(self) -> frozenset[str]:
+        """Return old-format payload groups that still have lazy readers."""
+        with self._lock:
+            paths = {
+                path
+                for reader in self._readers
+                if (path := reader.legacy_group_path) not in {None, "/"}
+            }
+            return frozenset(
+                path
+                for path in paths
+                if path.strip("/") in self.h5_file
+                and isinstance(self.h5_file[path], h5py.Group)
+                and any(
+                    isinstance(item, h5py.Dataset)
+                    for item in self.h5_file[path].values()
+                )
+            )
+
+    @staticmethod
+    def object_path(object_id: str) -> str:
+        if not object_id or "/" in object_id:
+            raise ValueError("Workspace object ID must be one path component")
+        return f"/{_WORKSPACE_OBJECTS_GROUP}/{object_id}"
+
+    @staticmethod
+    def _manifest_text(manifest: Mapping[str, typing.Any]) -> str:
+        return json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def _write_manifest(
+        cls,
+        group: typing.Any,
+        manifest: Mapping[str, typing.Any],
+    ) -> None:
+        text = cls._manifest_text(manifest)
+        dataset = group.create_dataset(
+            _WORKSPACE_MANIFEST_DATASET,
+            data=text,
+            dtype=h5py.string_dtype(encoding="utf-8"),
+        )
+        dataset.attrs["sha256"] = hashlib.sha256(text.encode()).hexdigest()
+
+    @classmethod
+    def _read_manifest(cls, group: typing.Any) -> dict[str, typing.Any]:
+        if _WORKSPACE_MANIFEST_DATASET not in group:
+            raise ValueError("Workspace generation has no manifest")
+        dataset = group[_WORKSPACE_MANIFEST_DATASET]
+        raw = dataset.asstr()[()]
+        if not isinstance(raw, str):
+            raise TypeError("Workspace generation manifest is not text")
+        expected = dataset.attrs.get("sha256")
+        if isinstance(expected, bytes):
+            expected = expected.decode()
+        actual = hashlib.sha256(raw.encode()).hexdigest()
+        if expected != actual:
+            raise ValueError("Workspace generation manifest checksum does not match")
+        manifest = json.loads(raw)
+        if not isinstance(manifest, dict):
+            raise TypeError("Workspace generation manifest is not an object")
+        if int(manifest.get("schema_version", 0)) != 5:
+            raise ValueError("Workspace generation has an unsupported schema")
+        nodes = manifest.get("nodes")
+        if not isinstance(nodes, list):
+            raise TypeError("Workspace generation nodes are not a list")
+        for entry in nodes:
+            if not isinstance(entry, dict):
+                raise TypeError("Workspace generation node is not an object")
+            object_id = entry.get("payload_object_id")
+            if not isinstance(object_id, str):
+                raise TypeError("Workspace generation node has no payload object")
+            object_path = cls.object_path(object_id)
+            if entry.get("payload_path") != object_path:
+                raise ValueError("Workspace generation payload path is not canonical")
+            if object_path.strip("/") not in group.file:
+                raise ValueError("Workspace generation payload object is missing")
+        return manifest
+
+    def generations(self) -> tuple[_WorkspaceGeneration, ...]:
+        """Return all valid committed generations in ascending order."""
+        with self._lock:
+            root = self.h5_file.get(_WORKSPACE_GENERATIONS_GROUP)
+            if root is None:
+                return ()
+            generations: list[_WorkspaceGeneration] = []
+            for name in sorted(root):
+                if len(name) != _WORKSPACE_GENERATION_WIDTH or not name.isdigit():
+                    continue
+                with contextlib.suppress(Exception):
+                    generations.append(
+                        _WorkspaceGeneration(int(name), self._read_manifest(root[name]))
+                    )
+            return tuple(generations)
+
+    def current_generation(self) -> _WorkspaceGeneration:
+        """Return the newest valid committed generation."""
+        generations = self.generations()
+        if not generations:
+            raise ValueError("Workspace has no committed generation")
+        return generations[-1]
+
+    def publish(self, manifest: Mapping[str, typing.Any]) -> _WorkspaceGeneration:
+        """Publish one completed manifest as the newest generation."""
+        with self._write_lock, self._lock:
+            self.require_current_path()
+            generation_root = self.h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
+            existing_sequences = [
+                int(name)
+                for name in generation_root
+                if len(name) == _WORKSPACE_GENERATION_WIDTH and name.isdigit()
+            ]
+            sequence = 1 if not existing_sequences else max(existing_sequences) + 1
+            staging_root = self.h5_file.require_group(_WORKSPACE_STAGING_GROUP)
+            staging_name = uuid.uuid4().hex
+            staging = staging_root.create_group(staging_name)
+            generation_manifest = dict(manifest)
+            generation_manifest["schema_version"] = 5
+            generation_manifest.pop("generation", None)
+            try:
+                self._write_manifest(staging, generation_manifest)
+                generation_manifest = self._read_manifest(staging)
+                self.flush()
+            except Exception:
+                with contextlib.suppress(Exception):
+                    del staging_root[staging_name]
+                    self.flush()
+                raise
+
+            generation_name = f"{sequence:0{_WORKSPACE_GENERATION_WIDTH}d}"
+            self.h5_file.move(
+                f"/{_WORKSPACE_STAGING_GROUP}/{staging_name}",
+                f"/{_WORKSPACE_GENERATIONS_GROUP}/{generation_name}",
+            )
+            self.h5_file.attrs["imagetool_workspace_schema_version"] = 5
+            self.h5_file.attrs["erlab_version"] = str(erlab.__version__)
+            self.flush(durable=True)
+            return _WorkspaceGeneration(sequence, generation_manifest)
+
+    def flush(self, *, durable: bool = False) -> None:
+        """Flush HDF5 buffers and optionally ask the operating system to sync."""
+        self.h5_file.flush()
+        if not durable:
+            return
+        with contextlib.suppress(Exception):
+            handle = self.h5_file.id.get_vfd_handle()
+            if isinstance(handle, tuple):
+                handle = handle[0]
+            os.fsync(int(handle))
+
+    @staticmethod
+    def manifest_object_ids(manifest: Mapping[str, typing.Any]) -> frozenset[str]:
+        """Return payload object IDs referenced by a manifest."""
+        object_ids: set[str] = set()
+        nodes = manifest.get("nodes", ())
+        if not isinstance(nodes, list):
+            return frozenset()
+        for entry in nodes:
+            if not isinstance(entry, dict):
+                continue
+            object_id = entry.get("payload_object_id")
+            if isinstance(object_id, str) and object_id:
+                object_ids.add(object_id)
+        return frozenset(object_ids)
+
+    def collect_garbage(self, *, max_objects: int = 1) -> bool:
+        """Retire old generations and unlink a bounded number of dead objects.
+
+        Returns ``True`` when more obsolete objects remain.
+        """
+        if max_objects < 1:
+            raise ValueError("max_objects must be positive")
+        with self._write_lock, self._lock:
+            self.require_current_path()
+            generations = self.generations()
+            retained = generations[-2:]
+            retained_names = {
+                f"{generation.sequence:0{_WORKSPACE_GENERATION_WIDTH}d}"
+                for generation in retained
+            }
+            generation_root = self.h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
+            for name in list(generation_root):
+                if name in retained_names:
+                    continue
+                del generation_root[name]
+
+            reachable = set(self._object_leases)
+            for generation in retained:
+                reachable.update(self.manifest_object_ids(generation.manifest))
+
+            object_root = self.h5_file.require_group(_WORKSPACE_OBJECTS_GROUP)
+            obsolete = [name for name in object_root if name not in reachable]
+            for name in obsolete[:max_objects]:
+                del object_root[name]
+            self.h5_file.flush()
+            return len(obsolete) > max_objects
+
+    def clear_staging(self) -> None:
+        """Remove unpublished staging groups left by interrupted saves."""
+        with self._write_lock, self._lock:
+            staging_root = self.h5_file.require_group(_WORKSPACE_STAGING_GROUP)
+            for name in list(staging_root):
+                del staging_root[name]
+            self.h5_file.flush()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -94,13 +94,31 @@ from erlab.interactive.imagetool.viewer_state import (
 logger = logging.getLogger(__name__)
 
 
-def _workspace_computation_session(
-    value: xr.DataArray | xr.Dataset,
-) -> contextlib.AbstractContextManager[None]:
-    """Return the manager workspace gate for one lazy computation."""
+def _workspace_write_in_progress(value: xr.DataArray | xr.Dataset) -> bool:
+    """Return whether a source workspace is waiting to write or is writing."""
     from erlab.interactive.imagetool.manager._workspace import _arrays
 
-    return _arrays.workspace_computation_session(value)
+    return _arrays.workspace_write_in_progress(value)
+
+
+def _repeatable_xarray_resource_closer(
+    value: xr.DataArray | xr.Dataset | xr.DataTree,
+) -> typing.Callable[[], None] | None:
+    """Return the backend closer without xarray's one-shot wrapper."""
+    closer = getattr(value, "_close", None)
+    seen_owners: set[int] = set()
+    while callable(closer):
+        owner = getattr(closer, "__self__", None)
+        if not isinstance(owner, xr.DataArray | xr.Dataset | xr.DataTree):
+            break
+        if id(owner) in seen_owners:
+            return None
+        seen_owners.add(id(owner))
+        owner_closer = getattr(owner, "_close", None)
+        if not callable(owner_closer):
+            break
+        closer = owner_closer
+    return closer if callable(closer) else None
 
 
 class ImageSlicerArea(QtWidgets.QWidget):
@@ -298,6 +316,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._in_manager: bool = _in_manager  #: Internal flag for tools inside manager
         self._update_delayed: bool = _in_manager  #: Internal flag for delayed updates
         self._defer_dask_point_value_readout: bool = False
+        self._workspace_dask_refresh_scheduled = False
+        self._workspace_pending_dask_refresh: (
+            tuple[int | tuple[int, ...], tuple[int, ...] | None] | None
+        ) = None
+        self._data_resource_closer: typing.Callable[[], None] | None = None
         self._defer_state_refresh = _defer_state_refresh
         self._defer_secondary_plots = _defer_secondary_plots
         self._secondary_plots_materialized = False
@@ -1438,8 +1461,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """Return a writable owned copy of the underlying values buffer."""
         values = darr.data
         if getattr(values, "chunks", None) is not None and hasattr(values, "compute"):
-            with _workspace_computation_session(darr):
-                return values.compute()
+            return values.compute()
         if hasattr(values, "copy"):
             return values.copy()
         return np.array(values, copy=True)
@@ -2248,6 +2270,13 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """
         if self.array_slicer._obj.chunks is None:
             return
+        if _workspace_write_in_progress(self._data):
+            self._workspace_pending_dask_refresh = (cursor, axes)
+            if not self._workspace_dask_refresh_scheduled:
+                self._workspace_dask_refresh_scheduled = True
+                QtCore.QTimer.singleShot(100, self._retry_workspace_dask_refresh)
+            return
+        self._workspace_pending_dask_refresh = None
 
         import dask
 
@@ -2275,8 +2304,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             )
 
         if arrays_list_flat:
-            with _workspace_computation_session(self._data):
-                arrays_list_flat = dask.compute(*arrays_list_flat)
+            arrays_list_flat = dask.compute(*arrays_list_flat)
 
         arrays_it = iter(arrays_list_flat)
 
@@ -2298,6 +2326,13 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.sigPointValueChanged.emit(
                 self.array_slicer.display_safe_float(next(arrays_it))
             )
+
+    @QtCore.Slot()
+    def _retry_workspace_dask_refresh(self) -> None:
+        self._workspace_dask_refresh_scheduled = False
+        pending = self._workspace_pending_dask_refresh
+        if pending is not None:
+            self._handle_refresh_dask(*pending)
 
     def link(self, proxy: SlicerLinkProxy) -> None:
         proxy.add(self)
@@ -2380,6 +2415,15 @@ class ImageSlicerArea(QtWidgets.QWidget):
             self.refresh_current()
         self.sigCurrentCursorChanged.emit(cursor)
 
+    def _close_data_resource_cache(self) -> None:
+        """Close the current backend cache while keeping it reusable."""
+        if self._data_resource_closer is not None:
+            self._data_resource_closer()
+
+    def _data_resource_close_callback(self) -> typing.Callable[[], None] | None:
+        """Return the repeatable backend closer for manager coordination."""
+        return self._data_resource_closer
+
     def set_data(
         self,
         data: xr.DataArray | npt.NDArray,
@@ -2419,6 +2463,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
             size is below the threshold defined in options.
 
         """
+        input_resource_closer = (
+            _repeatable_xarray_resource_closer(data)
+            if isinstance(data, xr.DataArray)
+            else None
+        )
         prepared_data = _prepare_input_data(data, self)
         if prepared_data is None:
             raise ValueError("Opening high-dimensional data was canceled.")
@@ -2430,6 +2479,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
             )
         if not preparation_operations:
             preparation_operations = prepared_data[0].operations
+        data_resource_closer = (
+            _repeatable_xarray_resource_closer(darr_list[0]) or input_resource_closer
+        )
 
         self._file_path = pathlib.Path(file_path) if file_path is not None else None
 
@@ -2448,8 +2500,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
         if hasattr(self, "_array_slicer") and hasattr(self, "_data"):
             n_cursors_old = self.n_cursors
-            if isinstance(self._data, xr.DataArray):  # pragma: no branch
-                self._data.close()
+            self._close_data_resource_cache()
+            self._data_resource_closer = None
             del self._data
             self.disconnect_axes_signals()
         else:
@@ -2485,11 +2537,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
             and (source.nbytes * 1e-6)
             < erlab.interactive.options.model.io.dask.compute_threshold
         ):
-            with _workspace_computation_session(source):
-                source = source.compute()
+            source = source.compute()
             shares_external_values = False
+            if data_resource_closer is not None:
+                data_resource_closer()
+                data_resource_closer = None
 
         self._data = source.copy(deep=False)
+        self._data_resource_closer = data_resource_closer
         self._data_shares_external_values = shares_external_values
         self._obj_shares_data_values = True
         self._applied_func = None
@@ -3310,8 +3365,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             try:
                 state = copy.deepcopy(self.state)
                 with erlab.interactive.utils.wait_dialog(self, "Computing…"):
-                    with _workspace_computation_session(self._data):
-                        self.set_data(self._data.load())
+                    self.set_data(self._data.load())
                     self.state = state
                 self.sigDataBackingChanged.emit()
             except Exception:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -94,6 +94,15 @@ from erlab.interactive.imagetool.viewer_state import (
 logger = logging.getLogger(__name__)
 
 
+def _workspace_computation_session(
+    value: xr.DataArray | xr.Dataset,
+) -> contextlib.AbstractContextManager[None]:
+    """Return the manager workspace gate for one lazy computation."""
+    from erlab.interactive.imagetool.manager._workspace import _arrays
+
+    return _arrays.workspace_computation_session(value)
+
+
 class ImageSlicerArea(QtWidgets.QWidget):
     """An interactive tool based on :mod:`pyqtgraph` for exploring 3D data.
 
@@ -1429,7 +1438,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """Return a writable owned copy of the underlying values buffer."""
         values = darr.data
         if getattr(values, "chunks", None) is not None and hasattr(values, "compute"):
-            return values.compute()
+            with _workspace_computation_session(darr):
+                return values.compute()
         if hasattr(values, "copy"):
             return values.copy()
         return np.array(values, copy=True)
@@ -2265,7 +2275,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
             )
 
         if arrays_list_flat:
-            arrays_list_flat = dask.compute(*arrays_list_flat)
+            with _workspace_computation_session(self._data):
+                arrays_list_flat = dask.compute(*arrays_list_flat)
 
         arrays_it = iter(arrays_list_flat)
 
@@ -2474,7 +2485,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
             and (source.nbytes * 1e-6)
             < erlab.interactive.options.model.io.dask.compute_threshold
         ):
-            source = source.compute()
+            with _workspace_computation_session(source):
+                source = source.compute()
             shares_external_values = False
 
         self._data = source.copy(deep=False)
@@ -3298,7 +3310,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
             try:
                 state = copy.deepcopy(self.state)
                 with erlab.interactive.utils.wait_dialog(self, "Computing…"):
-                    self.set_data(self._data.load())
+                    with _workspace_computation_session(self._data):
+                        self.set_data(self._data.load())
                     self.state = state
                 self.sigDataBackingChanged.emit()
             except Exception:

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -2276,15 +2276,6 @@ def ktool(
         seed the normal emission controls and derived angle offsets.
     initial_delta
         Optional delta value to apply alongside ``initial_normal_emission``.
-
-    Notes
-    -----
-    .. versionchanged:: 3.27.0
-        The tool opens the input-coordinate editor when the configuration or a required
-        scalar energy or angle coordinate is not in the data. Select a configuration
-        and enter a finite value for each blank coordinate to open the tool. The editor
-        also changes existing scalar coordinates such as ``hv`` and ``eV``. The
-        ``alpha`` coordinate and swept coordinates remain required in the source data.
     """
     if data_name is None:
         try:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -5560,10 +5560,14 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         source_parent_data: xr.DataArray | None,
         reference_resolver: Callable[[Mapping[str, typing.Any]], xr.DataArray | None]
         | None,
+        variable_names: Collection[str] | None = None,
     ) -> dict[str, xr.DataArray]:
+        requested = None if variable_names is None else frozenset(variable_names)
         references = cls._saved_tool_data_references(ds)
         data_items: dict[str, xr.DataArray] = {}
         for variable_name, reference in references.items():
+            if requested is not None and variable_name not in requested:
+                continue
             try:
                 data_items[variable_name] = cls._resolve_saved_tool_data_reference(
                     reference,
@@ -5579,6 +5583,8 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 raise
 
         for variable_name, data_array in ds.data_vars.items():
+            if requested is not None and variable_name not in requested:
+                continue
             if variable_name in data_items:
                 continue
             if _TOOL_DATA_BLOB_NAME_ATTR in data_array.attrs:
@@ -5586,7 +5592,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     raise TypeError("Saved tool data variable names must be strings")
                 data_items[variable_name] = _tool_data_from_blob(data_array)
 
-        if _SAVED_TOOL_DATA_NAME not in data_items:
+        if (
+            requested is None or _SAVED_TOOL_DATA_NAME in requested
+        ) and _SAVED_TOOL_DATA_NAME not in data_items:
             if _SAVED_TOOL_DATA_NAME not in ds:
                 raise ValueError("Saved tool dataset is missing primary tool data")
             data_items[_SAVED_TOOL_DATA_NAME] = ds[_SAVED_TOOL_DATA_NAME]

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
@@ -486,9 +486,7 @@ def test_manager_duplicate_deferred_figure_materializes_saved_payload(
         manager.get_imagetool(0).hide()
 
         workspace_path = tmp_path / "deferred-figure-duplicate.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -37,6 +37,7 @@ from tests.interactive.imagetool.manager.helpers import (
     trigger_menu_action,
 )
 from tests.interactive.imagetool.manager.workspace._support import (
+    _current_workspace_payload_path,
     _request_workspace_save_as_and_wait,
 )
 
@@ -960,9 +961,7 @@ def test_manager_workspace_restores_figure_preview_and_live_details(
         figure_uid = manager.add_figuretool(figure_tool, show=False)
         assert figure_tool.refresh_preview_pixmap(allow_offscreen=True) is not None
 
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
@@ -1527,12 +1526,10 @@ def test_manager_workspace_figure_sources_save_as_references(
             )
 
             fname = tmp_path / "figure-source-references.itws"
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
+            manager._workspace_controller.saving._save_workspace_document(fname)
             saved_ds = workspace_arrays._read_workspace_dataset_group_h5py(
                 fname,
-                f"figures/{figure_uid}/tool",
+                _current_workspace_payload_path(fname, f"figures/{figure_uid}"),
                 preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
             )
             assert saved_ds is not None
@@ -1620,16 +1617,41 @@ def test_manager_figure_workspace_reference_helper_edges(
                 current_reference, data
             )
 
+        saved_references = {"source": current_reference}
         snapshot = workspace_saving._WorkspaceSaveSnapshot(
             generation=0,
-            root_attrs={},
-            delta_save_count=0,
+            generation_plan=workspace_storage._WorkspaceGenerationPlan(
+                manifest={"schema_version": 5, "nodes": []},
+                objects=(),
+            ),
+            compression_mode="none",
             serialized_tool_data_references=(
-                ("missing", {}),
-                (root_node.uid, {}),
+                ("missing", "missing-token", {}),
+                (root_node.uid, root_node.snapshot_token, {}),
+                (figure_uid, figure_node.snapshot_token, saved_references),
             ),
         )
         controller._commit_saved_tool_data_references(snapshot)
+        assert figure_node._workspace_tool_data_references == saved_references
+
+        snapshot.serialized_tool_data_references = ((figure_uid, stale_revision, {}),)
+        controller._commit_saved_tool_data_references(snapshot)
+        assert figure_node._workspace_tool_data_references == saved_references
+
+        snapshot.serialized_tool_data_references = (
+            (
+                figure_uid,
+                figure_node.snapshot_token,
+                {
+                    "source": {
+                        **current_reference,
+                        "node_snapshot_token": stale_revision,
+                    }
+                },
+            ),
+        )
+        controller._commit_saved_tool_data_references(snapshot)
+        assert figure_node._workspace_tool_data_references == saved_references
 
         invalid_tool_dataset = xr.Dataset(
             attrs={"manager_node_kind": "tool", "manager_node_uid": ""}
@@ -1661,7 +1683,7 @@ def test_manager_figure_workspace_reference_helper_edges(
         )
 
         workspace_path = tmp_path / "reference-helper-edges.itws"
-        saver._save_workspace_document(workspace_path, force_full=True)
+        saver._save_workspace_document(workspace_path)
         adopt_workspace_path(manager, workspace_path)
         reference_datasets: dict[tuple[Path, str], xr.Dataset] = {}
         try:
@@ -1752,7 +1774,7 @@ def test_manager_workspace_embeds_figure_snapshot_after_source_transpose(
         assert _request_workspace_save_as_and_wait(qtbot, manager, native=False)
         saved_figure = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
-            f"figures/{figure_uid}/tool",
+            _current_workspace_payload_path(workspace_path, f"figures/{figure_uid}"),
             preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
         )
         assert saved_figure is not None
@@ -1770,12 +1792,10 @@ def test_manager_workspace_embeds_figure_snapshot_after_source_transpose(
         assert root_node.snapshot_token != source_state.node_snapshot_token
         assert figure_tool.source_data()[primary_source].dims == data.dims
 
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=False
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         rewritten_figure = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
-            f"figures/{figure_uid}/tool",
+            _current_workspace_payload_path(workspace_path, f"figures/{figure_uid}"),
             preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
         )
         assert rewritten_figure is not None
@@ -1837,9 +1857,7 @@ def test_manager_failed_save_keeps_last_saved_figure_references(
         figure_node = manager._child_node(figure_uid)
 
         workspace_path = tmp_path / "failed-figure-source-transpose.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         adopt_workspace_path(manager, workspace_path)
         saved_references = dict(figure_node._workspace_tool_data_references)
         assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in saved_references
@@ -1852,21 +1870,20 @@ def test_manager_failed_save_keeps_last_saved_figure_references(
 
         monkeypatch.setattr(
             workspace_storage,
-            "_write_workspace_transaction_file",
+            "_write_workspace_generation",
             _raise_write_error,
         )
 
         with pytest.raises(RuntimeError, match="write failed"):
             manager._workspace_controller.saving._save_workspace_document(
-                workspace_path, force_full=False
+                workspace_path
             )
 
         assert figure_node._workspace_tool_data_references == saved_references
 
 
-def test_manager_full_save_fallback_preserves_figure_source_snapshot(
+def test_manager_save_as_preserves_figure_source_snapshot(
     qtbot,
-    monkeypatch,
     tmp_path: Path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -1894,26 +1911,17 @@ def test_manager_full_save_fallback_preserves_figure_source_snapshot(
         source_name = figure.tool_status.primary_source
 
         source_path = tmp_path / "full-save-source.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            source_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(source_path)
         adopt_workspace_path(manager, source_path)
         manager._workspace_controller._mark_workspace_clean()
 
         root.slicer_area.transpose_main_image()
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_workspace_full_save_manifest_first_snapshot",
-            lambda *_args, **_kwargs: None,
-        )
         target_path = tmp_path / "full-save-target.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            target_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(target_path)
 
         saved_figure = workspace_arrays._read_workspace_dataset_group_h5py(
             target_path,
-            f"figures/{figure_uid}/tool",
+            _current_workspace_payload_path(target_path, f"figures/{figure_uid}"),
             preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
         )
         assert saved_figure is not None
@@ -1934,7 +1942,7 @@ def test_manager_full_save_fallback_preserves_figure_source_snapshot(
         xr.testing.assert_identical(restored.source_data()[source_name], data)
 
 
-def test_manager_incremental_save_preserves_pending_figure_snapshot(
+def test_manager_generation_save_preserves_pending_figure_snapshot(
     qtbot,
     tmp_path: Path,
     manager_context: Callable[
@@ -1956,9 +1964,7 @@ def test_manager_incremental_save_preserves_pending_figure_snapshot(
         assert figure_uid is not None
 
         workspace_path = tmp_path / "pending-figure-source-transpose.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,
@@ -1978,12 +1984,10 @@ def test_manager_incremental_save_preserves_pending_figure_snapshot(
         source_node.slicer_area.transpose_main_image()
         assert source_node.data_for_role("displayed").dims == ("eV", "kx")
 
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=False
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         rewritten_figure = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
-            f"figures/{figure_uid}/tool",
+            _current_workspace_payload_path(workspace_path, f"figures/{figure_uid}"),
             preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
         )
         assert rewritten_figure is not None
@@ -2033,12 +2037,11 @@ def test_manager_pending_figure_source_reference_uses_saved_imagetool_dim_order(
         assert figure_uid is not None
 
         workspace_path = tmp_path / "pending-figure-source-order.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+        payload_path = _current_workspace_payload_path(workspace_path)
         saved_ds = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
-            "0/imagetool",
+            payload_path,
             preferred_data_name=_ITOOL_DATA_NAME,
         )
         assert saved_ds is not None
@@ -2047,9 +2050,9 @@ def test_manager_pending_figure_source_reference_uses_saved_imagetool_dim_order(
             attrs=dict(saved_ds.attrs),
         )
         with h5py.File(workspace_path, "r+") as h5_file:
-            del h5_file["0/imagetool"]
+            del h5_file[payload_path]
         assert workspace_arrays._write_workspace_dataset_group_h5py(
-            workspace_path, "0/imagetool", stored
+            workspace_path, payload_path, stored
         )
 
         assert manager._workspace_controller.loading._load_workspace_file(
@@ -2074,8 +2077,9 @@ def test_manager_pending_figure_source_reference_uses_saved_imagetool_dim_order(
         assert source_node.pending_workspace_memory_payload is not None
 
 
-def test_manager_workspace_delta_snapshot_rewrites_stale_figure_source_references(
+def test_manager_workspace_generation_rewrites_stale_figure_source_references(
     qtbot,
+    tmp_path: Path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -2131,17 +2135,26 @@ def test_manager_workspace_delta_snapshot_rewrites_stale_figure_source_reference
         )
         manager._mark_workspace_layout_dirty()
 
-        snapshot = manager._workspace_controller.saving._workspace_delta_save_snapshot(
-            manager._workspace_state.dirty_generation,
-            manager._workspace_controller.saving._workspace_root_attrs_payload(
-                delta_save_count=1
-            ),
-            1,
+        snapshot = (
+            manager._workspace_controller.saving._workspace_generation_save_snapshot(
+                manager._workspace_state.dirty_generation,
+                fname=tmp_path / "snapshot.itws",
+            )
         )
         try:
-            rewrite_map = dict(snapshot.rewrite_groups)
-            constructor = rewrite_map[f"figures/{figure_uid}"]
-            rewritten_ds = constructor[f"figures/{figure_uid}/tool"]
+            figure_entry = next(
+                entry
+                for entry in snapshot.generation_plan.manifest["nodes"]
+                if entry["uid"] == figure_uid
+            )
+            object_id = figure_entry["payload_object_id"]
+            object_write = next(
+                item
+                for item in snapshot.generation_plan.objects
+                if item.object_id == object_id
+            )
+            rewritten_ds = object_write.dataset
+            assert rewritten_ds is not None
             rewritten_refs = json.loads(
                 rewritten_ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
             )

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_sources.py
@@ -658,9 +658,7 @@ def test_manager_figure_action_add_source_only_keeps_recipe_steps(
         assert isinstance(figure_tool, FigureComposerTool)
         operation_count = len(figure_tool.tool_status.operations)
         workspace_path = tmp_path / "add-source-only-delta.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
 
         select_tools(manager, [1])
 
@@ -1144,9 +1142,7 @@ def test_manager_figure_remove_unused_source_persists_workspace(
         assert figure_uid in snapshot["dirty_state"]
 
         workspace_path = tmp_path / "remove-unused-figure-source.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
         assert manager._workspace_controller.loading._load_workspace_file(

--- a/tests/interactive/imagetool/manager/helpers.py
+++ b/tests/interactive/imagetool/manager/helpers.py
@@ -129,7 +129,9 @@ def adopt_workspace_path(manager: ImageToolManager, path: str | pathlib.Path) ->
     with controller._workspace_document_access_context(path) as access:
         store = workspace_store.WorkspaceStore.active(access.path)
         if store is None:
-            store = workspace_store.WorkspaceStore(access.path)
+            store = workspace_store.WorkspaceStore(
+                access.path, create=not access.path.exists()
+            )
         controller._set_workspace_path(
             access.path,
             workspace_lock=access.take_lock(),

--- a/tests/interactive/imagetool/manager/helpers.py
+++ b/tests/interactive/imagetool/manager/helpers.py
@@ -12,6 +12,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.manager._registry as manager_registry
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
 
@@ -126,9 +127,13 @@ def adopt_workspace_path(manager: ImageToolManager, path: str | pathlib.Path) ->
     """Adopt a workspace path while preserving the document-lock contract."""
     controller = manager._workspace_controller
     with controller._workspace_document_access_context(path) as access:
+        store = workspace_store.WorkspaceStore.active(access.path)
+        if store is None:
+            store = workspace_store.WorkspaceStore(access.path)
         controller._set_workspace_path(
             access.path,
             workspace_lock=access.take_lock(),
+            store=store,
         )
 
 

--- a/tests/interactive/imagetool/manager/provenance/test_clipboard.py
+++ b/tests/interactive/imagetool/manager/provenance/test_clipboard.py
@@ -1660,9 +1660,7 @@ def test_manager_paste_structured_provenance_steps_into_pending_memory_imagetool
         tool.hide()
 
         workspace_path = tmp_path / "pending-provenance-paste.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path, replace=True, associate=True, mark_dirty=False, select=False
         )

--- a/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
+++ b/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
@@ -12,6 +12,7 @@ import erlab
 import erlab.interactive.imagetool._highdim as imagetool_highdim
 import erlab.interactive.imagetool.manager._lineage as manager_lineage
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
+import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 from erlab.interactive._fit2d import Fit2DTool
 from erlab.interactive._mesh import MeshTool
 from erlab.interactive.derivative import DerivativeTool
@@ -215,12 +216,11 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
 
         workspace_link_id = manager._workspace_state.link_id
         tree = manager._workspace_controller.saving._to_datatree()
-        tree.attrs.update(
-            manager._workspace_controller.saving._workspace_root_attrs_payload(
-                delta_save_count=0
-            )
+        manifest = manager._workspace_controller.saving._workspace_manifest()
+        tree.attrs["imagetool_workspace_schema_version"] = (
+            workspace_format._WORKSPACE_MANIFEST_SCHEMA_VERSION
         )
-        manifest = json.loads(tree.attrs["imagetool_workspace_manifest"])
+        tree.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(manifest)
         assert manifest["workspace_link_id"] == workspace_link_id
         attrs = tree["0/imagetool"].attrs
         assert attrs["manager_node_watched_varname"] == "data"

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -41,6 +41,7 @@ from erlab.interactive.imagetool.manager._widgets import _WorkspacePropertiesSta
 from erlab.interactive.imagetool.manager._workspace import (
     _controller as workspace_controller,
 )
+from erlab.interactive.imagetool.manager._workspace import _store as workspace_store
 from erlab.interactive.ptable import PeriodicTableWindow
 from tests.interactive.imagetool.manager.helpers import (
     action_map_by_object_name,
@@ -747,7 +748,8 @@ def test_manager_workspace_properties_action_uses_current_state(
         assert dialog_calls[-1][2] is manager
 
         workspace_path = tmp_path / "workspace.itws"
-        workspace_path.touch()
+        with workspace_store.WorkspaceStore(workspace_path, create=True):
+            pass
         adopt_workspace_path(manager, workspace_path)
 
         manager.workspace_properties_action.trigger()

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -3284,9 +3284,7 @@ def test_manager_reload_script_inputs_after_workspace_roundtrip(
         qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
 
         workspace_path = tmp_path / "script-derived-reload.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,
@@ -3618,9 +3616,7 @@ def test_manager_reload_script_inputs_reuses_shared_recorded_file_prefix(
         qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
 
         workspace_path = tmp_path / "shared-replay.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -1833,9 +1833,7 @@ def test_watched_metadata_assignments_retain_workspace_replay_source(
         assert manager._provenance_edit_controller.can_reorder_steps()[0]
 
         workspace_path = tmp_path / "watched-metadata-replay.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,
@@ -3851,9 +3849,7 @@ def test_batch_action_counts_pending_memory_imagetools_without_materializing(
             tool.hide()
 
         workspace_path = tmp_path / "pending-batch-targets.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -6899,9 +6895,7 @@ def test_manager_workspace_reload_preserves_manual_root_name(
 
         manager.rename_imagetool(0, "saved manual root")
         workspace_path = tmp_path / "manual-root-name.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
 
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
@@ -6972,9 +6966,7 @@ def test_manager_workspace_reload_preserves_manual_child_imagetool_name(
         manager._child_node(child_uid).name = "saved manual child"
 
         workspace_path = tmp_path / "manual-child-name.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
 
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
@@ -7046,9 +7038,7 @@ def test_manager_notes_persist_workspace_roundtrip(
         )
 
         workspace_path = tmp_path / "notes.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
 
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
@@ -7110,15 +7100,10 @@ def test_acquisition_context_persists_on_open_but_not_workspace_import(
         _add_batch_tools(qtbot, manager, _batch_data("scan"))
         manager._acquisition_context.set_state(saved_state, mark_dirty=False)
         workspace_path = tmp_path / "acquisition-context.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
 
         manager._acquisition_context.set_state(delta_saved_state)
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=False
-        )
-        assert manager._workspace_state.delta_save_count == 1
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
 
         manager._acquisition_context.set_state(transient_state, mark_dirty=False)
         assert manager._workspace_controller.loading._load_workspace_file(
@@ -7160,9 +7145,7 @@ def test_metadata_assignment_provenance_persists_for_live_replacement(
         )
 
         workspace_path = tmp_path / "metadata-assignment.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,
@@ -7237,9 +7220,7 @@ def test_metadata_editor_layout_persists_with_workspace(
         reopened.reject()
 
         workspace_path = tmp_path / "metadata-layout.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         manager._metadata_editor.set_layout_fields((transient,))
         manager._metadata_editor.set_column_width(None, 301)
         manager._metadata_editor.set_column_width(transient, 181)
@@ -7295,9 +7276,7 @@ def test_metadata_editor_reads_deferred_workspace_metadata_without_materializing
             tool.hide()
 
         workspace_path = tmp_path / "deferred-metadata-editor.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -3280,6 +3280,7 @@ def test_remove_imagetool_removes_childtools() -> None:
     removed_uids: list[str] = []
     removed_rows: list[int] = []
     refresh_calls: list[None] = []
+    imported_access_release_calls: list[None] = []
     cleared_dependency_uids: list[str] = []
     canceled_node_change_uids: list[str] = []
 
@@ -3315,7 +3316,15 @@ def test_remove_imagetool_removes_childtools() -> None:
         _dependency_tracker=types.SimpleNamespace(
             clear_uid=cleared_dependency_uids.append
         ),
-        _workspace_state=types.SimpleNamespace(closing_document=False),
+        _workspace_state=types.SimpleNamespace(
+            closing_document=False,
+            loading_depth=0,
+        ),
+        _workspace_controller=types.SimpleNamespace(
+            _release_unused_imported_workspace_accesses=lambda: (
+                imported_access_release_calls.append(None)
+            )
+        ),
         tree_view=types.SimpleNamespace(
             imagetool_removed=lambda index: removed_rows.append(index)
         ),
@@ -3325,6 +3334,7 @@ def test_remove_imagetool_removes_childtools() -> None:
     assert removed_uids == [uid]
     assert removed_rows == [0]
     assert refresh_calls == [None]
+    assert imported_access_release_calls == [None]
     assert cleared_dependency_uids == [wrapper.uid]
     assert canceled_node_change_uids == [wrapper.uid]
     assert wrapper.disposed

--- a/tests/interactive/imagetool/manager/workspace/_support.py
+++ b/tests/interactive/imagetool/manager/workspace/_support.py
@@ -1,7 +1,8 @@
+import contextlib
 import json
 import pathlib
 import typing
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 
 import h5py
 import hdf5plugin
@@ -11,8 +12,9 @@ import xarray as xr
 
 import erlab
 import erlab.interactive.imagetool._serialization as imagetool_serialization
+import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
-import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 from erlab.interactive.imagetool._provenance._model import (
     FileLoadSource,
     FileReplayCall,
@@ -169,12 +171,28 @@ def _open_external_hdf5_imagetool_data(
     }
     if chunks is not None:
         open_kwargs["chunks"] = chunks
-    tree = xr.open_datatree(fname, **open_kwargs)
     try:
-        ds = typing.cast("xr.DataTree", tree["0/imagetool"]).to_dataset(inherit=False)
-        return ds[next(iter(ds.data_vars))]
-    finally:
-        tree.close()
+        root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
+    except ValueError:
+        schema_version = None
+    else:
+        schema_version, _manifest = (
+            workspace_format._workspace_file_metadata_from_attrs(root_attrs)
+        )
+    if schema_version == workspace_format._current_workspace_schema_version():
+        ds = xr.open_dataset(
+            fname,
+            group=_current_workspace_payload_path(fname),
+            **open_kwargs,
+        )
+        data = ds[imagetool_serialization.ITOOL_DATA_NAME]
+        data.set_close(ds.close)
+        return data
+    tree = xr.open_datatree(fname, **open_kwargs)
+    ds = typing.cast("xr.DataTree", tree["0/imagetool"]).to_dataset(inherit=False)
+    data = ds[next(iter(ds.data_vars))]
+    data.set_close(tree.close)
+    return data
 
 
 def _open_external_lazy_hdf5_imagetool_data(fname: pathlib.Path) -> xr.DataArray:
@@ -189,6 +207,81 @@ def _open_external_file_backed_hdf5_imagetool_data(
 
 def _compute_first_value(darr: xr.DataArray) -> object:
     return darr.isel(dict.fromkeys(darr.dims, 0)).compute().item()
+
+
+def _current_workspace_manifest(path: pathlib.Path) -> dict[str, typing.Any]:
+    return workspace_format._workspace_manifest_from_attrs(
+        workspace_arrays._read_workspace_root_attrs_h5py(path)
+    )
+
+
+def _current_workspace_manifest_entry(
+    path: pathlib.Path, node_path: str = "0"
+) -> dict[str, typing.Any]:
+    for entry in workspace_format._iter_workspace_manifest_node_entries(
+        _current_workspace_manifest(path)
+    ):
+        if entry.get("path") == node_path:
+            return entry
+    raise AssertionError(f"No saved payload for node path {node_path!r}")
+
+
+def _current_workspace_payload_path(path: pathlib.Path, node_path: str = "0") -> str:
+    payload_path = _current_workspace_manifest_entry(path, node_path).get(
+        "payload_path"
+    )
+    assert isinstance(payload_path, str)
+    return payload_path
+
+
+def _current_workspace_payload_attrs(
+    path: pathlib.Path, node_path: str = "0"
+) -> dict[typing.Any, typing.Any]:
+    payload_attrs = _current_workspace_manifest_entry(path, node_path).get(
+        "payload_attrs"
+    )
+    if payload_attrs is None:
+        raise AssertionError(f"No saved payload attributes for node path {node_path!r}")
+    return workspace_format._restore_workspace_manifest_attrs(payload_attrs)
+
+
+def _publish_workspace_manifest(
+    path: pathlib.Path, manifest: Mapping[str, typing.Any]
+) -> None:
+    store = workspace_store.WorkspaceStore.active(path)
+    owns_store = store is None
+    if store is None:
+        store = workspace_store.WorkspaceStore(path)
+    try:
+        store.publish(manifest)
+    finally:
+        if owns_store:
+            store.close()
+
+
+@contextlib.contextmanager
+def _edit_current_workspace_payload_attrs(
+    path: pathlib.Path, node_path: str = "0"
+) -> Iterator[dict[typing.Any, typing.Any]]:
+    manifest = _current_workspace_manifest(path)
+    entry = next(
+        (
+            entry
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                manifest
+            )
+            if entry.get("path") == node_path
+        ),
+        None,
+    )
+    if entry is None:
+        raise AssertionError(f"No saved payload for node path {node_path!r}")
+    attrs = workspace_format._restore_workspace_manifest_attrs(
+        entry.get("payload_attrs", {})
+    )
+    yield attrs
+    entry["payload_attrs"] = workspace_format._workspace_manifest_attrs(attrs)
+    _publish_workspace_manifest(path, manifest)
 
 
 def _hdf5_filter_ids(dataset) -> list[int]:
@@ -229,23 +322,29 @@ def _transaction_test_dataset(value: float, *, title: str) -> xr.Dataset:
 
 
 def _write_transaction_test_workspace(fname: pathlib.Path, value: float = 1.0) -> None:
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(value, title="old")}
+    workspace_arrays._write_workspace_dataset_group_to_file(
+        fname,
+        "0/imagetool",
+        _transaction_test_dataset(value, title="old"),
     )
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, _transaction_test_root_attrs()
-        )
-    finally:
-        tree.close()
+    with h5py.File(fname, "a") as h5_file:
+        h5_file.attrs.update(_transaction_test_root_attrs())
 
 
 def _assert_no_workspace_internal_groups(fname: pathlib.Path) -> None:
-
     with h5py.File(fname, "r") as h5_file:
+        generation_groups = {
+            workspace_store._WORKSPACE_OBJECTS_GROUP,
+            workspace_store._WORKSPACE_STAGING_GROUP,
+            workspace_store._WORKSPACE_GENERATIONS_GROUP,
+        }
         assert not any(
-            workspace_format._is_workspace_internal_group_name(name) for name in h5_file
+            workspace_format._is_workspace_internal_group_name(name)
+            and name not in generation_groups
+            for name in h5_file
         )
+        if workspace_store._WORKSPACE_STAGING_GROUP in h5_file:
+            assert len(h5_file[workspace_store._WORKSPACE_STAGING_GROUP]) == 0
 
 
 def _rich_workspace_attr_value() -> dict[str, typing.Any]:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import pathlib
+import threading
 import types
 import typing
 import warnings
@@ -388,6 +389,41 @@ def test_workspace_file_manager_opens_unassociated_file_read_only(tmp_path) -> N
     finally:
         manager.close()
         del manager
+        gc.collect()
+
+
+def test_workspace_file_managers_serialize_shared_cached_handle_access(
+    tmp_path,
+) -> None:
+    fname = tmp_path / "shared-reader.itws"
+    _write_transaction_test_workspace(fname)
+    first = workspace_arrays.WorkspaceFileManager(fname)
+    second = workspace_arrays.WorkspaceFileManager(fname)
+    close_started = threading.Event()
+    close_finished = threading.Event()
+
+    def _close_second() -> None:
+        close_started.set()
+        second.close()
+        close_finished.set()
+
+    close_thread = threading.Thread(target=_close_second)
+    try:
+        with first.lock:
+            first.acquire(needs_lock=False)
+            close_thread.start()
+            assert close_started.wait(2)
+            assert not close_finished.wait(0.05)
+        close_thread.join(2)
+        assert not close_thread.is_alive()
+        assert close_finished.is_set()
+        with first.lock:
+            reopened = first.acquire(needs_lock=False)
+            assert pathlib.Path(reopened.filename).resolve() == fname.resolve()
+    finally:
+        first.close()
+        second.close()
+        close_thread.join(2)
         gc.collect()
 
 

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -4,9 +4,6 @@ import json
 import logging
 import os
 import pathlib
-import pickle
-import subprocess
-import sys
 import types
 import typing
 import warnings
@@ -22,101 +19,14 @@ import erlab
 import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
-import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from tests.interactive.imagetool.manager.workspace._support import (
     _assert_rich_workspace_attr,
     _hdf5_blosc2_level_codec,
     _hdf5_filter_ids,
     _rich_workspace_attr_value,
+    _write_transaction_test_workspace,
 )
-
-
-def test_workspace_h5py_helpers_reject_non_workspace_files(tmp_path) -> None:
-
-    fname = tmp_path / "not-workspace.itws"
-    with h5py.File(fname, "w") as h5_file:
-        h5_file.create_group("0")
-
-    with pytest.raises(ValueError, match="Not a valid workspace file"):
-        workspace_arrays._workspace_live_root_group_copy_groups(fname)
-    with pytest.raises(ValueError, match="Not a valid workspace file"):
-        workspace_arrays._workspace_h5_paths_storage_size(fname, ("0",))
-    with pytest.raises(ValueError, match="Not a valid workspace file"):
-        workspace_arrays._workspace_live_h5_storage_size(fname)
-
-    assert (
-        workspace_storage._workspace_obsolete_estimate(tmp_path / "missing.itws") == 0
-    )
-    assert workspace_arrays._workspace_h5_object_storage_size(object()) == 0
-
-
-def test_workspace_h5py_filter_matching_edge_cases(tmp_path) -> None:
-
-    fname = tmp_path / "filters.h5"
-    with h5py.File(fname, "w") as h5_file:
-        plain = h5_file.create_dataset("plain", data=np.arange(3))
-        compressed = h5_file.create_dataset(
-            "compressed",
-            data=np.arange(3),
-            **hdf5plugin.Blosc2(
-                cname="zstd",
-                clevel=1,
-                filters=hdf5plugin.Blosc2.SHUFFLE,
-            ),
-        )
-        group = h5_file.create_group("payload")
-        gzip_data = group.create_dataset("data", data=np.arange(3), compression="gzip")
-        metadata_group = h5_file.create_group("metadata")
-        metadata_group.create_group("nested")
-
-        assert workspace_arrays._workspace_h5py_blosc2_options_match((1, 2), (1, 2))
-        assert not workspace_arrays._workspace_h5py_blosc2_options_match((1,), (2,))
-        assert workspace_arrays._workspace_h5py_dataset_matches_encoding(plain, {})
-        assert not workspace_arrays._workspace_h5py_dataset_matches_encoding(
-            plain, {"compression": hdf5plugin.Blosc2.filter_id}
-        )
-        assert workspace_arrays._workspace_h5py_dataset_matches_encoding(
-            compressed, {"compression": hdf5plugin.Blosc2.filter_id}
-        )
-        assert workspace_arrays._workspace_h5py_dataset_matches_encoding(
-            compressed, workspace_arrays._workspace_blosc2_encoding("zstd1")
-        )
-        assert not workspace_arrays._workspace_h5py_dataset_matches_encoding(
-            compressed, workspace_arrays._workspace_blosc2_encoding("blosclz3")
-        )
-        gzip_filter = workspace_arrays._workspace_h5py_filter_options(gzip_data)
-        assert workspace_arrays._workspace_h5py_dataset_matches_encoding(
-            gzip_data,
-            {"compression": 1, "compression_opts": gzip_filter[1]},
-        )
-        assert not workspace_arrays._h5_group_matches_compression(
-            h5_file, "missing", "none"
-        )
-        assert not workspace_arrays._h5_group_matches_compression(
-            h5_file, "plain", "none"
-        )
-        assert workspace_arrays._h5_group_matches_compression(
-            h5_file, "metadata", "none"
-        )
-        assert not workspace_arrays._workspace_h5_group_matches_compression_mode(
-            h5_file,
-            "missing",
-            xr.Dataset({"data": ("x", np.arange(3))}),
-            "none",
-        )
-        assert not workspace_arrays._workspace_h5_group_matches_compression_mode(
-            h5_file,
-            "payload",
-            xr.Dataset({"missing": ("x", np.arange(3))}),
-            "none",
-        )
-        assert not workspace_arrays._workspace_h5_group_matches_compression_mode(
-            h5_file,
-            "payload",
-            xr.Dataset({"data": ("x", np.arange(3))}),
-            "none",
-        )
 
 
 def test_workspace_h5py_copy_rebuilds_attrs_and_dimension_scales(tmp_path) -> None:
@@ -454,55 +364,27 @@ def test_workspace_xarray_path_helpers_cover_fallbacks(monkeypatch, tmp_path) ->
 
 
 def test_workspace_file_manager_uses_fsdecode_fallback(monkeypatch) -> None:
-    captured: dict[str, object] = {}
-
     monkeypatch.setattr(workspace_arrays, "_normalized_file_path", lambda _path: None)
-
-    def _reader_snapshot(path: str):
-        captured["path"] = path
-        return "snapshot"
-
-    def _initialize(self, snapshot: object) -> None:
-        captured["snapshot"] = snapshot
-        self.workspace_path = "fallback.itws"
-        self._key = "fake-key"
-        self._ref_counter = types.SimpleNamespace(decrement=lambda _key: 1)
-        self._cache = {}
-
-    monkeypatch.setattr(
-        workspace_arrays, "_workspace_reader_snapshot", _reader_snapshot
-    )
-    monkeypatch.setattr(
-        workspace_arrays.WorkspaceFileManager, "_initialize", _initialize
-    )
-
     file_manager = workspace_arrays.WorkspaceFileManager("fallback.itws")
-
-    assert file_manager.workspace_path == "fallback.itws"
-    assert captured == {"path": "fallback.itws", "snapshot": "snapshot"}
-
-
-def test_workspace_file_manager_uses_immutable_read_only_copy(tmp_path) -> None:
-    fname = tmp_path / "reader-copy.itws"
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": xr.Dataset({"data": ("x", np.arange(4.0))})}
-    )
     try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, {"imagetool_workspace_schema_version": 4}
-        )
+        assert file_manager.workspace_path == "fallback.itws"
+        assert file_manager.reader_path == "fallback.itws"
     finally:
-        tree.close()
+        file_manager.close()
+
+
+def test_workspace_file_manager_opens_unassociated_file_read_only(tmp_path) -> None:
+    fname = tmp_path / "reader-copy.itws"
+    _write_transaction_test_workspace(fname)
 
     manager = workspace_arrays.WorkspaceFileManager(fname)
     reader_path = pathlib.Path(manager.reader_path)
     try:
-        assert reader_path != fname.resolve()
-        assert reader_path.read_bytes() == fname.read_bytes()
-        assert manager._args == (str(reader_path.resolve()),)
+        assert reader_path == fname.resolve()
+        assert manager._args == (str(fname.resolve()),)
         assert manager._mode == "r"
         with manager.acquire_context() as h5_file:
-            assert pathlib.Path(h5_file.filename).resolve() == reader_path.resolve()
+            assert pathlib.Path(h5_file.filename).resolve() == fname.resolve()
     finally:
         manager.close()
         del manager
@@ -510,239 +392,16 @@ def test_workspace_file_manager_uses_immutable_read_only_copy(tmp_path) -> None:
 
 
 def test_workspace_file_manager_reports_missing_published_file(tmp_path) -> None:
-    with pytest.raises(FileNotFoundError):
-        workspace_arrays.WorkspaceFileManager(tmp_path / "missing.itws")
-
-
-def test_workspace_reader_cleanup_removes_only_safe_stale_directories(
-    monkeypatch, tmp_path
-) -> None:
-    stale = tmp_path / "erlab-itws-readers-1234-stale"
-    stale.mkdir()
-    (stale / "reader-1234-data.itws").write_bytes(b"stale")
-    unsafe = tmp_path / "erlab-itws-readers-5678-unsafe"
-    unsafe.mkdir()
-    (unsafe / "unrelated.txt").write_text("keep")
-    monkeypatch.setattr(workspace_arrays.tempfile, "gettempdir", lambda: str(tmp_path))
-    monkeypatch.setattr(
-        workspace_arrays, "_workspace_process_is_running", lambda _pid: False
-    )
-    monkeypatch.setattr(workspace_arrays, "_WORKSPACE_READER_STALE_CLEANUP_DONE", False)
-
-    workspace_arrays._cleanup_stale_workspace_reader_directories()
-
-    assert not stale.exists()
-    assert unsafe.exists()
-
-
-def test_workspace_process_liveness_uses_non_destructive_probe(monkeypatch) -> None:
-    process_id = os.getpid()
-    probed: list[int] = []
-
-    def _pid_exists(pid: int) -> bool:
-        probed.append(pid)
-        return pid == process_id
-
-    def _fail_kill(*_args) -> None:
-        raise AssertionError("workspace cleanup must not signal another process")
-
-    monkeypatch.setattr(workspace_arrays.psutil, "pid_exists", _pid_exists)
-    monkeypatch.setattr(workspace_arrays.os, "kill", _fail_kill)
-
-    assert workspace_arrays._workspace_process_is_running(process_id)
-    assert not workspace_arrays._workspace_process_is_running(process_id + 1)
-    assert probed == [process_id, process_id + 1]
-
-    monkeypatch.setattr(
-        workspace_arrays.psutil,
-        "pid_exists",
-        lambda _pid: (_ for _ in ()).throw(OSError()),
-    )
-    assert workspace_arrays._workspace_process_is_running(process_id + 1)
-
-
-def test_workspace_reader_directory_rejects_non_directory(
-    monkeypatch, tmp_path
-) -> None:
-    invalid = tmp_path / "reader-path"
-    invalid.write_text("not a directory")
-    monkeypatch.setattr(
-        workspace_arrays, "_cleanup_stale_workspace_reader_directories", lambda: None
-    )
-    monkeypatch.setattr(
-        workspace_arrays, "_workspace_reader_directory", lambda: invalid
-    )
-
-    with pytest.raises(OSError, match="not a private directory"):
-        workspace_arrays._ensure_workspace_reader_directory()
-
-
-def test_workspace_reader_file_falls_back_to_copy_when_link_fails(
-    monkeypatch, tmp_path
-) -> None:
-    source = tmp_path / "source.itws"
-    source.write_bytes(b"workspace")
-    reader_directory = tmp_path / "readers"
-    reader_directory.mkdir()
-    monkeypatch.setattr(
-        workspace_arrays, "_ensure_workspace_reader_directory", lambda: reader_directory
-    )
-    monkeypatch.setattr(
-        workspace_arrays.os,
-        "link",
-        lambda _source, _destination: (_ for _ in ()).throw(OSError("no links")),
-    )
-
-    reader = workspace_arrays._create_workspace_reader_file(source, copy_only=False)
-
-    assert reader.read_bytes() == b"workspace"
-
-
-def test_open_workspace_dataset_keeps_old_generation_after_full_save(tmp_path) -> None:
-    fname = tmp_path / "immutable-generation.itws"
-
-    def _write(value: float) -> None:
-        tree = xr.DataTree.from_dict(
-            {"0/imagetool": xr.Dataset({"data": ("x", [value])})}
-        )
-        try:
-            workspace_storage._write_full_workspace_tree_file(
-                fname, tree, {"imagetool_workspace_schema_version": 4}
-            )
-        finally:
-            tree.close()
-
-    _write(1.0)
-    old = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
-    try:
-        assert workspace_arrays.dataarray_source_paths(old["data"]) == (
-            str(fname.resolve()),
-        )
-        _write(2.0)
-        assert float(old["data"].compute().item()) == 1.0
-        new = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
-        try:
-            assert float(new["data"].compute().item()) == 2.0
-        finally:
-            new.close()
-    finally:
-        old.close()
-
-
-def test_workspace_reader_pickle_reuses_process_owned_generation(tmp_path) -> None:
-    workspace_arrays._cleanup_workspace_reader_snapshots()
-    fname = tmp_path / "serialized-generation.itws"
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": xr.Dataset({"data": ("x", np.arange(4.0))})}
-    )
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, {"imagetool_workspace_schema_version": 4}
-        )
-    finally:
-        tree.close()
-
-    opened: xr.Dataset | None = workspace_arrays.open_workspace_dataset(
-        fname, "0/imagetool", chunks={}
-    )
-    restored: list[xr.DataArray] = []
-    try:
-        source_snapshots = tuple(workspace_arrays._WORKSPACE_READER_SNAPSHOTS.values())
-        assert len(source_snapshots) == 1
-        reader_path = source_snapshots[0].path
-        payload = pickle.dumps(opened["data"])
-        opened.close()
-        opened = None
-        gc.collect()
-
-        assert pathlib.Path(reader_path).exists()
-        restored = [pickle.loads(payload), pickle.loads(payload)]
-
-        assert len(workspace_arrays._WORKSPACE_READER_SNAPSHOTS) == 1
-        assert next(
-            iter(workspace_arrays._WORKSPACE_READER_SNAPSHOTS.values())
-        ).path == (reader_path)
-        for data in restored:
-            np.testing.assert_array_equal(data.compute(), np.arange(4.0))
-        for data in restored:
-            data.close()
-        restored.clear()
-        del payload
-        gc.collect()
-
-        assert pathlib.Path(reader_path).exists()
-    finally:
-        if opened is not None:
-            opened.close()
-        for data in restored:
-            data.close()
-        workspace_arrays._cleanup_workspace_reader_snapshots()
-
-
-def test_workspace_reader_pickle_creates_receiver_owned_generation(tmp_path) -> None:
-    workspace_arrays._cleanup_workspace_reader_snapshots()
-    fname = tmp_path / "cross-process-generation.itws"
-    payload_path = tmp_path / "data.pickle"
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": xr.Dataset({"data": ("x", np.arange(4.0))})}
-    )
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, {"imagetool_workspace_schema_version": 4}
-        )
-    finally:
-        tree.close()
-    opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
-    try:
-        payload_path.write_bytes(pickle.dumps(opened["data"]))
-        parent_reader = next(
-            iter(workspace_arrays._WORKSPACE_READER_SNAPSHOTS.values())
-        ).path
-        code = """
-import json
-import pathlib
-import pickle
-import sys
-
-from erlab.interactive.imagetool.manager._workspace import _arrays
-
-data = pickle.loads(pathlib.Path(sys.argv[1]).read_bytes())
-print(json.dumps({
-    "values": data.compute().values.tolist(),
-    "readers": [
-        snapshot.path
-        for snapshot in _arrays._WORKSPACE_READER_SNAPSHOTS.values()
-    ],
-}))
-data.close()
-"""
-        completed = subprocess.run(
-            [sys.executable, "-c", code, str(payload_path)],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        result = json.loads(completed.stdout)
-        assert result["values"] == [0.0, 1.0, 2.0, 3.0]
-        assert len(result["readers"]) == 1
-        assert result["readers"][0] != parent_reader
-    finally:
-        opened.close()
-        workspace_arrays._cleanup_workspace_reader_snapshots()
+    manager = workspace_arrays.WorkspaceFileManager(tmp_path / "missing.itws")
+    with pytest.raises(FileNotFoundError), manager.acquire_context():
+        pass
 
 
 def test_workspace_file_manager_rejects_inherited_process_access(
     monkeypatch, tmp_path
 ) -> None:
     fname = tmp_path / "process-owned.itws"
-    tree = xr.DataTree.from_dict({"0/imagetool": xr.Dataset({"data": ("x", [1.0])})})
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, {"imagetool_workspace_schema_version": 4}
-        )
-    finally:
-        tree.close()
+    _write_transaction_test_workspace(fname)
     manager = workspace_arrays.WorkspaceFileManager(fname)
     process_id = manager._process_id
     monkeypatch.setattr(workspace_arrays.os, "getpid", lambda: process_id + 1)
@@ -781,7 +440,14 @@ def test_open_workspace_dataset_uses_fsdecode_fallback(monkeypatch) -> None:
     calls: list[tuple[object, str, str | None]] = []
 
     class _FakeFileManager:
-        def __init__(self, path: str) -> None:
+        def __init__(
+            self,
+            path: str,
+            *,
+            object_id: str | None = None,
+            group_path: str | None = None,
+        ) -> None:
+            del object_id, group_path
             self.workspace_path = path
 
     def _fake_open(file_manager, group: str, *, chunks: str | None):
@@ -818,11 +484,20 @@ def test_open_workspace_datatree_closes_partial_groups_on_error(monkeypatch) -> 
     class _FakeFileManager:
         workspace_path = "fallback.itws"
 
-        def __init__(self, _path: str) -> None:
-            pass
+        def __init__(
+            self,
+            _path: str,
+            *,
+            object_id: str | None = None,
+            group_path: str | None = None,
+        ) -> None:
+            del object_id, group_path
 
         def acquire_context(self):
             return contextlib.nullcontext(object())
+
+        def close(self) -> None:
+            pass
 
     def _fake_open(_file_manager, group_path: str, *, chunks: str | None):
         if group_path == "/broken":
@@ -1401,6 +1076,9 @@ def test_workspace_writer_drops_invalid_attr_names_from_fallback(tmp_path) -> No
     _assert_rich_workspace_attr(loaded["left"].attrs["Single Motor Scan"])
     assert "" not in loaded.coords["x"].attrs
     assert loaded.coords["x"].attrs["axis_note"] == ""
+    assert all(
+        "_FillValue" not in variable.attrs for variable in loaded.variables.values()
+    )
     _assert_rich_workspace_attr(loaded.coords["x"].attrs["axis_config"])
     _assert_rich_workspace_attr(loaded.attrs["dataset_config"])
 

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -1,8 +1,12 @@
 import contextlib
+import gc
 import json
 import logging
 import os
 import pathlib
+import pickle
+import subprocess
+import sys
 import types
 import typing
 import warnings
@@ -430,7 +434,7 @@ def test_workspace_xarray_path_helpers_cover_fallbacks(monkeypatch, tmp_path) ->
     assert lock is workspace_arrays._workspace_file_lock("fallback.itws")
 
     def _raise_stat_oserror(_path: str):
-        raise OSError
+        raise FileNotFoundError
 
     monkeypatch.setattr(workspace_arrays.os, "stat", _raise_stat_oserror)
     assert workspace_arrays._workspace_file_identity("missing.itws") == (
@@ -438,34 +442,324 @@ def test_workspace_xarray_path_helpers_cover_fallbacks(monkeypatch, tmp_path) ->
         0,
         0,
         0,
+        0,
     )
+    monkeypatch.setattr(
+        workspace_arrays.os,
+        "stat",
+        lambda _path: (_ for _ in ()).throw(PermissionError("denied")),
+    )
+    with pytest.raises(PermissionError, match="denied"):
+        workspace_arrays._workspace_file_identity("denied.itws")
 
 
 def test_workspace_file_manager_uses_fsdecode_fallback(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    def _fake_init(self, opener, *args, **kwargs):
-        captured["opener"] = opener
-        captured["args"] = args
-        captured["kwargs"] = kwargs
+    monkeypatch.setattr(workspace_arrays, "_normalized_file_path", lambda _path: None)
+
+    def _reader_snapshot(path: str):
+        captured["path"] = path
+        return "snapshot"
+
+    def _initialize(self, snapshot: object) -> None:
+        captured["snapshot"] = snapshot
+        self.workspace_path = "fallback.itws"
         self._key = "fake-key"
-        self._ref_counter = types.SimpleNamespace(decrement=lambda _key: None)
+        self._ref_counter = types.SimpleNamespace(decrement=lambda _key: 1)
         self._cache = {}
 
     monkeypatch.setattr(
-        workspace_arrays, "ensure_workspace_hdf5_filters_registered", lambda: None
+        workspace_arrays, "_workspace_reader_snapshot", _reader_snapshot
     )
-    monkeypatch.setattr(workspace_arrays, "_normalized_file_path", lambda _path: None)
     monkeypatch.setattr(
-        workspace_arrays, "_workspace_file_identity", lambda path: (path, 0, 0, 0)
+        workspace_arrays.WorkspaceFileManager, "_initialize", _initialize
     )
-    monkeypatch.setattr(workspace_arrays.CachingFileManager, "__init__", _fake_init)
 
     file_manager = workspace_arrays.WorkspaceFileManager("fallback.itws")
 
     assert file_manager.workspace_path == "fallback.itws"
-    assert captured["args"][0] == "fallback.itws"
-    assert captured["kwargs"]["mode"] == "r+"
+    assert captured == {"path": "fallback.itws", "snapshot": "snapshot"}
+
+
+def test_workspace_file_manager_uses_immutable_read_only_copy(tmp_path) -> None:
+    fname = tmp_path / "reader-copy.itws"
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": xr.Dataset({"data": ("x", np.arange(4.0))})}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            fname, tree, {"imagetool_workspace_schema_version": 4}
+        )
+    finally:
+        tree.close()
+
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    reader_path = pathlib.Path(manager.reader_path)
+    try:
+        assert reader_path != fname.resolve()
+        assert reader_path.read_bytes() == fname.read_bytes()
+        assert manager._args == (str(reader_path.resolve()),)
+        assert manager._mode == "r"
+        with manager.acquire_context() as h5_file:
+            assert pathlib.Path(h5_file.filename).resolve() == reader_path.resolve()
+    finally:
+        manager.close()
+        del manager
+        gc.collect()
+
+
+def test_workspace_file_manager_reports_missing_published_file(tmp_path) -> None:
+    with pytest.raises(FileNotFoundError):
+        workspace_arrays.WorkspaceFileManager(tmp_path / "missing.itws")
+
+
+def test_workspace_reader_cleanup_removes_only_safe_stale_directories(
+    monkeypatch, tmp_path
+) -> None:
+    stale = tmp_path / "erlab-itws-readers-1234-stale"
+    stale.mkdir()
+    (stale / "reader-1234-data.itws").write_bytes(b"stale")
+    unsafe = tmp_path / "erlab-itws-readers-5678-unsafe"
+    unsafe.mkdir()
+    (unsafe / "unrelated.txt").write_text("keep")
+    monkeypatch.setattr(workspace_arrays.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        workspace_arrays, "_workspace_process_is_running", lambda _pid: False
+    )
+    monkeypatch.setattr(workspace_arrays, "_WORKSPACE_READER_STALE_CLEANUP_DONE", False)
+
+    workspace_arrays._cleanup_stale_workspace_reader_directories()
+
+    assert not stale.exists()
+    assert unsafe.exists()
+
+
+def test_workspace_process_liveness_checks_are_fail_safe(monkeypatch) -> None:
+    process_id = os.getpid()
+    assert workspace_arrays._workspace_process_is_running(process_id)
+
+    monkeypatch.setattr(
+        workspace_arrays.os,
+        "kill",
+        lambda _pid, _signal: (_ for _ in ()).throw(ProcessLookupError()),
+    )
+    assert not workspace_arrays._workspace_process_is_running(process_id + 1)
+    monkeypatch.setattr(
+        workspace_arrays.os,
+        "kill",
+        lambda _pid, _signal: (_ for _ in ()).throw(PermissionError()),
+    )
+    assert workspace_arrays._workspace_process_is_running(process_id + 1)
+    monkeypatch.setattr(
+        workspace_arrays.os,
+        "kill",
+        lambda _pid, _signal: (_ for _ in ()).throw(OSError()),
+    )
+    assert workspace_arrays._workspace_process_is_running(process_id + 1)
+    monkeypatch.setattr(workspace_arrays.os, "kill", lambda _pid, _signal: None)
+    assert workspace_arrays._workspace_process_is_running(process_id + 1)
+
+
+def test_workspace_reader_directory_rejects_non_directory(
+    monkeypatch, tmp_path
+) -> None:
+    invalid = tmp_path / "reader-path"
+    invalid.write_text("not a directory")
+    monkeypatch.setattr(
+        workspace_arrays, "_cleanup_stale_workspace_reader_directories", lambda: None
+    )
+    monkeypatch.setattr(
+        workspace_arrays, "_workspace_reader_directory", lambda: invalid
+    )
+
+    with pytest.raises(OSError, match="not a private directory"):
+        workspace_arrays._ensure_workspace_reader_directory()
+
+
+def test_workspace_reader_file_falls_back_to_copy_when_link_fails(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "source.itws"
+    source.write_bytes(b"workspace")
+    reader_directory = tmp_path / "readers"
+    reader_directory.mkdir()
+    monkeypatch.setattr(
+        workspace_arrays, "_ensure_workspace_reader_directory", lambda: reader_directory
+    )
+    monkeypatch.setattr(
+        workspace_arrays.os,
+        "link",
+        lambda _source, _destination: (_ for _ in ()).throw(OSError("no links")),
+    )
+
+    reader = workspace_arrays._create_workspace_reader_file(source, copy_only=False)
+
+    assert reader.read_bytes() == b"workspace"
+
+
+def test_open_workspace_dataset_keeps_old_generation_after_full_save(tmp_path) -> None:
+    fname = tmp_path / "immutable-generation.itws"
+
+    def _write(value: float) -> None:
+        tree = xr.DataTree.from_dict(
+            {"0/imagetool": xr.Dataset({"data": ("x", [value])})}
+        )
+        try:
+            workspace_storage._write_full_workspace_tree_file(
+                fname, tree, {"imagetool_workspace_schema_version": 4}
+            )
+        finally:
+            tree.close()
+
+    _write(1.0)
+    old = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    try:
+        assert workspace_arrays.dataarray_source_paths(old["data"]) == (
+            str(fname.resolve()),
+        )
+        _write(2.0)
+        assert float(old["data"].compute().item()) == 1.0
+        new = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+        try:
+            assert float(new["data"].compute().item()) == 2.0
+        finally:
+            new.close()
+    finally:
+        old.close()
+
+
+def test_workspace_reader_pickle_reuses_process_owned_generation(tmp_path) -> None:
+    workspace_arrays._cleanup_workspace_reader_snapshots()
+    fname = tmp_path / "serialized-generation.itws"
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": xr.Dataset({"data": ("x", np.arange(4.0))})}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            fname, tree, {"imagetool_workspace_schema_version": 4}
+        )
+    finally:
+        tree.close()
+
+    opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    restored: list[xr.DataArray] = []
+    try:
+        source_snapshots = tuple(workspace_arrays._WORKSPACE_READER_SNAPSHOTS.values())
+        assert len(source_snapshots) == 1
+        reader_path = source_snapshots[0].path
+        payload = pickle.dumps(opened["data"])
+        restored = [pickle.loads(payload), pickle.loads(payload)]
+
+        assert len(workspace_arrays._WORKSPACE_READER_SNAPSHOTS) == 1
+        assert next(
+            iter(workspace_arrays._WORKSPACE_READER_SNAPSHOTS.values())
+        ).path == (reader_path)
+        for data in restored:
+            np.testing.assert_array_equal(data.compute(), np.arange(4.0))
+    finally:
+        opened.close()
+        for data in restored:
+            data.close()
+        workspace_arrays._cleanup_workspace_reader_snapshots()
+
+
+def test_workspace_reader_pickle_creates_receiver_owned_generation(tmp_path) -> None:
+    workspace_arrays._cleanup_workspace_reader_snapshots()
+    fname = tmp_path / "cross-process-generation.itws"
+    payload_path = tmp_path / "data.pickle"
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": xr.Dataset({"data": ("x", np.arange(4.0))})}
+    )
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            fname, tree, {"imagetool_workspace_schema_version": 4}
+        )
+    finally:
+        tree.close()
+    opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    try:
+        payload_path.write_bytes(pickle.dumps(opened["data"]))
+        parent_reader = next(
+            iter(workspace_arrays._WORKSPACE_READER_SNAPSHOTS.values())
+        ).path
+        code = """
+import json
+import pathlib
+import pickle
+import sys
+
+from erlab.interactive.imagetool.manager._workspace import _arrays
+
+data = pickle.loads(pathlib.Path(sys.argv[1]).read_bytes())
+print(json.dumps({
+    "values": data.compute().values.tolist(),
+    "readers": [
+        snapshot.path
+        for snapshot in _arrays._WORKSPACE_READER_SNAPSHOTS.values()
+    ],
+}))
+data.close()
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", code, str(payload_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        result = json.loads(completed.stdout)
+        assert result["values"] == [0.0, 1.0, 2.0, 3.0]
+        assert len(result["readers"]) == 1
+        assert result["readers"][0] != parent_reader
+    finally:
+        opened.close()
+        workspace_arrays._cleanup_workspace_reader_snapshots()
+
+
+def test_workspace_file_manager_rejects_inherited_process_access(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "process-owned.itws"
+    tree = xr.DataTree.from_dict({"0/imagetool": xr.Dataset({"data": ("x", [1.0])})})
+    try:
+        workspace_storage._write_full_workspace_tree_file(
+            fname, tree, {"imagetool_workspace_schema_version": 4}
+        )
+    finally:
+        tree.close()
+    manager = workspace_arrays.WorkspaceFileManager(fname)
+    process_id = manager._process_id
+    monkeypatch.setattr(workspace_arrays.os, "getpid", lambda: process_id + 1)
+
+    with pytest.raises(RuntimeError, match="cannot be inherited across fork"):
+        manager.acquire()
+    monkeypatch.undo()
+    manager.close()
+    del manager
+    gc.collect()
+
+
+def test_retarget_workspace_xarray_sources_changes_only_matching_sources(
+    tmp_path,
+) -> None:
+    old_path = tmp_path / "old.itws"
+    new_path = tmp_path / "new.itws"
+    other_path = tmp_path / "other.itws"
+    data = xr.DataArray(
+        [1.0],
+        dims="x",
+        coords={"x": [0.0], "other": ("x", [2.0])},
+    )
+    data.encoding["source"] = str(old_path)
+    data.coords["x"].encoding["source"] = str(old_path)
+    data.coords["other"].encoding["source"] = str(other_path)
+
+    workspace_arrays.retarget_workspace_xarray_sources(data, old_path, new_path)
+
+    assert data.encoding["source"] == str(new_path.resolve())
+    assert data.coords["x"].encoding["source"] == str(new_path.resolve())
+    assert data.coords["other"].encoding["source"] == str(other_path)
 
 
 def test_open_workspace_dataset_uses_fsdecode_fallback(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -521,12 +521,39 @@ def test_workspace_file_manager_serialization_pins_exact_payload(tmp_path) -> No
             group_path="/legacy",
         )
         assert store.serialized_object_ids == set()
-        manager.__getstate__()
+        state = manager.__getstate__()
         legacy_manager.__getstate__()
         assert store.serialized_object_ids == {"payload"}
         assert store.serialized_legacy_group_paths == {"/legacy"}
+
+        store.clear_serialized_reader_pins()
+        forwarded_manager = workspace_arrays.WorkspaceFileManager.__new__(
+            workspace_arrays.WorkspaceFileManager
+        )
+        forwarded_manager.__setstate__(state)
+        forwarded_manager.__getstate__()
+        assert store.serialized_object_ids == {"payload"}
         del manager, legacy_manager
         gc.collect()
+
+
+def test_detached_workspace_file_manager_serialization_pins_legacy_group(
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with (
+        workspace_store.WorkspaceStore(path, create=True) as store,
+        store.write_session() as h5_file,
+    ):
+        h5_file.create_group("legacy")
+
+    manager = workspace_arrays.WorkspaceFileManager(path, group_path="/legacy")
+    manager.__getstate__()
+
+    with workspace_store.WorkspaceStore(path) as store:
+        assert store.serialized_legacy_group_paths == {"/legacy"}
+        store.clear_serialized_reader_pins()
+    manager.close()
 
 
 def test_workspace_dask_tokenization_pins_only_serialized_graph(tmp_path) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import pathlib
+import pickle
 import threading
 import types
 import typing
@@ -526,6 +527,36 @@ def test_workspace_file_manager_serialization_pins_exact_payload(tmp_path) -> No
         assert store.serialized_legacy_group_paths == {"/legacy"}
         del manager, legacy_manager
         gc.collect()
+
+
+def test_workspace_dask_tokenization_pins_only_serialized_graph(tmp_path) -> None:
+    path = tmp_path / "workspace.itws"
+    object_id = "payload"
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        name=_ITOOL_DATA_NAME,
+    ).to_dataset()
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session() as h5_file:
+            assert workspace_arrays._write_workspace_dataset_group_h5py(
+                h5_file,
+                store.object_path(object_id),
+                data,
+            )
+        store.publish({"schema_version": 5, "nodes": []})
+
+        opened = workspace_arrays.open_workspace_dataset(
+            path,
+            store.object_path(object_id),
+            chunks={},
+        )
+        try:
+            assert store.serialized_object_ids == set()
+            pickle.dumps(opened[_ITOOL_DATA_NAME].data.__dask_graph__())
+            assert store.serialized_object_ids == {object_id}
+        finally:
+            opened.close()
 
 
 def test_workspace_file_manager_rejects_inherited_process_access(

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -20,6 +20,7 @@ import erlab
 import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from tests.interactive.imagetool.manager.workspace._support import (
     _assert_rich_workspace_attr,
@@ -433,6 +434,75 @@ def test_workspace_file_manager_reports_missing_published_file(tmp_path) -> None
         pass
 
 
+def test_workspace_file_manager_lifecycle_guards(tmp_path) -> None:
+    path = tmp_path / "workspace.itws"
+    other_path = tmp_path / "other.itws"
+    with (
+        workspace_store.WorkspaceStore(path, create=True) as store,
+        workspace_store.WorkspaceStore(other_path, create=True) as other_store,
+    ):
+        manager = workspace_arrays.WorkspaceFileManager(
+            path,
+            group_path=f"/{workspace_store._WORKSPACE_GENERATIONS_GROUP}/current",
+        )
+        try:
+            manager._attach_store(store)
+            assert manager.legacy_group_path is None
+            assert manager.__dask_tokenize__()[1] == store.workspace_id
+            assert manager.acquire().filename == str(path)
+            assert manager.acquire(needs_lock=False).filename == str(path)
+            with manager.acquire_context() as netcdf_file:
+                assert netcdf_file.filename == str(path)
+            with manager.acquire_context(needs_lock=False) as netcdf_file:
+                assert netcdf_file.filename == str(path)
+            with pytest.raises(RuntimeError, match="already attached"):
+                manager._attach_store(other_store)
+        finally:
+            manager.close(needs_lock=False)
+
+    unattached = workspace_arrays.WorkspaceFileManager(path)
+    try:
+        with pytest.raises(RuntimeError, match="no active store"):
+            unattached._active_netcdf_file()
+    finally:
+        unattached.close()
+
+    worker = workspace_arrays.WorkspaceFileManager.__new__(
+        workspace_arrays.WorkspaceFileManager
+    )
+    with pytest.raises(ValueError, match="Unsupported serialized"):
+        worker.__setstate__(("wrong-marker", str(path), str(path), None, None, "/"))
+
+    worker.__setstate__(
+        (
+            "erlab-workspace-bounded-reader-v1",
+            str(path),
+            str(path),
+            None,
+            None,
+            "/",
+        )
+    )
+    with pytest.raises(RuntimeError, match="array selections only"):
+        worker.acquire()
+    with (
+        pytest.raises(RuntimeError, match="array selections only"),
+        worker.acquire_context(),
+    ):
+        pass
+    assert worker.__dask_tokenize__()[1] == str(path)
+    worker.close()
+
+    backend = workspace_arrays._WorkspaceBackendArray(
+        "data",
+        types.SimpleNamespace(_manager=object()),
+        shape=(1,),
+        dtype=np.dtype(float),
+    )
+    with pytest.raises(TypeError, match="WorkspaceFileManager"):
+        backend._getitem(slice(None))
+
+
 def test_workspace_file_manager_rejects_inherited_process_access(
     monkeypatch, tmp_path
 ) -> None:
@@ -470,6 +540,71 @@ def test_retarget_workspace_xarray_sources_changes_only_matching_sources(
     assert data.encoding["source"] == str(new_path.resolve())
     assert data.coords["x"].encoding["source"] == str(new_path.resolve())
     assert data.coords["other"].encoding["source"] == str(other_path)
+
+
+def test_workspace_xarray_source_lifecycle_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    source = tmp_path / "source.itws"
+    data = xr.DataArray([1.0], dims="x", coords={"x": [0.0]})
+    data.encoding["source"] = str(source)
+    snapshot = workspace_arrays._workspace_xarray_source_snapshot(data)
+
+    data.encoding.pop("source")
+    data.coords["x"].encoding["source"] = "added"
+    workspace_arrays._restore_workspace_xarray_source_snapshot(snapshot)
+    assert data.encoding["source"] == str(source)
+    assert "source" not in data.coords["x"].encoding
+
+    workspace_arrays.retarget_workspace_xarray_sources(data, source, source)
+    assert data.encoding["source"] == str(source)
+    workspace_arrays.set_workspace_xarray_sources(data, typing.cast("str", None))
+    assert data.encoding["source"] == str(source)
+
+    active_store = types.SimpleNamespace(write_in_progress=True)
+    monkeypatch.setattr(
+        workspace_store.WorkspaceStore,
+        "active",
+        lambda _path: active_store,
+    )
+    assert workspace_arrays.workspace_write_in_progress(data)
+
+
+def test_workspace_h5py_create_kwargs_maps_chunksizes() -> None:
+    assert workspace_arrays._workspace_h5py_create_kwargs(None) == {}
+    assert workspace_arrays._workspace_h5py_create_kwargs(
+        {
+            "chunksizes": (2, 3),
+            "compression": "gzip",
+            "compression_opts": 1,
+            "shuffle": True,
+            "fletcher32": False,
+            "ignored": "value",
+        }
+    ) == {
+        "chunks": (2, 3),
+        "compression": "gzip",
+        "compression_opts": 1,
+        "shuffle": True,
+        "fletcher32": False,
+    }
+
+
+def test_workspace_root_attrs_require_valid_generation(tmp_path) -> None:
+    path = tmp_path / "workspace.itws"
+    with h5py.File(path, "w") as h5_file:
+        h5_file.attrs["imagetool_workspace_schema_version"] = 5
+
+    with pytest.raises(ValueError, match="no committed generation"):
+        workspace_arrays._read_workspace_root_attrs_h5py(path)
+
+    with h5py.File(path, "r+") as h5_file:
+        generations = h5_file.create_group(workspace_store._WORKSPACE_GENERATIONS_GROUP)
+        generations.create_group("invalid-name")
+        generations.create_group("00000000000000000001")
+    with pytest.raises(ValueError, match="no valid committed generation"):
+        workspace_arrays._read_workspace_root_attrs_h5py(path)
 
 
 def test_open_workspace_dataset_uses_fsdecode_fallback(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -535,29 +535,29 @@ def test_workspace_reader_cleanup_removes_only_safe_stale_directories(
     assert unsafe.exists()
 
 
-def test_workspace_process_liveness_checks_are_fail_safe(monkeypatch) -> None:
+def test_workspace_process_liveness_uses_non_destructive_probe(monkeypatch) -> None:
     process_id = os.getpid()
+    probed: list[int] = []
+
+    def _pid_exists(pid: int) -> bool:
+        probed.append(pid)
+        return pid == process_id
+
+    def _fail_kill(*_args) -> None:
+        raise AssertionError("workspace cleanup must not signal another process")
+
+    monkeypatch.setattr(workspace_arrays.psutil, "pid_exists", _pid_exists)
+    monkeypatch.setattr(workspace_arrays.os, "kill", _fail_kill)
+
     assert workspace_arrays._workspace_process_is_running(process_id)
+    assert not workspace_arrays._workspace_process_is_running(process_id + 1)
+    assert probed == [process_id, process_id + 1]
 
     monkeypatch.setattr(
-        workspace_arrays.os,
-        "kill",
-        lambda _pid, _signal: (_ for _ in ()).throw(ProcessLookupError()),
+        workspace_arrays.psutil,
+        "pid_exists",
+        lambda _pid: (_ for _ in ()).throw(OSError()),
     )
-    assert not workspace_arrays._workspace_process_is_running(process_id + 1)
-    monkeypatch.setattr(
-        workspace_arrays.os,
-        "kill",
-        lambda _pid, _signal: (_ for _ in ()).throw(PermissionError()),
-    )
-    assert workspace_arrays._workspace_process_is_running(process_id + 1)
-    monkeypatch.setattr(
-        workspace_arrays.os,
-        "kill",
-        lambda _pid, _signal: (_ for _ in ()).throw(OSError()),
-    )
-    assert workspace_arrays._workspace_process_is_running(process_id + 1)
-    monkeypatch.setattr(workspace_arrays.os, "kill", lambda _pid, _signal: None)
     assert workspace_arrays._workspace_process_is_running(process_id + 1)
 
 

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -642,13 +642,20 @@ def test_workspace_reader_pickle_reuses_process_owned_generation(tmp_path) -> No
     finally:
         tree.close()
 
-    opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    opened: xr.Dataset | None = workspace_arrays.open_workspace_dataset(
+        fname, "0/imagetool", chunks={}
+    )
     restored: list[xr.DataArray] = []
     try:
         source_snapshots = tuple(workspace_arrays._WORKSPACE_READER_SNAPSHOTS.values())
         assert len(source_snapshots) == 1
         reader_path = source_snapshots[0].path
         payload = pickle.dumps(opened["data"])
+        opened.close()
+        opened = None
+        gc.collect()
+
+        assert pathlib.Path(reader_path).exists()
         restored = [pickle.loads(payload), pickle.loads(payload)]
 
         assert len(workspace_arrays._WORKSPACE_READER_SNAPSHOTS) == 1
@@ -657,8 +664,16 @@ def test_workspace_reader_pickle_reuses_process_owned_generation(tmp_path) -> No
         ).path == (reader_path)
         for data in restored:
             np.testing.assert_array_equal(data.compute(), np.arange(4.0))
+        for data in restored:
+            data.close()
+        restored.clear()
+        del payload
+        gc.collect()
+
+        assert pathlib.Path(reader_path).exists()
     finally:
-        opened.close()
+        if opened is not None:
+            opened.close()
         for data in restored:
             data.close()
         workspace_arrays._cleanup_workspace_reader_snapshots()

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -503,6 +503,31 @@ def test_workspace_file_manager_lifecycle_guards(tmp_path) -> None:
         backend._getitem(slice(None))
 
 
+def test_workspace_file_manager_serialization_pins_exact_payload(tmp_path) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("payload")
+            h5_file.create_group("legacy")
+        store.publish({"schema_version": 5, "nodes": []})
+        manager = workspace_arrays.WorkspaceFileManager(
+            path,
+            object_id="payload",
+            group_path=store.object_path("payload"),
+        )
+        legacy_manager = workspace_arrays.WorkspaceFileManager(
+            path,
+            group_path="/legacy",
+        )
+        assert store.serialized_object_ids == set()
+        manager.__getstate__()
+        legacy_manager.__getstate__()
+        assert store.serialized_object_ids == {"payload"}
+        assert store.serialized_legacy_group_paths == {"/legacy"}
+        del manager, legacy_manager
+        gc.collect()
+
+
 def test_workspace_file_manager_rejects_inherited_process_access(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -24,6 +24,7 @@ import erlab.interactive.imagetool.manager._modelview as manager_modelview
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
@@ -1584,7 +1585,9 @@ def test_manager_records_recent_workspace_accesses(
     opened = tmp_path / "opened.itws"
     saved = tmp_path / "saved.itws"
     imported = tmp_path / "imported.itws"
-    for path in (opened, saved, imported):
+    with workspace_store.WorkspaceStore(opened, create=True):
+        pass
+    for path in (saved, imported):
         path.touch()
 
     with manager_context() as manager:

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -4,7 +4,6 @@ import json
 import logging
 import pathlib
 import tempfile
-import types
 import typing
 import warnings
 from collections.abc import Callable
@@ -136,9 +135,7 @@ def test_manager_workspace_option_overrides_roundtrip_and_mark_dirty(
         assert manager.workspace_option_overrides() == overrides
 
         fname = tmp_path / "option-overrides.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manager._set_workspace_option_overrides({})
         manager._workspace_controller._mark_workspace_clean()
 
@@ -639,16 +636,12 @@ def test_manager_workspace_preserves_link_groups(
         qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
 
         fname = tmp_path / "linked.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert not manager.is_workspace_modified
 
         manager.link_imagetools(0, 1, link_colors=False)
         assert manager.is_workspace_modified
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         manifest = workspace_format._workspace_manifest_from_attrs(
             workspace_arrays._read_workspace_root_attrs_h5py(fname)
@@ -698,9 +691,7 @@ def test_manager_unlink_selected_prunes_live_link_singleton(
             manager.add_imagetool(root, show=False)
         manager.link_imagetools(0, 1, link_colors=False)
         fname = tmp_path / "live-unlink-singleton.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -991,7 +982,6 @@ def test_workspace_controller_helper_branch_edges(
     with manager_context() as manager:
         controller = manager._workspace_controller
         loader = controller.loading
-        saver = controller.saving
 
         invalid = xr.Dataset(attrs={"itool_state": b"not text"})
         assert (
@@ -1018,28 +1008,6 @@ def test_workspace_controller_helper_branch_edges(
             )
             is None
         )
-
-        try:
-            manager._tool_graph.nodes["parent"] = types.SimpleNamespace(parent_uid=None)
-            manager._tool_graph.nodes["child"] = types.SimpleNamespace(
-                parent_uid="parent"
-            )
-            manager._tool_graph.nodes["sibling"] = types.SimpleNamespace(
-                parent_uid=None
-            )
-            manager._workspace_state.dirty_data.update({"parent", "child", "sibling"})
-            with monkeypatch.context() as patch:
-                patch.setattr(saver, "_workspace_node_path", lambda uid: uid)
-                assert saver._workspace_highest_dirty_data_roots() == [
-                    "parent",
-                    "sibling",
-                ]
-        finally:
-            for uid in ("parent", "child", "sibling"):
-                manager._tool_graph.nodes.pop(uid, None)
-            manager._workspace_state.dirty_data.difference_update(
-                {"parent", "child", "sibling"}
-            )
 
         calls: list[str] = []
         with monkeypatch.context() as patch:
@@ -2101,9 +2069,7 @@ def test_manager_workspace_h5py_fast_path_preserves_spaced_associated_coord(
         fname = tmp_path / "spaced-coord.itws"
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
+            manager._workspace_controller.saving._save_workspace_document(fname)
         assert not any("space in its name" in str(item.message) for item in caught)
 
         manager.remove_all_tools()
@@ -2146,9 +2112,7 @@ def test_manager_workspace_dirty_markers_are_node_scoped(
         child_uid = manager.add_imagetool_child(child, 0, show=False)
 
         fname = tmp_path / "dirty.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         assert not manager.is_workspace_modified
         assert not root.isWindowModified()
@@ -2187,9 +2151,7 @@ def test_manager_close_suppresses_child_visibility_dirty(
         qtbot.wait_until(root.isVisible)
 
         fname = tmp_path / "quit-clean.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._drain_workspace_deferred_events()
         manager._workspace_controller._mark_workspace_clean()
@@ -2265,9 +2227,8 @@ def test_manager_update_info_accepts_selected_root_uid(
         assert rendered_uids == [wrappers[0].uid]
 
 
-def test_manager_workspace_rejects_external_xarray_reader_for_active_workspace(
+def test_manager_workspace_state_save_keeps_external_reader_usable(
     qtbot,
-    monkeypatch,
     tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -2282,9 +2243,7 @@ def test_manager_workspace_rejects_external_xarray_reader_for_active_workspace(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "lazy-state.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2294,12 +2253,9 @@ def test_manager_workspace_rejects_external_xarray_reader_for_active_workspace(
         assert _compute_first_value(manager.get_imagetool(0).slicer_area._data) == 0
         manager._workspace_controller._mark_workspace_clean()
 
-        errors: list[str] = []
-        monkeypatch.setattr(manager, "_show_workspace_save_worker_error", errors.append)
-
         manager.rename_imagetool(0, "lazy state")
-        assert not _request_workspace_save_and_wait(qtbot, manager)
-        assert errors
+        assert _request_workspace_save_and_wait(qtbot, manager)
+        assert _compute_first_value(lazy) == 0
         with contextlib.suppress(Exception):
             lazy.close()
 
@@ -2326,9 +2282,7 @@ def test_manager_workspace_roundtrip_preserves_controls_visibility(
         qtbot.wait_until(lambda: manager.is_workspace_modified, timeout=5000)
 
         fname = tmp_path / "controls.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         assert not manager.is_workspace_modified
 
@@ -2670,9 +2624,7 @@ def test_manager_workspace_roundtrip_fit2d_child_with_spaced_axis(
         fname = tmp_path / "fit2d-spaced-axis.itws"
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
+            manager._workspace_controller.saving._save_workspace_document(fname)
 
         assert not any("space in its name" in str(item.message) for item in caught)
         manager.remove_all_tools()

--- a/tests/interactive/imagetool/manager/workspace/test_format.py
+++ b/tests/interactive/imagetool/manager/workspace/test_format.py
@@ -370,61 +370,24 @@ def test_workspace_attr_typed_encoding_roundtrips_safe_values(caplog) -> None:
 
 
 def test_workspace_metadata_helpers_cover_invalid_payloads() -> None:
-    manifest_attrs = workspace_format._workspace_root_attrs_payload(
+    manifest = workspace_format._workspace_manifest_payload(
         root_order=["1"],
         nodes=[{"path": "1"}],
-        delta_save_count=2,
         erlab_version="test",
     )
-    raw_manifest = manifest_attrs[workspace_format._WORKSPACE_MANIFEST_ATTR]
+    raw_manifest = json.dumps(manifest)
 
-    assert (
-        workspace_format._workspace_manifest_from_attrs(
-            {workspace_format._WORKSPACE_MANIFEST_ATTR: raw_manifest.encode()}
-        )["delta_save_count"]
-        == 2
+    encoded_manifest = workspace_format._workspace_manifest_from_attrs(
+        {workspace_format._WORKSPACE_MANIFEST_ATTR: raw_manifest.encode()}
     )
-    manifest = workspace_format._workspace_manifest_from_attrs(
+    assert encoded_manifest["root_order"] == ["1"]
+    decoded_manifest = workspace_format._workspace_manifest_from_attrs(
         {workspace_format._WORKSPACE_MANIFEST_ATTR: raw_manifest}
     )
-    assert workspace_format._workspace_manifest_repack_estimate(
-        manifest, delta_save_count=2
-    ) == (0, 0, True)
-    assert workspace_format._workspace_manifest_repack_estimate(
-        {"delta_save_count": 2}, delta_save_count=2
-    ) == (0, 0, False)
-    assert workspace_format._workspace_manifest_repack_estimate(
-        None, delta_save_count=2
-    ) == (0, 0, False)
-    assert (
-        workspace_format._workspace_manifest_nonnegative_int(
-            {"estimated_obsolete_bytes": "not-an-int"},
-            "estimated_obsolete_bytes",
-        )
-        == 0
-    )
+    assert decoded_manifest["nodes"] == [{"path": "1"}]
     assert (
         workspace_format._workspace_manifest_from_attrs(
             {workspace_format._WORKSPACE_MANIFEST_ATTR: "{not-json"}
         )
         == {}
     )
-    assert (
-        workspace_format._workspace_delta_save_count_from_attrs(
-            {
-                workspace_format._WORKSPACE_MANIFEST_ATTR: (
-                    '{"delta_save_count": "not-an-int"}'
-                )
-            }
-        )
-        == 0
-    )
-    with pytest.raises(ValueError, match="current workspace schema"):
-        workspace_format._compacted_workspace_root_attrs(
-            {"imagetool_workspace_schema_version": 1}
-        )
-    assert workspace_format._workspace_root_attrs_with_repack_estimate(
-        {"imagetool_workspace_schema_version": 1},
-        estimated_obsolete_bytes=1,
-        replacement_delta_count=1,
-    ) == {"imagetool_workspace_schema_version": 1}

--- a/tests/interactive/imagetool/manager/workspace/test_format.py
+++ b/tests/interactive/imagetool/manager/workspace/test_format.py
@@ -391,3 +391,36 @@ def test_workspace_metadata_helpers_cover_invalid_payloads() -> None:
         )
         == {}
     )
+
+    assert list(workspace_format._iter_workspace_manifest_node_entries(None)) == []
+    assert (
+        list(
+            workspace_format._iter_workspace_manifest_node_entries({"nodes": "invalid"})
+        )
+        == []
+    )
+    assert workspace_format._workspace_manifest_payload_entries(
+        {
+            "nodes": [
+                {"uid": "legacy", "kind": "tool", "path": "2"},
+                {"uid": "missing", "kind": "tool"},
+            ]
+        }
+    ) == [("legacy", "tool", "2/tool")]
+    assert (
+        workspace_format._workspace_manifest_payload_path(manifest, "missing") is None
+    )
+
+
+def test_workspace_manifest_attrs_reject_invalid_entries(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        encoded = workspace_format._workspace_manifest_attrs(
+            {"kept": 1, "dropped": object()}
+        )
+    assert workspace_format._restore_workspace_manifest_attrs(encoded) == {"kept": 1}
+    assert "Dropping workspace attribute" in caplog.text
+
+    with pytest.raises(TypeError, match="must be a list"):
+        workspace_format._restore_workspace_manifest_attrs({})
+    with pytest.raises(TypeError, match="entry is invalid"):
+        workspace_format._restore_workspace_manifest_attrs([["too-short"]])

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -23,6 +23,7 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._loading as workspace_loading
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.plot_items as imagetool_plot_items
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive.derivative import DerivativeTool
@@ -2184,7 +2185,8 @@ def test_manager_loaded_workspace_association_updates_file_path(
 ) -> None:
     with manager_context() as manager:
         workspace = tmp_path / "loaded.itws"
-        workspace.touch()
+        with workspace_store.WorkspaceStore(workspace, create=True):
+            pass
         file_path_calls: list[str] = []
 
         with monkeypatch.context() as patch:
@@ -2218,7 +2220,8 @@ def test_manager_loaded_workspace_association_rebinds_data_after_path_update(
 ) -> None:
     with manager_context() as manager:
         workspace = tmp_path / "loaded-rebind.itws"
-        workspace.touch()
+        with workspace_store.WorkspaceStore(workspace, create=True):
+            pass
         rebind_paths: list[pathlib.Path] = []
 
         monkeypatch.setattr(

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -47,6 +47,10 @@ from erlab.interactive.imagetool.manager._dialogs import (
 from tests.interactive.imagetool.manager.helpers import adopt_workspace_path
 from tests.interactive.imagetool.manager.workspace._support import (
     _AddedTimeChildTool,
+    _current_workspace_manifest,
+    _current_workspace_payload_attrs,
+    _current_workspace_payload_path,
+    _edit_current_workspace_payload_attrs,
     _request_workspace_save_and_wait,
     _workspace_test_file_spec,
     _WorkspaceSweepChildTool,
@@ -311,8 +315,8 @@ def _workspace_sweep_h5_attr_payload(
         "tool_input_provenance_spec",
         "tool_data_references",
     }
-    with h5py.File(fname, "r") as h5_file:
-        attrs = dict(h5_file[payload_path].attrs)
+    node_path, _separator, _kind = payload_path.rpartition("/")
+    attrs = _current_workspace_payload_attrs(fname, node_path)
     payload: dict[str, typing.Any] = {}
     for key, value in attrs.items():
         if isinstance(value, bytes):
@@ -381,9 +385,7 @@ def test_manager_workspace_load_preserves_added_time(
         )
 
         fname = tmp_path / "added-time-load.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname,
             replace=True,
@@ -435,14 +437,12 @@ def test_manager_workspace_load_warns_for_unavailable_colormap(
         manager.add_imagetool(tool, show=False)
 
         fname = tmp_path / "missing-cmap.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
-        with h5py.File(fname, "a") as h5_file:
-            state = json.loads(h5_file["0/imagetool"].attrs["itool_state"])
+        with _edit_current_workspace_payload_attrs(fname) as attrs:
+            state = json.loads(attrs["itool_state"])
             state["color"]["cmap"] = missing
-            h5_file["0/imagetool"].attrs["itool_state"] = json.dumps(state)
+            attrs["itool_state"] = json.dumps(state)
 
         assert manager._workspace_controller.loading._load_workspace_file(
             fname,
@@ -519,15 +519,13 @@ def test_manager_workspace_load_falls_back_for_legacy_or_invalid_added_time(
             show=False,
         )
         fname = tmp_path / "legacy-added-time.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
-        with h5py.File(fname, "a") as h5_file:
+        with _edit_current_workspace_payload_attrs(fname) as attrs:
             if saved_attr is None:
-                del h5_file["0/imagetool"].attrs["manager_node_added_at"]
+                del attrs["manager_node_added_at"]
             else:
-                h5_file["0/imagetool"].attrs["manager_node_added_at"] = saved_attr
+                attrs["manager_node_added_at"] = saved_attr
 
         assert manager._workspace_controller.loading._load_workspace_file(
             fname,
@@ -571,12 +569,9 @@ def test_manager_workspace_roundtrip_restores_manager_layout(
         expected_right_sizes = manager.right_splitter.sizes()
 
         fname = tmp_path / "manager-layout.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manifest = _current_workspace_manifest(fname)
         assert manifest["manager_layout"] == expected_layout
 
         manager.resize(480, 500)
@@ -623,9 +618,7 @@ def test_manager_workspace_import_does_not_restore_manager_layout(
         manager.main_splitter.setSizes([220, 420])
         manager.right_splitter.setSizes([240, 140, 120])
         import_fname = tmp_path / "import-layout.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            import_fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(import_fname)
 
         manager.resize(480, 500)
         manager.main_splitter.setSizes([120, 360])
@@ -634,10 +627,7 @@ def test_manager_workspace_import_does_not_restore_manager_layout(
             manager._workspace_controller.saving._workspace_layout_snapshot()
         )
 
-        import h5py
-
-        with h5py.File(import_fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manifest = _current_workspace_manifest(import_fname)
         assert manager._workspace_controller.loading._from_h5py_workspace_file(
             import_fname, manifest, replace=False, mark_dirty=True
         )
@@ -646,13 +636,12 @@ def test_manager_workspace_import_does_not_restore_manager_layout(
             == current_layout
         )
 
-        tree = workspace_arrays.open_workspace_datatree(import_fname, chunks=None)
-        assert manager._workspace_controller.loading._from_datatree(
-            tree,
+        assert manager._workspace_controller.loading._load_workspace_file(
+            import_fname,
             replace=False,
             mark_dirty=True,
             select=False,
-            workspace_file_path=import_fname,
+            associate=False,
         )
         assert (
             manager._workspace_controller.saving._workspace_layout_snapshot()
@@ -733,13 +722,10 @@ def test_manager_workspace_roundtrip_restores_loader_and_standalone_apps(
         ptable._refresh_window_state(ensure_visible=False)
 
         fname = tmp_path / "loader-standalone.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         expected_ptable_size = ptable.size()
 
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manifest = _current_workspace_manifest(fname)
         assert manifest["loader_state"]["recent_directory"] == str(example_data_dir)
         assert manifest["loader_state"]["recent_name_filter"] == name_filter
         saved_manager_kwargs = manifest["loader_state"][
@@ -1089,15 +1075,15 @@ def test_manager_workspace_roundtrip_restores_full_serializable_state(
         qtbot.wait(100)
 
         fname = tmp_path / "maximal-state.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         expected_snapshot = _workspace_sweep_runtime_snapshot(manager)
         expected_data_items = _workspace_sweep_data_items(manager)
 
         root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
         manifest = workspace_format._workspace_manifest_from_attrs(root_attrs)
-        assert root_attrs["imagetool_workspace_schema_version"] == 4
+        assert root_attrs["imagetool_workspace_schema_version"] == (
+            workspace_format._current_workspace_schema_version()
+        )
         assert manifest["root_order"] == [1, 0]
         assert manifest["workspace_link_id"] == manager._workspace_state.link_id
         assert manifest["loader_state"] == expected_snapshot["loader_state"]
@@ -1208,7 +1194,9 @@ def test_manager_workspace_roundtrip_restores_full_serializable_state(
         )
         assert "tool_source_binding" not in tool_payload
         with h5py.File(fname, "r") as h5_file:
-            tool_group = h5_file["0/childtools/sweep-child-tool/tool"]
+            tool_group = h5_file[
+                _current_workspace_payload_path(fname, "0/childtools/sweep-child-tool")
+            ]
             assert "auxiliary" in tool_group
             assert (
                 tool_group["auxiliary"].attrs[
@@ -1266,11 +1254,8 @@ def test_manager_workspace_loader_state_does_not_create_explorer_app_state(
         )
 
         fname = tmp_path / "loader-no-explorer.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        manifest = _current_workspace_manifest(fname)
         assert manifest["loader_state"]["explorer_loader_kwargs_by_name"] == (
             explorer_kwargs
         )
@@ -1295,8 +1280,7 @@ def test_manager_workspace_loader_state_does_not_create_explorer_app_state(
 
         manager._mark_workspace_layout_dirty()
         assert _request_workspace_save_and_wait(qtbot, manager)
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manifest = _current_workspace_manifest(fname)
         assert "explorer" not in manifest["standalone_apps"]["apps"]
         assert manifest["loader_state"]["explorer_loader_kwargs_by_name"] == (
             explorer_kwargs
@@ -1527,9 +1511,7 @@ def test_manager_workspace_import_does_not_restore_standalone_apps(
         ptable._refresh_window_state(ensure_visible=False)
 
         fname = tmp_path / "import-standalone.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         ptable.hv_edit.setText("30")
         ptable._set_selection_state(
@@ -1537,21 +1519,19 @@ def test_manager_workspace_import_does_not_restore_standalone_apps(
         )
         ptable._refresh_window_state(ensure_visible=False)
 
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manifest = _current_workspace_manifest(fname)
         assert manager._workspace_controller.loading._from_h5py_workspace_file(
             fname, manifest, replace=False, mark_dirty=True
         )
         assert ptable.hv_edit.text() == "30"
         assert ptable.selected_atomic_numbers == (1,)
 
-        tree = workspace_arrays.open_workspace_datatree(fname, chunks=None)
-        assert manager._workspace_controller.loading._from_datatree(
-            tree,
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname,
             replace=False,
             mark_dirty=True,
             select=False,
-            workspace_file_path=fname,
+            associate=False,
         )
         assert ptable.hv_edit.text() == "30"
         assert ptable.selected_atomic_numbers == (1,)
@@ -1876,9 +1856,7 @@ def test_manager_workspace_roundtrips_child_plot_appearance(
         )
 
         fname = tmp_path / "child-plot-appearance.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname,
             replace=True,
@@ -2013,11 +1991,8 @@ def test_manager_from_h5py_workspace_falls_back_after_fast_read_error(
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
         fname = tmp_path / "fallback-load.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        manifest = _current_workspace_manifest(fname)
 
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
@@ -2037,7 +2012,7 @@ def test_manager_from_h5py_workspace_falls_back_after_fast_read_error(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
 
-def test_manager_load_workspace_file_falls_back_after_fast_path_error(
+def test_manager_load_workspace_file_reports_generation_loader_error(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -2052,9 +2027,7 @@ def test_manager_load_workspace_file_falls_back_after_fast_path_error(
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
         fname = tmp_path / "load-fallback.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
@@ -2067,15 +2040,16 @@ def test_manager_load_workspace_file_falls_back_after_fast_path_error(
             _raise_fast_load,
         )
 
-        assert manager._workspace_controller.loading._load_workspace_file(
-            fname,
-            replace=True,
-            associate=True,
-            mark_dirty=False,
-            select=False,
-        )
-        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
-        assert manager._workspace_state.path == fname.resolve()
+        with pytest.raises(RuntimeError, match="fast load failed"):
+            manager._workspace_controller.loading._load_workspace_file(
+                fname,
+                replace=True,
+                associate=True,
+                mark_dirty=False,
+                select=False,
+            )
+        assert manager.ntools == 0
+        assert manager._workspace_state.path is None
 
 
 def test_manager_from_h5py_workspace_logs_restore_failure(
@@ -2095,11 +2069,8 @@ def test_manager_from_h5py_workspace_logs_restore_failure(
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
         fname = tmp_path / "restore-failure.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        manifest = _current_workspace_manifest(fname)
 
         def _raise_load(*_args, **_kwargs):
             raise RuntimeError("load failed")
@@ -2436,9 +2407,7 @@ def test_open_multiple_files_loads_workspace_and_reads_metadata(
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
         fname = tmp_path / "open-multiple.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
@@ -2485,9 +2454,7 @@ def test_manager_workspace_import_appends_without_reassociation(
         manager.add_imagetool(base_tool, show=False)
 
         current_fname = tmp_path / "current.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            current_fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(current_fname)
         adopt_workspace_path(manager, current_fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -2495,9 +2462,7 @@ def test_manager_workspace_import_appends_without_reassociation(
         assert isinstance(import_tool, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(import_tool, show=False)
         import_fname = tmp_path / "import.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            import_fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(import_fname)
 
         manager.remove_imagetool(1)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
@@ -2548,11 +2513,8 @@ def test_manager_workspace_selected_import_uses_manifest_fast_path(
         )
 
         fname = tmp_path / "manifest-selected-import.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        manifest = _current_workspace_manifest(fname)
         nodes = manifest["nodes"]
         paths = {
             str(entry["path"])
@@ -2757,9 +2719,7 @@ def test_manager_workspace_load_uses_h5py_fast_path(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "h5py-fast-load.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
@@ -2806,13 +2766,9 @@ def test_manager_h5py_workspace_load_defers_hidden_imagetool_refresh_and_profile
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "profiled-h5py-load.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
-        _, _, manifest = workspace_format._workspace_file_metadata_from_attrs(
-            root_attrs
-        )
+        _, manifest = workspace_format._workspace_file_metadata_from_attrs(root_attrs)
         assert manifest is not None
 
         manager.remove_all_tools()
@@ -2885,9 +2841,7 @@ def test_manager_h5py_workspace_load_defers_hidden_secondary_plot_widgets(
             )
 
         fname = tmp_path / "lazy-secondary-plots.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
@@ -2968,9 +2922,7 @@ def test_manager_workspace_load_preserves_transposed_inverted_axis_limits(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "transposed-inverted-limits.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
@@ -3021,9 +2973,7 @@ def test_manager_workspace_load_h5py_fast_path_falls_back_per_payload(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "h5py-group-fallback.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
@@ -3063,9 +3013,7 @@ def test_manager_workspace_load_dialog_skips_stale_internal_groups(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "stale-dialog.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         with h5py.File(fname, "a") as h5_file:
             h5_file.create_group(
                 f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}stale"
@@ -3077,13 +3025,13 @@ def test_manager_workspace_load_dialog_skips_stale_internal_groups(
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
-        tree = workspace_arrays.open_workspace_datatree(fname, chunks="auto")
         accept_dialog(
-            lambda: manager._workspace_controller.loading._from_datatree(
-                tree,
+            lambda: manager._workspace_controller.loading._load_workspace_file(
+                fname,
                 replace=True,
                 mark_dirty=False,
                 select=True,
+                associate=False,
             )
         )
 
@@ -3111,9 +3059,7 @@ def test_manager_workspace_replace_load_failure_restores_previous_workspace(
         manager.add_imagetool(root, show=False)
 
         current_fname = tmp_path / "current.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            current_fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(current_fname)
         adopt_workspace_path(manager, current_fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -3160,9 +3106,7 @@ def test_manager_workspace_replace_load_failure_uses_clean_file_backup(
         manager.add_imagetool(root, show=False)
 
         current_fname = tmp_path / "current-clean.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            current_fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(current_fname)
         adopt_workspace_path(manager, current_fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -3211,9 +3155,7 @@ def test_manager_workspace_replace_load_failure_keeps_dirty_memory_backup(
         uid = manager._tool_graph.root_wrappers[0].uid
 
         current_fname = tmp_path / "current-dirty.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            current_fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(current_fname)
         adopt_workspace_path(manager, current_fname)
         manager._workspace_controller._mark_workspace_clean()
         manager._workspace_controller._mark_node_state_dirty(uid)
@@ -3269,9 +3211,7 @@ def test_manager_workspace_load_visible_windows_stays_clean_after_events(
         qtbot.wait_until(root.isVisible)
 
         fname = tmp_path / "visible.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -1975,6 +1975,44 @@ def test_manager_from_h5py_workspace_manifest_validation(
             )
 
 
+def test_manager_from_h5py_workspace_restores_empty_workspace(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+        manager.resize(640, 520)
+        expected_size = manager.size()
+        fname = tmp_path / "empty.itws"
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        manifest = _current_workspace_manifest(fname)
+        assert manifest["nodes"] == []
+
+        root = itool(
+            xr.DataArray(np.arange(9.0).reshape(3, 3), dims=("x", "y")),
+            manager=False,
+            execute=False,
+        )
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        manager.resize(480, 500)
+
+        assert manager._workspace_controller.loading._from_h5py_workspace_file(
+            fname,
+            manifest,
+            replace=True,
+            mark_dirty=False,
+        )
+        qtbot.wait_until(
+            lambda: manager.ntools == 0 and manager.size() == expected_size,
+            timeout=5000,
+        )
+
+
 def test_manager_from_h5py_workspace_falls_back_after_fast_read_error(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -19,12 +19,10 @@ import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._console as manager_console
 import erlab.interactive.imagetool.manager._lineage as manager_lineage
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
-import erlab.interactive.imagetool.manager._modelview as manager_modelview
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._loading as workspace_loading
 import erlab.interactive.imagetool.manager._workspace._pending as workspace_pending
-import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive.imagetool import itool
@@ -62,6 +60,9 @@ if typing.TYPE_CHECKING:
     )
 from tests.interactive.imagetool.manager.workspace._support import (
     _AddedTimeChildTool,
+    _current_workspace_manifest_entry,
+    _current_workspace_payload_attrs,
+    _current_workspace_payload_path,
     _open_external_file_backed_hdf5_imagetool_data,
     _request_workspace_save_and_wait,
     _transaction_test_root_attrs,
@@ -94,9 +95,7 @@ def test_manager_workspace_restore_hidden_memory_link_group_keeps_payload_pendin
 
         manager.link_imagetools(0, 1, link_colors=False)
         fname = tmp_path / "hidden-memory-linked.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         def _fail_materialize_pending_payload(_node) -> bool:
             pytest.fail("link restore should not materialize hidden memory payloads")
@@ -120,7 +119,7 @@ def test_manager_workspace_restore_hidden_memory_link_group_keeps_payload_pendin
         for index, wrapper in enumerate(wrappers):
             assert wrapper.pending_workspace_memory_payload == (
                 fname.resolve(),
-                f"{index}/imagetool",
+                _current_workspace_payload_path(fname, str(index)).lstrip("/"),
             )
             assert wrapper.imagetool is None
             assert wrapper.workspace_linked
@@ -129,32 +128,27 @@ def test_manager_workspace_restore_hidden_memory_link_group_keeps_payload_pendin
         assert wrappers[0].workspace_link_key == wrappers[1].workspace_link_key
         assert not manager.is_workspace_modified
 
-        icon_colors: list[QtGui.QColor] = []
-        original_icon = manager_modelview.qta.icon
-
-        def _record_icon(name, *args, **kwargs):
-            if name == "mdi6.link-variant":
-                icon_colors.append(kwargs["color"])
-            return original_icon(name, *args, **kwargs)
-
-        monkeypatch.setattr(manager_modelview.qta, "icon", _record_icon)
+        delegate = manager.tree_view._delegate
+        delegate._link_icon_cache.clear()
         index = manager.tree_view._model.index(0, 0)
-        option = manager.tree_view._delegate._option_for_index(manager.tree_view, index)
+        option = delegate._option_for_index(manager.tree_view, index)
         canvas = QtGui.QPixmap(200, 32)
         canvas.fill(QtGui.QColor("white"))
         painter = QtGui.QPainter(canvas)
         try:
-            manager.tree_view._delegate.paint(painter, option, index)
+            delegate.paint(painter, option, index)
         finally:
             painter.end()
 
-        assert icon_colors
-        assert icon_colors[-1] != option.palette.color(QtGui.QPalette.ColorRole.Mid)
+        link_color = manager.color_for_workspace_link_key(
+            typing.cast("str", wrappers[0].workspace_link_key)
+        )
+        assert link_color.rgba() in delegate._link_icon_cache
+        assert link_color != option.palette.color(QtGui.QPalette.ColorRole.Mid)
 
 
 def test_manager_workspace_mixed_pending_link_badge_uses_group_color(
     qtbot,
-    monkeypatch,
     tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -175,9 +169,7 @@ def test_manager_workspace_mixed_pending_link_badge_uses_group_color(
         manager.link_imagetools(0, 1, link_colors=False)
 
         fname = tmp_path / "mixed-hidden-memory-linked.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -194,28 +186,21 @@ def test_manager_workspace_mixed_pending_link_badge_uses_group_color(
         assert wrappers[0].slicer_area._linking_proxy is None
         assert wrappers[1].pending_workspace_memory_payload is not None
 
-        icon_colors: list[QtGui.QColor] = []
-        original_icon = manager_modelview.qta.icon
-
-        def _record_icon(name, *args, **kwargs):
-            if name == "mdi6.link-variant":
-                icon_colors.append(kwargs["color"])
-            return original_icon(name, *args, **kwargs)
-
-        monkeypatch.setattr(manager_modelview.qta, "icon", _record_icon)
+        delegate = manager.tree_view._delegate
+        delegate._link_icon_cache.clear()
         index = manager.tree_view._model.index(0, 0)
-        option = manager.tree_view._delegate._option_for_index(manager.tree_view, index)
+        option = delegate._option_for_index(manager.tree_view, index)
         canvas = QtGui.QPixmap(200, 32)
         canvas.fill(QtGui.QColor("white"))
         painter = QtGui.QPainter(canvas)
         try:
-            manager.tree_view._delegate.paint(painter, option, index)
+            delegate.paint(painter, option, index)
         finally:
             painter.end()
 
-        assert icon_colors
-        assert icon_colors[-1] == manager.color_for_workspace_link_key(link_key)
-        assert icon_colors[-1] != option.palette.color(QtGui.QPalette.ColorRole.Mid)
+        link_color = manager.color_for_workspace_link_key(link_key)
+        assert link_color.rgba() in delegate._link_icon_cache
+        assert link_color != option.palette.color(QtGui.QPalette.ColorRole.Mid)
 
 
 def test_manager_workspace_link_badge_colors_do_not_depend_on_materialization(
@@ -241,9 +226,7 @@ def test_manager_workspace_link_badge_colors_do_not_depend_on_materialization(
         manager.link_imagetools(2, 3, link_colors=False)
 
         fname = tmp_path / "pending-link-badge-colors.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -461,9 +444,7 @@ def test_manager_update_actions_for_pending_memory_link_state_does_not_materiali
             root.hide()
 
         fname = tmp_path / "pending-actions.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -525,9 +506,7 @@ def test_manager_pending_memory_reload_unavailable_does_not_materialize(
         root.hide()
 
         fname = tmp_path / "pending-reload.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -587,9 +566,7 @@ def test_manager_pending_memory_file_source_reload_available_without_materializi
         root.hide()
 
         fname = tmp_path / "pending-file-source-reload.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -662,9 +639,7 @@ def test_manager_pending_memory_child_routes_reload_to_file_source_parent(
         child.hide()
 
         fname = tmp_path / "pending-file-source-child-reload.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -744,9 +719,7 @@ def test_manager_pending_memory_child_source_change_marks_stale_not_unavailable(
         child.hide()
 
         fname = tmp_path / "pending-child-source-stale.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -805,9 +778,7 @@ def test_manager_pending_memory_output_child_source_change_marks_stale(
         output_tool.hide()
 
         fname = tmp_path / "pending-output-child-source-change.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -860,9 +831,7 @@ def test_manager_link_imagetools_keeps_hidden_memory_payload_pending(
             root.hide()
 
         fname = tmp_path / "pending-link.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -911,9 +880,7 @@ def test_manager_unlink_selected_keeps_hidden_memory_payload_pending(
         manager.link_imagetools(0, 1, link_colors=False)
 
         fname = tmp_path / "pending-unlink.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -961,9 +928,7 @@ def test_manager_unlink_selected_prunes_pending_link_singleton(
         manager.link_imagetools(0, 1, link_colors=False)
 
         fname = tmp_path / "pending-unlink-singleton.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1012,9 +977,7 @@ def test_manager_remove_pending_linked_root_prunes_partner_without_materializing
         manager.link_imagetools(0, 1, link_colors=False)
 
         fname = tmp_path / "pending-remove-linked-root.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1042,9 +1005,7 @@ def test_manager_remove_pending_linked_root_prunes_partner_without_materializing
         assert survivor.uid in manager._workspace_state.dirty_state
         assert survivor.uid not in manager._workspace_state.dirty_data
 
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manifest = workspace_format._workspace_manifest_from_attrs(
             workspace_arrays._read_workspace_root_attrs_h5py(fname)
         )
@@ -1081,9 +1042,7 @@ def test_manager_remove_pending_linked_child_prunes_partner_without_materializin
         manager.link_imagetools(*child_uids, link_colors=False)
 
         fname = tmp_path / "pending-remove-linked-child.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1127,9 +1086,7 @@ def test_manager_remove_pending_linked_child_prunes_partner_without_materializin
         assert survivor.uid in manager._workspace_state.dirty_state
         assert survivor.uid not in manager._workspace_state.dirty_data
 
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manifest = workspace_format._workspace_manifest_from_attrs(
             workspace_arrays._read_workspace_root_attrs_h5py(fname)
         )
@@ -1160,9 +1117,7 @@ def test_manager_materializing_pending_linked_partner_uses_pending_state(
         manager.link_imagetools(0, 1, link_colors=False)
 
         fname = tmp_path / "pending-linked-partner-materialize-state.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1473,13 +1428,10 @@ def test_manager_pending_linked_partner_respects_link_color_setting(
         manager.link_imagetools(0, 1, link_colors=False)
 
         fname = tmp_path / "pending-linked-partner-color-state.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        original_partner_state = json.loads(
+            _current_workspace_payload_attrs(fname, "1")["itool_state"]
         )
-        with h5py.File(fname, "r") as h5_file:
-            original_partner_state = json.loads(
-                h5_file["1/imagetool"].attrs["itool_state"]
-            )
         new_cmap = (
             "viridis"
             if original_partner_state["color"]["cmap"] != "viridis"
@@ -1522,10 +1474,9 @@ def test_manager_pending_linked_partner_respects_link_color_setting(
         assert materialized_calls == 1
         assert wrappers[1].pending_workspace_memory_payload is not None
 
-        with h5py.File(fname, "r") as h5_file:
-            saved_partner_state = json.loads(
-                h5_file["1/imagetool"].attrs["itool_state"]
-            )
+        saved_partner_state = json.loads(
+            _current_workspace_payload_attrs(fname, "1")["itool_state"]
+        )
         assert saved_partner_state["slice"]["indices"][0][0] == 3
         assert saved_partner_state["color"] == original_partner_state["color"]
 
@@ -1865,9 +1816,7 @@ def test_manager_workspace_data_backing_snapshot_includes_pending_memory(
         root.hide()
 
         fname = tmp_path / "pending-backing-snapshot.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1905,15 +1854,13 @@ def test_manager_workspace_file_backed_data_can_load_into_memory(
         dims=["x", "y"],
         coords={"x": np.arange(5), "y": np.arange(5)},
     )
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": source.to_dataset(name=_ITOOL_DATA_NAME)}
+    workspace_arrays._write_workspace_dataset_group_to_file(
+        source_file,
+        "0/imagetool",
+        source.to_dataset(name=_ITOOL_DATA_NAME),
     )
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            source_file, tree, _transaction_test_root_attrs()
-        )
-    finally:
-        tree.close()
+    with h5py.File(source_file, "a") as h5_file:
+        h5_file.attrs.update(_transaction_test_root_attrs())
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -1952,9 +1899,7 @@ def test_manager_workspace_load_keeps_hidden_memory_payload_pending(
         root.hide()
 
         fname = tmp_path / "load-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         def _fail_h5py_payload_read(*_args, **_kwargs):
             pytest.fail("hidden memory payload should not use fake h5py data")
@@ -1972,7 +1917,7 @@ def test_manager_workspace_load_keeps_hidden_memory_payload_pending(
         wrapper = manager._tool_graph.root_wrappers[0]
         assert wrapper.pending_workspace_memory_payload == (
             fname.resolve(),
-            "0/imagetool",
+            _current_workspace_payload_path(fname).lstrip("/"),
         )
         assert wrapper.imagetool is None
         index = manager.tree_view._model.index(0, 0)
@@ -2114,9 +2059,7 @@ def test_pending_workspace_1d_roles_match_materialized_provenance_input(
         }
 
         fname = tmp_path / "pending-1d-role-parity.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2218,9 +2161,7 @@ def test_manager_workspace_open_coalesces_pending_memory_wait_dialogs(
         root.hide()
 
         fname = tmp_path / "pending-wait-dialogs.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         messages: list[str] = []
 
         @contextlib.contextmanager
@@ -2282,9 +2223,7 @@ def test_hidden_workspace_toolwindows_restore_pending_until_shown(
         figure.hide()
 
         fname = tmp_path / "hidden-toolwindows-pending.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         original_from_dataset = erlab.interactive.utils.ToolWindow.from_dataset.__func__
         constructed: list[str] = []
@@ -2400,9 +2339,7 @@ def test_manager_get_imagetool_materializes_hidden_memory_payload(
         root.hide()
 
         fname = tmp_path / "get-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2439,9 +2376,7 @@ def test_manager_persistence_view_materializes_hidden_memory_payload(
         root.hide()
 
         fname = tmp_path / "persistence-view-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2479,9 +2414,7 @@ def test_manager_console_namespace_materializes_hidden_memory_payload(
         root.hide()
 
         fname = tmp_path / "console-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2517,9 +2450,7 @@ def test_manager_figure_operation_materializes_hidden_memory_payload(
         root.hide()
 
         fname = tmp_path / "figure-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2560,9 +2491,7 @@ def test_manager_reload_selected_materializes_hidden_memory_payload(
         root.hide()
 
         fname = tmp_path / "reload-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2627,9 +2556,7 @@ def test_manager_active_filter_edit_materializes_hidden_memory_payload(
         root.hide()
 
         fname = tmp_path / "active-filter-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2673,9 +2600,7 @@ def test_manager_workspace_show_materializes_hidden_memory_payload(
         root.hide()
 
         fname = tmp_path / "show-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2720,13 +2645,12 @@ def test_manager_workspace_child_tool_reference_keeps_pending_parent_unmateriali
         child_uid = manager.add_childtool(child, 0, show=False)
 
         fname = tmp_path / "pending-parent-child-reference.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        references = json.loads(
+            _current_workspace_payload_attrs(fname, f"0/childtools/{child_uid}")[
+                "tool_data_references"
+            ]
         )
-        with h5py.File(fname, "r") as h5_file:
-            references = json.loads(
-                h5_file[f"0/childtools/{child_uid}/tool"].attrs["tool_data_references"]
-            )
         assert references[imagetool_serialization.SAVED_TOOL_DATA_NAME] == {
             "kind": "parent_source"
         }
@@ -2804,12 +2728,13 @@ def test_manager_workspace_tool_manager_node_reference_keeps_pending_source(
         )
 
         fname = tmp_path / "pending-manager-node-reference.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        figure_attrs = _current_workspace_payload_attrs(fname, f"figures/{figure_uid}")
+        references = json.loads(figure_attrs["tool_data_references"])
         with h5py.File(fname, "r") as h5_file:
-            figure_group = h5_file[f"figures/{figure_uid}/tool"]
-            references = json.loads(figure_group.attrs["tool_data_references"])
+            figure_group = h5_file[
+                _current_workspace_payload_path(fname, f"figures/{figure_uid}")
+            ]
             assert references[imagetool_serialization.SAVED_TOOL_DATA_NAME] == {
                 "kind": "manager_node",
                 "node_uid": wrapper.uid,
@@ -2893,14 +2818,10 @@ def test_manager_workspace_embedded_child_tool_keeps_parent_payload_pending(
         )
 
         fname = tmp_path / "pending-parent-embedded-child.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        assert "tool_data_references" not in _current_workspace_payload_attrs(
+            fname, f"0/childtools/{child_uid}"
         )
-        with h5py.File(fname, "r") as h5_file:
-            assert (
-                "tool_data_references"
-                not in h5_file[f"0/childtools/{child_uid}/tool"].attrs
-            )
 
         materialize_calls = 0
         pending_payloads = manager._workspace_controller.loading.pending
@@ -2952,9 +2873,7 @@ def test_manager_workspace_replacing_pending_memory_data_clears_pending_payload(
         root.hide()
 
         fname = tmp_path / "replace-pending-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2976,8 +2895,10 @@ def test_manager_workspace_replacing_pending_memory_data_clears_pending_payload(
         assert wrapper.pending_workspace_memory_payload is None
 
         with h5py.File(fname, "r") as h5_file:
-            group = h5_file["0/imagetool"]
-            assert group.attrs["itool_name"] == "replacement"
+            group = h5_file[_current_workspace_payload_path(fname)]
+            assert _current_workspace_payload_attrs(fname)["itool_name"] == (
+                "replacement"
+            )
             np.testing.assert_array_equal(
                 group[_ITOOL_DATA_NAME][...],
                 replacement.values,
@@ -3011,15 +2932,14 @@ def test_manager_workspace_attr_update_keeps_pending_hidden_memory_unmaterialize
         root.hide()
 
         fname = tmp_path / "save-pending-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
 
         wrapper = manager._tool_graph.root_wrappers[0]
         assert wrapper.pending_workspace_memory_payload is not None
+        object_id = _current_workspace_manifest_entry(fname)["payload_object_id"]
 
         materialize_calls = 0
         pending_payloads = manager._workspace_controller.loading.pending
@@ -3037,25 +2957,19 @@ def test_manager_workspace_attr_update_keeps_pending_hidden_memory_unmaterialize
         )
 
         wrapper.name = "renamed"
-        update = manager._workspace_controller.saving._workspace_attr_update_snapshot(
-            wrapper.uid
-        )
-
-        assert update is not None
-        payload_path, attrs, (_node_path, constructor) = update
         assert materialize_calls == 0
         assert wrapper.pending_workspace_memory_payload is not None
-        assert attrs["itool_name"] == "renamed"
-        assert payload_path == "0/imagetool"
-        assert constructor == {}
 
         assert _request_workspace_save_and_wait(qtbot, manager)
         assert materialize_calls == 0
         assert wrapper.pending_workspace_memory_payload is not None
+        assert _current_workspace_manifest_entry(fname)["payload_object_id"] == (
+            object_id
+        )
+        assert _current_workspace_payload_attrs(fname)["itool_name"] == "renamed"
 
         with h5py.File(fname, "r") as h5_file:
-            group = h5_file["0/imagetool"]
-            assert group.attrs["itool_name"] == "renamed"
+            group = h5_file[_current_workspace_payload_path(fname)]
             np.testing.assert_array_equal(
                 group[_ITOOL_DATA_NAME][...],
                 data.values,

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -1835,7 +1835,13 @@ def test_manager_save_as_rebind_failure_keeps_old_live_references(
         manager.add_imagetool(root, show=False)
         root.hide()
         wrapper = manager._tool_graph.root_wrappers[0]
-        figure_uid = manager.add_figuretool(
+        first_figure_uid = manager.add_figuretool(
+            _WorkspaceManagerReferenceFigureTool(
+                data.copy(deep=False), reference_uid=wrapper.uid
+            ),
+            show=False,
+        )
+        failing_figure_uid = manager.add_figuretool(
             _WorkspaceManagerReferenceFigureTool(
                 data.copy(deep=False), reference_uid=wrapper.uid
             ),
@@ -1851,19 +1857,31 @@ def test_manager_save_as_rebind_failure_keeps_old_live_references(
             source, replace=True, associate=True, mark_dirty=False, select=False
         )
         loaded_wrapper = manager._tool_graph.root_wrappers[0]
-        loaded_figure = manager.get_childtool(figure_uid)
-        assert isinstance(loaded_figure, _WorkspaceManagerReferenceFigureTool)
-        original_paths = workspace_arrays.dataarray_source_paths(
-            loaded_figure.tool_data
+        first_figure = manager.get_childtool(first_figure_uid)
+        failing_figure = manager.get_childtool(failing_figure_uid)
+        assert isinstance(first_figure, _WorkspaceManagerReferenceFigureTool)
+        assert isinstance(failing_figure, _WorkspaceManagerReferenceFigureTool)
+        original_first_paths = workspace_arrays.dataarray_source_paths(
+            first_figure.tool_data
         )
-        assert str(source.resolve()) in original_paths
+        original_failing_paths = workspace_arrays.dataarray_source_paths(
+            failing_figure.tool_data
+        )
+        assert str(source.resolve()) in original_first_paths
+        assert str(source.resolve()) in original_failing_paths
+        first_node = manager._node_for_target(first_figure_uid)
+        failing_node = manager._node_for_target(failing_figure_uid)
+        original_first_reference_keys = tuple(first_node._workspace_reference_datasets)
+        original_failing_reference_keys = tuple(
+            failing_node._workspace_reference_datasets
+        )
 
         def _fail_replace(_data_items, _ds) -> None:
             raise RuntimeError("replacement failed")
 
         errors: list[tuple[str, str]] = []
         monkeypatch.setattr(
-            loaded_figure, "_replace_persistence_data_items", _fail_replace
+            failing_figure, "_replace_persistence_data_items", _fail_replace
         )
         monkeypatch.setattr(
             manager,
@@ -1875,7 +1893,7 @@ def test_manager_save_as_rebind_failure_keeps_old_live_references(
             "_workspace_save_dialog",
             lambda **_kwargs: target,
         )
-        manager._workspace_controller._mark_node_state_dirty(figure_uid)
+        manager._workspace_controller._mark_node_state_dirty(failing_figure_uid)
 
         assert not _request_workspace_save_as_and_wait(qtbot, manager, native=False)
         assert errors[-1] == (
@@ -1890,12 +1908,25 @@ def test_manager_save_as_rebind_failure_keeps_old_live_references(
             source.resolve(),
             "0/imagetool",
         )
-        assert workspace_arrays.dataarray_source_paths(loaded_figure.tool_data) == (
-            original_paths
+        assert (
+            workspace_arrays.dataarray_source_paths(first_figure.tool_data)
+            == original_first_paths
+        )
+        assert (
+            workspace_arrays.dataarray_source_paths(failing_figure.tool_data)
+            == original_failing_paths
+        )
+        assert (
+            tuple(first_node._workspace_reference_datasets)
+            == original_first_reference_keys
+        )
+        assert (
+            tuple(failing_node._workspace_reference_datasets)
+            == original_failing_reference_keys
         )
 
 
-def test_manager_compact_rebind_failure_keeps_workspace_modified(
+def test_manager_compact_does_not_rebind_live_tool_reference_dataset(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -1932,6 +1963,9 @@ def test_manager_compact_rebind_failure_keeps_workspace_modified(
         loaded_figure = manager.get_childtool(figure_uid)
         assert isinstance(loaded_figure, _WorkspaceManagerReferenceFigureTool)
         assert not manager.is_workspace_modified
+        original_paths = workspace_arrays.dataarray_source_paths(
+            loaded_figure.tool_data
+        )
 
         def _fail_replace(_data_items, _ds) -> None:
             raise RuntimeError("replacement failed")
@@ -1951,18 +1985,13 @@ def test_manager_compact_rebind_failure_keeps_workspace_modified(
             lambda *args, **kwargs: contextlib.nullcontext(),
         )
 
-        assert not manager.compact_workspace()
-        assert errors[-1] == (
-            "Workspace file saved but live references were not updated",
-            "The workspace file was saved, but live tool data could not be "
-            "updated to use the saved file. Reopen the workspace to continue "
-            "from the saved version.",
-        )
+        assert manager.compact_workspace()
+        assert errors == []
         assert manager._workspace_state.path == source.resolve()
-        assert manager.is_workspace_modified
-        assert manager._workspace_state.needs_full_save
-        assert "Live workspace data references need refresh" in (
-            manager._workspace_state.structure_reasons
+        assert not manager.is_workspace_modified
+        assert not manager._workspace_state.needs_full_save
+        assert workspace_arrays.dataarray_source_paths(loaded_figure.tool_data) == (
+            original_paths
         )
 
 

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -17,7 +17,6 @@ import erlab
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._loading as workspace_loading
 import erlab.interactive.imagetool.manager._workspace._pending as workspace_pending
-import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.viewer_linking as imagetool_viewer_linking
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
@@ -46,7 +45,9 @@ from erlab.interactive.imagetool._provenance._code import uses_default_replay_in
 from tests.interactive.imagetool.manager.workspace._support import (
     _AddedTimeChildTool,
     _compute_first_value,
-    _hdf5_blosc2_level_codec,
+    _current_workspace_payload_attrs,
+    _current_workspace_payload_path,
+    _edit_current_workspace_payload_attrs,
     _open_external_lazy_hdf5_imagetool_data,
     _request_workspace_save_and_wait,
     _request_workspace_save_as_and_wait,
@@ -80,9 +81,7 @@ def test_manager_save_updates_pending_linked_partner_state(
         manager.link_imagetools(0, 1, link_colors=False)
 
         fname = tmp_path / "pending-linked-partner-state.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -138,8 +137,9 @@ def test_manager_save_updates_pending_linked_partner_state(
         assert materialized_calls == 1
         assert wrappers[1].pending_workspace_memory_payload is not None
 
-        with h5py.File(fname, "r") as h5_file:
-            saved_state = json.loads(h5_file["1/imagetool"].attrs["itool_state"])
+        saved_state = json.loads(
+            _current_workspace_payload_attrs(fname, "1")["itool_state"]
+        )
         assert saved_state["slice"]["indices"][0][0] == 3
 
         manager.get_imagetool(1)
@@ -177,9 +177,7 @@ def test_pending_linked_splitter_sizes_follow_undo_redo(
         manager.link_imagetools(0, 1, link_colors=False)
 
         fname = tmp_path / "pending-linked-splitters.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -265,9 +263,7 @@ def test_link_selected_uses_pending_current_imagetool_layout(
             root.hide()
 
         fname = tmp_path / "pending-link-layout-source.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -340,9 +336,7 @@ def test_link_imagetools_handles_missing_pending_source_layout(
             root.hide()
 
         fname = tmp_path / "missing-pending-source-layout.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -414,9 +408,7 @@ def test_materializing_restored_link_preserves_saved_layouts(
             area.splitter_sizes = splitter_sizes
 
         fname = tmp_path / "restored-linked-layouts.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -659,9 +651,7 @@ def test_manager_save_updates_pending_linked_partner_manual_limits(
         manager.link_imagetools(0, 1, link_colors=False)
 
         fname = tmp_path / "pending-linked-partner-manual-limits.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -705,8 +695,9 @@ def test_manager_save_updates_pending_linked_partner_manual_limits(
         assert materialized_calls == 1
         assert wrappers[1].pending_workspace_memory_payload is not None
 
-        with h5py.File(fname, "r") as h5_file:
-            saved_state = json.loads(h5_file["1/imagetool"].attrs["itool_state"])
+        saved_state = json.loads(
+            _current_workspace_payload_attrs(fname, "1")["itool_state"]
+        )
         assert saved_state["manual_limits"] == expected_limits
 
         assert manager._workspace_controller.loading._load_workspace_file(
@@ -739,13 +730,10 @@ def test_manager_pending_linked_partner_saves_color_when_linked(
         manager.link_imagetools(0, 1, link_colors=True)
 
         fname = tmp_path / "pending-linked-partner-color-linked.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        original_partner_state = json.loads(
+            _current_workspace_payload_attrs(fname, "1")["itool_state"]
         )
-        with h5py.File(fname, "r") as h5_file:
-            original_partner_state = json.loads(
-                h5_file["1/imagetool"].attrs["itool_state"]
-            )
         new_cmap = (
             "viridis"
             if original_partner_state["color"]["cmap"] != "viridis"
@@ -785,146 +773,10 @@ def test_manager_pending_linked_partner_saves_color_when_linked(
         assert materialized_calls == 1
         assert wrappers[1].pending_workspace_memory_payload is not None
 
-        with h5py.File(fname, "r") as h5_file:
-            saved_partner_state = json.loads(
-                h5_file["1/imagetool"].attrs["itool_state"]
-            )
+        saved_partner_state = json.loads(
+            _current_workspace_payload_attrs(fname, "1")["itool_state"]
+        )
         assert saved_partner_state["color"]["cmap"] == new_cmap
-
-
-@pytest.mark.parametrize("force_fallback", [False, True])
-def test_manager_full_save_rewrites_pending_dirty_state_on_compression_mismatch(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-    force_fallback: bool,
-) -> None:
-    old_compression = erlab.interactive.options["io/workspace/compression"]
-    try:
-        erlab.interactive.options["io/workspace/compression"] = "none"
-        with manager_context() as manager:
-            qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-            data = xr.DataArray(
-                np.arange(512 * 512, dtype=np.float64).reshape(512, 512),
-                dims=("x", "y"),
-            )
-            root = itool(data, manager=False, execute=False)
-            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-            manager.add_imagetool(root, show=False)
-            root.hide()
-
-            fname = tmp_path / f"pending-compression-{force_fallback}.itws"
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
-            with h5py.File(fname, "r") as h5_file:
-                data_ds = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
-                assert _hdf5_blosc2_level_codec(data_ds) is None
-            assert manager._workspace_controller.loading._load_workspace_file(
-                fname, replace=True, associate=True, mark_dirty=False, select=False
-            )
-
-            wrapper = manager._tool_graph.root_wrappers[0]
-            assert wrapper.pending_workspace_memory_payload is not None
-            wrapper.name = "renamed pending"
-            assert wrapper.uid in manager._workspace_state.dirty_state
-            assert wrapper.uid not in manager._workspace_state.dirty_data
-
-            if force_fallback:
-                monkeypatch.setattr(
-                    manager._workspace_controller.saving,
-                    "_workspace_full_save_manifest_first_snapshot",
-                    lambda *_args, **_kwargs: None,
-                )
-
-            erlab.interactive.options["io/workspace/compression"] = "zstd1"
-            manager._workspace_controller.saving._save_workspace_document(
-                fname,
-                force_full=True,
-                require_matching_compression=True,
-            )
-
-            with h5py.File(fname, "r") as h5_file:
-                group = h5_file["0/imagetool"]
-                data_ds = group[_ITOOL_DATA_NAME]
-                assert _hdf5_blosc2_level_codec(data_ds) is not None
-                assert group.attrs["itool_name"] == "renamed pending"
-                np.testing.assert_array_equal(data_ds[...], data.values)
-    finally:
-        erlab.interactive.options["io/workspace/compression"] = old_compression
-
-
-def test_manager_fallback_save_materializes_pending_without_wait_dialog(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    old_compression = erlab.interactive.options["io/workspace/compression"]
-    try:
-        erlab.interactive.options["io/workspace/compression"] = "none"
-        with manager_context() as manager:
-            qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-            data = xr.DataArray(
-                np.arange(512 * 512, dtype=np.float64).reshape(512, 512),
-                dims=("x", "y"),
-            )
-            root = itool(data, manager=False, execute=False)
-            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-            manager.add_imagetool(root, show=False)
-            root.hide()
-
-            fname = tmp_path / "fallback-save-pending-no-wait.itws"
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
-            assert manager._workspace_controller.loading._load_workspace_file(
-                fname, replace=True, associate=True, mark_dirty=False, select=False
-            )
-
-            wrapper = manager._tool_graph.root_wrappers[0]
-            assert wrapper.pending_workspace_memory_payload is not None
-            wrapper.name = "renamed pending"
-            monkeypatch.setattr(
-                manager._workspace_controller.saving,
-                "_workspace_full_save_manifest_first_snapshot",
-                lambda *_args, **_kwargs: None,
-            )
-            messages: list[str] = []
-
-            @contextlib.contextmanager
-            def _record_wait_dialog(_parent, message):
-                messages.append(message)
-                yield types.SimpleNamespace(
-                    set_message=lambda updated: messages.append(updated)
-                )
-
-            monkeypatch.setattr(
-                erlab.interactive.utils, "wait_dialog", _record_wait_dialog
-            )
-            erlab.interactive.options["io/workspace/compression"] = "zstd1"
-
-            manager._workspace_controller.saving._save_workspace_document(
-                fname,
-                force_full=True,
-                require_matching_compression=True,
-            )
-
-            assert messages == []
-            assert wrapper.pending_workspace_memory_payload is None
-            with h5py.File(fname, "r") as h5_file:
-                assert h5_file["0/imagetool"].attrs["itool_name"] == "renamed pending"
-                np.testing.assert_array_equal(
-                    h5_file["0/imagetool"][_ITOOL_DATA_NAME][...],
-                    data.values,
-                )
-    finally:
-        erlab.interactive.options["io/workspace/compression"] = old_compression
 
 
 def test_pending_workspace_lazy_source_data_matches_saved_semantic_order(
@@ -1206,9 +1058,7 @@ def test_manager_pending_memory_file_source_full_code_uses_saved_load_code(
         )
 
         fname = tmp_path / "pending-file-source-replay.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1282,7 +1132,6 @@ def test_manager_replay_source_survives_pending_workspace_load_and_duplicate(
         fname = tmp_path / "pending-replay-source.itws"
         manager._workspace_controller.saving._save_workspace_document(
             fname,
-            force_full=True,
         )
         assert manager._workspace_controller.loading._load_workspace_file(
             fname,
@@ -1310,7 +1159,7 @@ def test_manager_replay_source_survives_pending_workspace_load_and_duplicate(
         xr.testing.assert_identical(duplicate.replay_source_data, source)
 
 
-def test_full_save_copies_unopened_pending_toolwindows_without_construction(
+def test_generation_save_copies_pending_tools_without_construction(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -1345,9 +1194,7 @@ def test_full_save_copies_unopened_pending_toolwindows_without_construction(
         figure.hide()
 
         fname = tmp_path / "pending-toolwindow-source.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1368,15 +1215,23 @@ def test_full_save_copies_unopened_pending_toolwindows_without_construction(
         )
 
         saved = tmp_path / "pending-toolwindow-copy.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            saved, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(saved)
 
         assert child_node.pending_workspace_tool_payload is not None
         assert figure_node.pending_workspace_tool_payload is not None
         with h5py.File(saved, "r") as h5_file:
-            assert f"0/childtools/{child_uid}/tool" in h5_file
-            assert f"figures/{figure_uid}/tool" in h5_file
+            assert (
+                _current_workspace_payload_path(
+                    saved, f"0/childtools/{child_uid}"
+                ).lstrip("/")
+                in h5_file
+            )
+            assert (
+                _current_workspace_payload_path(saved, f"figures/{figure_uid}").lstrip(
+                    "/"
+                )
+                in h5_file
+            )
 
 
 def test_hidden_toolwindow_with_missing_saved_class_is_skipped(
@@ -1410,11 +1265,11 @@ def test_hidden_toolwindow_with_missing_saved_class_is_skipped(
         child.hide()
 
         fname = tmp_path / "missing-hidden-tool-class.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        with h5py.File(fname, "r+") as h5_file:
-            h5_file[f"0/childtools/{child_uid}/tool"].attrs["tool_cls_qualname"] = (
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        with _edit_current_workspace_payload_attrs(
+            fname, f"0/childtools/{child_uid}"
+        ) as attrs:
+            attrs["tool_cls_qualname"] = (
                 "erlab.interactive._missing_tool_module:MissingTool"
             )
 
@@ -1507,9 +1362,7 @@ def test_manager_duplicate_pending_memory_uses_saved_payload(
         root.hide()
 
         fname = tmp_path / "duplicate-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1553,9 +1406,7 @@ def test_manager_duplicate_pending_child_tool_uses_saved_payload(
         child.hide()
 
         fname = tmp_path / "duplicate-hidden-child-tool.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1614,9 +1465,7 @@ def test_manager_duplicate_pending_mixed_subtree_is_complete(
         for window in (root, image_child, tool_child):
             window.hide()
         fname = tmp_path / "duplicate-pending-mixed-subtree.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1716,9 +1565,7 @@ def test_manager_promote_pending_child_memory_uses_saved_payload(
         child.hide()
 
         fname = tmp_path / "promote-child-hidden-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1787,9 +1634,7 @@ def test_manager_save_as_rebinds_live_tool_reference_dataset(
 
         source = tmp_path / "reference-source.itws"
         target = tmp_path / "reference-target.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            source, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(source)
         assert manager._workspace_controller.loading._load_workspace_file(
             source, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1813,7 +1658,7 @@ def test_manager_save_as_rebinds_live_tool_reference_dataset(
         assert str(source.resolve()) not in rebound_paths
         assert loaded_wrapper.pending_workspace_memory_payload == (
             target.resolve(),
-            "0/imagetool",
+            _current_workspace_payload_path(target).lstrip("/"),
         )
         np.testing.assert_array_equal(loaded_figure.tool_data.values, data.values)
 
@@ -1848,9 +1693,7 @@ def test_manager_save_as_rebinds_external_lazy_tool_data(
         source = tmp_path / "external-tool-source.itws"
         target = tmp_path / "external-tool-target.itws"
         external_path = tmp_path / "external-tool-data.h5"
-        manager._workspace_controller.saving._save_workspace_document(
-            source, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(source)
         assert manager._workspace_controller.loading._load_workspace_file(
             source, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1997,9 +1840,7 @@ def test_manager_save_as_rebind_failure_keeps_old_live_references(
 
         source = tmp_path / "reference-failure-source.itws"
         target = tmp_path / "reference-failure-target.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            source, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(source)
         assert manager._workspace_controller.loading._load_workspace_file(
             source, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2049,11 +1890,11 @@ def test_manager_save_as_rebind_failure_keeps_old_live_references(
             "updated to use the saved file. Reopen the workspace to continue "
             "from the saved version.",
         )
-        assert manager._workspace_state.path == source.resolve()
+        assert manager._workspace_state.path == target.resolve()
         assert manager.is_workspace_modified
         assert loaded_wrapper.pending_workspace_memory_payload == (
-            source.resolve(),
-            "0/imagetool",
+            target.resolve(),
+            _current_workspace_payload_path(target).lstrip("/"),
         )
         assert (
             workspace_arrays.dataarray_source_paths(first_figure.tool_data)
@@ -2101,9 +1942,7 @@ def test_manager_compact_does_not_rebind_live_tool_reference_dataset(
         )
 
         source = tmp_path / "reference-compact-failure-source.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            source, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(source)
         assert manager._workspace_controller.loading._load_workspace_file(
             source, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2136,7 +1975,6 @@ def test_manager_compact_does_not_rebind_live_tool_reference_dataset(
         assert errors == []
         assert manager._workspace_state.path == source.resolve()
         assert not manager.is_workspace_modified
-        assert not manager._workspace_state.needs_full_save
         assert workspace_arrays.dataarray_source_paths(loaded_figure.tool_data) == (
             original_paths
         )
@@ -2171,9 +2009,7 @@ def test_manager_save_as_does_not_revive_stale_live_tool_references(
 
         source = tmp_path / "stale-reference-source.itws"
         target = tmp_path / "stale-reference-target.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            source, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(source)
         assert manager._workspace_controller.loading._load_workspace_file(
             source, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -2223,9 +2059,7 @@ def test_manager_save_as_repoints_imported_pending_payload(
 
         source = tmp_path / "import-source.itws"
         target = tmp_path / "import-target.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            source, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(source)
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 
@@ -2234,9 +2068,7 @@ def test_manager_save_as_repoints_imported_pending_payload(
         assert isinstance(base_root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(base_root, show=False)
         base = tmp_path / "import-base.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            base, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(base)
         adopt_workspace_path(manager, base)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -2250,11 +2082,12 @@ def test_manager_save_as_repoints_imported_pending_payload(
         )
         assert wrapper.pending_workspace_memory_payload == (
             source.resolve(),
-            "0/imagetool",
+            _current_workspace_payload_path(source).lstrip("/"),
         )
         payload_path = manager._workspace_controller.saving._workspace_payload_path(
             wrapper.uid
         )
+        node_path = payload_path.rsplit("/", maxsplit=1)[0]
 
         monkeypatch.setattr(
             manager._workspace_controller,
@@ -2264,7 +2097,7 @@ def test_manager_save_as_repoints_imported_pending_payload(
         assert _request_workspace_save_as_and_wait(qtbot, manager, native=False)
         assert wrapper.pending_workspace_memory_payload == (
             target.resolve(),
-            payload_path,
+            _current_workspace_payload_path(target, node_path).lstrip("/"),
         )
 
         source.unlink()
@@ -2274,64 +2107,3 @@ def test_manager_save_as_repoints_imported_pending_payload(
             manager.get_imagetool(wrapper.index).slicer_area._data.values,
             data.values,
         )
-
-
-def test_manager_network_full_save_keeps_pending_hidden_memory_unmaterialized(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(
-            np.arange(25, dtype=np.float64).reshape((5, 5)),
-            dims=["x", "y"],
-            name="original",
-        )
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        root.hide()
-
-        fname = tmp_path / "network-full-save-pending-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        assert manager._workspace_controller.loading._load_workspace_file(
-            fname, replace=True, associate=True, mark_dirty=False, select=False
-        )
-
-        wrapper = manager._tool_graph.root_wrappers[0]
-        assert wrapper.pending_workspace_memory_payload is not None
-
-        def _fail_materialize_pending_payload(_node) -> bool:
-            pytest.fail(
-                "network full save should not materialize hidden memory payloads"
-            )
-
-        monkeypatch.setattr(
-            manager._workspace_controller.loading.pending,
-            "_materialize_pending_workspace_payload",
-            _fail_materialize_pending_payload,
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_workspace_path_is_likely_network_path",
-            lambda _path: True,
-        )
-
-        wrapper.name = "network-renamed"
-        manager._workspace_controller.saving._write_full_workspace_file(fname)
-        assert wrapper.pending_workspace_memory_payload is not None
-
-        with h5py.File(fname, "r") as h5_file:
-            group = h5_file["0/imagetool"]
-            assert group.attrs["itool_name"] == "network-renamed"
-            np.testing.assert_array_equal(
-                group[_ITOOL_DATA_NAME][...],
-                data.values,
-            )

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -45,10 +45,13 @@ if typing.TYPE_CHECKING:
 from erlab.interactive.imagetool._provenance._code import uses_default_replay_input
 from tests.interactive.imagetool.manager.workspace._support import (
     _AddedTimeChildTool,
+    _compute_first_value,
     _hdf5_blosc2_level_codec,
+    _open_external_lazy_hdf5_imagetool_data,
     _request_workspace_save_and_wait,
     _request_workspace_save_as_and_wait,
     _WorkspaceManagerReferenceFigureTool,
+    _WorkspaceSweepFigureTool,
 )
 
 
@@ -1813,6 +1816,150 @@ def test_manager_save_as_rebinds_live_tool_reference_dataset(
             "0/imagetool",
         )
         np.testing.assert_array_equal(loaded_figure.tool_data.values, data.values)
+
+
+def test_manager_save_as_rebinds_external_lazy_tool_data(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25, dtype=np.float64).reshape((5, 5)),
+            dims=["x", "y"],
+            name="source",
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        root.hide()
+        wrapper = manager._tool_graph.root_wrappers[0]
+        figure_uid = manager.add_figuretool(
+            _WorkspaceManagerReferenceFigureTool(
+                data.copy(deep=False), reference_uid=wrapper.uid
+            ),
+            show=False,
+        )
+
+        source = tmp_path / "external-tool-source.itws"
+        target = tmp_path / "external-tool-target.itws"
+        external_path = tmp_path / "external-tool-data.h5"
+        manager._workspace_controller.saving._save_workspace_document(
+            source, force_full=True
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            source, replace=True, associate=True, mark_dirty=False, select=False
+        )
+        loaded_figure = manager.get_childtool(figure_uid)
+        assert isinstance(loaded_figure, _WorkspaceManagerReferenceFigureTool)
+
+        external_data = data + 100.0
+        xr.DataTree.from_dict(
+            {"0/imagetool": external_data.to_dataset(name="data")}
+        ).to_netcdf(external_path, engine="h5netcdf", invalid_netcdf=True)
+        external = _open_external_lazy_hdf5_imagetool_data(external_path)
+        try:
+            loaded_figure.update_data(external + 0.0)
+            manager._workspace_controller._mark_node_data_dirty(figure_uid)
+            monkeypatch.setattr(
+                manager._workspace_controller,
+                "_workspace_save_dialog",
+                lambda **_kwargs: target,
+            )
+
+            assert _request_workspace_save_as_and_wait(qtbot, manager, native=False)
+            rebound = loaded_figure.tool_data
+            assert workspace_arrays.dataarray_source_paths(rebound) == (
+                str(target.resolve()),
+            )
+        finally:
+            external.close()
+        xr.backends.file_manager.FILE_CACHE.clear()
+        external_path.unlink()
+        assert _compute_first_value(rebound) == 100.0
+
+
+def test_full_save_binding_refresh_skips_in_memory_tool_data(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(9.0).reshape((3, 3)), dims=("x", "y"))
+        figure_uid = manager.add_figuretool(_WorkspaceSweepFigureTool(data), show=False)
+        figure = manager.get_childtool(figure_uid)
+        monkeypatch.setattr(
+            figure,
+            "to_dataset",
+            lambda: pytest.fail("In-memory tool data must stay on the fast path"),
+        )
+        monkeypatch.setattr(
+            workspace_arrays,
+            "open_workspace_dataset",
+            lambda *_args, **_kwargs: pytest.fail(
+                "In-memory tool data must not be reopened after a full save"
+            ),
+        )
+
+        manager._workspace_controller._refresh_workspace_tool_data_after_full_save(
+            None,
+            tmp_path / "saved.itws",
+            exclude_data_uids=frozenset(),
+            source_snapshot=[],
+        )
+
+        xr.testing.assert_identical(figure.tool_data, data)
+
+
+def test_manager_save_as_rebinds_new_external_lazy_figure_data(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    external_path = tmp_path / "new-figure-data.h5"
+    target = tmp_path / "new-figure-target.itws"
+    data = xr.DataArray(np.arange(9.0).reshape((3, 3)), dims=("x", "y"))
+    xr.DataTree.from_dict({"0/imagetool": data.to_dataset(name="data")}).to_netcdf(
+        external_path, engine="h5netcdf", invalid_netcdf=True
+    )
+    external = _open_external_lazy_hdf5_imagetool_data(external_path)
+    try:
+        with manager_context() as manager:
+            qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+            figure_uid = manager.add_figuretool(
+                _WorkspaceSweepFigureTool(external + 0.0), show=False
+            )
+            node = manager._node_for_target(figure_uid)
+            assert node._workspace_reference_datasets == {}
+            monkeypatch.setattr(
+                manager._workspace_controller,
+                "_workspace_save_dialog",
+                lambda **_kwargs: target,
+            )
+
+            assert _request_workspace_save_as_and_wait(qtbot, manager, native=False)
+            figure = manager.get_childtool(figure_uid)
+            rebound = figure.tool_data
+            assert workspace_arrays.dataarray_source_paths(rebound) == (
+                str(target.resolve()),
+            )
+            external.close()
+            xr.backends.file_manager.FILE_CACHE.clear()
+            external_path.unlink()
+            assert _compute_first_value(rebound) == 0.0
+    finally:
+        external.close()
 
 
 def test_manager_save_as_rebind_failure_keeps_old_live_references(

--- a/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
@@ -24,6 +24,9 @@ from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._model import full_data
 from tests.interactive.imagetool.manager.helpers import select_tools
+from tests.interactive.imagetool.manager.workspace._support import (
+    _edit_current_workspace_payload_attrs,
+)
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
@@ -181,9 +184,7 @@ def test_manager_pending_memory_sidebar_shows_metadata_without_materializing(
         root.hide()
 
         fname = tmp_path / "pending-sidebar-metadata.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -342,9 +343,7 @@ def test_manager_pending_memory_preview_button_materializes_selected_node(
             root.hide()
 
         fname = tmp_path / "pending-preview-button.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -438,11 +437,8 @@ def test_manager_pending_memory_sidebar_renders_partial_preview_without_material
         root.hide()
 
         fname = tmp_path / "pending-partial-preview.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        with h5py.File(fname, "r+") as h5_file:
-            attrs = h5_file["0/imagetool"].attrs
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        with _edit_current_workspace_payload_attrs(fname) as attrs:
             state = json.loads(attrs["itool_state"])
             state["slice"]["indices"][0] = [2, 3, 999]
             attrs["itool_state"] = json.dumps(state)
@@ -504,9 +500,7 @@ def test_manager_pending_memory_partial_preview_read_cap_falls_back_to_load_butt
         root.hide()
 
         fname = tmp_path / "pending-preview-cap.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -549,9 +543,7 @@ def test_manager_pending_memory_1d_preview_read_cap_falls_back_to_load_button(
         root.hide()
 
         fname = tmp_path / "pending-1d-preview-cap.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -595,9 +587,7 @@ def test_manager_pending_memory_1d_preview_uses_promoted_stack_dim(
         root.hide()
 
         fname = tmp_path / "pending-1d-preview.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1433,9 +1423,7 @@ def test_manager_pending_memory_hover_preview_does_not_materialize(
         root.hide()
 
         fname = tmp_path / "pending-hover-preview.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -1489,9 +1477,7 @@ def test_hidden_2d_workspace_preview_does_not_build_invalid_secondary_plots(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "hidden-2d-preview.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
 

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -680,6 +680,111 @@ def test_manager_compact_workspace_edge_paths(
         ]
 
 
+@pytest.mark.parametrize(
+    ("button_role", "expected"),
+    [
+        (QtWidgets.QMessageBox.ButtonRole.DestructiveRole, True),
+        (QtWidgets.QMessageBox.ButtonRole.RejectRole, False),
+    ],
+)
+def test_workspace_compaction_dask_warning_choices(
+    qtbot,
+    accept_dialog,
+    button_role: QtWidgets.QMessageBox.ButtonRole,
+    expected: bool,
+) -> None:
+    controller = workspace_controller._WorkspaceController.__new__(
+        workspace_controller._WorkspaceController
+    )
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+    results: list[bool] = []
+
+    def _choose_button(dialog: QtWidgets.QMessageBox) -> None:
+        button = next(
+            button
+            for button in dialog.buttons()
+            if dialog.buttonRole(button) == button_role
+        )
+        button.click()
+
+    accept_dialog(
+        lambda: results.append(
+            controller._confirm_compaction_with_dask_futures(parent)
+        ),
+        accept_call=_choose_button,
+    )
+
+    assert results == [expected]
+
+
+def test_manager_compaction_warns_only_for_exported_readers_with_futures(
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    path = tmp_path / "workspace.itws"
+    compacted: list[workspace_store.WorkspaceStore] = []
+    with (
+        manager_context() as manager,
+        workspace_store.WorkspaceStore(path, create=True) as store,
+    ):
+        controller = manager._workspace_controller
+        manager._workspace_state.path = path.resolve()
+        manager._workspace_state.schema_version = (
+            workspace_format._current_workspace_schema_version()
+        )
+        controller._workspace_store = store
+        monkeypatch.setattr(
+            erlab.interactive.utils,
+            "wait_dialog",
+            lambda *args, **kwargs: contextlib.nullcontext(),
+        )
+        monkeypatch.setattr(
+            workspace_storage,
+            "_compact_workspace_store",
+            compacted.append,
+        )
+        monkeypatch.setattr(
+            controller, "_default_dask_client_has_futures", lambda: True
+        )
+        confirmations: list[QtWidgets.QWidget] = []
+        monkeypatch.setattr(
+            controller,
+            "_confirm_compaction_with_dask_futures",
+            lambda parent: confirmations.append(parent) or False,
+        )
+
+        assert manager.compact_workspace()
+        assert compacted == [store]
+        assert confirmations == []
+
+        workspace_store.WorkspaceStore.pin_serialized_reader(
+            workspace_id=store.workspace_id,
+            path=path,
+            object_id="exported",
+            legacy_group_path=None,
+        )
+        assert not manager.compact_workspace()
+        assert compacted == [store]
+        assert len(confirmations) == 1
+        assert store.has_serialized_readers
+
+        monkeypatch.setattr(
+            controller,
+            "_confirm_compaction_with_dask_futures",
+            lambda _parent: True,
+        )
+        assert manager.compact_workspace()
+        assert compacted == [store, store]
+        assert not store.has_serialized_readers
+
+        controller._workspace_store = None
+        manager._workspace_state.path = None
+
+
 def test_manager_compact_workspace_detaches_store_that_cannot_reopen(
     monkeypatch,
     tmp_path,
@@ -1313,6 +1418,35 @@ def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
     assert constructor == {}
 
 
+@pytest.mark.parametrize(
+    ("client", "expected_clear_count"),
+    [
+        (None, 1),
+        (types.SimpleNamespace(futures={}), 1),
+        (types.SimpleNamespace(futures={"task": object()}), 0),
+    ],
+)
+def test_workspace_controller_releases_finished_dask_reader_pins(
+    client: object,
+    expected_clear_count: int,
+) -> None:
+    controller = workspace_controller._WorkspaceController.__new__(
+        workspace_controller._WorkspaceController
+    )
+    controller._manager = types.SimpleNamespace(
+        _dask_menu=types.SimpleNamespace(default_client=client)
+    )
+    clear_calls: list[None] = []
+    store = types.SimpleNamespace(
+        has_serialized_readers=True,
+        clear_serialized_reader_pins=lambda: clear_calls.append(None),
+    )
+
+    controller._release_finished_dask_reader_pins(store)
+
+    assert len(clear_calls) == expected_clear_count
+
+
 def test_workspace_gc_controller_lifecycle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -1336,7 +1470,11 @@ def test_workspace_gc_controller_lifecycle(
     assert not controller._workspace_gc_requested
 
     path = tmp_path / "workspace.itws"
-    store = types.SimpleNamespace(closed=False, path=path)
+    store = types.SimpleNamespace(
+        closed=False,
+        path=path,
+        has_serialized_readers=False,
+    )
     controller._workspace_store = store
     controller._current_workspace_document_path = types.MethodType(
         lambda _self: path, controller

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -385,18 +385,36 @@ def test_manager_load_workspace_dataset_ignores_invalid_saved_metadata(
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
 
 
-def test_workspace_state_repeated_options_dirty_during_save() -> None:
+@pytest.mark.parametrize(
+    ("mark_method", "event_field"),
+    [
+        ("mark_layout_dirty", "layout"),
+        ("mark_options_dirty", "options"),
+        ("mark_context_dirty", "context"),
+    ],
+)
+def test_workspace_state_repeated_non_node_dirty_during_save(
+    mark_method: str,
+    event_field: str,
+) -> None:
     state = workspace_state._ManagerWorkspaceState()
+    mark_dirty = getattr(state, mark_method)
 
-    assert state.mark_options_dirty()
+    assert mark_dirty()
     assert state.dirty_generation == 1
-    assert not state.mark_options_dirty()
+    assert len(state.dirty_events) == 1
+    assert getattr(state.dirty_events[0], event_field)
+    assert not mark_dirty()
     assert state.dirty_generation == 1
+    assert len(state.dirty_events) == 1
 
     state.save_in_progress = True
 
-    assert state.mark_options_dirty()
+    assert mark_dirty()
     assert state.dirty_generation == 2
+    assert len(state.dirty_events) == 2
+    assert state.dirty_events[-1].generation == 2
+    assert getattr(state.dirty_events[-1], event_field)
 
 
 def test_manager_close_save_path_updates_file_path(
@@ -1885,6 +1903,71 @@ def test_manager_background_save_as_preserves_post_snapshot_data_edit(
         assert manager.workspace_path == str(target_path.resolve())
         np.testing.assert_array_equal(root.slicer_area._data.values, replacement.values)
         assert manager.is_workspace_modified
+
+
+def test_manager_background_save_as_preserves_post_snapshot_non_node_changes(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    pool = _install_deferred_workspace_save_worker(monkeypatch)
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25.0).reshape((5, 5)),
+            dims=("x", "y"),
+            name="source",
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        source_path = tmp_path / "source.itws"
+        target_path = tmp_path / "target.itws"
+        manager._workspace_controller.saving._save_workspace_document(source_path)
+        adopt_workspace_path(manager, source_path)
+        manager._workspace_controller._mark_workspace_clean()
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_workspace_save_dialog",
+            lambda **_kwargs: target_path,
+        )
+
+        assert manager._workspace_controller.save_as(native=False)
+        assert len(pool.workers) == 1
+        worker = pool.workers[0]
+        snapshot_generation = worker._snapshot.generation
+
+        assert manager._workspace_state.mark_layout_dirty()
+        assert manager._workspace_state.mark_options_dirty()
+        assert manager._workspace_state.mark_context_dirty()
+        post_save_events = [
+            event
+            for event in manager._workspace_state.dirty_events
+            if event.generation > snapshot_generation
+        ]
+        assert any(event.layout for event in post_save_events)
+        assert any(event.options for event in post_save_events)
+        assert any(event.context for event in post_save_events)
+
+        with workspace_store.WorkspaceStore(worker._fname, create=True) as store:
+            workspace_storage._write_workspace_generation(
+                store,
+                worker._snapshot.generation_plan,
+                compression_mode=worker._snapshot.compression_mode,
+            )
+        worker.finish()
+        qtbot.wait_until(lambda: not manager._workspace_state.save_in_progress)
+
+        assert manager.workspace_path == str(target_path.resolve())
+        assert manager.is_workspace_modified
+        assert manager._workspace_state.layout_modified
+        assert manager._workspace_state.options_modified
+        assert manager._workspace_state.context_modified
 
 
 def test_manager_background_save_as_repoints_post_snapshot_pending_edit(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -2879,6 +2879,7 @@ def test_manager_workspace_save_as_rebinds_lazy_data_to_new_document(
             old_lazy = _open_external_lazy_hdf5_imagetool_data(old_fname)
             root.slicer_area.replace_source_data(old_lazy + 0, auto_compute=False)
             assert _compute_first_value(old_lazy) == 0
+            uid = manager._tool_graph.root_wrappers[0].uid
 
             def _load_workspace_file_should_not_run(*args, **kwargs):
                 raise AssertionError("Save As should not reload the saved workspace")
@@ -2887,6 +2888,20 @@ def test_manager_workspace_save_as_rebinds_lazy_data_to_new_document(
                 manager._workspace_controller.loading,
                 "_load_workspace_file",
                 _load_workspace_file_should_not_run,
+            )
+            rebind_calls: list[str] = []
+            rebind_data = (
+                manager._workspace_controller.loading._workspace_rebind_data_for_uid
+            )
+
+            def _record_rebind(fname, node_uid: str, *, chunks):
+                rebind_calls.append(node_uid)
+                return rebind_data(fname, node_uid, chunks=chunks)
+
+            monkeypatch.setattr(
+                manager._workspace_controller.loading,
+                "_workspace_rebind_data_for_uid",
+                _record_rebind,
             )
 
             def _go_to_file(dialog: QtWidgets.QFileDialog):
@@ -2905,10 +2920,147 @@ def test_manager_workspace_save_as_rebinds_lazy_data_to_new_document(
             assert workspace_arrays._normalized_file_path(
                 rebound.encoding.get("source")
             ) == str(new_fname.resolve())
+            assert rebind_calls == [uid]
+            old_lazy.close()
             old_fname.unlink()
             assert _compute_first_value(rebound) == 0
     finally:
         object.__setattr__(dask_options, "compute_threshold", old_threshold)
+
+
+def test_manager_workspace_save_as_retargets_private_dask_without_rebind(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        old_fname = tmp_path / "private-reader-old.itws"
+        new_fname = tmp_path / "private-reader-new.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            old_fname, force_full=True
+        )
+        adopt_workspace_path(manager, old_fname)
+        manager._workspace_controller.loading._rebind_workspace_backed_imagetools(
+            old_fname, targets=[0], chunks={}
+        )
+        manager._workspace_controller._mark_workspace_clean()
+
+        live_data = root.slicer_area._data
+        assert live_data.chunks is not None
+        assert workspace_arrays.dataarray_source_paths(live_data) == (
+            str(old_fname.resolve()),
+        )
+
+        def _fail_rebind(*_args, **_kwargs) -> None:
+            raise AssertionError("private workspace readers must not be reopened")
+
+        monkeypatch.setattr(
+            manager._workspace_controller.loading,
+            "_rebind_workspace_backed_imagetools",
+            _fail_rebind,
+        )
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_workspace_save_dialog",
+            lambda **_kwargs: new_fname,
+        )
+
+        assert _request_workspace_save_as_and_wait(qtbot, manager, native=False)
+
+        rebound = root.slicer_area._data
+        assert rebound is live_data
+        assert workspace_arrays.dataarray_source_paths(rebound) == (
+            str(new_fname.resolve()),
+        )
+        old_fname.unlink()
+        assert _compute_first_value(rebound) == 0
+
+
+def test_workspace_full_save_external_dask_rebind_rolls_back_on_later_failure(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+        external_fname = tmp_path / "rollback-external.h5"
+        workspace_fname = tmp_path / "rollback.itws"
+        xr.DataTree.from_dict({"0/imagetool": data.to_dataset(name="data")}).to_netcdf(
+            external_fname, engine="h5netcdf", invalid_netcdf=True
+        )
+        external = _open_external_lazy_hdf5_imagetool_data(external_fname)
+
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        root.slicer_area.replace_source_data(external + 0, auto_compute=False)
+        original_data = root.slicer_area._data
+        original_dask_name = original_data.data.name
+        original_source_paths = workspace_arrays.dataarray_source_paths(original_data)
+        original_name = manager._tool_graph.root_wrappers[0].name
+        backing_snapshot = (
+            manager._workspace_controller.loading._workspace_data_backing_snapshot()
+        )
+        uid = manager._tool_graph.root_wrappers[0].uid
+        manager._workspace_controller.saving._save_workspace_document(
+            workspace_fname, force_full=True
+        )
+
+        rebind_calls: list[str] = []
+        rebind_data = (
+            manager._workspace_controller.loading._workspace_rebind_data_for_uid
+        )
+
+        def _record_rebind(fname, node_uid: str, *, chunks):
+            rebind_calls.append(node_uid)
+            return rebind_data(fname, node_uid, chunks=chunks)
+
+        monkeypatch.setattr(
+            manager._workspace_controller.loading,
+            "_workspace_rebind_data_for_uid",
+            _record_rebind,
+        )
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_retarget_workspace_referenced_tool_data",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                workspace_controller._WorkspacePostSaveBindingError("later failure")
+            ),
+        )
+
+        with pytest.raises(
+            workspace_controller._WorkspacePostSaveBindingError,
+            match="later failure",
+        ):
+            manager._workspace_controller._refresh_workspace_payload_bindings_after_full_save(
+                workspace_fname,
+                backing_snapshot=backing_snapshot,
+                old_workspace_path=None,
+            )
+
+        assert rebind_calls == [uid]
+        restored_data = root.slicer_area._data
+        assert restored_data.data.name == original_dask_name
+        assert (
+            workspace_arrays.dataarray_source_paths(restored_data)
+            == original_source_paths
+        )
+        assert manager._tool_graph.root_wrappers[0].name == original_name
+        assert _compute_first_value(restored_data) == 0
+        external.close()
 
 
 def test_manager_workspace_save_clears_deferred_dirty_events(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -2271,6 +2271,68 @@ def test_manager_workspace_import_reopens_offloaded_data_as_dask(
         assert _compute_first_value(loaded_data) == 0.0
 
 
+def test_manager_workspace_save_rehomes_imported_dask_data(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = tmp_path / "source.itws"
+    target = tmp_path / "target.itws"
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        imported_data = xr.DataArray(np.arange(25.0).reshape((5, 5)), dims=["x", "y"])
+        imported = itool(imported_data, manager=False, execute=False)
+        assert isinstance(imported, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(imported, show=False)
+        manager._workspace_controller.saving._save_workspace_document(source)
+        adopt_workspace_path(manager, source)
+        manager._workspace_controller._mark_workspace_clean()
+        assert manager.offload_to_workspace([0], native=False)
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        existing = itool(
+            xr.DataArray(np.ones((2, 2)), dims=["x", "y"]),
+            manager=False,
+            execute=False,
+        )
+        assert isinstance(existing, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(existing, show=False)
+        manager._workspace_controller.saving._save_workspace_document(target)
+        adopt_workspace_path(manager, target)
+        manager._workspace_controller._mark_workspace_clean()
+
+        assert manager._workspace_controller.loading._load_workspace_file(
+            source,
+            replace=False,
+            associate=False,
+            mark_dirty=True,
+            select=False,
+        )
+        imported = manager.get_imagetool(1).slicer_area._data
+        assert imported.chunks is not None
+        assert source.resolve() in (
+            manager._workspace_controller._imported_workspace_accesses
+        )
+        with pytest.raises(BlockingIOError):
+            workspace_storage._acquire_workspace_document_lock(source)
+
+        assert _request_workspace_save_and_wait(qtbot, manager)
+        rebound = manager.get_imagetool(1).slicer_area._data
+        assert rebound.chunks is not None
+        assert workspace_arrays._normalized_file_path(
+            rebound.encoding.get("source")
+        ) == str(target.resolve())
+        assert _compute_first_value(rebound) == 0.0
+        assert source.resolve() not in (
+            manager._workspace_controller._imported_workspace_accesses
+        )
+        lock = workspace_storage._acquire_workspace_document_lock(source)
+        lock.unlock()
+
+
 def test_manager_workspace_load_reopens_offloaded_spaced_coord_data_as_dask(
     qtbot,
     tmp_path,

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -664,6 +664,18 @@ def test_manager_compact_workspace_edge_paths(
         assert not manager.compact_workspace()
         manager._workspace_state.save_in_progress = False
 
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_dask_client_has_live_futures",
+            lambda: True,
+        )
+        assert not manager.compact_workspace()
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_dask_client_has_live_futures",
+            lambda: False,
+        )
+
         operation_errors: list[tuple[typing.Any, ...]] = []
         monkeypatch.setattr(
             manager,
@@ -1195,8 +1207,17 @@ def test_workspace_gc_worker_reports_contention_and_errors() -> None:
     closed: list[None] = []
 
     class _Store:
-        def collect_garbage(self, *, max_objects, on_contention):
+        def collect_garbage(
+            self,
+            *,
+            max_objects,
+            delete_objects,
+            can_delete_objects,
+            on_contention,
+        ):
             assert max_objects == 1
+            assert delete_objects
+            assert can_delete_objects()
             on_contention()
             raise RuntimeError("cleanup failed")
 
@@ -1308,6 +1329,36 @@ def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
     assert constructor == {}
 
 
+def test_workspace_gc_dask_client_detection_is_conservative() -> None:
+    controller = workspace_controller._WorkspaceController.__new__(
+        workspace_controller._WorkspaceController
+    )
+    manager = types.SimpleNamespace(
+        _dask_menu=types.SimpleNamespace(default_client=None)
+    )
+    controller._manager = manager
+
+    assert not controller._dask_client_has_live_futures()
+    manager._dask_menu.default_client = types.SimpleNamespace(futures={"key": object()})
+    assert controller._dask_client_has_live_futures()
+
+    class _BrokenClient:
+        @property
+        def futures(self):
+            raise RuntimeError("client closed")
+
+    manager._dask_menu.default_client = _BrokenClient()
+    assert controller._dask_client_has_live_futures()
+
+    class _BrokenMenu:
+        @property
+        def default_client(self):
+            raise RuntimeError("client lookup failed")
+
+    manager._dask_menu = _BrokenMenu()
+    assert controller._dask_client_has_live_futures()
+
+
 def test_workspace_gc_controller_lifecycle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -1319,6 +1370,7 @@ def test_workspace_gc_controller_lifecycle(
     manager._workspace_state = types.SimpleNamespace(
         save_in_progress=False, document_id="document", path=None
     )
+    manager._dask_menu = types.SimpleNamespace(default_client=None)
     controller._manager = manager
     controller._workspace_gc_requested = False
     controller._workspace_gc_worker = None
@@ -1352,12 +1404,12 @@ def test_workspace_gc_controller_lifecycle(
             self.workers.append(worker)
 
     pool = _Pool()
-    scheduled: list[typing.Callable[[], None]] = []
+    scheduled: list[tuple[int, typing.Callable[[], None]]] = []
     monkeypatch.setattr(QtCore.QThreadPool, "globalInstance", lambda: pool)
     monkeypatch.setattr(
         QtCore.QTimer,
         "singleShot",
-        lambda _delay, callback: scheduled.append(callback),
+        lambda delay, callback: scheduled.append((delay, callback)),
     )
     controller._start_workspace_gc()
     pool.workers.pop().signals.finished.emit(False, "cleanup failed")
@@ -1368,7 +1420,23 @@ def test_workspace_gc_controller_lifecycle(
     controller._start_workspace_gc()
     pool.workers.pop().signals.finished.emit(True, None)
     assert controller._workspace_gc_requested
-    assert scheduled[-1] == controller._start_workspace_gc
+    assert scheduled[-1] == (0, controller._start_workspace_gc)
+
+    manager._dask_menu.default_client = types.SimpleNamespace(
+        futures={"result": object()}
+    )
+    controller._start_workspace_gc()
+    worker = pool.workers.pop()
+    assert not worker._delete_objects
+    worker.signals.finished.emit(True, None)
+    assert controller._workspace_gc_requested
+    assert scheduled[-1] == (1000, controller._resume_workspace_gc_after_dask)
+
+    controller._resume_workspace_gc_after_dask()
+    assert scheduled[-1] == (1000, controller._resume_workspace_gc_after_dask)
+    manager._dask_menu.default_client = None
+    controller._resume_workspace_gc_after_dask()
+    assert pool.workers
 
     class _FailingPool:
         @staticmethod
@@ -1377,6 +1445,7 @@ def test_workspace_gc_controller_lifecycle(
 
     controller._workspace_gc_worker = None
     controller._workspace_gc_receiver = None
+    controller._workspace_gc_requested = True
     monkeypatch.setattr(QtCore.QThreadPool, "globalInstance", _FailingPool)
     controller._start_workspace_gc()
     assert controller._workspace_gc_requested
@@ -3644,6 +3713,56 @@ def test_manager_workspace_upgrade_repoints_pending_payload_before_compaction(
         assert pending._materialize_pending_workspace_payload(wrapper)
         assert not operation_errors
         np.testing.assert_array_equal(wrapper.slicer_area._data.values, data.values)
+
+
+def test_manager_releases_eager_legacy_source_when_conversion_is_canceled(
+    qtbot,
+    tmp_path,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    fname = tmp_path / "schema-2-canceled.itws"
+    data = xr.DataArray(
+        np.arange(30).reshape((5, 6)),
+        dims=["x", "y"],
+    )
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        tree = manager._workspace_controller.saving._to_datatree()
+        tree.attrs["imagetool_workspace_schema_version"] = 2
+        tree.attrs.pop(workspace_format._WORKSPACE_MANIFEST_ATTR, None)
+        tree.to_netcdf(fname, engine="h5netcdf", invalid_netcdf=True)
+        tree.close()
+        manager.remove_all_tools()
+
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_save_legacy_workspace_as_current",
+            lambda *args, **kwargs: None,
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+
+        loaded = manager.get_imagetool(0).slicer_area._data
+        assert manager._workspace_state.path is None
+        assert loaded.chunks is None
+        assert _compute_first_value(loaded) == 0.0
+        assert fname.resolve() not in (
+            manager._workspace_controller._imported_workspace_accesses
+        )
+        assert workspace_store.WorkspaceStore.active(fname) is None
+        lock = workspace_storage._acquire_workspace_document_lock(fname)
+        lock.unlock()
 
 
 def test_manager_workspace_save_collects_old_generations_in_background(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -1111,6 +1111,10 @@ def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
             "publication_conflict_path",
         ),
         (
+            lambda _path: workspace_store.WorkspaceStoreConflictError("changed"),
+            "publication_conflict_path",
+        ),
+        (
             lambda path: PermissionError(errno.EACCES, "access denied", path),
             "access_denied_path",
         ),
@@ -1185,6 +1189,198 @@ def test_workspace_save_worker_closes_readers_only_after_contention(
 
     assert close_calls == ([None] if contended else [])
     assert waiting == ([None] if contended else [])
+
+
+def test_workspace_gc_worker_reports_contention_and_errors() -> None:
+    closed: list[None] = []
+
+    class _Store:
+        def collect_garbage(self, *, max_objects, on_contention):
+            assert max_objects == 1
+            on_contention()
+            raise RuntimeError("cleanup failed")
+
+    worker = workspace_saving._WorkspaceGcWorker(
+        typing.cast("workspace_store.WorkspaceStore", _Store()),
+        reader_closers=(lambda: closed.append(None),),
+    )
+    results: list[tuple[bool, str | None]] = []
+    worker.signals.finished.connect(
+        lambda more, error: results.append((more, typing.cast("str | None", error)))
+    )
+
+    worker.run()
+
+    assert closed == [None]
+    assert len(results) == 1
+    assert not results[0][0]
+    assert results[0][1] is not None
+    assert "cleanup failed" in results[0][1]
+
+
+def test_pending_workspace_tool_attrs_update_source_metadata() -> None:
+    saver = workspace_saving._WorkspaceSaver.__new__(workspace_saving._WorkspaceSaver)
+    pending_base = {
+        "tool_display_name": "old",
+        "tool_title": "prefix old",
+        erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR: "stale",
+    }
+    saver._pending_workspace_node_attrs = types.MethodType(
+        lambda _self, _node, _attrs, *, kind: dict(pending_base),
+        saver,
+    )
+    model = types.SimpleNamespace(model_dump=lambda **_kwargs: {"value": 1})
+    node = types.SimpleNamespace(
+        pending_workspace_payload_attrs={},
+        name="new",
+        source_spec=model,
+        source_binding=None,
+        has_source_binding=True,
+        source_state="valid",
+        source_auto_update=True,
+    )
+
+    attrs = saver._pending_workspace_tool_attrs(node)
+
+    assert attrs["tool_title"] == "prefix new"
+    assert erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR in attrs
+    assert erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR not in attrs
+    assert attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] == "valid"
+    assert attrs[erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR] is True
+
+    node.name = "plain"
+    node.source_spec = None
+    node.source_binding = model
+    node.has_source_binding = False
+    pending_base.clear()
+    attrs = saver._pending_workspace_tool_attrs(node)
+
+    assert attrs["tool_title"] == "plain"
+    assert erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR not in attrs
+    assert erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR in attrs
+    assert erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR not in attrs
+    assert erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR not in attrs
+
+
+def test_workspace_reference_uid_detection_and_invalid_reader_path() -> None:
+    references = {
+        "parent": {"kind": "parent_source"},
+        "node": {"kind": "manager_node", "node_uid": "source"},
+        "other": {"kind": "external"},
+    }
+    controller_type = workspace_controller._WorkspaceController
+    includes_uids = controller_type._workspace_tool_references_include_uids
+
+    assert not includes_uids(references, (), parent_uid="parent")
+    assert includes_uids(references, {"parent"}, parent_uid="parent")
+    assert includes_uids(references, {"source"}, parent_uid=None)
+    assert not includes_uids(references, {"missing"}, parent_uid=None)
+
+    saver = workspace_saving._WorkspaceSaver.__new__(workspace_saving._WorkspaceSaver)
+    assert saver._workspace_reader_closers(typing.cast("str", None)) == ()
+
+    closed: list[str] = []
+    saver._workspace_reader_closers = types.MethodType(
+        lambda _self, _path: (lambda: closed.append("closed"),), saver
+    )
+    saver._close_workspace_idle_readers("workspace.itws")
+    assert closed == ["closed"]
+
+
+def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
+    saver = workspace_saving._WorkspaceSaver.__new__(workspace_saving._WorkspaceSaver)
+    saver._manager = types.SimpleNamespace()
+    pending = types.SimpleNamespace(
+        is_imagetool=False,
+        pending_workspace_payload=("workspace.itws", "/tool"),
+        materialize_pending_workspace_payload=lambda: False,
+    )
+    with pytest.raises(ValueError, match="Could not read this saved tool"):
+        saver._serialize_workspace_node({}, pending, "0", include_children=False)
+
+    unsavable = types.SimpleNamespace(
+        is_imagetool=False,
+        pending_workspace_payload=None,
+        tool_window=types.SimpleNamespace(can_save_and_load=lambda: False),
+    )
+    constructor: dict[str, xr.Dataset] = {}
+    saver._serialize_workspace_node(constructor, unsavable, "0", include_children=False)
+    assert constructor == {}
+
+
+def test_workspace_gc_controller_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    controller = workspace_controller._WorkspaceController.__new__(
+        workspace_controller._WorkspaceController
+    )
+    manager = QtCore.QObject()
+    manager._workspace_state = types.SimpleNamespace(
+        save_in_progress=False, document_id="document", path=None
+    )
+    controller._manager = manager
+    controller._workspace_gc_requested = False
+    controller._workspace_gc_worker = None
+    controller._workspace_gc_receiver = None
+    controller._workspace_store = None
+    controller._start_workspace_gc()
+
+    controller._workspace_gc_requested = True
+    controller._start_workspace_gc()
+    assert not controller._workspace_gc_requested
+
+    path = tmp_path / "workspace.itws"
+    store = types.SimpleNamespace(closed=False, path=path)
+    controller._workspace_store = store
+    controller._current_workspace_document_path = types.MethodType(
+        lambda _self: path, controller
+    )
+    controller.saving = types.SimpleNamespace(
+        _workspace_reader_closers=lambda _path: ()
+    )
+    controller._workspace_gc_requested = True
+    monkeypatch.setattr(QtCore.QThreadPool, "globalInstance", lambda: None)
+    controller._start_workspace_gc()
+    assert controller._workspace_gc_worker is None
+
+    class _Pool:
+        def __init__(self) -> None:
+            self.workers = []
+
+        def start(self, worker) -> None:
+            self.workers.append(worker)
+
+    pool = _Pool()
+    scheduled: list[typing.Callable[[], None]] = []
+    monkeypatch.setattr(QtCore.QThreadPool, "globalInstance", lambda: pool)
+    monkeypatch.setattr(
+        QtCore.QTimer,
+        "singleShot",
+        lambda _delay, callback: scheduled.append(callback),
+    )
+    controller._start_workspace_gc()
+    pool.workers.pop().signals.finished.emit(False, "cleanup failed")
+    assert not controller._workspace_gc_requested
+    assert controller._workspace_gc_worker is None
+
+    controller._workspace_gc_requested = True
+    controller._start_workspace_gc()
+    pool.workers.pop().signals.finished.emit(True, None)
+    assert controller._workspace_gc_requested
+    assert scheduled[-1] == controller._start_workspace_gc
+
+    class _FailingPool:
+        @staticmethod
+        def start(_worker) -> None:
+            raise RuntimeError("cannot start")
+
+    controller._workspace_gc_worker = None
+    controller._workspace_gc_receiver = None
+    monkeypatch.setattr(QtCore.QThreadPool, "globalInstance", _FailingPool)
+    controller._start_workspace_gc()
+    assert controller._workspace_gc_requested
+    assert controller._workspace_gc_worker is None
 
 
 def test_manager_async_save_request_error_paths(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -3133,6 +3133,74 @@ def test_manager_workspace_compact_drops_history_and_keeps_store(
         assert generations[0].manifest == generations[1].manifest == current_manifest
 
 
+def test_manager_workspace_upgrade_repoints_pending_payload_before_compaction(
+    qtbot,
+    tmp_path,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(30).reshape((5, 6)),
+            dims=["x", "y"],
+            coords={"x": np.arange(5), "y": np.arange(6)},
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        fname = tmp_path / "schema-4-pending.itws"
+        tree = manager._workspace_controller.saving._to_datatree()
+        manifest = manager._workspace_controller.saving._workspace_manifest()
+        manifest["schema_version"] = 4
+        manifest["nodes"][0]["data_backing"] = "memory"
+        tree.attrs["imagetool_workspace_schema_version"] = 4
+        tree.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(manifest)
+        payload_attrs = tree["0/imagetool"].attrs
+        payload_attrs.pop("itool_window_state", None)
+        payload_attrs["itool_visible"] = False
+        tree.to_netcdf(fname, engine="h5netcdf", invalid_netcdf=True)
+        tree.close()
+
+        manager.remove_all_tools()
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+        wrapper = manager._tool_graph.root_wrappers[0]
+        assert wrapper.pending_workspace_memory_payload == (
+            fname.resolve(),
+            "0/imagetool",
+        )
+
+        manager._workspace_controller._mark_node_state_dirty(wrapper.uid)
+        assert _request_workspace_save_and_wait(qtbot, manager)
+        payload_path = _current_workspace_payload_path(fname)
+        assert wrapper.pending_workspace_memory_payload == (
+            fname.resolve(),
+            payload_path.lstrip("/"),
+        )
+
+        monkeypatch.setattr(
+            erlab.interactive.utils,
+            "wait_dialog",
+            lambda *args, **kwargs: contextlib.nullcontext(),
+        )
+        assert manager.compact_workspace()
+        operation_errors: list[tuple[object, ...]] = []
+        monkeypatch.setattr(
+            manager,
+            "_show_operation_error",
+            lambda *args: operation_errors.append(args),
+        )
+        pending = manager._workspace_controller.loading.pending
+        assert pending._materialize_pending_workspace_payload(wrapper)
+        assert not operation_errors
+        np.testing.assert_array_equal(wrapper.slicer_area._data.values, data.values)
+
+
 def test_manager_workspace_save_collects_old_generations_in_background(
     qtbot,
     tmp_path,

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -664,18 +664,6 @@ def test_manager_compact_workspace_edge_paths(
         assert not manager.compact_workspace()
         manager._workspace_state.save_in_progress = False
 
-        monkeypatch.setattr(
-            manager._workspace_controller,
-            "_dask_client_has_live_futures",
-            lambda: True,
-        )
-        assert not manager.compact_workspace()
-        monkeypatch.setattr(
-            manager._workspace_controller,
-            "_dask_client_has_live_futures",
-            lambda: False,
-        )
-
         operation_errors: list[tuple[typing.Any, ...]] = []
         monkeypatch.setattr(
             manager,
@@ -1211,13 +1199,9 @@ def test_workspace_gc_worker_reports_contention_and_errors() -> None:
             self,
             *,
             max_objects,
-            delete_objects,
-            can_delete_objects,
             on_contention,
         ):
             assert max_objects == 1
-            assert delete_objects
-            assert can_delete_objects()
             on_contention()
             raise RuntimeError("cleanup failed")
 
@@ -1329,36 +1313,6 @@ def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
     assert constructor == {}
 
 
-def test_workspace_gc_dask_client_detection_is_conservative() -> None:
-    controller = workspace_controller._WorkspaceController.__new__(
-        workspace_controller._WorkspaceController
-    )
-    manager = types.SimpleNamespace(
-        _dask_menu=types.SimpleNamespace(default_client=None)
-    )
-    controller._manager = manager
-
-    assert not controller._dask_client_has_live_futures()
-    manager._dask_menu.default_client = types.SimpleNamespace(futures={"key": object()})
-    assert controller._dask_client_has_live_futures()
-
-    class _BrokenClient:
-        @property
-        def futures(self):
-            raise RuntimeError("client closed")
-
-    manager._dask_menu.default_client = _BrokenClient()
-    assert controller._dask_client_has_live_futures()
-
-    class _BrokenMenu:
-        @property
-        def default_client(self):
-            raise RuntimeError("client lookup failed")
-
-    manager._dask_menu = _BrokenMenu()
-    assert controller._dask_client_has_live_futures()
-
-
 def test_workspace_gc_controller_lifecycle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -1370,7 +1324,6 @@ def test_workspace_gc_controller_lifecycle(
     manager._workspace_state = types.SimpleNamespace(
         save_in_progress=False, document_id="document", path=None
     )
-    manager._dask_menu = types.SimpleNamespace(default_client=None)
     controller._manager = manager
     controller._workspace_gc_requested = False
     controller._workspace_gc_worker = None
@@ -1421,22 +1374,6 @@ def test_workspace_gc_controller_lifecycle(
     pool.workers.pop().signals.finished.emit(True, None)
     assert controller._workspace_gc_requested
     assert scheduled[-1] == (0, controller._start_workspace_gc)
-
-    manager._dask_menu.default_client = types.SimpleNamespace(
-        futures={"result": object()}
-    )
-    controller._start_workspace_gc()
-    worker = pool.workers.pop()
-    assert not worker._delete_objects
-    worker.signals.finished.emit(True, None)
-    assert controller._workspace_gc_requested
-    assert scheduled[-1] == (1000, controller._resume_workspace_gc_after_dask)
-
-    controller._resume_workspace_gc_after_dask()
-    assert scheduled[-1] == (1000, controller._resume_workspace_gc_after_dask)
-    manager._dask_menu.default_client = None
-    controller._resume_workspace_gc_after_dask()
-    assert pool.workers
 
     class _FailingPool:
         @staticmethod

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -680,6 +680,52 @@ def test_manager_compact_workspace_edge_paths(
         ]
 
 
+def test_manager_compact_workspace_detaches_store_that_cannot_reopen(
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with (
+        manager_context() as manager,
+        workspace_store.WorkspaceStore(path, create=True) as store,
+    ):
+        manager._workspace_state.path = path.resolve()
+        manager._workspace_state.schema_version = (
+            workspace_format._current_workspace_schema_version()
+        )
+        manager._workspace_controller._workspace_store = store
+        operation_errors: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            erlab.interactive.utils,
+            "wait_dialog",
+            lambda *args, **kwargs: contextlib.nullcontext(),
+        )
+        monkeypatch.setattr(
+            manager,
+            "_show_operation_error",
+            lambda title, text: operation_errors.append((title, text)),
+        )
+
+        def _fail_after_replacement(
+            current_store: workspace_store.WorkspaceStore,
+        ) -> None:
+            current_store._close_handle()
+            raise workspace_store.WorkspaceStoreReopenError(path)
+
+        monkeypatch.setattr(
+            workspace_storage, "_compact_workspace_store", _fail_after_replacement
+        )
+
+        assert not manager.compact_workspace()
+        assert len(operation_errors) == 1
+        assert manager._workspace_controller._workspace_store is None
+        assert workspace_store.WorkspaceStore.active(path) is None
+        manager._workspace_state.path = None
+
+
 def test_manager_compact_workspace_reduces_internal_holes(
     qtbot,
     monkeypatch,
@@ -1459,6 +1505,107 @@ def test_manager_background_save_as_preserves_post_snapshot_data_edit(
         assert manager.workspace_path == str(target_path.resolve())
         np.testing.assert_array_equal(root.slicer_area._data.values, replacement.values)
         assert manager.is_workspace_modified
+
+
+def test_manager_background_save_as_repoints_post_snapshot_pending_edit(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    pool = _install_deferred_workspace_save_worker(monkeypatch)
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        imported_data = xr.DataArray(
+            np.arange(25, dtype=np.float64).reshape((5, 5)),
+            dims=("x", "y"),
+            name="imported",
+        )
+        imported_tool = itool(imported_data, manager=False, execute=False)
+        assert isinstance(imported_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(imported_tool, show=False)
+        imported_tool.hide()
+
+        source = tmp_path / "import-source.itws"
+        target = tmp_path / "import-target.itws"
+        manager._workspace_controller.saving._save_workspace_document(source)
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+
+        base_data = xr.DataArray(np.arange(4.0).reshape((2, 2)), dims=("x", "y"))
+        base_tool = itool(base_data, manager=False, execute=False)
+        assert isinstance(base_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(base_tool, show=False)
+        base = tmp_path / "base.itws"
+        manager._workspace_controller.saving._save_workspace_document(base)
+        adopt_workspace_path(manager, base)
+        manager._workspace_controller._mark_workspace_clean()
+
+        assert manager._workspace_controller.loading._load_workspace_file(
+            source,
+            replace=False,
+            associate=False,
+            mark_dirty=True,
+            select=False,
+        )
+        wrapper = next(
+            node
+            for node in manager._tool_graph.root_wrappers.values()
+            if node.pending_workspace_memory_payload is not None
+        )
+        payload_path = manager._workspace_controller.saving._workspace_payload_path(
+            wrapper.uid
+        )
+        node_path = payload_path.rsplit("/", maxsplit=1)[0]
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_workspace_save_dialog",
+            lambda **_kwargs: target,
+        )
+
+        assert manager._workspace_controller.save_as(native=False)
+        assert len(pool.workers) == 1
+        worker = pool.workers[0]
+        snapshot_generation = worker._snapshot.generation
+
+        pending_attrs = wrapper.pending_workspace_payload_attrs
+        assert pending_attrs is not None
+        pending_attrs["post_snapshot_marker"] = True
+        wrapper.update_pending_workspace_payload_attrs(pending_attrs)
+        assert manager._workspace_controller._mark_node_state_dirty(wrapper.uid)
+        assert any(
+            event.uid == wrapper.uid and event.generation > snapshot_generation
+            for event in manager._workspace_state.dirty_events
+        )
+
+        with workspace_store.WorkspaceStore(worker._fname, create=True) as target_store:
+            workspace_storage._write_workspace_generation(
+                target_store,
+                worker._snapshot.generation_plan,
+                compression_mode=worker._snapshot.compression_mode,
+            )
+        worker.finish()
+        qtbot.wait_until(lambda: not manager._workspace_state.save_in_progress)
+
+        assert wrapper.pending_workspace_memory_payload == (
+            target.resolve(),
+            _current_workspace_payload_path(target, node_path).lstrip("/"),
+        )
+        updated_attrs = wrapper.pending_workspace_payload_attrs
+        assert updated_attrs is not None
+        assert updated_attrs["post_snapshot_marker"] is True
+        assert manager.is_workspace_modified
+
+        source.unlink()
+        manager.show_imagetool(wrapper.index)
+        qtbot.wait_until(lambda: manager.get_imagetool(wrapper.index).isVisible())
+        np.testing.assert_array_equal(
+            manager.get_imagetool(wrapper.index).slicer_area._data.values,
+            imported_data.values,
+        )
 
 
 def test_manager_background_workspace_save_failure_restores_state(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -710,7 +710,7 @@ def test_workspace_compaction_dask_warning_choices(
 
     accept_dialog(
         lambda: results.append(
-            controller._confirm_compaction_with_dask_futures(parent)
+            controller._confirm_compaction_with_exported_readers(parent)
         ),
         accept_call=_choose_button,
     )
@@ -718,7 +718,7 @@ def test_workspace_compaction_dask_warning_choices(
     assert results == [expected]
 
 
-def test_manager_compaction_warns_only_for_exported_readers_with_futures(
+def test_manager_compaction_warns_only_for_exported_readers(
     monkeypatch,
     tmp_path: pathlib.Path,
     manager_context: Callable[
@@ -742,23 +742,40 @@ def test_manager_compaction_warns_only_for_exported_readers_with_futures(
             "wait_dialog",
             lambda *args, **kwargs: contextlib.nullcontext(),
         )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_compact_workspace_store",
-            compacted.append,
-        )
-        monkeypatch.setattr(
-            controller, "_default_dask_client_has_futures", lambda: True
-        )
+        discarded: list[tuple[frozenset[str], frozenset[str]]] = []
+
+        def _compact(
+            current_store: workspace_store.WorkspaceStore,
+            *,
+            discard_serialized_object_ids=(),
+            discard_serialized_legacy_group_paths=(),
+        ) -> None:
+            compacted.append(current_store)
+            discarded.append(
+                (
+                    frozenset(discard_serialized_object_ids),
+                    frozenset(discard_serialized_legacy_group_paths),
+                )
+            )
+            if discard_serialized_object_ids:
+                workspace_store.WorkspaceStore.pin_serialized_reader(
+                    workspace_id=store.workspace_id,
+                    path=path,
+                    object_id="new-export",
+                    legacy_group_path=None,
+                )
+
+        monkeypatch.setattr(workspace_storage, "_compact_workspace_store", _compact)
         confirmations: list[QtWidgets.QWidget] = []
         monkeypatch.setattr(
             controller,
-            "_confirm_compaction_with_dask_futures",
+            "_confirm_compaction_with_exported_readers",
             lambda parent: confirmations.append(parent) or False,
         )
 
         assert manager.compact_workspace()
         assert compacted == [store]
+        assert discarded == [(frozenset(), frozenset())]
         assert confirmations == []
 
         workspace_store.WorkspaceStore.pin_serialized_reader(
@@ -774,12 +791,14 @@ def test_manager_compaction_warns_only_for_exported_readers_with_futures(
 
         monkeypatch.setattr(
             controller,
-            "_confirm_compaction_with_dask_futures",
+            "_confirm_compaction_with_exported_readers",
             lambda _parent: True,
         )
         assert manager.compact_workspace()
         assert compacted == [store, store]
-        assert not store.has_serialized_readers
+        assert discarded[-1] == (frozenset({"exported"}), frozenset())
+        assert store.serialized_object_ids == {"new-export"}
+        store.clear_serialized_reader_pins()
 
         controller._workspace_store = None
         manager._workspace_state.path = None
@@ -816,6 +835,7 @@ def test_manager_compact_workspace_detaches_store_that_cannot_reopen(
 
         def _fail_after_replacement(
             current_store: workspace_store.WorkspaceStore,
+            **_kwargs,
         ) -> None:
             current_store._close_handle()
             raise workspace_store.WorkspaceStoreReopenError(path)
@@ -823,11 +843,24 @@ def test_manager_compact_workspace_detaches_store_that_cannot_reopen(
         monkeypatch.setattr(
             workspace_storage, "_compact_workspace_store", _fail_after_replacement
         )
+        workspace_store.WorkspaceStore.pin_serialized_reader(
+            workspace_id=store.workspace_id,
+            path=path,
+            object_id="exported",
+            legacy_group_path=None,
+        )
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_confirm_compaction_with_exported_readers",
+            lambda _parent: True,
+        )
 
         assert not manager.compact_workspace()
         assert len(operation_errors) == 1
+        assert store.serialized_object_ids == {"exported"}
         assert manager._workspace_controller._workspace_store is None
         assert workspace_store.WorkspaceStore.active(path) is None
+        store.clear_serialized_reader_pins()
         manager._workspace_state.path = None
 
 
@@ -919,7 +952,7 @@ def test_manager_compact_workspace_upgrades_previous_schema(
         monkeypatch.setattr(
             workspace_storage,
             "_compact_workspace_store",
-            lambda current_store: calls.append(
+            lambda current_store, **_kwargs: calls.append(
                 "compact" if current_store is store else "wrong-store"
             ),
         )
@@ -1418,35 +1451,6 @@ def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
     assert constructor == {}
 
 
-@pytest.mark.parametrize(
-    ("client", "expected_clear_count"),
-    [
-        (None, 1),
-        (types.SimpleNamespace(futures={}), 1),
-        (types.SimpleNamespace(futures={"task": object()}), 0),
-    ],
-)
-def test_workspace_controller_releases_finished_dask_reader_pins(
-    client: object,
-    expected_clear_count: int,
-) -> None:
-    controller = workspace_controller._WorkspaceController.__new__(
-        workspace_controller._WorkspaceController
-    )
-    controller._manager = types.SimpleNamespace(
-        _dask_menu=types.SimpleNamespace(default_client=client)
-    )
-    clear_calls: list[None] = []
-    store = types.SimpleNamespace(
-        has_serialized_readers=True,
-        clear_serialized_reader_pins=lambda: clear_calls.append(None),
-    )
-
-    controller._release_finished_dask_reader_pins(store)
-
-    assert len(clear_calls) == expected_clear_count
-
-
 def test_workspace_gc_controller_lifecycle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -1470,11 +1474,7 @@ def test_workspace_gc_controller_lifecycle(
     assert not controller._workspace_gc_requested
 
     path = tmp_path / "workspace.itws"
-    store = types.SimpleNamespace(
-        closed=False,
-        path=path,
-        has_serialized_readers=False,
-    )
+    store = types.SimpleNamespace(closed=False, path=path)
     controller._workspace_store = store
     controller._current_workspace_document_path = types.MethodType(
         lambda _self: path, controller

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -765,21 +765,30 @@ def test_manager_compaction_warns_only_for_exported_readers(
         def _compact(
             current_store: workspace_store.WorkspaceStore,
             *,
-            discard_serialized_object_ids=(),
-            discard_serialized_legacy_group_paths=(),
+            discard_serialized_reader_pins=None,
         ) -> None:
             compacted.append(current_store)
+            snapshot = (
+                discard_serialized_reader_pins
+                or workspace_store._SerializedReaderPinSnapshot({}, {})
+            )
             discarded.append(
                 (
-                    frozenset(discard_serialized_object_ids),
-                    frozenset(discard_serialized_legacy_group_paths),
+                    snapshot.object_ids,
+                    snapshot.legacy_group_paths,
                 )
             )
-            if discard_serialized_object_ids:
+            if snapshot.object_ids:
                 workspace_store.WorkspaceStore.pin_serialized_reader(
                     workspace_id=store.workspace_id,
                     path=path,
                     object_id="new-export",
+                    legacy_group_path=None,
+                )
+                workspace_store.WorkspaceStore.pin_serialized_reader(
+                    workspace_id=store.workspace_id,
+                    path=path,
+                    object_id="exported",
                     legacy_group_path=None,
                 )
 
@@ -815,7 +824,7 @@ def test_manager_compaction_warns_only_for_exported_readers(
         assert manager.compact_workspace()
         assert compacted == [store, store]
         assert discarded[-1] == (frozenset({"exported"}), frozenset())
-        assert store.serialized_object_ids == {"new-export"}
+        assert store.serialized_object_ids == {"exported", "new-export"}
         store.clear_serialized_reader_pins()
 
         controller._workspace_store = None
@@ -1968,6 +1977,70 @@ def test_manager_background_save_as_preserves_post_snapshot_non_node_changes(
         assert manager._workspace_state.layout_modified
         assert manager._workspace_state.options_modified
         assert manager._workspace_state.context_modified
+
+
+def test_manager_background_save_as_preserves_change_from_final_event_drain(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    pool = _install_deferred_workspace_save_worker(monkeypatch)
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(
+            xr.DataArray(np.arange(9.0).reshape((3, 3)), dims=("x", "y")),
+            manager=False,
+            execute=False,
+        )
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        source_path = tmp_path / "source.itws"
+        target_path = tmp_path / "target.itws"
+        controller = manager._workspace_controller
+        controller.saving._save_workspace_document(source_path)
+        adopt_workspace_path(manager, source_path)
+        controller._mark_workspace_clean()
+        monkeypatch.setattr(
+            controller,
+            "_workspace_save_dialog",
+            lambda **_kwargs: target_path,
+        )
+
+        assert controller.save_as(native=False)
+        worker = pool.workers[0]
+        original_drain = controller._drain_workspace_deferred_events
+        drain_count = 0
+
+        def _drain_and_edit_on_final_call() -> None:
+            nonlocal drain_count
+            original_drain()
+            drain_count += 1
+            if drain_count == 2:
+                assert manager._workspace_state.mark_layout_dirty()
+
+        monkeypatch.setattr(
+            controller,
+            "_drain_workspace_deferred_events",
+            _drain_and_edit_on_final_call,
+        )
+        with workspace_store.WorkspaceStore(worker._fname, create=True) as store:
+            workspace_storage._write_workspace_generation(
+                store,
+                worker._snapshot.generation_plan,
+                compression_mode=worker._snapshot.compression_mode,
+            )
+        worker.finish()
+        qtbot.wait_until(lambda: not manager._workspace_state.save_in_progress)
+
+        assert drain_count == 2
+        assert manager.workspace_path == str(target_path.resolve())
+        assert manager.is_workspace_modified
+        assert manager._workspace_state.layout_modified
 
 
 def test_manager_background_save_as_repoints_post_snapshot_pending_edit(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -1,5 +1,6 @@
 import contextlib
 import datetime
+import errno
 import json
 import logging
 import os
@@ -1492,6 +1493,50 @@ def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
     assert error.traceback_text
 
 
+@pytest.mark.parametrize(
+    ("exception_factory", "error_field"),
+    [
+        (
+            lambda path: workspace_storage._WorkspacePublicationConflictError(path),
+            "publication_conflict_path",
+        ),
+        (
+            lambda path: PermissionError(errno.EACCES, "access denied", path),
+            "access_denied_path",
+        ),
+    ],
+)
+def test_workspace_save_worker_classifies_publication_errors(
+    monkeypatch, tmp_path, exception_factory, error_field
+) -> None:
+    target = tmp_path / "target.itws"
+    snapshot = workspace_saving._WorkspaceSaveSnapshot(
+        generation=0,
+        root_attrs=_transaction_test_root_attrs(),
+        delta_save_count=0,
+        full_tree=xr.DataTree(),
+    )
+    monkeypatch.setattr(
+        workspace_storage,
+        "_write_full_workspace_tree_file",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(exception_factory(target)),
+    )
+    worker = workspace_saving._WorkspaceSaveWorker(target, snapshot)
+    results: list[workspace_saving._WorkspaceSaveError | None] = []
+    receiver = workspace_saving._WorkspaceSaveResultReceiver(
+        callback=lambda _elapsed, error: results.append(error),
+        parent=worker.signals,
+    )
+    worker.signals.finished.connect(receiver.finish)
+
+    worker.run()
+
+    assert len(results) == 1
+    error = results[0]
+    assert isinstance(error, workspace_saving._WorkspaceSaveError)
+    assert getattr(error, error_field) == str(target)
+
+
 def test_manager_async_save_request_error_paths(
     qtbot,
     monkeypatch,
@@ -1521,6 +1566,20 @@ def test_manager_async_save_request_error_paths(
         )
         manager._show_workspace_save_worker_error(missing_error)
         assert len(critical_calls) == 2
+
+        manager._show_workspace_save_worker_error(
+            workspace_saving._WorkspaceSaveError(
+                traceback_text="Conflict traceback",
+                publication_conflict_path=str(tmp_path / "changed.itws"),
+            )
+        )
+        manager._show_workspace_save_worker_error(
+            workspace_saving._WorkspaceSaveError(
+                traceback_text="Access traceback",
+                access_denied_path=str(tmp_path / "denied.itws"),
+            )
+        )
+        assert len(critical_calls) == 4
 
         manager._workspace_state.path = tmp_path / "workspace.itws"
         manager._workspace_state.save_in_progress = True
@@ -3375,9 +3434,31 @@ def test_manager_workspace_shutdown_compacts_clean_delta_workspace(
             "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
             0.0,
         )
+        controller = manager._workspace_controller
+        refresh = controller._refresh_workspace_payload_bindings_after_full_save
+        refresh_calls: list[tuple[pathlib.Path, pathlib.Path | None]] = []
+
+        def _record_refresh(workspace_path, **kwargs) -> None:
+            old_workspace_path = kwargs.get("old_workspace_path")
+            refresh_calls.append(
+                (
+                    pathlib.Path(workspace_path).resolve(),
+                    None
+                    if old_workspace_path is None
+                    else pathlib.Path(old_workspace_path).resolve(),
+                )
+            )
+            refresh(workspace_path, **kwargs)
+
+        monkeypatch.setattr(
+            controller,
+            "_refresh_workspace_payload_bindings_after_full_save",
+            _record_refresh,
+        )
 
         assert _compact_workspace_before_shutdown_and_wait(qtbot, manager)
 
+        assert refresh_calls == [(fname.resolve(), fname.resolve())]
         assert manager._workspace_state.delta_save_count == 0
         assert manager._workspace_state.estimated_obsolete_bytes == 0
         assert manager._workspace_state.replacement_delta_count == 0

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -2,7 +2,6 @@ import contextlib
 import datetime
 import errno
 import json
-import logging
 import os
 import pathlib
 import sys
@@ -10,7 +9,7 @@ import time
 import types
 import typing
 import warnings
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable
 
 import h5py
 import numpy as np
@@ -25,6 +24,7 @@ import erlab.interactive.imagetool.manager._workspace._format as workspace_forma
 import erlab.interactive.imagetool.manager._workspace._saving as workspace_saving
 import erlab.interactive.imagetool.manager._workspace._state as workspace_state
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.derivative import DerivativeTool
@@ -50,13 +50,14 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _assert_no_workspace_internal_groups,
     _assert_rich_workspace_attr,
     _compute_first_value,
-    _hdf5_blosc2_level_codec,
+    _current_workspace_manifest,
+    _current_workspace_payload_attrs,
+    _current_workspace_payload_path,
     _open_external_file_backed_hdf5_imagetool_data,
     _open_external_lazy_hdf5_imagetool_data,
     _request_workspace_save_and_wait,
     _request_workspace_save_as_and_wait,
     _rich_workspace_attr_value,
-    _transaction_test_root_attrs,
     _write_transaction_test_workspace,
 )
 
@@ -69,8 +70,6 @@ def test_manager_workspace_saves_added_time_for_all_node_kinds(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
-
     root_added = datetime.datetime(
         2024, 1, 2, 3, 4, 5, tzinfo=datetime.timezone(datetime.timedelta(hours=9))
     )
@@ -100,20 +99,30 @@ def test_manager_workspace_saves_added_time_for_all_node_kinds(
         )
 
         fname = tmp_path / "added-time.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
-    with h5py.File(fname, "r") as h5_file:
-        assert h5_file["0/imagetool"].attrs[
-            "manager_node_added_at"
-        ] == root_added.isoformat(timespec="seconds")
-        assert h5_file[f"0/childtools/{child_uid}/imagetool"].attrs[
-            "manager_node_added_at"
-        ] == child_added.isoformat(timespec="seconds")
-        assert h5_file[f"0/childtools/{tool_uid}/tool"].attrs[
-            "manager_node_added_at"
-        ] == tool_added.isoformat(timespec="seconds")
+    attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
+    manifest = workspace_format._workspace_manifest_from_attrs(attrs)
+    attrs_by_uid = {
+        str(entry["uid"]): workspace_format._restore_workspace_manifest_attrs(
+            entry["payload_attrs"]
+        )
+        for entry in workspace_format._iter_workspace_manifest_node_entries(manifest)
+    }
+    root_uid = next(
+        str(entry["uid"])
+        for entry in workspace_format._iter_workspace_manifest_node_entries(manifest)
+        if entry["path"] == "0"
+    )
+    assert attrs_by_uid[root_uid]["manager_node_added_at"] == root_added.isoformat(
+        timespec="seconds"
+    )
+    assert attrs_by_uid[child_uid]["manager_node_added_at"] == child_added.isoformat(
+        timespec="seconds"
+    )
+    assert attrs_by_uid[tool_uid]["manager_node_added_at"] == tool_added.isoformat(
+        timespec="seconds"
+    )
 
 
 def test_manager_workspace_restores_hidden_ktool_angle_scales(
@@ -151,9 +160,7 @@ def test_manager_workspace_restores_hidden_ktool_angle_scales(
         tool_uid = manager.add_childtool(kspace_tool, 0, show=False)
 
         workspace_path = tmp_path / "hidden-ktool-scales.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,
@@ -178,9 +185,7 @@ def test_manager_workspace_restores_hidden_ktool_angle_scales(
         assert "alpha_scale=1.25" in code
         assert "beta_scale=0.75" in code
 
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_path, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,
@@ -203,8 +208,6 @@ def test_manager_workspace_layout_only_save_updates_root_manifest_only(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
-
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         manager.show()
@@ -212,12 +215,9 @@ def test_manager_workspace_layout_only_save_updates_root_manifest_only(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "layout-only.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
-        delta_save_count = manager._workspace_state.delta_save_count
 
         manager.resize(manager.width() + 40, manager.height() + 30)
         qtbot.wait_until(lambda: manager.is_workspace_modified, timeout=5000)
@@ -228,24 +228,18 @@ def test_manager_workspace_layout_only_save_updates_root_manifest_only(
         def _forbid_node_serialization(*_args, **_kwargs):
             raise AssertionError("layout-only save serialized a node")
 
-        def _forbid_full_save(*_args, **_kwargs):
-            raise AssertionError("layout-only save requested a full workspace write")
-
         monkeypatch.setattr(
             manager._workspace_controller.saving,
             "_serialize_workspace_node",
             _forbid_node_serialization,
         )
-        monkeypatch.setattr(
-            workspace_storage, "_write_full_workspace_tree_file", _forbid_full_save
-        )
 
         assert _request_workspace_save_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == delta_save_count
         assert not manager.is_workspace_modified
 
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manifest = workspace_format._workspace_manifest_from_attrs(
+            workspace_arrays._read_workspace_root_attrs_h5py(fname)
+        )
         assert "delta_save_count" not in manifest
         assert (
             manifest["manager_layout"]
@@ -262,8 +256,6 @@ def test_manager_workspace_standalone_app_only_save_updates_root_manifest_only(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
-
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         manager.show()
@@ -271,12 +263,9 @@ def test_manager_workspace_standalone_app_only_save_updates_root_manifest_only(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "standalone-only.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
-        delta_save_count = manager._workspace_state.delta_save_count
 
         manager.show_ptable()
         ptable = manager.ptable_window
@@ -287,26 +276,18 @@ def test_manager_workspace_standalone_app_only_save_updates_root_manifest_only(
         def _forbid_node_serialization(*_args, **_kwargs):
             raise AssertionError("standalone-only save serialized a node")
 
-        def _forbid_full_save(*_args, **_kwargs):
-            raise AssertionError(
-                "standalone-only save requested a full workspace write"
-            )
-
         monkeypatch.setattr(
             manager._workspace_controller.saving,
             "_serialize_workspace_node",
             _forbid_node_serialization,
         )
-        monkeypatch.setattr(
-            workspace_storage, "_write_full_workspace_tree_file", _forbid_full_save
-        )
 
         assert _request_workspace_save_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == delta_save_count
         assert not manager.is_workspace_modified
 
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        manifest = workspace_format._workspace_manifest_from_attrs(
+            workspace_arrays._read_workspace_root_attrs_h5py(fname)
+        )
         assert "delta_save_count" not in manifest
         assert manifest["standalone_apps"]["apps"]["ptable"]["photon_energy"] == "150"
 
@@ -327,16 +308,12 @@ def test_manager_workspace_unlink_removes_saved_link_group(
 
         fname = tmp_path / "unlinked.itws"
         manager.link_imagetools(0, 1)
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         select_tools(manager, [0, 1])
         manager.unlink_selected()
         assert manager.is_workspace_modified
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         manifest = workspace_format._workspace_manifest_from_attrs(
             workspace_arrays._read_workspace_root_attrs_h5py(fname)
@@ -408,120 +385,6 @@ def test_manager_load_workspace_dataset_ignores_invalid_saved_metadata(
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
 
 
-def test_manager_workspace_full_save_copy_group_edge_cases(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    workspace_path = tmp_path / "copy-groups.itws"
-    workspace_path.touch()
-
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        manager._workspace_state.path = workspace_path
-        monkeypatch.setattr(
-            workspace_arrays,
-            "_read_workspace_root_attrs_h5py",
-            lambda _path: (_ for _ in ()).throw(RuntimeError("metadata failed")),
-        )
-        assert manager._workspace_controller.saving._workspace_full_save_copy_groups(
-            xr.DataTree()
-        ) == (None, ())
-
-        monkeypatch.setattr(
-            workspace_arrays,
-            "_read_workspace_root_attrs_h5py",
-            lambda _path: {"imagetool_workspace_schema_version": 1},
-        )
-        assert manager._workspace_controller.saving._workspace_full_save_copy_groups(
-            xr.DataTree()
-        ) == (None, ())
-
-        data = xr.DataArray(np.arange(25.0).reshape(5, 5), dims=("x", "y"))
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-        tool = DerivativeTool(data)
-        monkeypatch.setattr(tool, "can_save_and_load", lambda: False)
-        manager.add_childtool(tool, 0, show=False)
-        manager.add_childtool(_AddedTimeChildTool(data), 0, show=False)
-        manager._workspace_controller._mark_workspace_clean()
-        tree = manager._workspace_controller.saving._to_datatree()
-        monkeypatch.setitem(
-            manager._tool_graph.nodes,
-            "missing-tool",
-            types.SimpleNamespace(
-                is_imagetool=False,
-                tool_window=None,
-                pending_workspace_tool_payload=None,
-            ),
-        )
-        try:
-            manifest_without_identities = {
-                "schema_version": workspace_format._current_workspace_schema_version(),
-                "nodes": [[]],
-                "root_order": [0],
-            }
-            monkeypatch.setattr(
-                workspace_arrays,
-                "_read_workspace_root_attrs_h5py",
-                lambda _path: {
-                    "imagetool_workspace_schema_version": (
-                        workspace_format._current_workspace_schema_version()
-                    ),
-                    workspace_format._WORKSPACE_MANIFEST_ATTR: json.dumps(
-                        manifest_without_identities
-                    ),
-                },
-            )
-            assert (
-                manager._workspace_controller.saving._workspace_full_save_copy_groups(
-                    tree
-                )
-                == (
-                    str(workspace_path),
-                    (),
-                )
-            )
-
-            manifest_with_missing_tree_payload = {
-                "schema_version": workspace_format._current_workspace_schema_version(),
-                "nodes": [
-                    [],
-                    {"uid": uid, "kind": "imagetool", "path": "0"},
-                ],
-                "root_order": [0],
-            }
-            monkeypatch.setattr(
-                workspace_arrays,
-                "_read_workspace_root_attrs_h5py",
-                lambda _path: {
-                    "imagetool_workspace_schema_version": (
-                        workspace_format._current_workspace_schema_version()
-                    ),
-                    workspace_format._WORKSPACE_MANIFEST_ATTR: json.dumps(
-                        manifest_with_missing_tree_payload
-                    ),
-                },
-            )
-            assert (
-                manager._workspace_controller.saving._workspace_full_save_copy_groups(
-                    xr.DataTree()
-                )
-                == (
-                    str(workspace_path),
-                    (),
-                )
-            )
-        finally:
-            tree.close()
-            manager._tool_graph.nodes.pop("missing-tool", None)
-
-
 def test_workspace_state_repeated_options_dirty_during_save() -> None:
     state = workspace_state._ManagerWorkspaceState()
 
@@ -584,75 +447,6 @@ def test_manager_close_save_path_updates_file_path(
         assert not manager._workspace_state.closing_document
 
 
-def test_manager_close_ignores_active_save_and_async_compaction(
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        manager._workspace_state.save_in_progress = True
-        saving_event = QtGui.QCloseEvent()
-        manager.closeEvent(saving_event)
-
-        assert not saving_event.isAccepted()
-
-        manager._workspace_state.save_in_progress = False
-        manager._workspace_state.path = tmp_path / "close-compact.itws"
-        close_calls: list[str] = []
-        compaction_callbacks: list[Callable[[], None]] = []
-
-        def _compact_workspace_before_shutdown(
-            *, on_finished: Callable[[], None]
-        ) -> bool:
-            compaction_callbacks.append(on_finished)
-            return True
-
-        with monkeypatch.context() as patch:
-            patch.setattr(
-                manager._workspace_controller,
-                "_dirty_workspace_save_choice",
-                lambda _message: "discard",
-            )
-            patch.setattr(
-                manager._workspace_controller,
-                "_compact_workspace_before_shutdown",
-                _compact_workspace_before_shutdown,
-            )
-            patch.setattr(manager, "close", lambda: close_calls.append("close") or True)
-            compacting_event = QtGui.QCloseEvent()
-            manager.closeEvent(compacting_event)
-            assert not compacting_event.isAccepted()
-            assert len(compaction_callbacks) == 1
-            compaction_callbacks[0]()
-
-        assert close_calls == ["close"]
-
-
-def test_manager_close_compacts_clean_delta_workspace(
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        manager._workspace_state.path = tmp_path / "close-no-compact.itws"
-        manager._workspace_state.delta_save_count = 1
-        compact_calls: list[str] = []
-
-        monkeypatch.setattr(
-            manager._workspace_controller,
-            "_compact_workspace_before_shutdown",
-            lambda **_kwargs: compact_calls.append("compact") or False,
-        )
-
-        assert manager.close()
-
-    assert compact_calls == ["compact"]
-
-
 def test_manager_workspace_save_as_locked_target_does_not_write(
     monkeypatch,
     tmp_path,
@@ -709,7 +503,7 @@ def test_manager_workspace_save_as_reports_snapshot_error(
         )
         monkeypatch.setattr(
             manager._workspace_controller.saving,
-            "_workspace_full_save_snapshot",
+            "_workspace_generation_save_snapshot",
             lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
         )
         monkeypatch.setattr(
@@ -871,110 +665,19 @@ def test_manager_compact_workspace_edge_paths(
         manager._workspace_state.save_in_progress = False
 
         operation_errors: list[tuple[typing.Any, ...]] = []
-        focus_restores: list[QtWidgets.QWidget | None] = []
-        monkeypatch.setattr(
-            erlab.interactive.utils,
-            "wait_dialog",
-            lambda *args, **kwargs: contextlib.nullcontext(),
-        )
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_save_workspace_document",
-            lambda *args, **kwargs: (_ for _ in ()).throw(
-                RuntimeError("compact failed")
-            ),
-        )
         monkeypatch.setattr(
             manager,
             "_show_operation_error",
             lambda *args: operation_errors.append(args),
-        )
-        monkeypatch.setattr(
-            manager._workspace_controller,
-            "_restore_focus_after_workspace_save",
-            lambda origin: focus_restores.append(origin),
         )
 
         assert not manager.compact_workspace()
         assert operation_errors == [
             (
                 "Error while compacting workspace",
-                "An error occurred while compacting the workspace file.",
+                "The workspace file is not open. Reopen it and try again.",
             )
         ]
-        assert focus_restores == [None]
-
-
-def test_manager_compact_workspace_copies_matching_groups(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25.0).reshape(5, 5), dims=("x", "y"))
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-
-        fname = tmp_path / "manual-repack.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-
-        tree = manager._workspace_controller.saving._to_datatree()
-        try:
-            copy_source, copy_groups = (
-                manager._workspace_controller.saving._workspace_full_save_copy_groups(
-                    tree
-                )
-            )
-        finally:
-            tree.close()
-        assert copy_source == str(fname)
-        assert copy_groups
-
-        original_write = workspace_storage._write_full_workspace_tree_file
-        full_write_calls: list[
-            tuple[
-                str | os.PathLike[str] | None,
-                tuple[tuple[str, str, dict[str, typing.Any] | None], ...],
-            ]
-        ] = []
-
-        def _record_full_write(
-            write_fname: str | os.PathLike[str],
-            write_tree: xr.DataTree,
-            root_attrs: Mapping[str, typing.Any],
-            **kwargs: typing.Any,
-        ) -> None:
-            full_write_calls.append(
-                (kwargs.get("copy_source"), tuple(kwargs.get("copy_groups", ())))
-            )
-            original_write(write_fname, write_tree, root_attrs, **kwargs)
-
-        monkeypatch.setattr(
-            erlab.interactive.utils,
-            "wait_dialog",
-            lambda *args, **kwargs: contextlib.nullcontext(),
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_write_full_workspace_tree_file",
-            _record_full_write,
-        )
-
-        assert manager.compact_workspace()
-
-        copy_source, copy_groups = full_write_calls[-1]
-        assert copy_source == str(fname)
-        assert copy_groups
 
 
 def test_manager_compact_workspace_reduces_internal_holes(
@@ -1006,9 +709,7 @@ def test_manager_compact_workspace_reduces_internal_holes(
             uid = manager._tool_graph.root_wrappers[0].uid
 
             fname = tmp_path / "hole-repack.itws"
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
+            manager._workspace_controller.saving._save_workspace_document(fname)
             adopt_workspace_path(manager, fname)
             manager._workspace_controller._mark_workspace_clean()
             size_full = fname.stat().st_size
@@ -1036,188 +737,47 @@ def test_manager_compact_workspace_reduces_internal_holes(
         erlab.interactive.options["io/workspace/compression"] = old_compression
 
 
-def test_manager_compact_workspace_reapplies_compression_mode(
-    qtbot,
+def test_manager_compact_workspace_upgrades_previous_schema(
     monkeypatch,
     tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
-
-    old_compression = erlab.interactive.options["io/workspace/compression"]
-    try:
-        erlab.interactive.options["io/workspace/compression"] = "none"
-        with manager_context() as manager:
-            qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-            data = xr.DataArray(
-                np.arange(512 * 512, dtype=np.float64).reshape(512, 512),
-                dims=("x", "y"),
-            )
-
-            root = itool(data, manager=False, execute=False)
-            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-            manager.add_imagetool(root, show=False)
-
-            fname = tmp_path / "compression-repack.itws"
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
-            adopt_workspace_path(manager, fname)
-            manager._workspace_controller._mark_workspace_clean()
-            with h5py.File(fname, "r") as h5_file:
-                assert (
-                    _hdf5_blosc2_level_codec(h5_file["0/imagetool"][_ITOOL_DATA_NAME])
-                    is None
-                )
-
-            original_write = workspace_storage._write_full_workspace_tree_file
-            full_write_calls: list[
-                tuple[str | os.PathLike[str] | None, tuple[object, ...]]
-            ] = []
-
-            def _record_full_write(
-                write_fname: str | os.PathLike[str],
-                write_tree: xr.DataTree,
-                root_attrs: Mapping[str, typing.Any],
-                **kwargs: typing.Any,
-            ) -> None:
-                full_write_calls.append(
-                    (kwargs.get("copy_source"), tuple(kwargs.get("copy_groups", ())))
-                )
-                original_write(write_fname, write_tree, root_attrs, **kwargs)
-
-            erlab.interactive.options["io/workspace/compression"] = "zstd1"
-            monkeypatch.setattr(
-                erlab.interactive.utils,
-                "wait_dialog",
-                lambda *args, **kwargs: contextlib.nullcontext(),
-            )
-            monkeypatch.setattr(
-                workspace_storage,
-                "_write_full_workspace_tree_file",
-                _record_full_write,
-            )
-            assert manager.compact_workspace()
-
-            assert full_write_calls[-1] == (str(fname), ())
-            with h5py.File(fname, "r") as h5_file:
-                assert _hdf5_blosc2_level_codec(
-                    h5_file["0/imagetool"][_ITOOL_DATA_NAME]
-                ) == (1, 5)
-    finally:
-        erlab.interactive.options["io/workspace/compression"] = old_compression
-
-
-def test_manager_shutdown_compact_preserves_existing_dataset_filters(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    import h5py
-
-    old_compression = erlab.interactive.options["io/workspace/compression"]
-    try:
-        erlab.interactive.options["io/workspace/compression"] = "none"
-        with manager_context() as manager:
-            qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-            data = xr.DataArray(
-                np.arange(512 * 512, dtype=np.float64).reshape(512, 512),
-                dims=("x", "y"),
-            )
-
-            root = itool(data, manager=False, execute=False)
-            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-            manager.add_imagetool(root, show=False)
-            uid = manager._tool_graph.root_wrappers[0].uid
-
-            fname = tmp_path / "shutdown-preserve-filters.itws"
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
-            adopt_workspace_path(manager, fname)
-            manager._workspace_controller._mark_workspace_clean()
-            manager._workspace_controller._mark_node_data_dirty(uid)
-            assert _request_workspace_save_and_wait(qtbot, manager)
-
-            with h5py.File(fname, "r") as h5_file:
-                assert (
-                    _hdf5_blosc2_level_codec(h5_file["0/imagetool"][_ITOOL_DATA_NAME])
-                    is None
-                )
-
-            erlab.interactive.options["io/workspace/compression"] = "zstd1"
-            monkeypatch.setattr(
-                workspace_saving,
-                "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
-                1,
-            )
-            monkeypatch.setattr(
-                workspace_saving,
-                "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
-                0.0,
-            )
-
-            assert _compact_workspace_before_shutdown_and_wait(qtbot, manager)
-
-            with h5py.File(fname, "r") as h5_file:
-                assert (
-                    _hdf5_blosc2_level_codec(h5_file["0/imagetool"][_ITOOL_DATA_NAME])
-                    is None
-                )
-    finally:
-        erlab.interactive.options["io/workspace/compression"] = old_compression
-
-
-def test_manager_shutdown_compaction_logs_failure(
-    caplog,
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    pool = _install_deferred_workspace_save_worker(monkeypatch)
-
-    with manager_context() as manager:
-        manager._workspace_state.path = tmp_path / "workspace.itws"
-        manager._workspace_state.delta_save_count = 1
-        manager._workspace_state.set_repack_estimate(
-            estimated_obsolete_bytes=100,
-            replacement_delta_count=1,
+    path = tmp_path / "previous-schema.itws"
+    calls: list[str] = []
+    with (
+        manager_context() as manager,
+        workspace_store.WorkspaceStore(path, create=True) as store,
+    ):
+        manager._workspace_state.path = path.resolve()
+        manager._workspace_state.schema_version = (
+            workspace_format._current_workspace_schema_version() - 1
         )
-
+        manager._workspace_controller._workspace_store = store
         monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_workspace_should_repack_before_shutdown",
-            lambda: True,
+            erlab.interactive.utils,
+            "wait_dialog",
+            lambda *args, **kwargs: contextlib.nullcontext(),
         )
         monkeypatch.setattr(
             manager._workspace_controller.saving,
-            "_workspace_file_repack_snapshot",
-            lambda generation: workspace_saving._WorkspaceSaveSnapshot(
-                generation=generation,
-                root_attrs=_transaction_test_root_attrs(delta_save_count=1),
-                delta_save_count=0,
-                file_repack=True,
+            "_save_workspace_document",
+            lambda *_args, **_kwargs: calls.append("save"),
+        )
+        monkeypatch.setattr(
+            workspace_storage,
+            "_compact_workspace_store",
+            lambda current_store: calls.append(
+                "compact" if current_store is store else "wrong-store"
             ),
         )
 
-        with caplog.at_level(logging.ERROR):
-            assert manager._workspace_controller._compact_workspace_before_shutdown()
-            assert len(pool.workers) == 1
-            pool.workers[0].finish(
-                error=workspace_saving._WorkspaceSaveError("compact failed"),
-            )
-            qtbot.wait_until(lambda: not manager._workspace_state.save_in_progress)
+        assert manager.compact_workspace()
+        assert calls == ["save", "compact"]
 
-    assert "Failed to compact workspace before shutdown" in caplog.text
-    assert "compact failed" in caplog.text
+        manager._workspace_controller._workspace_store = None
+        manager._workspace_state.path = None
 
 
 def test_manager_workspace_save_dialog_paths(
@@ -1352,7 +912,7 @@ def test_manager_legacy_itws_schema_save_helpers(
             lambda **_kwargs: None,
         )
         assert (
-            manager._workspace_controller._save_legacy_workspace_as_v4(
+            manager._workspace_controller._save_legacy_workspace_as_current(
                 tmp_path / "legacy-schema.itws"
             )
             is None
@@ -1361,7 +921,7 @@ def test_manager_legacy_itws_schema_save_helpers(
         dirty_reasons: list[str] = []
         monkeypatch.setattr(
             manager._workspace_controller,
-            "_save_legacy_workspace_as_v4",
+            "_save_legacy_workspace_as_current",
             lambda *args, **kwargs: None,
         )
         monkeypatch.setattr(
@@ -1375,7 +935,6 @@ def test_manager_legacy_itws_schema_save_helpers(
         )
 
         assert manager._workspace_state.path is None
-        assert manager._workspace_state.needs_full_save
         assert dirty_reasons == ["Legacy workspace needs conversion"]
 
 
@@ -1384,9 +943,13 @@ class _DeferredWorkspaceSaveWorker:
         self,
         _fname: str | os.PathLike[str],
         snapshot: workspace_saving._WorkspaceSaveSnapshot,
+        *,
+        store: workspace_store.WorkspaceStore | None = None,
     ) -> None:
         self.signals = workspace_saving._WorkspaceSaveWorkerSignals()
+        self._fname = pathlib.Path(_fname)
         self._snapshot = snapshot
+        self._store = store
 
     def finish(
         self,
@@ -1436,48 +999,44 @@ def _workspace_save_test_snapshot(
 ) -> workspace_saving._WorkspaceSaveSnapshot:
     return workspace_saving._WorkspaceSaveSnapshot(
         generation=manager._workspace_state.dirty_generation,
-        root_attrs={},
-        delta_save_count=manager._workspace_state.delta_save_count + 1,
+        generation_plan=workspace_storage._WorkspaceGenerationPlan(
+            manifest={"schema_version": 5, "nodes": []},
+            objects=(),
+        ),
+        compression_mode="none",
     )
-
-
-def _compact_workspace_before_shutdown_and_wait(
-    qtbot,
-    manager: erlab.interactive.imagetool.manager.ImageToolManager,
-) -> bool:
-    completed = False
-
-    def _mark_completed() -> None:
-        nonlocal completed
-        completed = True
-
-    requested = manager._workspace_controller._compact_workspace_before_shutdown(
-        on_finished=_mark_completed
-    )
-    if requested:
-        qtbot.wait_until(lambda: completed, timeout=10000)
-    return requested
 
 
 def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
     missing_source = tmp_path / "deleted-source.itws"
     target = tmp_path / "target.itws"
+    object_id = "missing"
     snapshot = workspace_saving._WorkspaceSaveSnapshot(
         generation=0,
-        root_attrs=_transaction_test_root_attrs(),
-        delta_save_count=0,
-        full_tree=xr.DataTree(),
-        expected_publication_state=workspace_storage._workspace_publication_state(
-            target
-        ),
-        copy_group_sources=(
-            (
-                str(missing_source),
-                "0/imagetool",
-                "0/imagetool",
-                None,
+        generation_plan=workspace_storage._WorkspaceGenerationPlan(
+            manifest={
+                "schema_version": 5,
+                "nodes": [
+                    {
+                        "uid": "node",
+                        "kind": "imagetool",
+                        "path": "0",
+                        "payload_object_id": object_id,
+                        "payload_path": workspace_store.WorkspaceStore.object_path(
+                            object_id
+                        ),
+                    }
+                ],
+            },
+            objects=(
+                workspace_storage._WorkspaceObjectWrite(
+                    object_id,
+                    source_file=str(missing_source),
+                    source_path="0/imagetool",
+                ),
             ),
         ),
+        compression_mode="none",
     )
     worker = workspace_saving._WorkspaceSaveWorker(target, snapshot)
     results: list[tuple[float, workspace_saving._WorkspaceSaveError | None]] = []
@@ -1494,54 +1053,6 @@ def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
     assert isinstance(error, workspace_saving._WorkspaceSaveError)
     assert error.missing_source_path == str(missing_source)
     assert error.traceback_text
-
-
-def test_workspace_save_worker_rejects_unbound_snapshot(tmp_path) -> None:
-    snapshot = workspace_saving._WorkspaceSaveSnapshot(
-        generation=0,
-        root_attrs={},
-        delta_save_count=0,
-    )
-
-    with pytest.raises(ValueError, match="not bound to its destination"):
-        workspace_saving._WorkspaceSaveWorker(tmp_path / "target.itws", snapshot)
-
-
-@pytest.mark.parametrize("full_save", [False, True])
-def test_workspace_save_worker_uses_snapshot_publication_state(
-    monkeypatch, tmp_path, full_save
-) -> None:
-    target = tmp_path / "target.itws"
-    expected_state: workspace_storage._WorkspacePublicationState = (
-        True,
-        1,
-        2,
-        3,
-        4,
-        5,
-    )
-    snapshot = workspace_saving._WorkspaceSaveSnapshot(
-        generation=0,
-        root_attrs=_transaction_test_root_attrs(),
-        delta_save_count=0,
-        full_tree=xr.DataTree() if full_save else None,
-        expected_publication_state=expected_state,
-    )
-    received: list[workspace_storage._WorkspacePublicationState | None] = []
-    writer_name = (
-        "_write_full_workspace_tree_file"
-        if full_save
-        else "_write_workspace_transaction_file"
-    )
-    monkeypatch.setattr(
-        workspace_storage,
-        writer_name,
-        lambda *_args, **kwargs: received.append(kwargs["expected_state"]),
-    )
-
-    workspace_saving._WorkspaceSaveWorker(target, snapshot).run()
-
-    assert received == [expected_state]
 
 
 @pytest.mark.parametrize(
@@ -1563,16 +1074,15 @@ def test_workspace_save_worker_classifies_publication_errors(
     target = tmp_path / "target.itws"
     snapshot = workspace_saving._WorkspaceSaveSnapshot(
         generation=0,
-        root_attrs=_transaction_test_root_attrs(),
-        delta_save_count=0,
-        full_tree=xr.DataTree(),
-        expected_publication_state=workspace_storage._workspace_publication_state(
-            target
+        generation_plan=workspace_storage._WorkspaceGenerationPlan(
+            manifest={"schema_version": 5, "nodes": []},
+            objects=(),
         ),
+        compression_mode="none",
     )
     monkeypatch.setattr(
         workspace_storage,
-        "_write_full_workspace_tree_file",
+        "_write_workspace_generation",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(exception_factory(target)),
     )
     worker = workspace_saving._WorkspaceSaveWorker(target, snapshot)
@@ -1741,60 +1251,6 @@ def test_manager_save_action_runs_workspace_save_in_background(
         manager._workspace_state.path = None
 
 
-def test_manager_background_save_rejects_changed_destination(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    workers: list[workspace_saving._WorkspaceSaveWorker] = []
-
-    class _HeldWorkspaceSaveThreadPool:
-        @staticmethod
-        def start(worker: workspace_saving._WorkspaceSaveWorker) -> None:
-            workers.append(worker)
-
-    monkeypatch.setattr(
-        QtCore.QThreadPool,
-        "globalInstance",
-        staticmethod(_HeldWorkspaceSaveThreadPool),
-    )
-
-    with manager_context() as manager:
-        data = xr.DataArray(np.arange(9.0).reshape((3, 3)), dims=("x", "y"))
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-        fname = tmp_path / "changed-before-background-write.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        root.slicer_area.replace_source_data(data + 100.0, auto_compute=False)
-        manager._workspace_controller._mark_node_data_dirty(uid)
-        errors: list[workspace_saving._WorkspaceSaveError] = []
-        monkeypatch.setattr(manager, "_show_workspace_save_worker_error", errors.append)
-
-        assert manager._workspace_controller.save(restore_focus=False)
-        assert len(workers) == 1
-        _write_transaction_test_workspace(fname, 2.0)
-
-        workers[0].run()
-        qtbot.wait_until(lambda: not manager._workspace_state.save_in_progress)
-
-        assert len(errors) == 1
-        assert errors[0].publication_conflict_path == str(fname.resolve())
-        with h5py.File(fname, "r") as h5_file:
-            assert float(h5_file["0/imagetool/data"][0]) == 2.0
-        assert manager.is_workspace_modified
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_state.path = None
-
-
 def test_manager_background_workspace_save_keeps_new_changes_and_queues_followup(
     qtbot,
     monkeypatch,
@@ -1898,9 +1354,7 @@ def test_manager_background_full_save_preserves_post_snapshot_data_edit(
         uid = manager._tool_graph.root_wrappers[0].uid
 
         fname = tmp_path / "post-snapshot-edit.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller.loading._rebind_workspace_backed_imagetools(
             fname, targets=[0], chunks={}
@@ -1910,7 +1364,6 @@ def test_manager_background_full_save_preserves_post_snapshot_data_edit(
         manager._workspace_controller._mark_workspace_clean()
 
         manager._workspace_controller._mark_node_data_dirty(uid)
-        manager._workspace_state.needs_full_save = True
         assert manager._workspace_controller.save()
         assert len(pool.workers) == 1
         assert manager._workspace_state.save_in_progress
@@ -1941,6 +1394,71 @@ def test_manager_background_full_save_preserves_post_snapshot_data_edit(
         assert uid in manager._workspace_state.dirty_data
         assert not operation_errors
         manager._workspace_state.path = None
+
+
+def test_manager_background_save_as_preserves_post_snapshot_data_edit(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    pool = _install_deferred_workspace_save_worker(monkeypatch)
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25.0).reshape((5, 5)),
+            dims=("x", "y"),
+            name="source",
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        source_path = tmp_path / "source.itws"
+        target_path = tmp_path / "target.itws"
+        manager._workspace_controller.saving._save_workspace_document(source_path)
+        adopt_workspace_path(manager, source_path)
+        manager._workspace_controller.loading._rebind_workspace_backed_imagetools(
+            source_path, chunks={}
+        )
+        manager._workspace_controller._mark_workspace_clean()
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_workspace_save_dialog",
+            lambda **_kwargs: target_path,
+        )
+
+        assert manager._workspace_controller.save_as(native=False)
+        assert len(pool.workers) == 1
+        worker = pool.workers[0]
+        snapshot_generation = worker._snapshot.generation
+
+        replacement = xr.full_like(data, 42.0)
+        root.slicer_area.replace_source_data(
+            replacement,
+            auto_compute=False,
+            emit_edited=True,
+        )
+        assert any(
+            event.uid is not None and event.generation > snapshot_generation
+            for event in manager._workspace_state.dirty_events
+        )
+
+        with workspace_store.WorkspaceStore(worker._fname, create=True) as store:
+            workspace_storage._write_workspace_generation(
+                store,
+                worker._snapshot.generation_plan,
+                compression_mode=worker._snapshot.compression_mode,
+            )
+        worker.finish()
+        qtbot.wait_until(lambda: not manager._workspace_state.save_in_progress)
+
+        assert manager.workspace_path == str(target_path.resolve())
+        np.testing.assert_array_equal(root.slicer_area._data.values, replacement.values)
+        assert manager.is_workspace_modified
 
 
 def test_manager_background_workspace_save_failure_restores_state(
@@ -2086,15 +1604,13 @@ def test_open_multiple_files_workspace_locks_before_recovery(
     assert lock_calls == [fname]
 
 
-def test_manager_workspace_v4_save_open_replaces_and_binds_path(
+def test_manager_workspace_generation_save_open_replaces_and_binds_path(
     qtbot,
     tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
-
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
@@ -2107,17 +1623,15 @@ def test_manager_workspace_v4_save_open_replaces_and_binds_path(
         child_uid = manager.add_imagetool_child(child, 0, show=False)
 
         fname = tmp_path / "bound.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         assert manager.workspace_path == str(fname.resolve())
         assert not manager.is_workspace_modified
 
-        with h5py.File(fname, "r") as h5_file:
-            assert h5_file.attrs["imagetool_workspace_schema_version"] == 4
-            manifest = json.loads(h5_file.attrs["imagetool_workspace_manifest"])
-        assert manifest["schema_version"] == 4
+        attrs = workspace_arrays._read_workspace_root_attrs_h5py(fname)
+        assert attrs["imagetool_workspace_schema_version"] == 5
+        manifest = workspace_format._workspace_manifest_from_attrs(attrs)
+        assert manifest["schema_version"] == 5
         assert {node["uid"] for node in manifest["nodes"]} >= {
             manager._tool_graph.root_wrappers[0].uid,
             child_uid,
@@ -2309,9 +1823,7 @@ def test_manager_workspace_load_reopens_offloaded_data_as_dask(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "offload-reopen.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -2346,9 +1858,7 @@ def test_manager_workspace_import_reopens_offloaded_data_as_dask(
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
 
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
         assert manager.offload_to_workspace([0], native=False)
@@ -2404,9 +1914,7 @@ def test_manager_workspace_load_reopens_offloaded_spaced_coord_data_as_dask(
         fname = tmp_path / "offload-spaced-coord.itws"
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
+            manager._workspace_controller.saving._save_workspace_document(fname)
         assert not any("space in its name" in str(item.message) for item in caught)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
@@ -2434,7 +1942,6 @@ def test_manager_offload_to_workspace_saves_dirty_workspace_before_rebind(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -2445,9 +1952,7 @@ def test_manager_offload_to_workspace_saves_dirty_workspace_before_rebind(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "dirty-offload.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -2489,7 +1994,7 @@ def test_manager_offload_to_workspace_saves_dirty_workspace_before_rebind(
         assert not manager.is_workspace_modified
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
             assert saved[0, 0] == 10.0
 
 
@@ -2500,7 +2005,6 @@ def test_manager_compute_offloaded_workspace_data_marks_backing_dirty(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -2512,9 +2016,7 @@ def test_manager_compute_offloaded_workspace_data_marks_backing_dirty(
         uid = manager._tool_graph.root_wrappers[0].uid
 
         fname = tmp_path / "compute-offloaded.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -2536,7 +2038,7 @@ def test_manager_compute_offloaded_workspace_data_marks_backing_dirty(
         assert not manager.is_workspace_modified
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
             assert saved.chunks is None
 
 
@@ -2566,9 +2068,7 @@ def test_manager_offload_to_workspace_save_cancel_or_failure_noop(
         assert root.slicer_area._data.chunks is None
 
         fname = tmp_path / "failure-offload.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
         manager._workspace_controller._mark_node_data_dirty(
@@ -2620,7 +2120,6 @@ def test_manager_offload_to_workspace_edge_paths(
     with manager_context() as manager:
         workspace = tmp_path / "offload-error.itws"
         manager._workspace_state.path = workspace
-        manager._workspace_state.needs_full_save = False
         monkeypatch.setattr(manager, "_node_for_target", lambda _target: fake_node)
         monkeypatch.setattr(
             manager._workspace_controller,
@@ -2688,9 +2187,7 @@ def test_manager_offload_to_workspace_preserves_child_source_state(
         child_node = manager._child_node(child_uid)
 
         fname = tmp_path / "child-offload.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -2720,7 +2217,6 @@ def test_manager_manual_chunk_edits_persist_on_next_workspace_save(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -2732,9 +2228,7 @@ def test_manager_manual_chunk_edits_persist_on_next_workspace_save(
         uid = manager._tool_graph.root_wrappers[0].uid
 
         fname = tmp_path / "manual-chunks.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -2745,19 +2239,19 @@ def test_manager_manual_chunk_edits_persist_on_next_workspace_save(
         assert manager.is_workspace_modified
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
             assert saved.chunks is None
 
         assert _request_workspace_save_and_wait(qtbot, manager)
         assert not manager.is_workspace_modified
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
             assert saved.chunks == (2, 3)
 
         opened = workspace_arrays.open_workspace_dataset(
             fname,
-            manager._workspace_controller.saving._workspace_payload_path(uid),
+            _current_workspace_payload_path(fname),
             chunks={},
         )
         try:
@@ -2788,12 +2282,9 @@ def test_manager_workspace_full_save_preserves_non_dask_data(
             assert root.slicer_area._data.chunks is None
 
             fname = tmp_path / "full-save.itws"
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
+            manager._workspace_controller.saving._save_workspace_document(fname)
             adopt_workspace_path(manager, fname)
             manager._workspace_controller._mark_workspace_clean()
-            manager._workspace_state.needs_full_save = True
 
             assert _request_workspace_save_and_wait(qtbot, manager)
             assert root.slicer_area._data.chunks is None
@@ -2871,9 +2362,7 @@ def test_manager_workspace_save_as_rebinds_workspace_non_dask_file_backed_data(
 
         old_fname = tmp_path / "old.itws"
         new_fname = tmp_path / "new.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            old_fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(old_fname)
         adopt_workspace_path(manager, old_fname)
         manager._workspace_controller.loading._rebind_workspace_backed_imagetools(
             old_fname, targets=[0], chunks=None
@@ -3053,9 +2542,7 @@ def test_manager_workspace_save_as_retargets_private_dask_without_rebind(
 
         old_fname = tmp_path / "private-reader-old.itws"
         new_fname = tmp_path / "private-reader-new.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            old_fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(old_fname)
         adopt_workspace_path(manager, old_fname)
         manager._workspace_controller.loading._rebind_workspace_backed_imagetools(
             old_fname, targets=[0], chunks={}
@@ -3123,9 +2610,7 @@ def test_workspace_full_save_external_dask_rebind_rolls_back_on_later_failure(
             manager._workspace_controller.loading._workspace_data_backing_snapshot()
         )
         uid = manager._tool_graph.root_wrappers[0].uid
-        manager._workspace_controller.saving._save_workspace_document(
-            workspace_fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_fname)
 
         rebind_calls: list[str] = []
         rebind_data = (
@@ -3189,9 +2674,7 @@ def test_manager_workspace_save_clears_deferred_dirty_events(
         uid = manager._tool_graph.root_wrappers[0].uid
 
         fname = tmp_path / "deferred-dirty.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -3239,9 +2722,7 @@ def test_manager_workspace_save_during_active_interaction_uses_dirty_state(
         uid = manager._tool_graph.root_wrappers[0].uid
 
         fname = tmp_path / "active-save.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -3289,7 +2770,7 @@ def test_manager_workspace_save_drain_does_not_force_deferred_delete(
         assert idle_flushes == [{"force": True}]
 
 
-def test_manager_workspace_state_save_updates_attrs_without_full_rewrite(
+def test_manager_workspace_state_save_reuses_immutable_payload(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -3307,60 +2788,109 @@ def test_manager_workspace_state_save_updates_attrs_without_full_rewrite(
         uid = manager._tool_graph.root_wrappers[0].uid
 
         fname = tmp_path / "state-delta.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
+        before_manifest = _current_workspace_manifest(fname)
+        before_entry = next(
+            entry
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                before_manifest
+            )
+            if entry.get("uid") == uid
+        )
         manager._workspace_controller._mark_node_state_dirty(uid)
 
-        original_transaction_write = workspace_storage._write_workspace_transaction_file
-        attr_write_calls: list[str] = []
-
-        def _record_transaction_write(
-            _fname: str | os.PathLike[str],
-            rewrite_groups: Iterable[tuple[str, dict[str, xr.Dataset]]],
-            attr_updates: Iterable[
-                tuple[
-                    str,
-                    dict[str, typing.Any],
-                    tuple[str, dict[str, xr.Dataset]],
-                ]
-            ],
-            root_attrs: Mapping[str, typing.Any],
-            **kwargs: typing.Any,
-        ) -> None:
-            rewrite_groups = tuple(rewrite_groups)
-            updates = tuple(attr_updates)
-            assert rewrite_groups == ()
-            attr_write_calls.extend(update[0] for update in updates)
-            original_transaction_write(
-                _fname, rewrite_groups, updates, root_attrs, **kwargs
-            )
-
         monkeypatch.setattr(
-            workspace_storage,
-            "_write_full_workspace_tree_file",
+            workspace_arrays,
+            "_write_workspace_dataset_group_to_file",
             lambda *args, **kwargs: pytest.fail(
-                "state-only Save should not rewrite the full workspace"
+                "state-only save must not write a payload object"
             ),
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_write_workspace_root_attrs_to_file",
-            lambda *args, **kwargs: pytest.fail(
-                "state-only Save should batch root attrs with node attrs"
-            ),
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_write_workspace_transaction_file",
-            _record_transaction_write,
         )
         assert _request_workspace_save_and_wait(qtbot, manager)
-        assert attr_write_calls == ["0/imagetool"]
+        after_manifest = _current_workspace_manifest(fname)
+        after_entry = next(
+            entry
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                after_manifest
+            )
+            if entry.get("uid") == uid
+        )
+        assert after_entry["payload_object_id"] == before_entry["payload_object_id"]
+        assert "payload_attrs" in after_entry
         assert not manager.is_workspace_modified
         assert not root.isWindowModified()
+
+
+def test_workspace_save_as_snapshot_preserves_live_history(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        uid = manager._tool_graph.root_wrappers[0].uid
+
+        source_path = tmp_path / "source.itws"
+        manager._workspace_controller.saving._save_workspace_document(source_path)
+        adopt_workspace_path(manager, source_path)
+        manager._workspace_controller.loading._rebind_workspace_backed_imagetools(
+            source_path, chunks={}
+        )
+        manager._workspace_controller._mark_workspace_clean()
+        old_data = root.slicer_area._data
+        old_entry = next(
+            entry
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                _current_workspace_manifest(source_path)
+            )
+            if entry.get("uid") == uid
+        )
+        old_object_id = typing.cast("str", old_entry["payload_object_id"])
+
+        store = manager._workspace_controller._workspace_store
+        assert store is not None
+        with store.lock:
+            workspace_arrays._write_workspace_dataset_group_to_file(
+                store.h5_file,
+                "/legacy/imagetool",
+                data.to_dataset(name="data"),
+                compression_mode="none",
+            )
+        legacy_data = workspace_arrays.open_workspace_dataset(
+            source_path, "/legacy/imagetool", chunks={}
+        )
+        root.slicer_area.replace_source_data(data + 100, auto_compute=False)
+        manager._workspace_controller._mark_node_data_dirty(uid)
+
+        snapshot = (
+            manager._workspace_controller.saving._workspace_generation_save_snapshot(
+                manager._workspace_state.dirty_generation,
+                fname=tmp_path / "target.itws",
+            )
+        )
+        try:
+            object_ids = {item.object_id for item in snapshot.generation_plan.objects}
+            assert old_object_id in object_ids
+            assert snapshot.generation_plan.preserved_groups == (
+                workspace_storage._WorkspaceGroupCopy(
+                    source_file=str(source_path.resolve()),
+                    source_path="/legacy/imagetool",
+                    target_path="/legacy/imagetool",
+                ),
+            )
+            assert _compute_first_value(old_data) == 0
+            assert float(legacy_data["data"].sum().compute()) == 300.0
+        finally:
+            snapshot.close()
+            legacy_data.close()
 
 
 def test_manager_workspace_save_does_not_close_live_workspace_handles(
@@ -3380,9 +2910,7 @@ def test_manager_workspace_save_does_not_close_live_workspace_handles(
         uid = manager._tool_graph.root_wrappers[0].uid
 
         fname = tmp_path / "live-handles.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
         manager._workspace_controller._mark_node_state_dirty(uid)
@@ -3410,9 +2938,7 @@ def test_manager_workspace_save_preserves_live_lazy_readers_during_write(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "live-lazy.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -3429,10 +2955,10 @@ def test_manager_workspace_save_preserves_live_lazy_readers_during_write(
         assert _compute_first_value(live_data) == 0.0
 
         manager._workspace_controller._mark_node_state_dirty(uid)
-        original_write = workspace_storage._write_workspace_transaction_file
+        original_write = workspace_storage._write_workspace_generation
         computed_values: list[object] = []
 
-        def _slow_write_workspace_transaction_file(*args, **kwargs):
+        def _slow_write_workspace_generation(*args, **kwargs):
             time.sleep(0.05)
             return original_write(*args, **kwargs)
 
@@ -3441,8 +2967,8 @@ def test_manager_workspace_save_preserves_live_lazy_readers_during_write(
 
         monkeypatch.setattr(
             workspace_storage,
-            "_write_workspace_transaction_file",
-            _slow_write_workspace_transaction_file,
+            "_write_workspace_generation",
+            _slow_write_workspace_generation,
         )
         QtCore.QTimer.singleShot(10, _compute_live_data)
 
@@ -3467,18 +2993,16 @@ def test_manager_workspace_slow_save_reports_status_after_background_write(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "slow-save.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
         manager._workspace_controller._mark_node_state_dirty(
             manager._tool_graph.root_wrappers[0].uid
         )
 
-        original_write = workspace_storage._write_workspace_transaction_file
+        original_write = workspace_storage._write_workspace_generation
 
-        def _slow_write_workspace_transaction_file(*args, **kwargs):
+        def _slow_write_workspace_generation(*args, **kwargs):
             time.sleep(0.05)
             return original_write(*args, **kwargs)
 
@@ -3490,8 +3014,8 @@ def test_manager_workspace_slow_save_reports_status_after_background_write(
         )
         monkeypatch.setattr(
             workspace_storage,
-            "_write_workspace_transaction_file",
-            _slow_write_workspace_transaction_file,
+            "_write_workspace_generation",
+            _slow_write_workspace_generation,
         )
         monkeypatch.setattr(
             manager._workspace_controller, "_active_managed_window", lambda: root
@@ -3527,9 +3051,7 @@ def test_manager_workspace_save_keeps_post_command_changes_dirty(
         uid = manager._tool_graph.root_wrappers[0].uid
 
         fname = tmp_path / "post-command-dirty.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
         manager._workspace_controller._mark_node_data_dirty(uid)
@@ -3545,7 +3067,7 @@ def test_manager_workspace_save_keeps_post_command_changes_dirty(
         assert "Data modified:" not in details
 
 
-def test_manager_workspace_compact_resets_delta_count_and_cleans_internal_groups(
+def test_manager_workspace_compact_drops_history_and_keeps_store(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -3553,8 +3075,6 @@ def test_manager_workspace_compact_resets_delta_count_and_cleans_internal_groups
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
-
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
@@ -3565,20 +3085,34 @@ def test_manager_workspace_compact_resets_delta_count_and_cleans_internal_groups
         uid = manager._tool_graph.root_wrappers[0].uid
 
         fname = tmp_path / "compact.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_state_dirty(uid)
+        initial_entry = next(
+            entry
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                _current_workspace_manifest(fname)
+            )
+            if entry.get("uid") == uid
+        )
+        root.slicer_area.replace_source_data(
+            data + 10,
+            auto_compute=False,
+            emit_edited=True,
+        )
         assert _request_workspace_save_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == 1
-        assert manager._workspace_state.estimated_obsolete_bytes == 0
-        assert manager._workspace_state.replacement_delta_count == 0
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
-        assert manifest["estimated_obsolete_bytes"] == 0
-        assert manifest["replacement_delta_count"] == 0
+        current_manifest = _current_workspace_manifest(fname)
+        current_entry = next(
+            entry
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                current_manifest
+            )
+            if entry.get("uid") == uid
+        )
+        assert current_entry["payload_object_id"] != initial_entry["payload_object_id"]
+        store = manager._workspace_controller._workspace_store
+        assert store is not None
+        assert len(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) >= 2
 
         monkeypatch.setattr(
             erlab.interactive.utils,
@@ -3587,553 +3121,67 @@ def test_manager_workspace_compact_resets_delta_count_and_cleans_internal_groups
         )
 
         assert manager.compact_workspace()
-        assert manager._workspace_state.delta_save_count == 0
-        assert manager._workspace_state.estimated_obsolete_bytes == 0
-        assert manager._workspace_state.replacement_delta_count == 0
+        assert manager._workspace_controller._workspace_store is store
+        assert workspace_store.WorkspaceStore.active(fname) is store
+        assert store.h5_file.id.valid
         _assert_no_workspace_internal_groups(fname)
-        with h5py.File(fname, "r") as h5_file:
-            assert (
-                workspace_format._workspace_delta_save_count_from_attrs(h5_file.attrs)
-                == 0
-            )
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
-            assert "delta_save_count" not in manifest
-            assert "transaction_protocol" not in manifest
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            current_entry["payload_object_id"]
+        }
+        generations = store.generations()
+        assert len(generations) == 2
+        assert generations[0].manifest == generations[1].manifest == current_manifest
 
 
-def test_manager_workspace_delta_save_tracks_repack_benefit(
+def test_manager_workspace_save_collects_old_generations_in_background(
     qtbot,
     tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
-
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
         root = itool(data, manager=False, execute=False)
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
 
-        fname = tmp_path / "delta-benefit.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        fname = tmp_path / "generation-gc.itws"
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_data_dirty(uid)
-        assert _request_workspace_save_and_wait(qtbot, manager)
-
-        assert manager._workspace_state.delta_save_count == 1
-        assert manager._workspace_state.estimated_obsolete_bytes > 0
-        assert manager._workspace_state.replacement_delta_count == 1
-        assert manager._workspace_state.repack_estimate_known
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
-        assert (
-            manifest["estimated_obsolete_bytes"]
-            == manager._workspace_state.estimated_obsolete_bytes
-        )
-        assert manifest["replacement_delta_count"] == 1
-
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-
-        assert manager._workspace_state.delta_save_count == 0
-        assert manager._workspace_state.estimated_obsolete_bytes == 0
-        assert manager._workspace_state.replacement_delta_count == 0
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
-        assert "estimated_obsolete_bytes" not in manifest
-        assert "replacement_delta_count" not in manifest
-
-
-def test_manager_workspace_shutdown_compacts_clean_delta_workspace(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    import h5py
-
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        fname = tmp_path / "shutdown-compact.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_data_dirty(uid)
-        assert _request_workspace_save_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == 1
-        assert manager._workspace_state.estimated_obsolete_bytes > 0
-        assert manager._workspace_state.replacement_delta_count == 1
-
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
-            1,
-        )
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
-            0.0,
-        )
-        controller = manager._workspace_controller
-        refresh = controller._refresh_workspace_payload_bindings_after_full_save
-        refresh_calls: list[tuple[pathlib.Path, pathlib.Path | None]] = []
-
-        def _record_refresh(workspace_path, **kwargs) -> None:
-            old_workspace_path = kwargs.get("old_workspace_path")
-            refresh_calls.append(
-                (
-                    pathlib.Path(workspace_path).resolve(),
-                    None
-                    if old_workspace_path is None
-                    else pathlib.Path(old_workspace_path).resolve(),
+        first_object_id = next(
+            iter(
+                workspace_store.WorkspaceStore.manifest_object_ids(
+                    _current_workspace_manifest(fname)
                 )
             )
-            refresh(workspace_path, **kwargs)
-
-        monkeypatch.setattr(
-            controller,
-            "_refresh_workspace_payload_bindings_after_full_save",
-            _record_refresh,
         )
 
-        assert _compact_workspace_before_shutdown_and_wait(qtbot, manager)
-
-        assert refresh_calls == [(fname.resolve(), fname.resolve())]
-        assert manager._workspace_state.delta_save_count == 0
-        assert manager._workspace_state.estimated_obsolete_bytes == 0
-        assert manager._workspace_state.replacement_delta_count == 0
-        _assert_no_workspace_internal_groups(fname)
-        with h5py.File(fname, "r") as h5_file:
-            assert (
-                workspace_format._workspace_delta_save_count_from_attrs(h5_file.attrs)
-                == 0
+        for offset in (10, 20):
+            root.slicer_area.replace_source_data(
+                data + offset,
+                auto_compute=False,
+                emit_edited=True,
             )
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
-            assert "delta_save_count" not in manifest
-            assert "transaction_protocol" not in manifest
-
-
-def test_manager_workspace_shutdown_compact_uses_file_level_repack(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    import h5py
-
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        fname = tmp_path / "shutdown-file-repack.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_data_dirty(uid)
-        assert _request_workspace_save_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == 1
-        assert manager._workspace_state.replacement_delta_count == 1
-
-        def _fail_to_datatree() -> xr.DataTree:
-            pytest.fail("Shutdown file-level repack should not serialize tools")
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving, "_to_datatree", _fail_to_datatree
-        )
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
-            1,
-        )
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
-            0.0,
-        )
-
-        assert _compact_workspace_before_shutdown_and_wait(qtbot, manager)
-
-        assert manager._workspace_state.delta_save_count == 0
-        _assert_no_workspace_internal_groups(fname)
-        with h5py.File(fname, "r") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
-            assert "delta_save_count" not in manifest
-            assert "transaction_protocol" not in manifest
-
-
-def test_manager_workspace_shutdown_compact_skips_state_only_delta(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        fname = tmp_path / "shutdown-state-skip.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_state_dirty(uid)
-        assert _request_workspace_save_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == 1
-        assert manager._workspace_state.replacement_delta_count == 0
-
-        monkeypatch.setattr(
-            manager._workspace_controller,
-            "_start_workspace_save_worker",
-            lambda *args, **kwargs: pytest.fail(
-                "State-only shutdown compaction should skip"
-            ),
-        )
-
-        assert not manager._workspace_controller._compact_workspace_before_shutdown()
-
-        assert manager._workspace_state.delta_save_count == 1
-
-
-def test_manager_workspace_shutdown_compact_skips_below_threshold_data_delta(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        fname = tmp_path / "shutdown-threshold-skip.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_data_dirty(uid)
-        assert _request_workspace_save_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == 1
-        assert manager._workspace_state.estimated_obsolete_bytes > 0
-        assert manager._workspace_state.replacement_delta_count == 1
-
-        monkeypatch.setattr(
-            manager._workspace_controller,
-            "_start_workspace_save_worker",
-            lambda *args, **kwargs: pytest.fail(
-                "Below-threshold shutdown compaction should skip"
-            ),
-        )
-
-        assert not manager._workspace_controller._compact_workspace_before_shutdown()
-
-        assert manager._workspace_state.delta_save_count == 1
-
-
-def test_manager_workspace_shutdown_compact_scans_when_estimate_missing(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    import h5py
-
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        fname = tmp_path / "shutdown-missing-estimate.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_data_dirty(uid)
-        assert _request_workspace_save_and_wait(qtbot, manager)
-        with h5py.File(fname, "a") as h5_file:
-            manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
-            manifest.pop("estimated_obsolete_bytes", None)
-            manifest.pop("replacement_delta_count", None)
-            h5_file.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(
-                manifest
+            assert _request_workspace_save_and_wait(qtbot, manager)
+            qtbot.wait_until(
+                lambda: (
+                    manager._workspace_controller._workspace_gc_worker is None
+                    and not manager._workspace_controller._workspace_gc_requested
+                ),
+                timeout=5000,
             )
-        manager._workspace_state.set_repack_estimate(
-            estimated_obsolete_bytes=0,
-            replacement_delta_count=0,
-            known=False,
+
+        store = manager._workspace_controller._workspace_store
+        assert store is not None
+        assert len(store.generations()) == 2
+        assert (
+            first_object_id
+            not in store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
         )
-
-        scan_calls: list[pathlib.Path] = []
-
-        def _fake_estimate(path: str | os.PathLike[str]) -> int:
-            scan_calls.append(pathlib.Path(path))
-            return 100
-
-        monkeypatch.setattr(
-            workspace_storage,
-            "_workspace_obsolete_estimate",
-            _fake_estimate,
-        )
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
-            1,
-        )
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
-            0.0,
-        )
-
-        assert _compact_workspace_before_shutdown_and_wait(qtbot, manager)
-
-        assert scan_calls == [fname.resolve()]
-        assert manager._workspace_state.delta_save_count == 0
-
-
-def test_manager_workspace_shutdown_compact_skips_if_file_repack_unavailable(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        fname = tmp_path / "shutdown-fallback-repack.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_data_dirty(uid)
-        assert _request_workspace_save_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == 1
-
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
-            1,
-        )
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
-            0.0,
-        )
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_workspace_file_repack_snapshot",
-            lambda _generation: None,
-        )
-
-        def _fail_full_save_snapshot(
-            _generation: int,
-        ) -> workspace_saving._WorkspaceSaveSnapshot:
-            pytest.fail("Shutdown compaction should not serialize as a fallback")
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_workspace_full_save_snapshot",
-            _fail_full_save_snapshot,
-        )
-
-        assert not manager._workspace_controller._compact_workspace_before_shutdown()
-
-        assert manager._workspace_state.delta_save_count == 1
-
-
-def test_manager_workspace_shutdown_compact_runs_in_background(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        fname = tmp_path / "slow-shutdown-compact.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_data_dirty(uid)
-        assert _request_workspace_save_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == 1
-
-        original_write = workspace_storage._write_full_workspace_tree_file
-
-        def _slow_write_full_workspace_tree_file(*args, **kwargs):
-            time.sleep(0.05)
-            return original_write(*args, **kwargs)
-
-        monkeypatch.setattr(
-            erlab.interactive.imagetool.manager._workspace._controller,
-            "_WORKSPACE_SAVE_WAIT_DIALOG_THRESHOLD_SECONDS",
-            0.01,
-        )
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_BYTES",
-            1,
-        )
-        monkeypatch.setattr(
-            workspace_saving,
-            "_WORKSPACE_SHUTDOWN_REPACK_MIN_OBSOLETE_RATIO",
-            0.0,
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_write_full_workspace_tree_file",
-            _slow_write_full_workspace_tree_file,
-        )
-        assert _compact_workspace_before_shutdown_and_wait(qtbot, manager)
-        assert manager._workspace_state.delta_save_count == 0
-
-
-def test_manager_workspace_shutdown_compact_skips_dirty_workspace(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        fname = tmp_path / "dirty-shutdown-compact.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_state.delta_save_count = 1
-        manager._workspace_controller._mark_node_state_dirty(uid)
-
-        monkeypatch.setattr(
-            manager._workspace_controller,
-            "_start_workspace_save_worker",
-            lambda *args, **kwargs: pytest.fail(
-                "Dirty shutdown compaction should not write discarded changes"
-            ),
-        )
-
-        assert not manager._workspace_controller._compact_workspace_before_shutdown()
-
-
-def test_manager_workspace_high_risk_path_forces_full_save_snapshot(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25).reshape((5, 5)), dims=["x", "y"])
-
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        fname = tmp_path / "high-risk.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._workspace_controller._mark_node_state_dirty(uid)
-        monkeypatch.setattr(
-            workspace_storage, "_workspace_path_is_high_risk", lambda *_args: True
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_workspace_path_is_likely_network_path",
-            lambda *_args: True,
-        )
-
-        snapshot = manager._workspace_controller.saving._workspace_save_snapshot(fname)
-        try:
-            assert snapshot.full_tree is not None
-            assert snapshot.delta_save_count == 0
-            assert snapshot.copy_groups == ()
-        finally:
-            snapshot.close()
+        assert len(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == 2
 
 
 def test_manager_workspace_save_snapshot_uses_compression_override(
@@ -4157,27 +3205,9 @@ def test_manager_workspace_save_snapshot_uses_compression_override(
             manager._workspace_controller.saving._workspace_compression_mode()
             == "blosclz3"
         )
-        manager._workspace_state.delta_save_count = 2
-        manager._workspace_state.set_repack_estimate(
-            estimated_obsolete_bytes=128,
-            replacement_delta_count=3,
-            known=False,
-        )
-        root_attrs = (
-            manager._workspace_controller.saving._workspace_root_attrs_payload()
-        )
-        manifest = workspace_format._workspace_manifest_from_attrs(root_attrs)
-        assert manifest["delta_save_count"] == 2
+        manifest = manager._workspace_controller.saving._workspace_manifest()
+        assert "delta_save_count" not in manifest
         assert "estimated_obsolete_bytes" not in manifest
-        root_attrs = manager._workspace_controller.saving._workspace_root_attrs_payload(
-            delta_save_count=1,
-            estimated_obsolete_bytes=1024,
-            replacement_delta_count=5,
-            repack_estimate_known=True,
-        )
-        manifest = workspace_format._workspace_manifest_from_attrs(root_attrs)
-        assert manifest["estimated_obsolete_bytes"] == 1024
-        assert manifest["replacement_delta_count"] == 5
 
         snapshot = manager._workspace_controller.saving._workspace_save_snapshot(
             tmp_path / "snapshot.itws"
@@ -4186,239 +3216,6 @@ def test_manager_workspace_save_snapshot_uses_compression_override(
             assert snapshot.compression_mode == "blosclz3"
         finally:
             snapshot.close()
-
-
-def test_manager_workspace_delta_save_updates_repack_state(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        writes: list[tuple[object, ...]] = []
-
-        def _snapshot(
-            generation: int,
-            root_attrs: dict[str, typing.Any],
-            delta_save_count: int,
-        ) -> workspace_saving._WorkspaceSaveSnapshot:
-            return workspace_saving._WorkspaceSaveSnapshot(
-                generation=generation,
-                root_attrs=root_attrs,
-                delta_save_count=delta_save_count,
-                estimated_obsolete_bytes=256,
-                replacement_delta_count=4,
-                rewrite_groups=(),
-                attr_updates=(),
-            )
-
-        def _record_write(*args, **kwargs) -> None:
-            writes.append((*args, kwargs))
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_workspace_delta_save_snapshot",
-            _snapshot,
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_write_workspace_transaction_file",
-            _record_write,
-        )
-
-        manager._workspace_state.dirty_generation = 5
-        manager._workspace_state.delta_save_count = 6
-        manager._workspace_controller.saving._save_workspace_delta(
-            tmp_path / "delta.itws"
-        )
-
-        assert writes
-        assert manager._workspace_state.delta_save_count == 7
-        assert manager._workspace_state.estimated_obsolete_bytes == 256
-        assert manager._workspace_state.replacement_delta_count == 4
-
-
-def test_manager_workspace_delta_snapshot_keeps_replacement_count_for_missing_groups(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        controller = manager._workspace_controller
-        saver = controller.saving
-
-        manager._workspace_state.path = tmp_path / "workspace.itws"
-        manager._workspace_state.set_repack_estimate(
-            estimated_obsolete_bytes=100,
-            replacement_delta_count=2,
-        )
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_workspace_highest_dirty_data_roots",
-            lambda: ("uid",),
-        )
-        monkeypatch.setattr(
-            controller.saving,
-            "_workspace_rewrite_group_snapshot",
-            lambda _uid: ("0", {}),
-        )
-        monkeypatch.setattr(manager, "_iter_descendant_uids", lambda _uid: ())
-        monkeypatch.setattr(
-            controller.saving,
-            "_workspace_manifest_node_uids",
-            lambda _root_attrs: frozenset(),
-        )
-        monkeypatch.setattr(
-            controller.saving,
-            "_workspace_stale_reference_rewrite_uids",
-            lambda _manifest_uids: (),
-        )
-        monkeypatch.setattr(
-            workspace_arrays,
-            "_workspace_h5_paths_storage_size",
-            lambda *_args, **_kwargs: (256, 0),
-        )
-
-        snapshot = saver._workspace_delta_save_snapshot(1, {}, 3)
-
-        assert snapshot.estimated_obsolete_bytes == 356
-        assert snapshot.replacement_delta_count == 2
-
-
-def test_manager_write_full_workspace_file_can_disable_group_reuse(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        controller = manager._workspace_controller
-        saver = controller.saving
-        tree = xr.DataTree()
-        writes: list[dict[str, typing.Any]] = []
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving, "_to_datatree", lambda: tree
-        )
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_workspace_full_save_copy_groups",
-            lambda *_args, **_kwargs: pytest.fail("copy groups should not be reused"),
-        )
-
-        def _record_write(*_args, **kwargs) -> None:
-            writes.append(kwargs)
-
-        monkeypatch.setattr(
-            workspace_storage,
-            "_write_full_workspace_tree_file",
-            _record_write,
-        )
-
-        saver._write_full_workspace_file(
-            tmp_path / "full.itws", reuse_unchanged_groups=False
-        )
-
-        assert writes
-        assert writes[0]["copy_source"] is None
-        assert writes[0]["copy_groups"] == ()
-
-
-def test_workspace_manifest_first_helper_edge_cases(
-    qtbot,
-    tmp_path,
-    monkeypatch,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        controller = manager._workspace_controller
-        saver = controller.saving
-        data = xr.DataArray(np.arange(9, dtype=float).reshape(3, 3), dims=("x", "y"))
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-        uid = manager._tool_graph.root_wrappers[0].uid
-
-        with monkeypatch.context() as mp:
-            mp.setattr(saver, "_workspace_node_path", lambda uid: uid)
-            assert not saver._workspace_datatree_for_payload_uids(("missing",)).children
-        assert (
-            saver._workspace_full_save_manifest_entries(
-                {
-                    workspace_format._WORKSPACE_MANIFEST_ATTR: json.dumps(
-                        {"nodes": {"not": "a-list"}}
-                    )
-                }
-            )
-            == []
-        )
-        root_attrs = {
-            workspace_format._WORKSPACE_MANIFEST_ATTR: json.dumps(
-                {
-                    "nodes": [
-                        None,
-                        {"uid": uid, "kind": "unknown", "path": "0"},
-                        {"uid": uid, "kind": "imagetool", "path": "0"},
-                    ]
-                }
-            )
-        }
-        assert saver._workspace_full_save_manifest_entries(root_attrs) == [
-            (uid, "imagetool", "0/imagetool")
-        ]
-
-        manager._workspace_state.dirty_added.add("missing")
-        manager._workspace_state.dirty_data.add(uid)
-        assert saver._workspace_full_save_dirty_payload_uids() == {uid}
-        manager._workspace_state.dirty_added.clear()
-        manager._workspace_state.dirty_data.clear()
-
-        assert saver._workspace_full_save_source_identities() is None
-        missing_workspace = tmp_path / "missing.itws"
-        manager._workspace_state.path = missing_workspace
-        assert saver._workspace_full_save_source_identities() is None
-
-        workspace = tmp_path / "identity.itws"
-        manifest = {
-            "nodes": [
-                "bad-entry",
-                {"uid": uid, "kind": "tool", "path": 1},
-                {"uid": uid, "kind": "imagetool", "path": "0"},
-            ]
-        }
-        with h5py.File(workspace, "w") as h5_file:
-            h5_file.attrs["imagetool_workspace_schema_version"] = (
-                workspace_format._current_workspace_schema_version()
-            )
-            h5_file.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(
-                manifest
-            )
-        manager._workspace_state.path = workspace
-        source = saver._workspace_full_save_source_identities()
-        assert source is not None
-        assert source[0] == workspace
-        assert source[1] == {(uid, "imagetool"): "0/imagetool"}
-
-        monkeypatch.setattr(
-            workspace_arrays,
-            "_read_workspace_root_attrs_h5py",
-            lambda _path: (_ for _ in ()).throw(OSError("boom")),
-        )
-        assert saver._workspace_full_save_source_identities() is None
 
 
 def test_workspace_save_worker_start_and_finish_error_branches(
@@ -4432,7 +3229,6 @@ def test_workspace_save_worker_start_and_finish_error_branches(
     class Snapshot:
         def __init__(self) -> None:
             self.closed = False
-            self.expected_publication_state = (False, 0, 0, 0, 0, 0)
 
         def close(self) -> None:
             self.closed = True
@@ -4550,8 +3346,6 @@ def test_background_workspace_save_finish_branches(
         controller._finish_background_workspace_save(
             document_id=manager._workspace_state.document_id,
             workspace_path=workspace_path,
-            old_workspace_path=None,
-            backing_snapshot={},
             snapshot=typing.cast(
                 "workspace_saving._WorkspaceSaveSnapshot", types.SimpleNamespace()
             ),
@@ -4582,8 +3376,6 @@ def test_background_workspace_save_finish_branches(
         controller._finish_background_workspace_save(
             document_id=manager._workspace_state.document_id,
             workspace_path=workspace_path,
-            old_workspace_path=None,
-            backing_snapshot={},
             snapshot=typing.cast(
                 "workspace_saving._WorkspaceSaveSnapshot", types.SimpleNamespace()
             ),
@@ -4615,11 +3407,11 @@ def test_workspace_save_and_save_as_error_continuation_branches(
     def snapshot(generation: int = 0) -> workspace_saving._WorkspaceSaveSnapshot:
         return workspace_saving._WorkspaceSaveSnapshot(
             generation=generation,
-            root_attrs={},
-            delta_save_count=0,
-            estimated_obsolete_bytes=0,
-            replacement_delta_count=0,
-            full_tree=xr.DataTree(),
+            generation_plan=workspace_storage._WorkspaceGenerationPlan(
+                manifest={"schema_version": 5, "nodes": []},
+                objects=(),
+            ),
+            compression_mode="none",
         )
 
     with manager_context() as manager:
@@ -4666,7 +3458,7 @@ def test_workspace_save_and_save_as_error_continuation_branches(
         )
         monkeypatch.setattr(
             controller.saving,
-            "_workspace_full_save_snapshot",
+            "_workspace_generation_save_snapshot",
             lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
         )
         finished.clear()
@@ -4679,7 +3471,7 @@ def test_workspace_save_and_save_as_error_continuation_branches(
 
         monkeypatch.setattr(
             controller.saving,
-            "_workspace_full_save_snapshot",
+            "_workspace_generation_save_snapshot",
             lambda generation, **_kwargs: snapshot(generation),
         )
         worker_errors: list[workspace_saving._WorkspaceSaveError] = []
@@ -4753,13 +3545,15 @@ def test_workspace_save_completion_ignores_inactive_document(
         controller = manager._workspace_controller
         workspace_path = tmp_path / "stale-save.itws"
         manager._workspace_state.path = workspace_path.resolve()
-        manager._workspace_state.delta_save_count = 7
         manager._workspace_state.mark_layout_dirty()
 
         snapshot = workspace_saving._WorkspaceSaveSnapshot(
             generation=manager._workspace_state.dirty_generation,
-            root_attrs={},
-            delta_save_count=99,
+            generation_plan=workspace_storage._WorkspaceGenerationPlan(
+                manifest={"schema_version": 5, "nodes": []},
+                objects=(),
+            ),
+            compression_mode="none",
         )
         monkeypatch.setattr(
             controller.saving, "_workspace_save_snapshot", lambda _path: snapshot
@@ -4786,7 +3580,6 @@ def test_workspace_save_completion_ignores_inactive_document(
         assert controller.save(on_finished=finished.append, restore_focus=False)
 
         assert finished == [False]
-        assert manager._workspace_state.delta_save_count == 7
         assert manager.is_workspace_modified
         assert recorded_recent == []
 
@@ -4816,11 +3609,14 @@ def test_workspace_save_as_completion_ignores_inactive_document(
         )
         monkeypatch.setattr(
             controller.saving,
-            "_workspace_full_save_snapshot",
+            "_workspace_generation_save_snapshot",
             lambda generation, **_kwargs: workspace_saving._WorkspaceSaveSnapshot(
                 generation=generation,
-                root_attrs={},
-                delta_save_count=0,
+                generation_plan=workspace_storage._WorkspaceGenerationPlan(
+                    manifest={"schema_version": 5, "nodes": []},
+                    objects=(),
+                ),
+                compression_mode="none",
             ),
         )
 
@@ -4844,421 +3640,7 @@ def test_workspace_save_as_completion_ignores_inactive_document(
         assert manager.is_workspace_modified
 
 
-def test_manager_manifest_first_full_save_copies_clean_payloads(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        for offset in (0, 100):
-            data = xr.DataArray(
-                np.arange(25, dtype=float).reshape(5, 5) + offset,
-                dims=("x", "y"),
-            )
-            root = itool(data, manager=False, execute=False)
-            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-            manager.add_imagetool(root, show=False)
-
-        fname = tmp_path / "manifest-copy-clean.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_serialize_workspace_node",
-            lambda *_args, **_kwargs: pytest.fail(
-                "Clean full save should copy payload groups"
-            ),
-        )
-
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-
-        with h5py.File(fname, "r") as h5_file:
-            assert "0/imagetool" in h5_file
-            assert "1/imagetool" in h5_file
-
-
-def test_manager_manifest_first_full_save_serializes_missing_source_group(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        for offset in (0, 100):
-            data = xr.DataArray(
-                np.arange(25, dtype=float).reshape(5, 5) + offset,
-                dims=("x", "y"),
-            )
-            root = itool(data, manager=False, execute=False)
-            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-            manager.add_imagetool(root, show=False)
-
-        fname = tmp_path / "manifest-copy-missing-source.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        with h5py.File(fname, "a") as h5_file:
-            del h5_file["0/imagetool"]
-
-        original_serialize = (
-            manager._workspace_controller.saving._serialize_workspace_node
-        )
-        serialized_paths: list[str] = []
-
-        def _record_serialize(*args, **kwargs) -> None:
-            serialized_paths.append(args[2])
-            original_serialize(*args, **kwargs)
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_serialize_workspace_node",
-            _record_serialize,
-        )
-
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-
-        assert serialized_paths == ["0"]
-        with h5py.File(fname, "r") as h5_file:
-            assert "0/imagetool" in h5_file
-            assert "1/imagetool" in h5_file
-
-
-def test_manager_manifest_first_full_save_preserves_clean_mismatched_compression(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    old_compression = erlab.interactive.options["io/workspace/compression"]
-    try:
-        erlab.interactive.options["io/workspace/compression"] = "none"
-        with manager_context() as manager:
-            qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-            data = xr.DataArray(
-                np.arange(512 * 512, dtype=np.float64).reshape(512, 512),
-                dims=("x", "y"),
-            )
-            root = itool(data, manager=False, execute=False)
-            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-            manager.add_imagetool(root, show=False)
-
-            fname = tmp_path / "manifest-copy-mismatched-compression.itws"
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
-            adopt_workspace_path(manager, fname)
-            manager._workspace_controller._mark_workspace_clean()
-            with h5py.File(fname, "r") as h5_file:
-                data_ds = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
-                assert _hdf5_blosc2_level_codec(data_ds) is None
-
-            writes: list[
-                tuple[
-                    str | os.PathLike[str] | None,
-                    tuple[tuple[str, str, dict[str, typing.Any] | None], ...],
-                ]
-            ] = []
-            original_write = workspace_storage._write_full_workspace_tree_file
-
-            def _record_write(*args, **kwargs) -> None:
-                writes.append(
-                    (kwargs.get("copy_source"), tuple(kwargs.get("copy_groups", ())))
-                )
-                original_write(*args, **kwargs)
-
-            erlab.interactive.options["io/workspace/compression"] = "zstd1"
-            monkeypatch.setattr(
-                manager._workspace_controller.saving,
-                "_serialize_workspace_node",
-                lambda *_args, **_kwargs: pytest.fail(
-                    "Clean mismatched payload should be copied"
-                ),
-            )
-            monkeypatch.setattr(
-                workspace_storage,
-                "_write_full_workspace_tree_file",
-                _record_write,
-            )
-
-            manager._workspace_controller.saving._save_workspace_document(
-                fname, force_full=True
-            )
-
-            assert writes[-1] == (
-                str(fname),
-                (("0/imagetool", "0/imagetool", None),),
-            )
-            with h5py.File(fname, "r") as h5_file:
-                data_ds = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
-                assert _hdf5_blosc2_level_codec(data_ds) is None
-    finally:
-        erlab.interactive.options["io/workspace/compression"] = old_compression
-
-
-def test_manager_manifest_first_full_save_serializes_only_dirty_data(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        for offset in (0, 100):
-            data = xr.DataArray(
-                np.arange(25, dtype=float).reshape(5, 5) + offset,
-                dims=("x", "y"),
-            )
-            root = itool(data, manager=False, execute=False)
-            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-            manager.add_imagetool(root, show=False)
-
-        fname = tmp_path / "manifest-copy-dirty.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        dirty_uid = manager._tool_graph.root_wrappers[0].uid
-        updated = xr.DataArray(np.full((5, 5), 42.0), dims=("x", "y"))
-        manager.get_imagetool(0).slicer_area.replace_source_data(
-            updated, auto_compute=False
-        )
-        manager._workspace_controller._mark_node_data_dirty(dirty_uid)
-
-        original_serialize = (
-            manager._workspace_controller.saving._serialize_workspace_node
-        )
-        serialized_paths: list[str] = []
-
-        def _record_serialize(*args, **kwargs) -> None:
-            serialized_paths.append(args[2])
-            original_serialize(*args, **kwargs)
-
-        original_write = workspace_storage._write_full_workspace_tree_file
-        writes: list[tuple[tuple[str, str, dict[str, typing.Any] | None], ...]] = []
-
-        def _record_write(*args, **kwargs) -> None:
-            writes.append(tuple(kwargs.get("copy_groups", ())))
-            original_write(*args, **kwargs)
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_serialize_workspace_node",
-            _record_serialize,
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_write_full_workspace_tree_file",
-            _record_write,
-        )
-
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-
-        assert serialized_paths == ["0"]
-        assert ("1/imagetool", "1/imagetool", None) in writes[-1]
-        assert all(group[1] != "0/imagetool" for group in writes[-1])
-
-
-def test_manager_manifest_first_full_save_rewrites_dirty_state_attrs(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25, dtype=float).reshape(5, 5), dims=("x", "y"))
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-
-        fname = tmp_path / "manifest-copy-state.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-        manager._tool_graph.root_wrappers[0].name = "renamed"
-
-        original_serialize = (
-            manager._workspace_controller.saving._serialize_workspace_node
-        )
-        serialized_paths: list[str] = []
-
-        def _record_serialize(*args, **kwargs) -> None:
-            serialized_paths.append(args[2])
-            original_serialize(*args, **kwargs)
-
-        original_write = workspace_storage._write_full_workspace_tree_file
-        writes: list[tuple[tuple[str, str, dict[str, typing.Any] | None], ...]] = []
-
-        def _record_write(*args, **kwargs) -> None:
-            writes.append(tuple(kwargs.get("copy_groups", ())))
-            original_write(*args, **kwargs)
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_serialize_workspace_node",
-            _record_serialize,
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_write_full_workspace_tree_file",
-            _record_write,
-        )
-
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-
-        assert serialized_paths == ["0"]
-        assert all(group[1] != "0/imagetool" for group in writes[-1])
-        with h5py.File(fname, "r") as h5_file:
-            assert h5_file["0/imagetool"].attrs["itool_title"] == "renamed"
-
-
-def test_manager_manifest_first_save_as_copies_clean_payloads(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25, dtype=float).reshape(5, 5), dims=("x", "y"))
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-
-        source = tmp_path / "manifest-copy-source.itws"
-        target = tmp_path / "manifest-copy-target.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            source, force_full=True
-        )
-        adopt_workspace_path(manager, source)
-        manager._workspace_controller._mark_workspace_clean()
-
-        writes: list[
-            tuple[
-                str | os.PathLike[str] | None,
-                tuple[tuple[str, str, dict[str, typing.Any] | None], ...],
-            ]
-        ] = []
-        original_write = workspace_storage._write_full_workspace_tree_file
-
-        def _record_write(*args, **kwargs) -> None:
-            writes.append(
-                (kwargs.get("copy_source"), tuple(kwargs.get("copy_groups", ())))
-            )
-            original_write(*args, **kwargs)
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_serialize_workspace_node",
-            lambda *_args, **_kwargs: pytest.fail(
-                "Clean Save As should copy payload groups"
-            ),
-        )
-        monkeypatch.setattr(
-            manager._workspace_controller,
-            "_workspace_save_dialog",
-            lambda **_kwargs: target,
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_write_full_workspace_tree_file",
-            _record_write,
-        )
-
-        assert _request_workspace_save_as_and_wait(qtbot, manager, native=False)
-
-        assert manager.workspace_path == str(target.resolve())
-        assert writes[-1] == (str(source), (("0/imagetool", "0/imagetool", None),))
-        with h5py.File(target, "r") as h5_file:
-            assert "0/imagetool" in h5_file
-
-
-def test_manager_manifest_first_full_save_falls_back_without_usable_source(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        data = xr.DataArray(np.arange(25, dtype=float).reshape(5, 5), dims=("x", "y"))
-        root = itool(data, manager=False, execute=False)
-        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
-
-        fname = tmp_path / "manifest-copy-fallback.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
-        adopt_workspace_path(manager, fname)
-        manager._workspace_controller._mark_workspace_clean()
-
-        monkeypatch.setattr(
-            workspace_arrays,
-            "_read_workspace_root_attrs_h5py",
-            lambda _path: {"imagetool_workspace_schema_version": 1},
-        )
-
-        def _fail_materializing_fallback() -> typing.NoReturn:
-            pytest.fail("fallback full save should not call _to_datatree()")
-
-        monkeypatch.setattr(
-            manager._workspace_controller.saving,
-            "_to_datatree",
-            _fail_materializing_fallback,
-        )
-
-        snapshot = manager._workspace_controller.saving._workspace_full_save_snapshot(
-            1, fname=fname
-        )
-        try:
-            assert snapshot.full_tree is not None
-            assert snapshot.copy_source is None
-            assert snapshot.copy_groups == ()
-            assert snapshot.copy_group_sources == ()
-            ds = typing.cast(
-                "xr.DataTree", snapshot.full_tree["0/imagetool"]
-            ).to_dataset(inherit=False)
-            assert _ITOOL_DATA_NAME in ds
-        finally:
-            snapshot.close()
-
-
-def test_manager_associate_loaded_legacy_workspace_resets_repack_state(
+def test_manager_associate_loaded_legacy_workspace_uses_converted_store(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -5269,6 +3651,8 @@ def test_manager_associate_loaded_legacy_workspace_resets_repack_state(
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         converted = tmp_path / "converted.itws"
+        converted_store = workspace_store.WorkspaceStore(converted, create=True)
+        converted_store.close()
         manager._workspace_state.path = converted.resolve()
 
         monkeypatch.setattr(
@@ -5278,132 +3662,21 @@ def test_manager_associate_loaded_legacy_workspace_resets_repack_state(
         )
         monkeypatch.setattr(
             manager._workspace_controller,
-            "_save_legacy_workspace_as_v4",
+            "_save_legacy_workspace_as_current",
             lambda *_, **__: (str(converted), None),
         )
 
         manager._workspace_controller._associate_loaded_workspace_file(
             tmp_path / "legacy.itws",
             1,
-            delta_save_count=5,
-            estimated_obsolete_bytes=100,
-            replacement_delta_count=2,
-            repack_estimate_known=False,
             rebind_data=False,
         )
 
         assert manager._workspace_state.path == converted
-        assert manager._workspace_state.delta_save_count == 0
-        assert manager._workspace_state.estimated_obsolete_bytes == 0
-        assert manager._workspace_state.replacement_delta_count == 0
-        assert manager._workspace_state.repack_estimate_known
-
-
-def test_manager_workspace_file_repack_snapshot_guards(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        controller = manager._workspace_controller
-        saver = controller.saving
-
-        manager._workspace_state.path = None
-        assert saver._workspace_file_repack_snapshot(1) is None
-
-        manager._workspace_state.path = tmp_path / "network.itws"
-        monkeypatch.setattr(
-            workspace_storage,
-            "_workspace_path_is_likely_network_path",
-            lambda _path: True,
+        assert (
+            manager._workspace_state.schema_version
+            == workspace_format._current_workspace_schema_version()
         )
-        assert saver._workspace_file_repack_snapshot(1) is None
-
-        monkeypatch.setattr(
-            workspace_storage,
-            "_workspace_path_is_likely_network_path",
-            lambda _path: False,
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_workspace_file_repack_payload",
-            lambda _path: (_ for _ in ()).throw(RuntimeError("repack failed")),
-        )
-        assert saver._workspace_file_repack_snapshot(1) is None
-
-
-def test_manager_workspace_shutdown_repack_gate_edges(
-    qtbot,
-    monkeypatch,
-    tmp_path,
-    manager_context: Callable[
-        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
-    ],
-) -> None:
-    with manager_context() as manager:
-        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        controller = manager._workspace_controller
-        saver = controller.saving
-
-        manager._workspace_state.path = None
-        assert not saver._workspace_should_repack_before_shutdown()
-
-        workspace_path = tmp_path / "workspace.itws"
-        manager._workspace_state.path = workspace_path
-        manager._workspace_state.set_repack_estimate(
-            estimated_obsolete_bytes=0,
-            replacement_delta_count=0,
-            known=False,
-        )
-        monkeypatch.setattr(
-            workspace_storage,
-            "_workspace_obsolete_estimate",
-            lambda _path: (_ for _ in ()).throw(RuntimeError("estimate failed")),
-        )
-        assert not saver._workspace_should_repack_before_shutdown()
-
-        manager._workspace_state.set_repack_estimate(
-            estimated_obsolete_bytes=100,
-            replacement_delta_count=1,
-        )
-        assert not saver._workspace_should_repack_before_shutdown()
-
-        workspace_path.touch()
-        assert not saver._workspace_should_repack_before_shutdown()
-
-
-def test_workspace_remote_incremental_option_allows_delta_save(
-    monkeypatch,
-    tmp_path,
-) -> None:
-    options = erlab.interactive.options
-    incremental_name = "io/workspace/incremental_save_on_remote"
-    use_incremental_name = "io/workspace/use_incremental"
-    old_remote_value = options[incremental_name]
-    old_incremental_value = options[use_incremental_name]
-    fname = tmp_path / "remote-incremental.itws"
-    fname.touch()
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_high_risk", lambda *_args: True
-    )
-    options[incremental_name] = True
-    options[use_incremental_name] = True
-    try:
-        assert not workspace_storage._workspace_requires_full_save(
-            fname,
-            needs_full_save=False,
-            schema_version=workspace_format._current_workspace_schema_version(),
-            structure_modified=False,
-            has_dirty_added=False,
-            has_dirty_removed=False,
-        )
-    finally:
-        options[incremental_name] = old_remote_value
-        options[use_incremental_name] = old_incremental_value
 
 
 def test_manager_workspace_dirty_marker_not_saved_in_titles(
@@ -5453,15 +3726,12 @@ def test_manager_workspace_dirty_marker_not_saved_in_titles(
         )
 
         fname = tmp_path / "titles.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
-        import h5py
-
-        with h5py.File(fname, "r") as h5_file:
-            root_title = h5_file["0/imagetool"].attrs["itool_title"]
-            tool_title = h5_file[f"0/childtools/{tool_uid}/tool"].attrs["tool_title"]
+        root_title = _current_workspace_payload_attrs(fname)["itool_title"]
+        tool_title = _current_workspace_payload_attrs(
+            fname, f"0/childtools/{tool_uid}"
+        )["tool_title"]
 
         assert "[*]" not in root_title
         assert "[*]" not in tool_title
@@ -5475,7 +3745,6 @@ def test_manager_workspace_full_save_drops_empty_attr_name(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -5490,13 +3759,13 @@ def test_manager_workspace_full_save_drops_empty_attr_name(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "empty-attr-name.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         assert "" in root.slicer_area._data.attrs
         with h5py.File(fname, "r") as h5_file:
-            saved_attrs = h5_file["0/imagetool"][_ITOOL_DATA_NAME].attrs
+            saved_attrs = h5_file[_current_workspace_payload_path(fname)][
+                _ITOOL_DATA_NAME
+            ].attrs
             assert "" not in list(saved_attrs)
             assert saved_attrs["note"] == ""
 
@@ -5508,7 +3777,6 @@ def test_manager_workspace_full_save_roundtrips_non_native_data_attrs(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
 
     rich_attr = _rich_workspace_attr_value()
     with manager_context() as manager:
@@ -5534,9 +3802,7 @@ def test_manager_workspace_full_save_roundtrips_non_native_data_attrs(
         live_axis_attr = root.slicer_area._data.coords["x"].attrs["axis_config"]
 
         fname = tmp_path / "rich-data-attrs.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         assert root.slicer_area._data.attrs["Single Motor Scan"] is live_rich_attr
         assert root.slicer_area._data.coords["x"].attrs["axis_config"] is live_axis_attr
@@ -5545,7 +3811,9 @@ def test_manager_workspace_full_save_roundtrips_non_native_data_attrs(
             not in root.slicer_area._data.attrs
         )
         with h5py.File(fname, "r") as h5_file:
-            saved_data = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+            saved_data = h5_file[_current_workspace_payload_path(fname)][
+                _ITOOL_DATA_NAME
+            ]
             assert "Single Motor Scan" not in saved_data.attrs
             assert workspace_format._WORKSPACE_ENCODED_ATTRS_ATTR in saved_data.attrs
 
@@ -5564,18 +3832,16 @@ def test_manager_workspace_full_save_roundtrips_non_native_data_attrs(
 
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
-        tree = workspace_arrays.open_workspace_datatree(fname, chunks=None)
+        opened = workspace_arrays.open_workspace_dataset(
+            fname,
+            _current_workspace_payload_path(fname),
+            chunks=None,
+        )
         try:
-            assert manager._workspace_controller.loading._from_datatree(
-                tree,
-                replace=True,
-                mark_dirty=False,
-                select=False,
-                workspace_file_path=fname,
-            )
+            restored = workspace_format._restore_workspace_dataset_attrs(opened)
+            loaded = restored[_ITOOL_DATA_NAME]
         finally:
-            tree.close()
-        loaded = manager.get_imagetool(0).slicer_area._data
+            opened.close()
         _assert_rich_workspace_attr(loaded.attrs["Single Motor Scan"])
         _assert_rich_workspace_attr(loaded.coords["x"].attrs["axis_config"])
 
@@ -5587,7 +3853,6 @@ def test_manager_workspace_save_preserves_reordered_roots(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -5600,9 +3865,7 @@ def test_manager_workspace_save_preserves_reordered_roots(
             manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "ordered.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -5618,8 +3881,7 @@ def test_manager_workspace_save_preserves_reordered_roots(
         assert manager.is_workspace_modified
         assert _request_workspace_save_and_wait(qtbot, manager)
 
-        with h5py.File(fname, "r") as h5_file:
-            manifest = json.loads(h5_file.attrs["imagetool_workspace_manifest"])
+        manifest = _current_workspace_manifest(fname)
         assert manifest["root_order"] == [1, 2, 0]
 
         assert manager._workspace_controller.loading._load_workspace_file(
@@ -5704,9 +3966,7 @@ def test_manager_workspace_delta_save_splits_state_and_data_writes(
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
         fname = tmp_path / "delta.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
 
         dataset_writes: list[str | None] = []
@@ -5730,7 +3990,7 @@ def test_manager_workspace_delta_save_splits_state_and_data_writes(
         import h5py
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
             assert saved[0, 0] == 10
 
 
@@ -5750,9 +4010,7 @@ def test_manager_workspace_full_save_keeps_full_persistence_for_serialized_nodes
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
         fname = tmp_path / "full-persistence.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         replacement = data.copy(deep=True)
         replacement.data = np.asarray(replacement.data) + 1
@@ -5772,9 +4030,7 @@ def test_manager_workspace_full_save_keeps_full_persistence_for_serialized_nodes
             _persistence_data_and_state_spy,
         )
 
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
 
         assert calls >= 1
 
@@ -5802,9 +4058,7 @@ def test_manager_workspace_full_save_preserves_in_memory_backing_after_rebind(
         backing_snapshot = (
             manager._workspace_controller.loading._workspace_data_backing_snapshot()
         )
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         manager._workspace_controller.loading._rebind_workspace_backed_imagetools(
             fname,
             backing_snapshot=backing_snapshot,
@@ -5834,9 +4088,7 @@ def test_manager_workspace_load_keeps_visible_saved_data_in_memory(
         manager.add_imagetool(root, show=True)
 
         fname = tmp_path / "load-visible-memory.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -5866,9 +4118,7 @@ def test_manager_workspace_lazy_data_delta_save_uses_pending_group_before_replac
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "lazy-data.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -5884,7 +4134,7 @@ def test_manager_workspace_lazy_data_delta_save_uses_pending_group_before_replac
         import h5py
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
             assert saved[0, 0] == 10
 
 
@@ -5908,9 +4158,7 @@ def test_manager_workspace_same_file_lazy_data_delta_save_does_not_deadlock(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "same-file-lazy.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
         )
@@ -5927,7 +4175,7 @@ def test_manager_workspace_same_file_lazy_data_delta_save_does_not_deadlock(
         import h5py
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
             assert saved[0, 0] == 0
             assert saved.chunks == (128, 64)
 
@@ -5949,44 +4197,40 @@ def test_manager_workspace_lazy_data_delta_pending_failure_preserves_old_group(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "lazy-failure.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
+        manifest_before = _current_workspace_manifest(fname)
 
         replacement = data.copy(deep=True)
         replacement.data = np.asarray(replacement.data) + 10
         root.slicer_area.replace_source_data(replacement, auto_compute=False)
 
-        def _write_partial_pending_then_raise(
-            fname: str | os.PathLike[str],
-            _constructor: Mapping[str, xr.Dataset],
-            _group_path: str,
-            pending_path: str,
+        def _write_partial_object_then_raise(
+            h5_file,
+            group_path: str,
+            _dataset: xr.Dataset,
+            **_kwargs,
         ) -> None:
-            with workspace_storage._open_workspace_h5_file_for_update(fname) as h5_file:
-                h5_file.create_group(pending_path)
-            raise RuntimeError("pending write failed")
+            h5_file.require_group(group_path)
+            raise RuntimeError("object write failed")
 
         monkeypatch.setattr(
-            workspace_storage,
-            "_write_workspace_constructor_groups_to_pending",
-            _write_partial_pending_then_raise,
+            workspace_arrays,
+            "_write_workspace_dataset_group_to_file",
+            _write_partial_object_then_raise,
         )
         monkeypatch.setattr(
             manager, "_show_workspace_save_worker_error", lambda *args: None
         )
 
         assert not _request_workspace_save_and_wait(qtbot, manager)
-        import h5py
-
+        assert _current_workspace_manifest(fname) == manifest_before
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
             assert saved[0, 0] == 0
-            assert not any(
-                workspace_format._is_workspace_internal_group_name(name)
-                for name in h5_file
+            assert set(h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == set(
+                workspace_store.WorkspaceStore.manifest_object_ids(manifest_before)
             )
 
 
@@ -5997,7 +4241,6 @@ def test_manager_workspace_stale_pending_groups_do_not_poison_open_or_save(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -6008,9 +4251,7 @@ def test_manager_workspace_stale_pending_groups_do_not_poison_open_or_save(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "stale-pending.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         with h5py.File(fname, "a") as h5_file:
             h5_file.create_group(
                 f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}stale"
@@ -6026,11 +4267,7 @@ def test_manager_workspace_stale_pending_groups_do_not_poison_open_or_save(
 
         manager.rename_imagetool(0, "cleaned")
         assert _request_workspace_save_and_wait(qtbot, manager)
-        with h5py.File(fname, "r") as h5_file:
-            assert not any(
-                workspace_format._is_workspace_internal_group_name(name)
-                for name in h5_file
-            )
+        _assert_no_workspace_internal_groups(fname)
 
 
 def test_manager_workspace_delta_save_persists_geometry_changes(
@@ -6040,7 +4277,6 @@ def test_manager_workspace_delta_save_persists_geometry_changes(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    import h5py
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
@@ -6051,9 +4287,7 @@ def test_manager_workspace_delta_save_persists_geometry_changes(
         manager.add_imagetool(root, show=False)
 
         fname = tmp_path / "geometry.itws"
-        manager._workspace_controller.saving._save_workspace_document(
-            fname, force_full=True
-        )
+        manager._workspace_controller.saving._save_workspace_document(fname)
         adopt_workspace_path(manager, fname)
         manager._workspace_controller._mark_workspace_clean()
 
@@ -6062,7 +4296,16 @@ def test_manager_workspace_delta_save_persists_geometry_changes(
         expected_rect = tuple(root.geometry().getRect())
 
         assert _request_workspace_save_and_wait(qtbot, manager)
-        with h5py.File(fname, "r") as h5_file:
-            saved_state = json.loads(h5_file["0/imagetool"].attrs["itool_window_state"])
-            saved_rect = tuple(int(value) for value in saved_state["rect"])
+        entry = next(
+            entry
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                _current_workspace_manifest(fname)
+            )
+            if entry.get("path") == "0"
+        )
+        saved_attrs = workspace_format._restore_workspace_manifest_attrs(
+            entry["payload_attrs"]
+        )
+        saved_state = json.loads(saved_attrs["itool_window_state"])
+        saved_rect = tuple(int(value) for value in saved_state["rect"])
         assert saved_rect == expected_rect

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -1467,6 +1467,9 @@ def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
         root_attrs=_transaction_test_root_attrs(),
         delta_save_count=0,
         full_tree=xr.DataTree(),
+        expected_publication_state=workspace_storage._workspace_publication_state(
+            target
+        ),
         copy_group_sources=(
             (
                 str(missing_source),
@@ -1493,6 +1496,54 @@ def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
     assert error.traceback_text
 
 
+def test_workspace_save_worker_rejects_unbound_snapshot(tmp_path) -> None:
+    snapshot = workspace_saving._WorkspaceSaveSnapshot(
+        generation=0,
+        root_attrs={},
+        delta_save_count=0,
+    )
+
+    with pytest.raises(ValueError, match="not bound to its destination"):
+        workspace_saving._WorkspaceSaveWorker(tmp_path / "target.itws", snapshot)
+
+
+@pytest.mark.parametrize("full_save", [False, True])
+def test_workspace_save_worker_uses_snapshot_publication_state(
+    monkeypatch, tmp_path, full_save
+) -> None:
+    target = tmp_path / "target.itws"
+    expected_state: workspace_storage._WorkspacePublicationState = (
+        True,
+        1,
+        2,
+        3,
+        4,
+        5,
+    )
+    snapshot = workspace_saving._WorkspaceSaveSnapshot(
+        generation=0,
+        root_attrs=_transaction_test_root_attrs(),
+        delta_save_count=0,
+        full_tree=xr.DataTree() if full_save else None,
+        expected_publication_state=expected_state,
+    )
+    received: list[workspace_storage._WorkspacePublicationState | None] = []
+    writer_name = (
+        "_write_full_workspace_tree_file"
+        if full_save
+        else "_write_workspace_transaction_file"
+    )
+    monkeypatch.setattr(
+        workspace_storage,
+        writer_name,
+        lambda *_args, **kwargs: received.append(kwargs["expected_state"]),
+    )
+
+    workspace_saving._WorkspaceSaveWorker(target, snapshot).run()
+
+    assert received == [expected_state]
+
+
 @pytest.mark.parametrize(
     ("exception_factory", "error_field"),
     [
@@ -1515,6 +1566,9 @@ def test_workspace_save_worker_classifies_publication_errors(
         root_attrs=_transaction_test_root_attrs(),
         delta_save_count=0,
         full_tree=xr.DataTree(),
+        expected_publication_state=workspace_storage._workspace_publication_state(
+            target
+        ),
     )
     monkeypatch.setattr(
         workspace_storage,
@@ -1684,6 +1738,60 @@ def test_manager_save_action_runs_workspace_save_in_background(
         assert not manager.offload_action.isEnabled()
         assert not manager.is_workspace_modified
         assert not operation_errors
+        manager._workspace_state.path = None
+
+
+def test_manager_background_save_rejects_changed_destination(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    workers: list[workspace_saving._WorkspaceSaveWorker] = []
+
+    class _HeldWorkspaceSaveThreadPool:
+        @staticmethod
+        def start(worker: workspace_saving._WorkspaceSaveWorker) -> None:
+            workers.append(worker)
+
+    monkeypatch.setattr(
+        QtCore.QThreadPool,
+        "globalInstance",
+        staticmethod(_HeldWorkspaceSaveThreadPool),
+    )
+
+    with manager_context() as manager:
+        data = xr.DataArray(np.arange(9.0).reshape((3, 3)), dims=("x", "y"))
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        uid = manager._tool_graph.root_wrappers[0].uid
+        fname = tmp_path / "changed-before-background-write.itws"
+        manager._workspace_controller.saving._save_workspace_document(
+            fname, force_full=True
+        )
+        adopt_workspace_path(manager, fname)
+        manager._workspace_controller._mark_workspace_clean()
+        root.slicer_area.replace_source_data(data + 100.0, auto_compute=False)
+        manager._workspace_controller._mark_node_data_dirty(uid)
+        errors: list[workspace_saving._WorkspaceSaveError] = []
+        monkeypatch.setattr(manager, "_show_workspace_save_worker_error", errors.append)
+
+        assert manager._workspace_controller.save(restore_focus=False)
+        assert len(workers) == 1
+        _write_transaction_test_workspace(fname, 2.0)
+
+        workers[0].run()
+        qtbot.wait_until(lambda: not manager._workspace_state.save_in_progress)
+
+        assert len(errors) == 1
+        assert errors[0].publication_conflict_path == str(fname.resolve())
+        with h5py.File(fname, "r") as h5_file:
+            assert float(h5_file["0/imagetool/data"][0]) == 2.0
+        assert manager.is_workspace_modified
+        manager._workspace_controller._mark_workspace_clean()
         manager._workspace_state.path = None
 
 
@@ -3035,7 +3143,7 @@ def test_workspace_full_save_external_dask_rebind_rolls_back_on_later_failure(
         )
         monkeypatch.setattr(
             manager._workspace_controller,
-            "_retarget_workspace_referenced_tool_data",
+            "_refresh_workspace_tool_data_after_full_save",
             lambda *_args, **_kwargs: (_ for _ in ()).throw(
                 workspace_controller._WorkspacePostSaveBindingError("later failure")
             ),
@@ -4324,6 +4432,7 @@ def test_workspace_save_worker_start_and_finish_error_branches(
     class Snapshot:
         def __init__(self) -> None:
             self.closed = False
+            self.expected_publication_state = (False, 0, 0, 0, 0, 0)
 
         def close(self) -> None:
             self.closed = True

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -3004,9 +3004,9 @@ def test_workspace_save_as_snapshot_preserves_live_history(
 
         store = manager._workspace_controller._workspace_store
         assert store is not None
-        with store.lock:
+        with store.write_session() as h5_file:
             workspace_arrays._write_workspace_dataset_group_to_file(
-                store.h5_file,
+                h5_file,
                 "/legacy/imagetool",
                 data.to_dataset(name="data"),
                 compression_mode="none",

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -991,11 +991,13 @@ class _DeferredWorkspaceSaveWorker:
         snapshot: workspace_saving._WorkspaceSaveSnapshot,
         *,
         store: workspace_store.WorkspaceStore | None = None,
+        reader_closers: tuple[Callable[[], None], ...] = (),
     ) -> None:
         self.signals = workspace_saving._WorkspaceSaveWorkerSignals()
         self._fname = pathlib.Path(_fname)
         self._snapshot = snapshot
         self._store = store
+        self._reader_closers = reader_closers
 
     def finish(
         self,
@@ -1145,6 +1147,44 @@ def test_workspace_save_worker_classifies_publication_errors(
     error = results[0]
     assert isinstance(error, workspace_saving._WorkspaceSaveError)
     assert getattr(error, error_field) == str(target)
+
+
+@pytest.mark.parametrize("contended", [False, True])
+def test_workspace_save_worker_closes_readers_only_after_contention(
+    monkeypatch,
+    tmp_path,
+    contended: bool,
+) -> None:
+    target = tmp_path / "target.itws"
+    snapshot = workspace_saving._WorkspaceSaveSnapshot(
+        generation=0,
+        generation_plan=workspace_storage._WorkspaceGenerationPlan(
+            manifest={"schema_version": 5, "nodes": []},
+            objects=(),
+        ),
+        compression_mode="none",
+    )
+    close_calls: list[None] = []
+
+    def _write(*_args, on_contention=None, **_kwargs) -> None:
+        assert close_calls == []
+        if contended:
+            assert on_contention is not None
+            on_contention()
+
+    monkeypatch.setattr(workspace_storage, "_write_workspace_generation", _write)
+    worker = workspace_saving._WorkspaceSaveWorker(
+        target,
+        snapshot,
+        reader_closers=(lambda: close_calls.append(None),),
+    )
+    waiting: list[None] = []
+    worker.signals.waiting.connect(lambda: waiting.append(None))
+
+    worker.run()
+
+    assert close_calls == ([None] if contended else [])
+    assert waiting == ([None] if contended else [])
 
 
 def test_manager_async_save_request_error_paths(
@@ -3498,6 +3538,7 @@ def test_workspace_save_worker_start_and_finish_error_branches(
                 self.worker = worker
 
         errors: list[tuple[str, str]] = []
+        status_messages: list[tuple[typing.Any, ...]] = []
         pool = RecordingPool()
         monkeypatch.setattr(
             workspace_controller.QtCore.QThreadPool,
@@ -3509,12 +3550,19 @@ def test_workspace_save_worker_start_and_finish_error_branches(
             "_show_operation_error",
             lambda title, text: errors.append((title, text)),
         )
+        monkeypatch.setattr(
+            manager._status_bar,
+            "showMessage",
+            lambda *args: status_messages.append(args),
+        )
         assert controller._start_workspace_save_worker(
             tmp_path / "finish.itws",
             typing.cast("workspace_saving._WorkspaceSaveSnapshot", Snapshot()),
             on_finished=lambda *_args: (_ for _ in ()).throw(RuntimeError("boom")),
         )
         assert pool.worker is not None
+        pool.worker.signals.waiting.emit()
+        assert len(status_messages) == 1
         pool.worker.signals.finished.emit(0.1, None)
         assert errors == [
             (

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -70,6 +70,7 @@ def test_replace_workspace_file_retries_transient_access_denied(
     original_replace = workspace_storage.os.replace
     replace_attempts = 0
     delays: list[float] = []
+    synced_parents: list[pathlib.Path] = []
 
     def _replace_with_transient_denial(src, dst) -> None:
         nonlocal replace_attempts
@@ -85,6 +86,9 @@ def test_replace_workspace_file_retries_transient_access_denied(
     )
     monkeypatch.setattr(workspace_storage.os, "replace", _replace_with_transient_denial)
     monkeypatch.setattr(workspace_storage.time, "sleep", delays.append)
+    monkeypatch.setattr(
+        workspace_storage, "_fsync_parent_directory", synced_parents.append
+    )
 
     workspace_storage._replace_workspace_file(
         source, destination, expected_state=expected_state
@@ -92,6 +96,7 @@ def test_replace_workspace_file_retries_transient_access_denied(
 
     assert replace_attempts == 3
     assert delays == [0.02, 0.05]
+    assert synced_parents == [destination]
     assert destination.read_bytes() == b"new"
 
 
@@ -134,6 +139,7 @@ def test_replace_workspace_file_preserves_permission_error_after_retries(
     destination.write_bytes(b"old")
     expected_state = workspace_storage._workspace_publication_state(destination)
     attempts = 0
+    synced_parents: list[pathlib.Path] = []
 
     def _deny_replace(_src, dst) -> None:
         nonlocal attempts
@@ -152,6 +158,9 @@ def test_replace_workspace_file_preserves_permission_error_after_retries(
     )
     monkeypatch.setattr(workspace_storage.os, "replace", _deny_replace)
     monkeypatch.setattr(workspace_storage.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(
+        workspace_storage, "_fsync_parent_directory", synced_parents.append
+    )
 
     with pytest.raises(PermissionError, match="file is in use"):
         workspace_storage._replace_workspace_file(
@@ -159,6 +168,7 @@ def test_replace_workspace_file_preserves_permission_error_after_retries(
         )
 
     assert attempts == 3
+    assert synced_parents == []
     assert source.read_bytes() == b"new"
     assert destination.read_bytes() == b"old"
 

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -13,6 +13,7 @@ import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
+import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 from tests.interactive.imagetool.manager.workspace._support import (
     _assert_no_workspace_internal_groups,
     _transaction_test_dataset,
@@ -79,13 +80,8 @@ def test_replace_workspace_file_retries_transient_access_denied(
             raise PermissionError(errno.EACCES, "file is in use", dst)
         original_replace(src, dst)
 
-    monkeypatch.setattr(
-        workspace_storage,
-        "_is_retryable_windows_workspace_replace_error",
-        lambda _exc: True,
-    )
     monkeypatch.setattr(workspace_storage.os, "replace", _replace_with_transient_denial)
-    monkeypatch.setattr(workspace_storage.time, "sleep", delays.append)
+    monkeypatch.setattr(workspace_store.time, "sleep", delays.append)
     monkeypatch.setattr(
         workspace_storage, "_fsync_parent_directory", synced_parents.append
     )
@@ -113,13 +109,8 @@ def test_replace_workspace_file_stops_if_destination_changes_during_retry(
         pathlib.Path(dst).write_bytes(b"changed outside the manager")
         raise PermissionError(errno.EACCES, "file is in use", dst)
 
-    monkeypatch.setattr(
-        workspace_storage,
-        "_is_retryable_windows_workspace_replace_error",
-        lambda _exc: True,
-    )
     monkeypatch.setattr(workspace_storage.os, "replace", _replace_after_external_change)
-    monkeypatch.setattr(workspace_storage.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(workspace_store.time, "sleep", lambda _delay: None)
 
     with pytest.raises(workspace_storage._WorkspacePublicationConflictError):
         workspace_storage._replace_workspace_file(
@@ -147,17 +138,12 @@ def test_replace_workspace_file_preserves_permission_error_after_retries(
         raise PermissionError(errno.EACCES, "file is in use", dst)
 
     monkeypatch.setattr(
-        workspace_storage,
-        "_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS",
+        workspace_store,
+        "_FILE_ACCESS_RETRY_DELAYS",
         (0.0, 0.0),
     )
-    monkeypatch.setattr(
-        workspace_storage,
-        "_is_retryable_windows_workspace_replace_error",
-        lambda _exc: True,
-    )
     monkeypatch.setattr(workspace_storage.os, "replace", _deny_replace)
-    monkeypatch.setattr(workspace_storage.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(workspace_store.time, "sleep", lambda _delay: None)
     monkeypatch.setattr(
         workspace_storage, "_fsync_parent_directory", synced_parents.append
     )
@@ -173,21 +159,14 @@ def test_replace_workspace_file_preserves_permission_error_after_retries(
     assert destination.read_bytes() == b"old"
 
 
-def test_windows_workspace_replace_retry_filter_is_specific(monkeypatch) -> None:
+def test_workspace_file_access_retry_filter_is_specific() -> None:
     access_denied = PermissionError(errno.EACCES, "access denied")
+    busy = OSError(errno.EBUSY, "busy")
     wrong_error = PermissionError(errno.ENOENT, "missing")
 
-    assert not workspace_storage._is_retryable_windows_workspace_replace_error(
-        access_denied
-    )
-    with monkeypatch.context() as patch:
-        patch.setattr(workspace_storage.os, "name", "nt")
-        assert workspace_storage._is_retryable_windows_workspace_replace_error(
-            access_denied
-        )
-        assert not workspace_storage._is_retryable_windows_workspace_replace_error(
-            wrong_error
-        )
+    assert workspace_store._is_retryable_file_access_error(access_denied)
+    assert workspace_store._is_retryable_file_access_error(busy)
+    assert not workspace_store._is_retryable_file_access_error(wrong_error)
 
 
 def test_workspace_recovery_discards_prepared_legacy_transaction(tmp_path) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -169,6 +169,78 @@ def test_workspace_file_access_retry_filter_is_specific() -> None:
     assert not workspace_store._is_retryable_file_access_error(wrong_error)
 
 
+def test_copy_workspace_group_rejects_missing_source_group(tmp_path) -> None:
+    source = tmp_path / "source.itws"
+    target = tmp_path / "target.itws"
+    with h5py.File(source, "w"):
+        pass
+    with workspace_store.WorkspaceStore(target, create=True) as target_store:
+        with (
+            target_store.write_session(),
+            pytest.raises(KeyError, match="payload group"),
+        ):
+            workspace_storage._copy_workspace_group(
+                target_store,
+                source_file=str(source),
+                source_path="/missing",
+                target_path=target_store.object_path("missing"),
+            )
+        assert target_store.object_path("missing").strip("/") not in (
+            target_store.h5_file
+        )
+
+
+def test_workspace_generation_keeps_existing_preserved_group(tmp_path) -> None:
+    path = tmp_path / "workspace.itws"
+    plan = workspace_storage._WorkspaceGenerationPlan(
+        manifest={"schema_version": 5, "nodes": [], "root_order": []},
+        objects=(),
+        preserved_groups=(
+            workspace_storage._WorkspaceGroupCopy(
+                source_file=str(tmp_path / "unused.itws"),
+                source_path="/unused",
+                target_path="/preserved",
+            ),
+        ),
+    )
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session() as h5_file:
+            h5_file.create_group("preserved")
+        generation = workspace_storage._write_workspace_generation(
+            store, plan, compression_mode="none"
+        )
+
+        assert generation.sequence == 1
+        assert "preserved" in store.h5_file
+
+
+def test_workspace_storage_rejects_changed_publication_and_nonworkspace_recovery(
+    tmp_path,
+) -> None:
+    path = tmp_path / "plain.h5"
+    with h5py.File(path, "w") as h5_file:
+        h5_file.attrs["plain"] = True
+    expected = workspace_storage._workspace_publication_state(path)
+    path.write_bytes(b"changed")
+
+    with pytest.raises(workspace_storage._WorkspacePublicationConflictError):
+        workspace_storage._require_workspace_publication_state(path, expected)
+
+    workspace_storage._recover_workspace_transactions(tmp_path / "missing.itws")
+    workspace_storage._recover_workspace_transactions(tmp_path / "not-workspace.txt")
+    with h5py.File(path, "w") as h5_file:
+        h5_file.attrs["plain"] = True
+    workspace_storage._recover_workspace_transactions(path)
+
+
+def test_open_workspace_h5_file_for_update_uses_legacy_path(tmp_path) -> None:
+    path = tmp_path / "legacy.h5"
+    with workspace_storage._open_workspace_h5_file_for_update(path) as h5_file:
+        h5_file.attrs["updated"] = True
+    with h5py.File(path, "r") as h5_file:
+        assert h5_file.attrs["updated"]
+
+
 def test_workspace_recovery_discards_prepared_legacy_transaction(tmp_path) -> None:
     fname = tmp_path / "prepared.itws"
     _write_transaction_test_workspace(fname)

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -1,17 +1,11 @@
 import errno
 import json
-import os
 import pathlib
-import threading
 import types
 import typing
 
 import h5py
-import hdf5plugin
-import numpy as np
 import pytest
-import xarray
-import xarray as xr
 from qtpy import QtWidgets
 
 import erlab
@@ -19,16 +13,15 @@ import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from tests.interactive.imagetool.manager.workspace._support import (
     _assert_no_workspace_internal_groups,
-    _assert_rich_workspace_attr,
-    _hdf5_filter_ids,
-    _rich_workspace_attr_value,
     _transaction_test_dataset,
     _transaction_test_root_attrs,
     _write_transaction_test_workspace,
 )
+
+if typing.TYPE_CHECKING:
+    import xarray as xr
 
 
 def _read_transaction_test_value(fname: pathlib.Path) -> float:
@@ -42,599 +35,28 @@ def _read_transaction_test_value(fname: pathlib.Path) -> float:
         opened.close()
 
 
-def test_workspace_file_repack_payload_strips_delta_and_skips_internal_groups(
-    tmp_path,
-) -> None:
-
-    fname = tmp_path / "file-repack.itws"
-    _write_transaction_test_workspace(fname)
-    workspace_storage._write_workspace_root_attrs_to_file(
-        fname,
-        _transaction_test_root_attrs(delta_save_count=3),
-        replace=True,
-    )
-    with h5py.File(fname, "a") as h5_file:
-        h5_file.create_group("__itws_pending_orphan")
-        h5_file.create_dataset("root_dataset", data=np.arange(3))
-
-    assert workspace_arrays._workspace_live_root_group_copy_groups(fname) == (
-        ("0", "0", None),
-    )
-    storage_size, existing_count = workspace_arrays._workspace_h5_paths_storage_size(
-        fname, ("0", "missing")
-    )
-    assert storage_size >= np.dtype(np.float64).itemsize
-    assert existing_count == 1
-    assert workspace_arrays._workspace_live_h5_storage_size(fname) == storage_size
-    assert workspace_storage._workspace_obsolete_estimate(fname) >= 0
-    root_attrs, copy_groups, expected_state = (
-        workspace_storage._workspace_file_repack_payload(fname)
-    )
-
-    manifest = workspace_format._workspace_manifest_from_attrs(root_attrs)
-    assert "delta_save_count" not in manifest
-    assert expected_state == workspace_storage._workspace_publication_state(fname)
-    assert "transaction_protocol" not in manifest
-    assert (
-        manifest["schema_version"]
-        == workspace_format._current_workspace_schema_version()
-    )
-    assert manifest["erlab_version"] == erlab.__version__
-    assert copy_groups == (("0", "0", None),)
-
-    workspace_storage._write_full_workspace_tree_file(
-        fname,
-        None,
-        root_attrs,
-        copy_source=fname,
-        copy_groups=copy_groups,
-    )
-
-    assert _read_transaction_test_value(fname) == 1.0
-    _assert_no_workspace_internal_groups(fname)
-    with h5py.File(fname, "r") as h5_file:
-        assert set(h5_file) == {"0"}
-        manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
-        assert "delta_save_count" not in manifest
-
-
-def test_workspace_file_repack_payload_rejects_change_during_snapshot(
-    monkeypatch, tmp_path
-) -> None:
-    fname = tmp_path / "changed-during-repack-snapshot.itws"
-    _write_transaction_test_workspace(fname)
-    original_copy_groups = workspace_arrays._workspace_live_root_group_copy_groups
-
-    def _copy_groups_after_external_change(path):
-        copy_groups = original_copy_groups(path)
-        stat_result = os.stat(path)
-        os.utime(
-            path,
-            ns=(stat_result.st_atime_ns, stat_result.st_mtime_ns + 1_000_000),
-        )
-        return copy_groups
-
-    monkeypatch.setattr(
-        workspace_arrays,
-        "_workspace_live_root_group_copy_groups",
-        _copy_groups_after_external_change,
-    )
-
-    with pytest.raises(workspace_storage._WorkspacePublicationConflictError):
-        workspace_storage._workspace_file_repack_payload(fname)
-
-
-def test_write_full_workspace_tree_file_compresses_payload_not_coords(
-    tmp_path,
-) -> None:
-
-    ds = xr.Dataset(
+def _create_legacy_transaction(
+    h5_file: h5py.File,
+    txn_id: str,
+    *,
+    status: str,
+    group_replacements: list[dict[str, object]] | None = None,
+) -> tuple[h5py.Group, str, str]:
+    txn_path = f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
+    pending_root = f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
+    backup_root = f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
+    txn_group = h5_file.create_group(txn_path)
+    txn_group.attrs.update(
         {
-            "data": (
-                ("x", "y"),
-                np.arange(512 * 512, dtype=np.float64).reshape(512, 512),
-            ),
-            "small": ("x", np.arange(512, dtype=np.int64)),
-        },
-        coords={
-            "x": np.linspace(-1.0, 1.0, 512),
-            "y": np.linspace(-2.0, 2.0, 512),
-        },
-    )
-    tree = xr.DataTree.from_dict({"0/imagetool": ds})
-    fname = tmp_path / "compressed.itws"
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, {"imagetool_workspace_schema_version": 4}
-        )
-    finally:
-        tree.close()
-
-    with h5py.File(fname, "r") as h5_file:
-        assert hdf5plugin.Blosc2.filter_id in _hdf5_filter_ids(
-            h5_file["0/imagetool/data"]
-        )
-        assert _hdf5_filter_ids(h5_file["0/imagetool/x"]) == []
-        assert _hdf5_filter_ids(h5_file["0/imagetool/y"]) == []
-        assert _hdf5_filter_ids(h5_file["0/imagetool/small"]) == []
-
-    opened = workspace_arrays.open_workspace_datatree(fname, chunks=None)
-    try:
-        loaded = typing.cast("xr.DataTree", opened["/0/imagetool"]).to_dataset(
-            inherit=False
-        )
-        xarray.testing.assert_equal(loaded["data"], ds["data"])
-        xarray.testing.assert_equal(loaded["x"], ds["x"])
-        xarray.testing.assert_equal(loaded["y"], ds["y"])
-    finally:
-        opened.close()
-
-
-def test_prepare_workspace_transaction_promotes_missing_attr_fallback(
-    tmp_path,
-) -> None:
-    fname = tmp_path / "fallback.itws"
-    _write_transaction_test_workspace(fname)
-    fallback = (
-        "0",
-        {"0/imagetool": _transaction_test_dataset(2.0, title="fallback")},
-    )
-    rewrite_map: dict[str, tuple[str, dict[str, xr.Dataset]]] = {}
-
-    group_operations, attr_updates = workspace_storage._prepare_workspace_transaction(
-        fname,
-        f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}fallback",
-        f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}fallback",
-        f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}fallback",
-        rewrite_map,
-        (("0/missing", {"itool_title": "new"}, fallback),),
-        _transaction_test_root_attrs(delta_save_count=1),
-    )
-
-    assert rewrite_map == {"0": fallback}
-    assert attr_updates == []
-    assert group_operations[0]["group_path"] == "0"
-    workspace_storage._recover_workspace_transactions(fname)
-    _assert_no_workspace_internal_groups(fname)
-
-
-def test_write_full_workspace_tree_file_skips_missing_copy_source_group(
-    tmp_path,
-) -> None:
-    fname = tmp_path / "missing-copy-group.itws"
-    _write_transaction_test_workspace(fname)
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(3.0, title="rewritten")}
-    )
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname,
-            tree,
-            _transaction_test_root_attrs(),
-            copy_source=fname,
-            copy_groups=(("missing/source", "0/imagetool", None),),
-        )
-    finally:
-        tree.close()
-
-    assert _read_transaction_test_value(fname) == 3.0
-
-
-def test_write_full_workspace_tree_file_reports_missing_backing_source(
-    tmp_path,
-) -> None:
-    fname = tmp_path / "missing-backing-source-target.itws"
-    missing_source = tmp_path / "deleted-source.itws"
-    _write_transaction_test_workspace(fname)
-    original_contents = fname.read_bytes()
-
-    with pytest.raises(
-        workspace_storage._WorkspaceBackingFileNotFoundError
-    ) as exc_info:
-        workspace_storage._write_full_workspace_tree_file(
-            fname,
-            None,
-            _transaction_test_root_attrs(),
-            copy_group_sources=(
-                (
-                    str(missing_source),
-                    "0/imagetool",
-                    "0/imagetool",
-                    None,
-                ),
-            ),
-        )
-
-    assert exc_info.value.source_path == str(missing_source)
-    assert fname.read_bytes() == original_contents
-
-
-def test_write_full_workspace_tree_file_replaces_stale_root_attrs(tmp_path) -> None:
-
-    fname = tmp_path / "root-attrs.itws"
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(1.0, title="old")}
-    )
-    tree.attrs["stale_workspace_attr"] = "remove me"
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, _transaction_test_root_attrs()
-        )
-    finally:
-        tree.close()
-
-    with h5py.File(fname, "r") as h5_file:
-        assert "stale_workspace_attr" not in h5_file.attrs
-        manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
-        assert manifest == {"schema_version": 4, "root_order": [0], "nodes": []}
-
-
-def test_write_full_workspace_tree_file_local_path_uses_destination_temp(
-    monkeypatch, tmp_path
-) -> None:
-    fname = tmp_path / "local.itws"
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(1.0, title="local")}
-    )
-    write_targets: list[pathlib.Path] = []
-    original_write = workspace_arrays._write_workspace_dataset_group_to_file
-
-    def _record_write(target, *args, **kwargs):
-        write_targets.append(pathlib.Path(target))
-        return original_write(target, *args, **kwargs)
-
-    monkeypatch.setattr(
-        workspace_arrays, "_write_workspace_dataset_group_to_file", _record_write
-    )
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_network_path", lambda _path: False
-    )
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_cloud_path", lambda _path: False
-    )
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, _transaction_test_root_attrs()
-        )
-    finally:
-        tree.close()
-
-    assert write_targets
-    assert all(target.parent == fname.parent for target in write_targets)
-    assert all(target.name.startswith(f"{fname.name}.tmp-") for target in write_targets)
-
-
-def test_write_full_workspace_tree_file_cloud_path_uses_scratch_and_replace_first(
-    monkeypatch, tmp_path
-) -> None:
-    fname = tmp_path / "Dropbox" / "cloud.itws"
-    fname.parent.mkdir()
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(2.0, title="cloud")}
-    )
-    write_targets: list[pathlib.Path] = []
-    replace_calls: list[tuple[pathlib.Path, pathlib.Path]] = []
-    original_write = workspace_arrays._write_workspace_dataset_group_to_file
-
-    def _record_write(target, *args, **kwargs):
-        write_targets.append(pathlib.Path(target))
-        return original_write(target, *args, **kwargs)
-
-    def _replace_by_copy(src, dst):
-        src_path = pathlib.Path(src)
-        dst_path = pathlib.Path(dst)
-        replace_calls.append((src_path, dst_path))
-        dst_path.write_bytes(src_path.read_bytes())
-        src_path.unlink()
-
-    monkeypatch.setattr(
-        workspace_arrays, "_write_workspace_dataset_group_to_file", _record_write
-    )
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_network_path", lambda _path: False
-    )
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_cloud_path", lambda _path: True
-    )
-    monkeypatch.setattr(workspace_storage.os, "replace", _replace_by_copy)
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, _transaction_test_root_attrs()
-        )
-    finally:
-        tree.close()
-
-    assert write_targets
-    assert all(target.parent != fname.parent for target in write_targets)
-    assert replace_calls == [(write_targets[0], fname)]
-    assert _read_transaction_test_value(fname) == 2.0
-
-
-def test_write_full_workspace_tree_file_copies_unchanged_payload_groups(
-    monkeypatch,
-    tmp_path,
-) -> None:
-
-    fname = tmp_path / "copy.itws"
-    ds = xr.Dataset(
-        {
-            _ITOOL_DATA_NAME: (
-                ("x", "y"),
-                np.arange(12, dtype=np.float64).reshape(3, 4),
-            )
-        },
-        coords={
-            "x": np.arange(3, dtype=np.float64),
-            "y": np.arange(4, dtype=np.float64),
-        },
-        attrs={
-            "itool_title": "old",
-            "manager_node_uid": "n0",
-            "manager_node_kind": "imagetool",
-        },
-    )
-    tree = xr.DataTree.from_dict({"0/imagetool": ds})
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, _transaction_test_root_attrs()
-        )
-    finally:
-        tree.close()
-
-    rewritten = ds.assign_attrs(
-        {
-            "itool_title": "new",
-            "manager_node_uid": "n0",
-            "manager_node_kind": "imagetool",
-            "Single Motor Scan": _rich_workspace_attr_value(),
+            "status": status,
+            "pending_root": pending_root,
+            "backup_root": backup_root,
+            "operations": json.dumps({"group_replacements": group_replacements or []}),
         }
     )
-    tree = xr.DataTree.from_dict({"0/imagetool": rewritten})
-
-    def _fail_to_netcdf(*_args, **_kwargs):
-        raise AssertionError("unchanged payload should be copied with h5py")
-
-    monkeypatch.setattr(xr.Dataset, "to_netcdf", _fail_to_netcdf)
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname,
-            tree,
-            _transaction_test_root_attrs(),
-            copy_source=fname,
-            copy_groups=(("0/imagetool", "0/imagetool", dict(rewritten.attrs)),),
-        )
-    finally:
-        tree.close()
-
-    with h5py.File(fname, "r") as h5_file:
-        group = h5_file["0/imagetool"]
-        assert group.attrs["itool_title"] == "new"
-        decoded_attrs = workspace_arrays._h5py_attrs_to_dict(group.attrs)
-        _assert_rich_workspace_attr(decoded_attrs["Single Motor Scan"])
-        np.testing.assert_array_equal(
-            group[_ITOOL_DATA_NAME][...],
-            np.arange(12, dtype=np.float64).reshape(3, 4),
-        )
-    opened = workspace_arrays.open_workspace_datatree(fname, chunks=None)
-    try:
-        xr.testing.assert_identical(
-            opened["0/imagetool"].to_dataset()[_ITOOL_DATA_NAME],
-            rewritten[_ITOOL_DATA_NAME],
-        )
-    finally:
-        opened.close()
-
-
-def test_write_full_workspace_tree_file_network_scratch_skips_copy_reuse(
-    monkeypatch, tmp_path
-) -> None:
-    import shutil
-
-    fname = tmp_path / "network-copy-reuse.itws"
-    _write_transaction_test_workspace(fname)
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(3.0, title="rewritten")}
-    )
-
-    def _fail_copyfile(*_args, **_kwargs):
-        raise AssertionError("network scratch save should not copy old workspace")
-
-    def _replace_by_copy(src, dst):
-        src_path = pathlib.Path(src)
-        dst_path = pathlib.Path(dst)
-        dst_path.write_bytes(src_path.read_bytes())
-        src_path.unlink()
-
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_network_path", lambda _path: True
-    )
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_cloud_path", lambda _path: False
-    )
-    monkeypatch.setattr(shutil, "copyfile", _fail_copyfile)
-    monkeypatch.setattr(workspace_storage.os, "replace", _replace_by_copy)
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname,
-            tree,
-            _transaction_test_root_attrs(),
-            copy_source=fname,
-            copy_groups=(("0/imagetool", "0/imagetool", None),),
-        )
-    finally:
-        tree.close()
-
-    monkeypatch.undo()
-    assert _read_transaction_test_value(fname) == 3.0
-
-
-def test_write_full_workspace_tree_file_scratch_exdev_fallback(
-    monkeypatch, tmp_path
-) -> None:
-    fname = tmp_path / "fallback.itws"
-    _write_transaction_test_workspace(fname)
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(4.0, title="fallback")}
-    )
-    original_replace = workspace_storage.os.replace
-    replace_calls: list[tuple[pathlib.Path, pathlib.Path]] = []
-    scratch_path: pathlib.Path | None = None
-
-    def _replace_with_exdev(src, dst):
-        nonlocal scratch_path
-        src_path = pathlib.Path(src)
-        dst_path = pathlib.Path(dst)
-        replace_calls.append((src_path, dst_path))
-        if dst_path == fname and src_path.parent != fname.parent:
-            scratch_path = src_path
-            raise OSError(errno.EXDEV, "cross-device link")
-        return original_replace(src, dst)
-
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_network_path", lambda _path: False
-    )
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_cloud_path", lambda _path: True
-    )
-    monkeypatch.setattr(workspace_storage.os, "replace", _replace_with_exdev)
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname, tree, _transaction_test_root_attrs()
-        )
-    finally:
-        tree.close()
-
-    assert _read_transaction_test_value(fname) == 4.0
-    assert scratch_path is not None
-    assert not scratch_path.exists()
-    assert len(replace_calls) == 2
-    assert replace_calls[0] == (scratch_path, fname)
-    assert replace_calls[1][0].parent == fname.parent
-    assert replace_calls[1][1] == fname
-    assert not list(fname.parent.glob(f"{fname.name}.tmp-*"))
-
-
-def test_write_full_workspace_tree_file_rejects_file_repack_on_network_path(
-    monkeypatch, tmp_path
-) -> None:
-    fname = tmp_path / "network.itws"
-    _write_transaction_test_workspace(fname)
-
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_high_risk", lambda *_: True
-    )
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_network_path", lambda *_: True
-    )
-
-    with pytest.raises(ValueError, match="File-level workspace repack cannot run"):
-        workspace_storage._write_full_workspace_tree_file(
-            fname,
-            None,
-            _transaction_test_root_attrs(),
-            copy_source=fname,
-            copy_groups=(("0", "0", None),),
-        )
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(5.0, title="network")}
-    )
-    try:
-        workspace_storage._write_full_workspace_tree_file(
-            fname,
-            tree,
-            _transaction_test_root_attrs(),
-            copy_source=fname,
-            copy_groups=(("0", "0", None),),
-        )
-    finally:
-        tree.close()
-    assert _read_transaction_test_value(fname) == 5.0
-
-
-def test_write_full_workspace_tree_file_scratch_replace_failure_preserves_old(
-    monkeypatch, tmp_path
-) -> None:
-    fname = tmp_path / "replace-failure.itws"
-    _write_transaction_test_workspace(fname)
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(5.0, title="failure")}
-    )
-    scratch_paths: list[pathlib.Path] = []
-
-    def _fail_replace(src, dst):
-        src_path = pathlib.Path(src)
-        if pathlib.Path(dst) == fname:
-            scratch_paths.append(src_path)
-        raise OSError(errno.EPERM, "replace failed")
-
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_network_path", lambda _path: False
-    )
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_cloud_path", lambda _path: True
-    )
-    monkeypatch.setattr(workspace_storage.os, "replace", _fail_replace)
-    try:
-        with pytest.raises(OSError, match="replace failed"):
-            workspace_storage._write_full_workspace_tree_file(
-                fname, tree, _transaction_test_root_attrs()
-            )
-    finally:
-        tree.close()
-
-    monkeypatch.undo()
-    assert _read_transaction_test_value(fname) == 1.0
-    assert scratch_paths
-    assert all(not scratch_path.exists() for scratch_path in scratch_paths)
-    assert not list(fname.parent.glob(f"{fname.name}.tmp-*"))
-
-
-def test_write_full_workspace_tree_file_scratch_copy_failure_cleans_destination_tmp(
-    monkeypatch, tmp_path
-) -> None:
-    import shutil
-
-    fname = tmp_path / "copy-failure.itws"
-    _write_transaction_test_workspace(fname)
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(6.0, title="failure")}
-    )
-    original_replace = workspace_storage.os.replace
-    scratch_paths: list[pathlib.Path] = []
-
-    def _replace_with_exdev(src, dst):
-        src_path = pathlib.Path(src)
-        dst_path = pathlib.Path(dst)
-        if dst_path == fname and src_path.parent != fname.parent:
-            scratch_paths.append(src_path)
-            raise OSError(errno.EXDEV, "cross-device link")
-        return original_replace(src, dst)
-
-    def _fail_copyfile(src, dst):
-        pathlib.Path(dst).write_bytes(b"partial")
-        raise OSError(errno.EIO, "copy failed")
-
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_network_path", lambda _path: False
-    )
-    monkeypatch.setattr(
-        workspace_storage, "_workspace_path_is_likely_cloud_path", lambda _path: True
-    )
-    monkeypatch.setattr(workspace_storage.os, "replace", _replace_with_exdev)
-    monkeypatch.setattr(shutil, "copyfile", _fail_copyfile)
-    try:
-        with pytest.raises(OSError, match="copy failed"):
-            workspace_storage._write_full_workspace_tree_file(
-                fname, tree, _transaction_test_root_attrs()
-            )
-    finally:
-        tree.close()
-
-    monkeypatch.undo()
-    assert _read_transaction_test_value(fname) == 1.0
-    assert scratch_paths
-    assert all(not scratch_path.exists() for scratch_path in scratch_paths)
-    assert not list(fname.parent.glob(f"{fname.name}.tmp-*"))
+    h5_file.create_group(pending_root)
+    h5_file.create_group(backup_root)
+    return txn_group, pending_root, backup_root
 
 
 def test_replace_workspace_file_retries_transient_access_denied(
@@ -741,29 +163,6 @@ def test_replace_workspace_file_preserves_permission_error_after_retries(
     assert destination.read_bytes() == b"old"
 
 
-def test_full_save_rejects_destination_changed_since_snapshot(tmp_path) -> None:
-    fname = tmp_path / "changed-before-worker.itws"
-    _write_transaction_test_workspace(fname, 1.0)
-    expected_state = workspace_storage._workspace_publication_state(fname)
-    _write_transaction_test_workspace(fname, 2.0)
-    tree = xr.DataTree.from_dict(
-        {"0/imagetool": _transaction_test_dataset(3.0, title="snapshot")}
-    )
-
-    try:
-        with pytest.raises(workspace_storage._WorkspacePublicationConflictError):
-            workspace_storage._write_full_workspace_tree_file(
-                fname,
-                tree,
-                _transaction_test_root_attrs(),
-                expected_state=expected_state,
-            )
-    finally:
-        tree.close()
-
-    assert _read_transaction_test_value(fname) == 2.0
-
-
 def test_windows_workspace_replace_retry_filter_is_specific(monkeypatch) -> None:
     access_denied = PermissionError(errno.EACCES, "access denied")
     wrong_error = PermissionError(errno.ENOENT, "missing")
@@ -781,148 +180,11 @@ def test_windows_workspace_replace_retry_filter_is_specific(monkeypatch) -> None
         )
 
 
-def test_full_workspace_saves_hold_one_lock_for_each_destination(
-    monkeypatch, tmp_path
-) -> None:
-    destination = tmp_path / "serialized.itws"
-    first_entered = threading.Event()
-    release_first = threading.Event()
-    second_entered = threading.Event()
-    call_count = 0
-    errors: list[BaseException] = []
-
-    def _record_locked_save(*_args, **_kwargs) -> None:
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            first_entered.set()
-            if not release_first.wait(2):
-                raise TimeoutError("first save was not released")
-        else:
-            second_entered.set()
-
-    def _save() -> None:
-        try:
-            workspace_storage._write_full_workspace_tree_file(destination, None, {})
-        except BaseException as exc:
-            errors.append(exc)
-
-    monkeypatch.setattr(
-        workspace_storage,
-        "_write_full_workspace_tree_file_locked",
-        _record_locked_save,
-    )
-    first = threading.Thread(target=_save)
-    second = threading.Thread(target=_save)
-    first.start()
-    assert first_entered.wait(2)
-    second.start()
-    assert not second_entered.wait(0.05)
-    release_first.set()
-    first.join(2)
-    second.join(2)
-
-    assert not first.is_alive()
-    assert not second.is_alive()
-    assert second_entered.is_set()
-    assert errors == []
-
-
-def test_incremental_workspace_save_does_not_copy_or_replace(
-    monkeypatch, tmp_path
-) -> None:
-    fname = tmp_path / "incremental-no-copy.itws"
+def test_workspace_recovery_discards_prepared_legacy_transaction(tmp_path) -> None:
+    fname = tmp_path / "prepared.itws"
     _write_transaction_test_workspace(fname)
-    rewrite = (
-        "0",
-        {"0/imagetool": _transaction_test_dataset(2.0, title="new")},
-    )
-
-    def _unexpected_file_operation(*_args, **_kwargs):
-        raise AssertionError("incremental saves must not copy or replace the file")
-
-    with monkeypatch.context() as patch:
-        patch.setattr(workspace_storage.shutil, "copyfile", _unexpected_file_operation)
-        patch.setattr(workspace_storage.os, "replace", _unexpected_file_operation)
-        workspace_storage._write_workspace_transaction_file(
-            fname,
-            (rewrite,),
-            (),
-            _transaction_test_root_attrs(delta_save_count=1),
-        )
-
-    assert _read_transaction_test_value(fname) == 2.0
-
-
-def test_incremental_save_rejects_destination_changed_since_snapshot(tmp_path) -> None:
-    fname = tmp_path / "changed-before-transaction.itws"
-    _write_transaction_test_workspace(fname, 1.0)
-    expected_state = workspace_storage._workspace_publication_state(fname)
-    _write_transaction_test_workspace(fname, 2.0)
-    rewrite = (
-        "0",
-        {"0/imagetool": _transaction_test_dataset(3.0, title="snapshot")},
-    )
-
-    with pytest.raises(workspace_storage._WorkspacePublicationConflictError):
-        workspace_storage._write_workspace_transaction_file(
-            fname,
-            (rewrite,),
-            (),
-            _transaction_test_root_attrs(delta_save_count=1),
-            expected_state=expected_state,
-        )
-
-    assert _read_transaction_test_value(fname) == 2.0
-
-
-def test_incremental_save_streams_stripped_lazy_data_from_private_reader(
-    tmp_path,
-) -> None:
-    fname = tmp_path / "lazy-private-reader.itws"
-    _write_transaction_test_workspace(fname)
-    opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
-    try:
-        transformed = (opened["data"] + 5.0).rename("data").to_dataset()
-        for variable in transformed.variables.values():
-            variable.encoding.clear()
-        assert transformed["data"].chunks is not None
-        assert workspace_arrays.dataarray_source_paths(transformed["data"]) == ()
-
-        workspace_storage._write_workspace_transaction_file(
-            fname,
-            (("0", {"0/imagetool": transformed}),),
-            (),
-            _transaction_test_root_attrs(delta_save_count=1),
-        )
-    finally:
-        opened.close()
-
-    assert _read_transaction_test_value(fname) == 6.0
-
-
-def test_workspace_recovery_discards_pending_only_transaction(tmp_path) -> None:
-    fname = tmp_path / "pending-only.itws"
-    _write_transaction_test_workspace(fname)
-    rewrite = ("0", {"0/imagetool": _transaction_test_dataset(2.0, title="new")})
-    rewrite_map = {"0": rewrite}
-    txn_id = "pendingonly"
-    txn_path = f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
-    pending_root = f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
-    backup_root = f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
-
-    workspace_storage._prepare_workspace_transaction(
-        fname,
-        txn_path,
-        pending_root,
-        backup_root,
-        rewrite_map,
-        (),
-        _transaction_test_root_attrs(delta_save_count=1),
-    )
-    workspace_storage._write_workspace_transaction_pending_groups(
-        fname, rewrite_map, pending_root
-    )
+    with h5py.File(fname, "a") as h5_file:
+        _create_legacy_transaction(h5_file, "prepared", status="preparing")
 
     workspace_storage._recover_workspace_transactions(fname)
 
@@ -930,41 +192,33 @@ def test_workspace_recovery_discards_pending_only_transaction(tmp_path) -> None:
     _assert_no_workspace_internal_groups(fname)
 
 
-def test_workspace_recovery_restores_backup_before_pending_move(tmp_path) -> None:
-
-    fname = tmp_path / "backup-before-pending.itws"
+@pytest.mark.parametrize("replacement_moved", [False, True])
+def test_workspace_recovery_rolls_back_legacy_group_replacement(
+    tmp_path, *, replacement_moved: bool
+) -> None:
+    fname = tmp_path / "committing.itws"
     _write_transaction_test_workspace(fname)
-    rewrite = ("0", {"0/imagetool": _transaction_test_dataset(2.0, title="new")})
-    rewrite_map = {"0": rewrite}
-    txn_id = "backuponly"
-    txn_path = f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
-    pending_root = f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
-    backup_root = f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
-    group_operations, _ = workspace_storage._prepare_workspace_transaction(
-        fname,
-        txn_path,
-        pending_root,
-        backup_root,
-        rewrite_map,
-        (),
-        _transaction_test_root_attrs(delta_save_count=1),
-    )
-    workspace_storage._write_workspace_transaction_pending_groups(
-        fname, rewrite_map, pending_root
-    )
-
+    backup_path = "__itws_backup_committing/imagetool"
+    operation = {
+        "group_path": "0/imagetool",
+        "pending_path": "__itws_pending_committing/imagetool",
+        "backup_path": backup_path,
+        "old_exists": True,
+    }
     with h5py.File(fname, "a") as h5_file:
-        workspace_storage._set_workspace_transaction_status(
+        _create_legacy_transaction(
             h5_file,
-            txn_path,
             "committing",
+            status="committing",
+            group_replacements=[operation],
         )
-        operation = group_operations[0]
-        workspace_storage._move_h5_path(
-            h5_file,
-            typing.cast("str", operation["group_path"]),
-            typing.cast("str", operation["backup_path"]),
-        )
+        h5_file.move("0/imagetool", backup_path)
+        if replacement_moved:
+            workspace_arrays._write_workspace_dataset_group_to_file(
+                h5_file,
+                "0/imagetool",
+                _transaction_test_dataset(2.0, title="new"),
+            )
 
     workspace_storage._recover_workspace_transactions(fname)
 
@@ -972,78 +226,29 @@ def test_workspace_recovery_restores_backup_before_pending_move(tmp_path) -> Non
     _assert_no_workspace_internal_groups(fname)
 
 
-def test_workspace_recovery_rolls_back_active_moved_before_commit(tmp_path) -> None:
-
-    fname = tmp_path / "active-before-commit.itws"
+def test_workspace_recovery_keeps_committed_legacy_replacement(tmp_path) -> None:
+    fname = tmp_path / "committed.itws"
     _write_transaction_test_workspace(fname)
-    rewrite = ("0", {"0/imagetool": _transaction_test_dataset(2.0, title="new")})
-    rewrite_map = {"0": rewrite}
-    txn_id = "activemoved"
-    txn_path = f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
-    pending_root = f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
-    backup_root = f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
-    group_operations, _ = workspace_storage._prepare_workspace_transaction(
-        fname,
-        txn_path,
-        pending_root,
-        backup_root,
-        rewrite_map,
-        (),
-        _transaction_test_root_attrs(delta_save_count=1),
-    )
-    workspace_storage._write_workspace_transaction_pending_groups(
-        fname, rewrite_map, pending_root
-    )
-
+    backup_path = "__itws_backup_committed/imagetool"
+    operation = {
+        "group_path": "0/imagetool",
+        "pending_path": "__itws_pending_committed/imagetool",
+        "backup_path": backup_path,
+        "old_exists": True,
+    }
     with h5py.File(fname, "a") as h5_file:
-        workspace_storage._set_workspace_transaction_status(
+        _create_legacy_transaction(
             h5_file,
-            txn_path,
-            "committing",
+            "committed",
+            status="committed",
+            group_replacements=[operation],
         )
-        operation = group_operations[0]
-        workspace_storage._move_h5_path(
+        h5_file.move("0/imagetool", backup_path)
+        workspace_arrays._write_workspace_dataset_group_to_file(
             h5_file,
-            typing.cast("str", operation["group_path"]),
-            typing.cast("str", operation["backup_path"]),
+            "0/imagetool",
+            _transaction_test_dataset(2.0, title="new"),
         )
-        workspace_storage._move_h5_path(
-            h5_file,
-            typing.cast("str", operation["pending_path"]),
-            typing.cast("str", operation["group_path"]),
-        )
-
-    workspace_storage._recover_workspace_transactions(fname)
-
-    assert _read_transaction_test_value(fname) == 1.0
-    _assert_no_workspace_internal_groups(fname)
-
-
-def test_workspace_recovery_accepts_committed_before_cleanup(tmp_path) -> None:
-    fname = tmp_path / "committed-before-cleanup.itws"
-    _write_transaction_test_workspace(fname)
-    rewrite = ("0", {"0/imagetool": _transaction_test_dataset(2.0, title="new")})
-    rewrite_map = {"0": rewrite}
-    txn_id = "committed"
-    txn_path = f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
-    pending_root = f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
-    backup_root = f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
-    root_attrs = _transaction_test_root_attrs(delta_save_count=1)
-    group_operations, attr_updates = workspace_storage._prepare_workspace_transaction(
-        fname,
-        txn_path,
-        pending_root,
-        backup_root,
-        rewrite_map,
-        (),
-        root_attrs,
-    )
-    workspace_storage._write_workspace_transaction_pending_groups(
-        fname, rewrite_map, pending_root
-    )
-    workspace_storage._commit_workspace_transaction(
-        fname, txn_path, group_operations, attr_updates, root_attrs
-    )
 
     workspace_storage._recover_workspace_transactions(fname)
 
@@ -1051,77 +256,28 @@ def test_workspace_recovery_accepts_committed_before_cleanup(tmp_path) -> None:
     _assert_no_workspace_internal_groups(fname)
 
 
-def test_workspace_recovery_rolls_back_attr_only_transaction(tmp_path) -> None:
-
-    fname = tmp_path / "attrs-before-commit.itws"
+def test_workspace_recovery_restores_legacy_attribute_backups(tmp_path) -> None:
+    fname = tmp_path / "attrs.itws"
     _write_transaction_test_workspace(fname)
-    fallback = (
-        "0",
-        {"0/imagetool": _transaction_test_dataset(2.0, title="fallback")},
-    )
-    attr_update = ("0/imagetool", {"itool_title": "new"}, fallback)
-    txn_id = "attrrollback"
-    txn_path = f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
-    pending_root = f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
-    backup_root = f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
-    root_attrs = _transaction_test_root_attrs(delta_save_count=1)
-    _, attr_updates = workspace_storage._prepare_workspace_transaction(
-        fname, txn_path, pending_root, backup_root, {}, (attr_update,), root_attrs
-    )
-
     with h5py.File(fname, "a") as h5_file:
-        workspace_storage._set_workspace_transaction_status(
-            h5_file,
-            txn_path,
-            "committing",
+        txn_group, _pending_root, _backup_root = _create_legacy_transaction(
+            h5_file, "attrs", status="committing"
+        )
+        workspace_storage._write_workspace_attr_backup(txn_group, 0, "/", h5_file.attrs)
+        workspace_storage._write_workspace_attr_backup(
+            txn_group, 1, "0/imagetool", h5_file["0/imagetool"].attrs
         )
         workspace_arrays._replace_h5_attrs(
-            h5_file["0/imagetool"].attrs, attr_updates[0][1]
+            h5_file.attrs, _transaction_test_root_attrs(delta_save_count=1)
         )
-        workspace_storage._write_root_attrs_to_open_workspace_file(h5_file, root_attrs)
-        h5_file.flush()
+        h5_file["0/imagetool"].attrs["itool_title"] = "new"
 
     workspace_storage._recover_workspace_transactions(fname)
 
     with h5py.File(fname, "r") as h5_file:
         assert h5_file["0/imagetool"].attrs["itool_title"] == "old"
-        assert (
-            workspace_format._workspace_delta_save_count_from_attrs(h5_file.attrs) == 0
-        )
-    _assert_no_workspace_internal_groups(fname)
-
-
-def test_workspace_transaction_attr_update_encodes_non_native_values(tmp_path) -> None:
-
-    fname = tmp_path / "rich-attrs-transaction.itws"
-    _write_transaction_test_workspace(fname)
-    fallback = (
-        "0",
-        {"0/imagetool": _transaction_test_dataset(2.0, title="fallback")},
-    )
-    rich_attr = _rich_workspace_attr_value()
-    workspace_storage._write_workspace_transaction_file(
-        fname,
-        (),
-        (
-            (
-                "0/imagetool",
-                {"itool_title": "new", "Single Motor Scan": rich_attr},
-                fallback,
-            ),
-        ),
-        _transaction_test_root_attrs(delta_save_count=1),
-    )
-
-    with h5py.File(fname, "r") as h5_file:
-        decoded_attrs = workspace_arrays._h5py_attrs_to_dict(
-            h5_file["0/imagetool"].attrs
-        )
-        assert decoded_attrs["itool_title"] == "new"
-        _assert_rich_workspace_attr(decoded_attrs["Single Motor Scan"])
-        assert (
-            workspace_format._workspace_delta_save_count_from_attrs(h5_file.attrs) == 1
-        )
+        manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
+        assert "delta_save_count" not in manifest
     _assert_no_workspace_internal_groups(fname)
 
 
@@ -1338,22 +494,6 @@ def test_workspace_document_access_releases_lock(tmp_path) -> None:
     assert lock.unlock_count == 1
 
 
-def test_workspace_high_risk_path_detection() -> None:
-    assert workspace_storage._workspace_path_is_high_risk(
-        pathlib.Path.home() / "OneDrive" / "workspace.itws"
-    )
-    assert workspace_storage._workspace_path_is_high_risk(
-        pathlib.Path.home()
-        / "Library"
-        / "Mobile Documents"
-        / "com~apple~CloudDocs"
-        / "workspace.itws"
-    )
-    assert workspace_storage._workspace_path_is_high_risk(
-        pathlib.Path("//server/share/workspace.itws")
-    )
-
-
 def test_workspace_lock_error_detection_message_variants() -> None:
     transient = OSError(errno.EACCES, "resource temporarily unavailable")
     assert workspace_storage._is_workspace_file_lock_error(transient)
@@ -1397,78 +537,6 @@ def test_workspace_document_lock_info_without_lock(tmp_path) -> None:
     assert info.pid is None
     assert info.hostname == ""
     assert info.appname == ""
-
-
-def test_workspace_path_risk_detection_fallbacks(monkeypatch, tmp_path) -> None:
-    def _raise_oserror(_path: pathlib.Path) -> pathlib.Path:
-        raise OSError("resolve failed")
-
-    monkeypatch.setattr(pathlib.Path, "resolve", _raise_oserror)
-    assert workspace_storage._workspace_path_is_likely_cloud_path(
-        tmp_path / "Dropbox" / "workspace.itws"
-    )
-    assert workspace_storage._workspace_path_is_likely_network_path(
-        pathlib.Path("/net/server/workspace.itws")
-    )
-
-    monkeypatch.setattr(workspace_storage.sys, "platform", "darwin")
-    assert workspace_storage._workspace_path_is_likely_network_path(
-        pathlib.Path("/Volumes/share/workspace.itws")
-    )
-
-
-def test_workspace_requires_full_save_reasons(tmp_path) -> None:
-    options = erlab.interactive.options
-    old_incremental = options["io/workspace/use_incremental"]
-    old_remote = options["io/workspace/incremental_save_on_remote"]
-    existing = tmp_path / "existing.itws"
-    existing.touch()
-    try:
-        options["io/workspace/use_incremental"] = False
-        assert workspace_storage._workspace_requires_full_save(
-            existing,
-            needs_full_save=False,
-            schema_version=workspace_format._current_workspace_schema_version(),
-            structure_modified=False,
-            has_dirty_added=False,
-            has_dirty_removed=False,
-        )
-
-        options["io/workspace/use_incremental"] = True
-        options["io/workspace/incremental_save_on_remote"] = True
-        assert workspace_storage._workspace_requires_full_save(
-            tmp_path / "missing.itws",
-            needs_full_save=False,
-            schema_version=workspace_format._current_workspace_schema_version(),
-            structure_modified=False,
-            has_dirty_added=False,
-            has_dirty_removed=False,
-        )
-        for kwargs in (
-            {"needs_full_save": True},
-            {
-                "schema_version": (
-                    workspace_format._current_workspace_schema_version() - 1
-                )
-            },
-            {"structure_modified": True},
-            {"has_dirty_added": True},
-            {"has_dirty_removed": True},
-        ):
-            call_kwargs = {
-                "needs_full_save": False,
-                "schema_version": workspace_format._current_workspace_schema_version(),
-                "structure_modified": False,
-                "has_dirty_added": False,
-                "has_dirty_removed": False,
-            }
-            call_kwargs.update(kwargs)
-            assert workspace_storage._workspace_requires_full_save(
-                existing, **call_kwargs
-            )
-    finally:
-        options["io/workspace/use_incremental"] = old_incremental
-        options["io/workspace/incremental_save_on_remote"] = old_remote
 
 
 def test_workspace_h5_transaction_helper_edge_cases(tmp_path) -> None:
@@ -1545,24 +613,3 @@ def test_recover_workspace_transactions_ignores_non_workspace_file(tmp_path) -> 
 
     with h5py.File(fname, "r") as h5_file:
         assert f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}x" in h5_file
-
-
-def test_validate_workspace_h5_file_rejects_non_workspace(tmp_path) -> None:
-
-    fname = tmp_path / "invalid.h5"
-    with h5py.File(fname, "w"):
-        pass
-
-    with pytest.raises(ValueError, match="not valid"):
-        workspace_storage._validate_workspace_h5_file(fname)
-
-
-def test_fsync_parent_directory_skips_non_posix(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr(workspace_storage.os, "name", "nt")
-    monkeypatch.setattr(
-        workspace_storage.os,
-        "open",
-        lambda *args, **kwargs: pytest.fail("non-posix platforms should not fsync"),
-    )
-
-    workspace_storage._fsync_parent_directory(tmp_path / "workspace.itws")

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -1,5 +1,6 @@
 import errno
 import json
+import os
 import pathlib
 import threading
 import types
@@ -66,10 +67,13 @@ def test_workspace_file_repack_payload_strips_delta_and_skips_internal_groups(
     assert existing_count == 1
     assert workspace_arrays._workspace_live_h5_storage_size(fname) == storage_size
     assert workspace_storage._workspace_obsolete_estimate(fname) >= 0
-    root_attrs, copy_groups = workspace_storage._workspace_file_repack_payload(fname)
+    root_attrs, copy_groups, expected_state = (
+        workspace_storage._workspace_file_repack_payload(fname)
+    )
 
     manifest = workspace_format._workspace_manifest_from_attrs(root_attrs)
     assert "delta_save_count" not in manifest
+    assert expected_state == workspace_storage._workspace_publication_state(fname)
     assert "transaction_protocol" not in manifest
     assert (
         manifest["schema_version"]
@@ -92,6 +96,32 @@ def test_workspace_file_repack_payload_strips_delta_and_skips_internal_groups(
         assert set(h5_file) == {"0"}
         manifest = workspace_format._workspace_manifest_from_attrs(h5_file.attrs)
         assert "delta_save_count" not in manifest
+
+
+def test_workspace_file_repack_payload_rejects_change_during_snapshot(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "changed-during-repack-snapshot.itws"
+    _write_transaction_test_workspace(fname)
+    original_copy_groups = workspace_arrays._workspace_live_root_group_copy_groups
+
+    def _copy_groups_after_external_change(path):
+        copy_groups = original_copy_groups(path)
+        stat_result = os.stat(path)
+        os.utime(
+            path,
+            ns=(stat_result.st_atime_ns, stat_result.st_mtime_ns + 1_000_000),
+        )
+        return copy_groups
+
+    monkeypatch.setattr(
+        workspace_arrays,
+        "_workspace_live_root_group_copy_groups",
+        _copy_groups_after_external_change,
+    )
+
+    with pytest.raises(workspace_storage._WorkspacePublicationConflictError):
+        workspace_storage._workspace_file_repack_payload(fname)
 
 
 def test_write_full_workspace_tree_file_compresses_payload_not_coords(
@@ -711,6 +741,29 @@ def test_replace_workspace_file_preserves_permission_error_after_retries(
     assert destination.read_bytes() == b"old"
 
 
+def test_full_save_rejects_destination_changed_since_snapshot(tmp_path) -> None:
+    fname = tmp_path / "changed-before-worker.itws"
+    _write_transaction_test_workspace(fname, 1.0)
+    expected_state = workspace_storage._workspace_publication_state(fname)
+    _write_transaction_test_workspace(fname, 2.0)
+    tree = xr.DataTree.from_dict(
+        {"0/imagetool": _transaction_test_dataset(3.0, title="snapshot")}
+    )
+
+    try:
+        with pytest.raises(workspace_storage._WorkspacePublicationConflictError):
+            workspace_storage._write_full_workspace_tree_file(
+                fname,
+                tree,
+                _transaction_test_root_attrs(),
+                expected_state=expected_state,
+            )
+    finally:
+        tree.close()
+
+    assert _read_transaction_test_value(fname) == 2.0
+
+
 def test_windows_workspace_replace_retry_filter_is_specific(monkeypatch) -> None:
     access_denied = PermissionError(errno.EACCES, "access denied")
     wrong_error = PermissionError(errno.ENOENT, "missing")
@@ -796,6 +849,28 @@ def test_incremental_workspace_save_does_not_copy_or_replace(
             (rewrite,),
             (),
             _transaction_test_root_attrs(delta_save_count=1),
+        )
+
+    assert _read_transaction_test_value(fname) == 2.0
+
+
+def test_incremental_save_rejects_destination_changed_since_snapshot(tmp_path) -> None:
+    fname = tmp_path / "changed-before-transaction.itws"
+    _write_transaction_test_workspace(fname, 1.0)
+    expected_state = workspace_storage._workspace_publication_state(fname)
+    _write_transaction_test_workspace(fname, 2.0)
+    rewrite = (
+        "0",
+        {"0/imagetool": _transaction_test_dataset(3.0, title="snapshot")},
+    )
+
+    with pytest.raises(workspace_storage._WorkspacePublicationConflictError):
+        workspace_storage._write_workspace_transaction_file(
+            fname,
+            (rewrite,),
+            (),
+            _transaction_test_root_attrs(delta_save_count=1),
+            expected_state=expected_state,
         )
 
     assert _read_transaction_test_value(fname) == 2.0

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -1,6 +1,7 @@
 import errno
 import json
 import pathlib
+import threading
 import types
 import typing
 
@@ -433,6 +434,7 @@ def test_write_full_workspace_tree_file_network_scratch_skips_copy_reuse(
     finally:
         tree.close()
 
+    monkeypatch.undo()
     assert _read_transaction_test_value(fname) == 3.0
 
 
@@ -550,6 +552,7 @@ def test_write_full_workspace_tree_file_scratch_replace_failure_preserves_old(
     finally:
         tree.close()
 
+    monkeypatch.undo()
     assert _read_transaction_test_value(fname) == 1.0
     assert scratch_paths
     assert all(not scratch_path.exists() for scratch_path in scratch_paths)
@@ -597,10 +600,230 @@ def test_write_full_workspace_tree_file_scratch_copy_failure_cleans_destination_
     finally:
         tree.close()
 
+    monkeypatch.undo()
     assert _read_transaction_test_value(fname) == 1.0
     assert scratch_paths
     assert all(not scratch_path.exists() for scratch_path in scratch_paths)
     assert not list(fname.parent.glob(f"{fname.name}.tmp-*"))
+
+
+def test_replace_workspace_file_retries_transient_access_denied(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "prepared.itws"
+    destination = tmp_path / "workspace.itws"
+    source.write_bytes(b"new")
+    destination.write_bytes(b"old")
+    expected_state = workspace_storage._workspace_publication_state(destination)
+    original_replace = workspace_storage.os.replace
+    replace_attempts = 0
+    delays: list[float] = []
+
+    def _replace_with_transient_denial(src, dst) -> None:
+        nonlocal replace_attempts
+        replace_attempts += 1
+        if replace_attempts < 3:
+            raise PermissionError(errno.EACCES, "file is in use", dst)
+        original_replace(src, dst)
+
+    monkeypatch.setattr(
+        workspace_storage,
+        "_is_retryable_windows_workspace_replace_error",
+        lambda _exc: True,
+    )
+    monkeypatch.setattr(workspace_storage.os, "replace", _replace_with_transient_denial)
+    monkeypatch.setattr(workspace_storage.time, "sleep", delays.append)
+
+    workspace_storage._replace_workspace_file(
+        source, destination, expected_state=expected_state
+    )
+
+    assert replace_attempts == 3
+    assert delays == [0.02, 0.05]
+    assert destination.read_bytes() == b"new"
+
+
+def test_replace_workspace_file_stops_if_destination_changes_during_retry(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "prepared.itws"
+    destination = tmp_path / "workspace.itws"
+    source.write_bytes(b"new")
+    destination.write_bytes(b"old")
+    expected_state = workspace_storage._workspace_publication_state(destination)
+
+    def _replace_after_external_change(_src, dst) -> None:
+        pathlib.Path(dst).write_bytes(b"changed outside the manager")
+        raise PermissionError(errno.EACCES, "file is in use", dst)
+
+    monkeypatch.setattr(
+        workspace_storage,
+        "_is_retryable_windows_workspace_replace_error",
+        lambda _exc: True,
+    )
+    monkeypatch.setattr(workspace_storage.os, "replace", _replace_after_external_change)
+    monkeypatch.setattr(workspace_storage.time, "sleep", lambda _delay: None)
+
+    with pytest.raises(workspace_storage._WorkspacePublicationConflictError):
+        workspace_storage._replace_workspace_file(
+            source, destination, expected_state=expected_state
+        )
+
+    assert source.read_bytes() == b"new"
+    assert destination.read_bytes() == b"changed outside the manager"
+
+
+def test_replace_workspace_file_preserves_permission_error_after_retries(
+    monkeypatch, tmp_path
+) -> None:
+    source = tmp_path / "prepared.itws"
+    destination = tmp_path / "workspace.itws"
+    source.write_bytes(b"new")
+    destination.write_bytes(b"old")
+    expected_state = workspace_storage._workspace_publication_state(destination)
+    attempts = 0
+
+    def _deny_replace(_src, dst) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise PermissionError(errno.EACCES, "file is in use", dst)
+
+    monkeypatch.setattr(
+        workspace_storage,
+        "_WINDOWS_WORKSPACE_REPLACE_RETRY_DELAYS",
+        (0.0, 0.0),
+    )
+    monkeypatch.setattr(
+        workspace_storage,
+        "_is_retryable_windows_workspace_replace_error",
+        lambda _exc: True,
+    )
+    monkeypatch.setattr(workspace_storage.os, "replace", _deny_replace)
+    monkeypatch.setattr(workspace_storage.time, "sleep", lambda _delay: None)
+
+    with pytest.raises(PermissionError, match="file is in use"):
+        workspace_storage._replace_workspace_file(
+            source, destination, expected_state=expected_state
+        )
+
+    assert attempts == 3
+    assert source.read_bytes() == b"new"
+    assert destination.read_bytes() == b"old"
+
+
+def test_windows_workspace_replace_retry_filter_is_specific(monkeypatch) -> None:
+    access_denied = PermissionError(errno.EACCES, "access denied")
+    wrong_error = PermissionError(errno.ENOENT, "missing")
+
+    assert not workspace_storage._is_retryable_windows_workspace_replace_error(
+        access_denied
+    )
+    with monkeypatch.context() as patch:
+        patch.setattr(workspace_storage.os, "name", "nt")
+        assert workspace_storage._is_retryable_windows_workspace_replace_error(
+            access_denied
+        )
+        assert not workspace_storage._is_retryable_windows_workspace_replace_error(
+            wrong_error
+        )
+
+
+def test_full_workspace_saves_hold_one_lock_for_each_destination(
+    monkeypatch, tmp_path
+) -> None:
+    destination = tmp_path / "serialized.itws"
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    call_count = 0
+    errors: list[BaseException] = []
+
+    def _record_locked_save(*_args, **_kwargs) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            first_entered.set()
+            if not release_first.wait(2):
+                raise TimeoutError("first save was not released")
+        else:
+            second_entered.set()
+
+    def _save() -> None:
+        try:
+            workspace_storage._write_full_workspace_tree_file(destination, None, {})
+        except BaseException as exc:
+            errors.append(exc)
+
+    monkeypatch.setattr(
+        workspace_storage,
+        "_write_full_workspace_tree_file_locked",
+        _record_locked_save,
+    )
+    first = threading.Thread(target=_save)
+    second = threading.Thread(target=_save)
+    first.start()
+    assert first_entered.wait(2)
+    second.start()
+    assert not second_entered.wait(0.05)
+    release_first.set()
+    first.join(2)
+    second.join(2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert second_entered.is_set()
+    assert errors == []
+
+
+def test_incremental_workspace_save_does_not_copy_or_replace(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "incremental-no-copy.itws"
+    _write_transaction_test_workspace(fname)
+    rewrite = (
+        "0",
+        {"0/imagetool": _transaction_test_dataset(2.0, title="new")},
+    )
+
+    def _unexpected_file_operation(*_args, **_kwargs):
+        raise AssertionError("incremental saves must not copy or replace the file")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(workspace_storage.shutil, "copyfile", _unexpected_file_operation)
+        patch.setattr(workspace_storage.os, "replace", _unexpected_file_operation)
+        workspace_storage._write_workspace_transaction_file(
+            fname,
+            (rewrite,),
+            (),
+            _transaction_test_root_attrs(delta_save_count=1),
+        )
+
+    assert _read_transaction_test_value(fname) == 2.0
+
+
+def test_incremental_save_streams_stripped_lazy_data_from_private_reader(
+    tmp_path,
+) -> None:
+    fname = tmp_path / "lazy-private-reader.itws"
+    _write_transaction_test_workspace(fname)
+    opened = workspace_arrays.open_workspace_dataset(fname, "0/imagetool", chunks={})
+    try:
+        transformed = (opened["data"] + 5.0).rename("data").to_dataset()
+        for variable in transformed.variables.values():
+            variable.encoding.clear()
+        assert transformed["data"].chunks is not None
+        assert workspace_arrays.dataarray_source_paths(transformed["data"]) == ()
+
+        workspace_storage._write_workspace_transaction_file(
+            fname,
+            (("0", {"0/imagetool": transformed}),),
+            (),
+            _transaction_test_root_attrs(delta_save_count=1),
+        )
+    finally:
+        opened.close()
+
+    assert _read_transaction_test_value(fname) == 6.0
 
 
 def test_workspace_recovery_discards_pending_only_transaction(tmp_path) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -255,6 +255,60 @@ def test_workspace_generation_removes_partial_object_after_copy_error(
         assert target_store.generations() == ()
 
 
+def test_workspace_generation_removes_all_new_objects_after_plan_error(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    plan = workspace_storage._WorkspaceGenerationPlan(
+        manifest=_manifest("written"),
+        objects=(
+            workspace_storage._WorkspaceObjectWrite(
+                "written", dataset=xr.Dataset({"data": ("x", np.arange(3))})
+            ),
+            workspace_storage._WorkspaceObjectWrite("missing-source"),
+        ),
+    )
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with pytest.raises(ValueError, match="has no source"):
+            workspace_storage._write_workspace_generation(
+                store, plan, compression_mode="none"
+            )
+
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == set()
+        assert store.generations() == ()
+
+
+def test_workspace_generation_keeps_objects_referenced_by_committed_generation(
+    monkeypatch, tmp_path: pathlib.Path
+) -> None:
+    path = tmp_path / "workspace.itws"
+    plan = workspace_storage._WorkspaceGenerationPlan(
+        manifest=_manifest("committed"),
+        objects=(
+            workspace_storage._WorkspaceObjectWrite(
+                "committed", dataset=xr.Dataset({"data": ("x", np.arange(3))})
+            ),
+        ),
+    )
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        original_publish = store.publish
+
+        def _publish_then_fail(manifest) -> workspace_store._WorkspaceGeneration:
+            original_publish(manifest)
+            raise RuntimeError("post-publication failure")
+
+        monkeypatch.setattr(store, "publish", _publish_then_fail)
+        with pytest.raises(RuntimeError, match="post-publication failure"):
+            workspace_storage._write_workspace_generation(
+                store, plan, compression_mode="none"
+            )
+
+        assert store.current_generation().manifest == _manifest("committed")
+        assert "committed" in store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+
+
 def test_workspace_store_shares_lazy_reader_and_generation_writer(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -358,6 +412,81 @@ def test_workspace_compaction_keeps_current_state_and_reopens_store(
         assert path.stat().st_size < size_before
 
 
+def test_workspace_store_active_waits_for_file_replacement(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared_path = tmp_path / "prepared.itws"
+    with workspace_store.WorkspaceStore(prepared_path, create=True) as prepared_store:
+        prepared_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
+            "prepared"
+        )
+        prepared_store.publish(_manifest("prepared"))
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+        store.publish(_manifest("current"))
+        replacement_started = threading.Event()
+        allow_replacement = threading.Event()
+        lookup_finished = threading.Event()
+        lookup_result: list[workspace_store.WorkspaceStore | None] = []
+        errors: list[BaseException] = []
+
+        def _replace(source, destination) -> None:
+            replacement_started.set()
+            if not allow_replacement.wait(2):
+                raise TimeoutError("replacement was not released")
+            source.replace(destination)
+
+        def _run_replacement() -> None:
+            try:
+                store.replace_from(prepared_path, _replace)
+            except BaseException as exc:
+                errors.append(exc)
+
+        def _lookup_active_store() -> None:
+            lookup_result.append(workspace_store.WorkspaceStore.active(path))
+            lookup_finished.set()
+
+        replacement_thread = threading.Thread(target=_run_replacement)
+        lookup_thread = threading.Thread(target=_lookup_active_store)
+        replacement_thread.start()
+        assert replacement_started.wait(2)
+        lookup_thread.start()
+        try:
+            assert not lookup_finished.wait(0.05)
+        finally:
+            allow_replacement.set()
+        replacement_thread.join(2)
+        lookup_thread.join(2)
+
+        assert not replacement_thread.is_alive()
+        assert not lookup_thread.is_alive()
+        assert errors == []
+        assert lookup_result == [store]
+        assert store.current_generation().manifest == _manifest("prepared")
+
+
+def test_workspace_store_reopens_after_failed_file_replacement(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared_path = tmp_path / "prepared.itws"
+    prepared_path.write_bytes(b"prepared")
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store.publish(_manifest())
+
+        def _fail_replace(_source, destination) -> None:
+            raise PermissionError(f"Cannot replace {destination}")
+
+        with pytest.raises(PermissionError, match="Cannot replace"):
+            store.replace_from(prepared_path, _fail_replace)
+
+        assert not store.conflicted
+        assert workspace_store.WorkspaceStore.active(path) is store
+        assert store.current_generation().manifest == _manifest()
+
+
 def test_workspace_compaction_does_not_overwrite_external_replacement(
     monkeypatch, tmp_path: pathlib.Path
 ) -> None:
@@ -387,7 +516,15 @@ def test_workspace_compaction_does_not_overwrite_external_replacement(
         with pytest.raises(workspace_store.WorkspaceStoreConflictError):
             workspace_storage._compact_workspace_store(store)
 
-        assert store.current_generation().manifest == _manifest("external")
+        assert store.conflicted
+        assert workspace_store.WorkspaceStore.active(path) is store
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            _ = store.h5_file
+        store.close()
+        with workspace_store.WorkspaceStore(path) as replacement_store:
+            assert replacement_store.current_generation().manifest == _manifest(
+                "external"
+            )
 
 
 def test_workspace_compaction_preserves_leased_payloads(
@@ -513,3 +650,7 @@ def test_workspace_store_rejects_replaced_document_path(
 
         with pytest.raises(workspace_store.WorkspaceStoreConflictError):
             store.publish(_manifest())
+        assert store.conflicted
+        assert workspace_store.WorkspaceStore.active(path) is store
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            _ = store.h5_file

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -625,8 +625,53 @@ def test_workspace_store_rejects_changed_copy_on_write_source(
         ):
             _write_while_source_changes()
 
-        assert "staged" not in store.h5_file.attrs
-        assert store.h5_file.attrs["external"]
+        assert store.conflicted
+        assert store.recovery_path is not None
+        assert store.read_h5_file.attrs["staged"]
+        with h5py.File(path, "r", locking=False) as external:
+            assert "staged" not in external.attrs
+            assert external.attrs["external"]
+        with (
+            pytest.raises(
+                workspace_store.WorkspaceStoreConflictError,
+                match="no longer owns its path",
+            ),
+            store.write_session(),
+        ):
+            pass
+
+
+def test_workspace_store_quarantines_failed_copy_on_write_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    import h5py
+
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store._locking_supported = False
+        monkeypatch.setattr(
+            store,
+            "_use_recovery_source",
+            lambda _path: (_ for _ in ()).throw(RuntimeError("cannot reopen")),
+        )
+
+        def _write_while_source_changes() -> None:
+            with (
+                store.write_session(),
+                h5py.File(path, "r+", locking=False) as external,
+            ):
+                external.attrs["external"] = True
+                external.flush()
+
+        with pytest.raises(
+            workspace_store.WorkspaceStoreConflictError,
+            match="changed during save",
+        ):
+            _write_while_source_changes()
+
+        assert store.conflicted
+        assert store.recovery_path is None
         assert set(tmp_path.iterdir()) == {path}
 
 
@@ -703,6 +748,45 @@ def test_workspace_store_gc_retains_two_generations_and_leases(
 
         store.release_object("first")
         assert not store.collect_garbage(max_objects=10)
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "second",
+            "third",
+        }
+
+
+def test_workspace_store_gc_can_defer_obsolete_object_deletion(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session() as h5_file:
+            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            for object_id in ("first", "second", "third"):
+                objects.create_group(object_id)
+        store.publish(_manifest("first"))
+        store.publish(_manifest("second"))
+        store.publish(_manifest("third"))
+
+        assert store.collect_garbage(max_objects=1, delete_objects=False)
+        assert len(store.generations()) == 2
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "first",
+            "second",
+            "third",
+        }
+
+        checks = iter((True, False))
+        assert store.collect_garbage(
+            max_objects=1,
+            can_delete_objects=lambda: next(checks),
+        )
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "first",
+            "second",
+            "third",
+        }
+
+        assert not store.collect_garbage(max_objects=1)
         assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
             "second",
             "third",

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import threading
 import typing
 
@@ -485,6 +486,114 @@ def test_workspace_store_reopens_after_failed_file_replacement(
         assert not store.conflicted
         assert workspace_store.WorkspaceStore.active(path) is store
         assert store.current_generation().manifest == _manifest()
+
+
+def test_workspace_store_uses_prepared_recovery_if_original_cannot_reopen(
+    monkeypatch, tmp_path: pathlib.Path
+) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared_path = tmp_path / "prepared.itws"
+    with workspace_store.WorkspaceStore(prepared_path, create=True) as prepared_store:
+        prepared_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
+            "prepared"
+        )
+        prepared_store.publish(_manifest("prepared"))
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store.publish(_manifest())
+
+        def _deny_reopen(*, create: bool) -> None:
+            if create:
+                raise AssertionError("Replacement recovery must not create a file")
+            raise PermissionError(errno.EACCES, "reopen denied", path)
+
+        monkeypatch.setattr(store, "_open", _deny_reopen)
+        monkeypatch.setattr(workspace_store, "_FILE_ACCESS_RETRY_DELAYS", (0.0, 0.0))
+        monkeypatch.setattr(workspace_store.time, "sleep", lambda _delay: None)
+
+        def _fail_replace(_source, destination) -> None:
+            raise PermissionError(f"Cannot replace {destination}")
+
+        with pytest.raises(PermissionError, match="Cannot replace"):
+            store.replace_from(prepared_path, _fail_replace)
+
+        assert store.conflicted
+        assert workspace_store.WorkspaceStore.active(path) is store
+        assert store.current_generation().manifest == _manifest("prepared")
+
+
+def test_workspace_store_retries_reopen_after_successful_replacement(
+    monkeypatch, tmp_path: pathlib.Path
+) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared_path = tmp_path / "prepared.itws"
+    with workspace_store.WorkspaceStore(prepared_path, create=True) as prepared_store:
+        prepared_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
+            "prepared"
+        )
+        prepared_store.publish(_manifest("prepared"))
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store.publish(_manifest())
+        original_open = store._open
+        reopen_attempts = 0
+        delays: list[float] = []
+
+        def _open_with_transient_denial(*, create: bool) -> None:
+            nonlocal reopen_attempts
+            reopen_attempts += 1
+            if reopen_attempts < 3:
+                raise PermissionError(errno.EACCES, "reopen denied", path)
+            original_open(create=create)
+
+        monkeypatch.setattr(store, "_open", _open_with_transient_denial)
+        monkeypatch.setattr(workspace_store, "_FILE_ACCESS_RETRY_DELAYS", (0.0, 0.0))
+        monkeypatch.setattr(workspace_store.time, "sleep", delays.append)
+
+        store.replace_from(
+            prepared_path,
+            lambda source, destination: source.replace(destination),
+        )
+
+        assert reopen_attempts == 3
+        assert delays == [0.0, 0.0]
+        assert workspace_store.WorkspaceStore.active(path) is store
+        assert store.current_generation().manifest == _manifest("prepared")
+
+
+def test_workspace_compaction_retains_prepared_recovery_file(
+    monkeypatch, tmp_path: pathlib.Path
+) -> None:
+    path = tmp_path / "workspace.itws"
+    recovery_path: pathlib.Path | None = None
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+        store.publish(_manifest("current"))
+
+        def _deny_reopen(*, create: bool) -> None:
+            if create:
+                raise AssertionError("Replacement recovery must not create a file")
+            raise PermissionError(errno.EACCES, "reopen denied", path)
+
+        def _fail_replace(*_args, **_kwargs) -> None:
+            raise PermissionError(errno.EACCES, "replace denied", path)
+
+        monkeypatch.setattr(store, "_open", _deny_reopen)
+        monkeypatch.setattr(workspace_storage, "_replace_workspace_file", _fail_replace)
+        monkeypatch.setattr(workspace_store, "_FILE_ACCESS_RETRY_DELAYS", (0.0,))
+        monkeypatch.setattr(workspace_store.time, "sleep", lambda _delay: None)
+
+        with pytest.raises(PermissionError, match="replace denied"):
+            workspace_storage._compact_workspace_store(store)
+
+        recovery_path = store.recovery_path
+        assert recovery_path is not None
+        assert recovery_path.exists()
+        assert store.conflicted
+        assert store.current_generation().manifest == _manifest("current")
+
+    assert recovery_path is not None
+    assert not recovery_path.exists()
 
 
 def test_workspace_compaction_does_not_overwrite_external_replacement(

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -249,6 +249,18 @@ def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None
         assert store.serialized_object_ids == {"old-object"}
         assert store.serialized_legacy_group_paths == {"/legacy"}
         assert store.has_serialized_readers
+        workspace_store.WorkspaceStore.pin_serialized_reader(
+            workspace_id=workspace_id,
+            path=path,
+            object_id="kept-object",
+            legacy_group_path="/kept-legacy",
+        )
+        store.release_serialized_reader_pins(
+            object_ids={"old-object"},
+            legacy_group_paths={"/legacy"},
+        )
+        assert store.serialized_object_ids == {"kept-object"}
+        assert store.serialized_legacy_group_paths == {"/kept-legacy"}
         store.clear_serialized_reader_pins()
         assert not store.has_serialized_readers
         assert store.serialized_object_ids == set()
@@ -1729,12 +1741,23 @@ def test_workspace_compaction_preserves_leased_and_serialized_payloads(
             "leased",
             "serialized",
         }
-        store.release_object("leased")
-        assert not store.collect_garbage(max_objects=1)
+
+        workspace_storage._compact_workspace_store(
+            store,
+            discard_serialized_object_ids={"serialized"},
+        )
+
         assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
             "current",
-            "serialized",
+            "leased",
         }
+        assert store.serialized_object_ids == {"serialized"}
+        store.release_serialized_reader_pins(object_ids={"serialized"})
+        assert not store.has_serialized_readers
+        store.release_object("leased")
+        assert not store.collect_garbage(max_objects=1)
+        remaining = set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP])
+        assert remaining == {"current"}
 
 
 def test_workspace_compaction_preserves_serialized_legacy_group(

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import threading
+import typing
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from erlab.interactive.imagetool.manager._workspace import _arrays as workspace_arrays
+from erlab.interactive.imagetool.manager._workspace import _storage as workspace_storage
+from erlab.interactive.imagetool.manager._workspace import _store as workspace_store
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+
+def _manifest(*object_ids: str) -> dict[str, object]:
+    return {
+        "schema_version": 5,
+        "nodes": [
+            {
+                "uid": f"node-{index}",
+                "kind": "imagetool",
+                "path": str(index),
+                "payload_object_id": object_id,
+                "payload_path": workspace_store.WorkspaceStore.object_path(object_id),
+            }
+            for index, object_id in enumerate(object_ids)
+        ],
+        "root_order": list(range(len(object_ids))),
+    }
+
+
+def test_workspace_store_publishes_valid_generations(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+        objects.create_group("first")
+        objects.create_group("second")
+        first = store.publish(_manifest("first"))
+        second = store.publish(_manifest("second"))
+
+        assert first.sequence == 1
+        assert second.sequence == 2
+        assert store.current_generation() == second
+
+        generation_group = store.h5_file[
+            f"{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}"
+        ]
+        generation_group[workspace_store._WORKSPACE_MANIFEST_DATASET].attrs[
+            "sha256"
+        ] = "invalid"
+
+        assert store.current_generation() == first
+
+
+def test_workspace_store_rejects_generation_with_missing_object(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with pytest.raises(ValueError, match="payload object is missing"):
+            store.publish(_manifest("missing"))
+
+        assert store.generations() == ()
+        assert len(store.h5_file[workspace_store._WORKSPACE_STAGING_GROUP]) == 0
+
+
+def test_workspace_store_gc_retains_two_generations_and_leases(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+        for object_id in ("first", "second", "third"):
+            objects.create_group(object_id)
+        store.publish(_manifest("first"))
+        store.publish(_manifest("second"))
+        store.acquire_object("first")
+        store.publish(_manifest("third"))
+
+        assert not store.collect_garbage(max_objects=10)
+        assert set(objects) == {"first", "second", "third"}
+        assert len(store.generations()) == 2
+
+        store.release_object("first")
+        assert not store.collect_garbage(max_objects=10)
+        assert set(objects) == {"second", "third"}
+
+
+def test_workspace_store_gc_removes_malformed_generation_names(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+        objects.create_group("current")
+        store.publish(_manifest("current"))
+        generation_root = store.h5_file[workspace_store._WORKSPACE_GENERATIONS_GROUP]
+        generation_root.create_group("1")
+
+        assert not store.collect_garbage(max_objects=1)
+
+        assert set(generation_root) == {"00000000000000000001"}
+
+
+def test_workspace_generation_write_blocks_concurrent_gc(
+    monkeypatch, tmp_path: pathlib.Path
+) -> None:
+    path = tmp_path / "workspace.itws"
+    object_written = threading.Event()
+    release_write = threading.Event()
+    gc_finished = threading.Event()
+    errors: list[BaseException] = []
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        plan = workspace_storage._WorkspaceGenerationPlan(
+            manifest=_manifest("pending"),
+            objects=(
+                workspace_storage._WorkspaceObjectWrite(
+                    "pending", dataset=xr.Dataset()
+                ),
+            ),
+        )
+
+        monkeypatch.setattr(
+            workspace_arrays, "_workspace_dataset_can_write_h5py", lambda _ds: False
+        )
+
+        def _delayed_write(h5_file, group_path, _ds, **_kwargs) -> None:
+            h5_file.require_group(group_path)
+            object_written.set()
+            if not release_write.wait(2):
+                raise TimeoutError("generation write was not released")
+
+        monkeypatch.setattr(
+            workspace_arrays,
+            "_write_workspace_dataset_group_to_file",
+            _delayed_write,
+        )
+
+        def _save() -> None:
+            try:
+                workspace_storage._write_workspace_generation(
+                    store, plan, compression_mode="none"
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        def _collect() -> None:
+            try:
+                store.collect_garbage(max_objects=1)
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                gc_finished.set()
+
+        save_thread = threading.Thread(target=_save)
+        gc_thread = threading.Thread(target=_collect)
+        save_thread.start()
+        assert object_written.wait(2)
+        gc_thread.start()
+        try:
+            assert not gc_finished.wait(0.05)
+        finally:
+            release_write.set()
+        save_thread.join(2)
+        gc_thread.join(2)
+
+        assert not save_thread.is_alive()
+        assert not gc_thread.is_alive()
+        assert errors == []
+        assert store.current_generation().manifest == _manifest("pending")
+        assert "pending" in store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+
+
+def test_workspace_generation_removes_partial_object_after_write_error(
+    monkeypatch, tmp_path: pathlib.Path
+) -> None:
+    path = tmp_path / "workspace.itws"
+    plan = workspace_storage._WorkspaceGenerationPlan(
+        manifest=_manifest("partial"),
+        objects=(
+            workspace_storage._WorkspaceObjectWrite(
+                "partial", dataset=xr.Dataset({"data": ("x", np.arange(3))})
+            ),
+        ),
+    )
+
+    def _write_partial_then_fail(h5_file, group_path, _dataset, **_kwargs) -> None:
+        h5_file.require_group(group_path)
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr(
+        workspace_arrays,
+        "_write_workspace_dataset_group_to_file",
+        _write_partial_then_fail,
+    )
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with pytest.raises(RuntimeError, match="write failed"):
+            workspace_storage._write_workspace_generation(
+                store, plan, compression_mode="none"
+            )
+
+        assert store.object_path("partial").strip("/") not in store.h5_file
+        assert store.generations() == ()
+
+
+def test_workspace_generation_removes_partial_object_after_copy_error(
+    monkeypatch, tmp_path: pathlib.Path
+) -> None:
+    source_path = tmp_path / "source.itws"
+    target_path = tmp_path / "target.itws"
+    with workspace_store.WorkspaceStore(source_path, create=True) as source_store:
+        source_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
+            "source"
+        )
+        source_store.publish(_manifest("source"))
+
+    def _copy_partial_then_fail(
+        _source_file,
+        target_file,
+        _source_path,
+        target_group_path,
+        _attrs,
+    ) -> bool:
+        target_file.require_group(target_group_path)
+        raise RuntimeError("copy failed")
+
+    monkeypatch.setattr(
+        workspace_arrays,
+        "_copy_workspace_h5_group_to_open_file",
+        _copy_partial_then_fail,
+    )
+    plan = workspace_storage._WorkspaceGenerationPlan(
+        manifest=_manifest("copied"),
+        objects=(
+            workspace_storage._WorkspaceObjectWrite(
+                "copied",
+                source_file=str(source_path),
+                source_path=workspace_store.WorkspaceStore.object_path("source"),
+            ),
+        ),
+    )
+
+    with workspace_store.WorkspaceStore(target_path, create=True) as target_store:
+        with pytest.raises(RuntimeError, match="copy failed"):
+            workspace_storage._write_workspace_generation(
+                target_store, plan, compression_mode="none"
+            )
+
+        assert target_store.object_path("copied").strip("/") not in target_store.h5_file
+        assert target_store.generations() == ()
+
+
+def test_workspace_store_shares_lazy_reader_and_generation_writer(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    dataset = xr.Dataset(
+        {"data": (("x", "y"), np.arange(30, dtype=np.float64).reshape(5, 6))}
+    )
+    object_id = "payload"
+    plan = workspace_storage._WorkspaceGenerationPlan(
+        manifest=_manifest(object_id),
+        objects=(workspace_storage._WorkspaceObjectWrite(object_id, dataset=dataset),),
+    )
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        workspace_storage._write_workspace_generation(
+            store,
+            plan,
+            compression_mode="none",
+        )
+        opened = workspace_arrays.open_workspace_dataset(
+            path,
+            store.object_path(object_id),
+            chunks={},
+        )
+        try:
+            assert opened["data"].chunks is not None
+            assert float(opened["data"].sum().compute()) == 435.0
+            derived_id = "derived"
+            derived = opened + 1
+            import dask
+
+            with dask.config.set(scheduler="processes"):
+                workspace_storage._write_workspace_generation(
+                    store,
+                    workspace_storage._WorkspaceGenerationPlan(
+                        manifest=_manifest(derived_id),
+                        objects=(
+                            workspace_storage._WorkspaceObjectWrite(
+                                derived_id,
+                                dataset=derived,
+                            ),
+                        ),
+                    ),
+                    compression_mode="none",
+                )
+            saved = workspace_arrays.open_workspace_dataset(
+                path,
+                store.object_path(derived_id),
+                chunks={},
+            )
+            try:
+                assert float(saved["data"].sum().compute()) == 465.0
+                workspace_storage._compact_workspace_store(store)
+                assert float(opened["data"].sum().compute()) == 435.0
+                assert float(saved["data"].sum().compute()) == 465.0
+            finally:
+                saved.close()
+            assert store.h5_file.id.valid
+        finally:
+            opened.close()
+
+
+def test_workspace_raw_reads_reuse_active_store_handle(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with (
+        workspace_store.WorkspaceStore(path, create=True) as store,
+        workspace_arrays._open_workspace_h5_file_for_read(path) as h5_file,
+    ):
+        assert h5_file is store.h5_file
+
+
+def test_workspace_compaction_keeps_current_state_and_reopens_store(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+        objects.create_group("obsolete").create_dataset(
+            "data", data=np.ones(2_000_000, dtype=np.float64)
+        )
+        objects.create_group("current").create_dataset(
+            "data", data=np.arange(10, dtype=np.float64)
+        )
+        store.publish(_manifest("obsolete"))
+        store.publish(_manifest("current"))
+        size_before = path.stat().st_size
+
+        workspace_storage._compact_workspace_store(store)
+
+        assert workspace_store.WorkspaceStore.active(path) is store
+        assert store.h5_file.id.valid
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "current"
+        }
+        generations = store.generations()
+        assert len(generations) == 2
+        assert generations[0].manifest == generations[1].manifest
+        assert store.current_generation().manifest == _manifest("current")
+        assert path.stat().st_size < size_before
+
+
+def test_workspace_compaction_does_not_overwrite_external_replacement(
+    monkeypatch, tmp_path: pathlib.Path
+) -> None:
+    path = tmp_path / "workspace.itws"
+    external_path = tmp_path / "external.itws"
+    with workspace_store.WorkspaceStore(external_path, create=True) as external_store:
+        external_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
+            "external"
+        )
+        external_store.publish(_manifest("external"))
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+        store.publish(_manifest("current"))
+        original_close = store._close_handle
+        replacement_installed = False
+
+        def _close_and_replace_document() -> None:
+            nonlocal replacement_installed
+            original_close()
+            if not replacement_installed:
+                replacement_installed = True
+                external_path.replace(path)
+
+        monkeypatch.setattr(store, "_close_handle", _close_and_replace_document)
+
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            workspace_storage._compact_workspace_store(store)
+
+        assert store.current_generation().manifest == _manifest("external")
+
+
+def test_workspace_compaction_preserves_leased_payloads(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+        objects.create_group("leased")
+        objects.create_group("current")
+        store.publish(_manifest("leased"))
+        store.publish(_manifest("current"))
+        store.acquire_object("leased")
+
+        workspace_storage._compact_workspace_store(store)
+
+        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+        assert set(objects) == {"current", "leased"}
+        store.release_object("leased")
+        assert not store.collect_garbage(max_objects=1)
+        assert set(objects) == {"current"}
+
+
+def test_workspace_compaction_preserves_live_legacy_group(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    dataset = xr.Dataset({"data": ("x", np.arange(5, dtype=np.float64))})
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        workspace_arrays._write_workspace_dataset_group_to_file(
+            store.h5_file, "legacy/imagetool", dataset, compression_mode="none"
+        )
+        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+        objects.create_group("current")
+        store.publish(_manifest("current"))
+        opened = workspace_arrays.open_workspace_dataset(
+            path, "legacy/imagetool", chunks={}
+        )
+        try:
+            workspace_storage._compact_workspace_store(store)
+
+            assert "legacy/imagetool" in store.h5_file
+            assert float(opened["data"].sum().compute()) == 10.0
+        finally:
+            opened.close()
+
+
+def test_workspace_store_switch_keeps_preserved_lazy_readers(
+    tmp_path: pathlib.Path,
+) -> None:
+    source_path = tmp_path / "source.itws"
+    target_path = tmp_path / "target.itws"
+    dataset = xr.Dataset({"data": ("x", np.arange(5, dtype=np.float64))})
+    with workspace_store.WorkspaceStore(source_path, create=True) as source_store:
+        for group_path in (
+            source_store.object_path("old"),
+            source_store.object_path("current"),
+            "/legacy/imagetool",
+        ):
+            workspace_arrays._write_workspace_dataset_group_to_file(
+                source_store.h5_file,
+                group_path,
+                dataset,
+                compression_mode="none",
+            )
+        source_store.publish(_manifest("current"))
+        old_reader = workspace_arrays.open_workspace_dataset(
+            source_path, source_store.object_path("old"), chunks={}
+        )
+        legacy_reader = workspace_arrays.open_workspace_dataset(
+            source_path, "/legacy/imagetool", chunks={}
+        )
+        try:
+            plan = workspace_storage._WorkspaceGenerationPlan(
+                manifest=_manifest("current"),
+                objects=(
+                    workspace_storage._WorkspaceObjectWrite(
+                        "current",
+                        source_file=str(source_path),
+                        source_path=source_store.object_path("current"),
+                    ),
+                    workspace_storage._WorkspaceObjectWrite(
+                        "old",
+                        source_file=str(source_path),
+                        source_path=source_store.object_path("old"),
+                    ),
+                ),
+                preserved_groups=(
+                    workspace_storage._WorkspaceGroupCopy(
+                        source_file=str(source_path),
+                        source_path="/legacy/imagetool",
+                        target_path="/legacy/imagetool",
+                    ),
+                ),
+            )
+            with workspace_store.WorkspaceStore(
+                target_path, create=True
+            ) as target_store:
+                workspace_storage._write_workspace_generation(
+                    target_store, plan, compression_mode="none"
+                )
+
+            source_store.switch_path(target_path)
+            source_path.unlink()
+
+            assert float(old_reader["data"].sum().compute()) == 10.0
+            assert float(legacy_reader["data"].sum().compute()) == 10.0
+        finally:
+            old_reader.close()
+            legacy_reader.close()
+
+
+def test_workspace_store_rejects_replaced_document_path(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    replacement = tmp_path / "replacement.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with workspace_store.WorkspaceStore(replacement, create=True):
+            pass
+        path.unlink()
+        replacement.rename(path)
+
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            store.publish(_manifest())

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -6,6 +6,7 @@ import json
 import threading
 import typing
 
+import h5py
 import numpy as np
 import pytest
 import xarray as xr
@@ -215,6 +216,30 @@ def test_workspace_store_identity_helpers_decode_bytes() -> None:
         workspace_store.WorkspaceStore._workspace_id_from_file(_File(b"bytes-id"))
         == "bytes-id"
     )
+
+
+def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True):
+        pass
+    with h5py.File(path, "a") as h5_file:
+        del h5_file.attrs[workspace_store._WORKSPACE_ID_ATTR]
+        h5_file.attrs["imagetool_workspace_schema_version"] = 4
+
+    unchanged = path.read_bytes()
+    with workspace_store.WorkspaceStore(path) as store:
+        assert store.workspace_id is None
+    assert path.read_bytes() == unchanged
+    with h5py.File(path, "r") as h5_file:
+        assert workspace_store._WORKSPACE_ID_ATTR not in h5_file.attrs
+
+    with workspace_store.WorkspaceStore(path) as store:
+        store.publish(_manifest())
+        workspace_id = store.workspace_id
+
+    assert workspace_id
+    with h5py.File(path, "r") as h5_file:
+        assert h5_file.attrs[workspace_store._WORKSPACE_ID_ATTR] == workspace_id
 
 
 def test_hdf5_error_filters_cover_platform_independent_messages() -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -36,9 +36,10 @@ def _manifest(*object_ids: str) -> dict[str, object]:
 def test_workspace_store_publishes_valid_generations(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
-        objects.create_group("first")
-        objects.create_group("second")
+        with store.write_session() as h5_file:
+            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            objects.create_group("first")
+            objects.create_group("second")
         first = store.publish(_manifest("first"))
         second = store.publish(_manifest("second"))
 
@@ -46,12 +47,13 @@ def test_workspace_store_publishes_valid_generations(tmp_path: pathlib.Path) -> 
         assert second.sequence == 2
         assert store.current_generation() == second
 
-        generation_group = store.h5_file[
-            f"{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}"
-        ]
-        generation_group[workspace_store._WORKSPACE_MANIFEST_DATASET].attrs[
-            "sha256"
-        ] = "invalid"
+        with store.write_session() as h5_file:
+            generation_group = h5_file[
+                f"{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}"
+            ]
+            generation_group[workspace_store._WORKSPACE_MANIFEST_DATASET].attrs[
+                "sha256"
+            ] = "invalid"
 
         assert store.current_generation() == first
 
@@ -68,26 +70,46 @@ def test_workspace_store_rejects_generation_with_missing_object(
         assert len(store.h5_file[workspace_store._WORKSPACE_STAGING_GROUP]) == 0
 
 
+def test_workspace_store_limits_writable_handle_to_write_session(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        assert store.h5_file.mode == "r"
+        with store.write_session() as h5_file:
+            assert h5_file.mode == "r+"
+        assert store._h5_file is None
+        assert store.h5_file.mode == "r"
+
+
 def test_workspace_store_gc_retains_two_generations_and_leases(
     tmp_path: pathlib.Path,
 ) -> None:
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
-        for object_id in ("first", "second", "third"):
-            objects.create_group(object_id)
+        with store.write_session() as h5_file:
+            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            for object_id in ("first", "second", "third"):
+                objects.create_group(object_id)
         store.publish(_manifest("first"))
         store.publish(_manifest("second"))
         store.acquire_object("first")
         store.publish(_manifest("third"))
 
         assert not store.collect_garbage(max_objects=10)
-        assert set(objects) == {"first", "second", "third"}
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "first",
+            "second",
+            "third",
+        }
         assert len(store.generations()) == 2
 
         store.release_object("first")
         assert not store.collect_garbage(max_objects=10)
-        assert set(objects) == {"second", "third"}
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "second",
+            "third",
+        }
 
 
 def test_workspace_store_gc_removes_malformed_generation_names(
@@ -95,15 +117,17 @@ def test_workspace_store_gc_removes_malformed_generation_names(
 ) -> None:
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
-        objects.create_group("current")
+        with store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
         store.publish(_manifest("current"))
-        generation_root = store.h5_file[workspace_store._WORKSPACE_GENERATIONS_GROUP]
-        generation_root.create_group("1")
+        with store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_GENERATIONS_GROUP].create_group("1")
 
         assert not store.collect_garbage(max_objects=1)
 
-        assert set(generation_root) == {"00000000000000000001"}
+        assert set(store.h5_file[workspace_store._WORKSPACE_GENERATIONS_GROUP]) == {
+            "00000000000000000001"
+        }
 
 
 def test_workspace_generation_write_blocks_concurrent_gc(
@@ -215,9 +239,8 @@ def test_workspace_generation_removes_partial_object_after_copy_error(
     source_path = tmp_path / "source.itws"
     target_path = tmp_path / "target.itws"
     with workspace_store.WorkspaceStore(source_path, create=True) as source_store:
-        source_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
-            "source"
-        )
+        with source_store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("source")
         source_store.publish(_manifest("source"))
 
     def _copy_partial_then_fail(
@@ -372,6 +395,162 @@ def test_workspace_store_shares_lazy_reader_and_generation_writer(
             opened.close()
 
 
+def test_workspace_lazy_array_uses_bounded_process_reads(
+    tmp_path: pathlib.Path,
+) -> None:
+    import dask
+
+    path = tmp_path / "workspace.itws"
+    dataset = xr.Dataset(
+        {"data": (("x", "y"), np.arange(30, dtype=np.float64).reshape(5, 6))}
+    )
+    object_id = "payload"
+    plan = workspace_storage._WorkspaceGenerationPlan(
+        manifest=_manifest(object_id),
+        objects=(workspace_storage._WorkspaceObjectWrite(object_id, dataset=dataset),),
+    )
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        workspace_storage._write_workspace_generation(
+            store, plan, compression_mode="none"
+        )
+        opened = workspace_arrays.open_workspace_dataset(
+            path, store.object_path(object_id), chunks={"x": 2}
+        )
+        try:
+            with (
+                store.computation_session(),
+                dask.config.set(scheduler="processes"),
+            ):
+                result = opened["data"].sum().compute()
+            assert float(result) == 435.0
+            assert store.h5_file.mode == "r"
+        finally:
+            opened.close()
+
+
+def test_workspace_lazy_array_uses_process_localcluster_without_copy(
+    tmp_path: pathlib.Path,
+) -> None:
+    distributed = pytest.importorskip("distributed")
+
+    path = tmp_path / "workspace.itws"
+    dataset = xr.Dataset(
+        {"data": (("x", "y"), np.arange(30, dtype=np.float64).reshape(5, 6))}
+    )
+    object_id = "payload"
+    plan = workspace_storage._WorkspaceGenerationPlan(
+        manifest=_manifest(object_id),
+        objects=(workspace_storage._WorkspaceObjectWrite(object_id, dataset=dataset),),
+    )
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        workspace_storage._write_workspace_generation(
+            store, plan, compression_mode="none"
+        )
+        opened = workspace_arrays.open_workspace_dataset(
+            path, store.object_path(object_id), chunks={"x": 2}
+        )
+        try:
+            with (
+                distributed.LocalCluster(
+                    n_workers=2,
+                    threads_per_worker=1,
+                    processes=True,
+                    dashboard_address=None,
+                ) as cluster,
+                distributed.Client(cluster),
+                store.computation_session(),
+            ):
+                result = opened["data"].sum().compute()
+            assert float(result) == 435.0
+            assert set(tmp_path.iterdir()) == {path}
+        finally:
+            opened.close()
+
+
+def test_workspace_computation_session_blocks_background_write(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    write_started = threading.Event()
+    write_finished = threading.Event()
+    errors: list[BaseException] = []
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        value = xr.DataArray([1.0])
+        value.encoding["source"] = str(path)
+
+        def _write() -> None:
+            write_started.set()
+            try:
+                store.clear_staging()
+            except BaseException as exc:
+                errors.append(exc)
+            finally:
+                write_finished.set()
+
+        with workspace_arrays.workspace_computation_session(value):
+            writer = threading.Thread(target=_write)
+            writer.start()
+            assert write_started.wait(2)
+            assert not write_finished.wait(0.05)
+
+        writer.join(2)
+        assert not writer.is_alive()
+        assert write_finished.is_set()
+        assert errors == []
+
+
+def test_workspace_worker_reports_inaccessible_shared_path(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    group_path = workspace_store.WorkspaceStore.object_path("payload")
+    with workspace_store.WorkspaceStore(path, create=True):
+        manager = workspace_arrays.WorkspaceFileManager(
+            path, object_id="payload", group_path=group_path
+        )
+        state = manager.__getstate__()
+    path.unlink()
+    worker_manager = workspace_arrays.WorkspaceFileManager.__new__(
+        workspace_arrays.WorkspaceFileManager
+    )
+    worker_manager.__setstate__(state)
+
+    with pytest.raises(
+        workspace_arrays.WorkspaceWorkerAccessError,
+        match="same readable file on every worker",
+    ):
+        worker_manager._read_bounded_variable("data", slice(None))
+
+
+def test_workspace_worker_rejects_different_file_at_shared_path(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    replacement = tmp_path / "replacement.itws"
+    group_path = workspace_store.WorkspaceStore.object_path("payload")
+    with workspace_store.WorkspaceStore(path, create=True):
+        manager = workspace_arrays.WorkspaceFileManager(
+            path, object_id="payload", group_path=group_path
+        )
+        state = manager.__getstate__()
+    with workspace_store.WorkspaceStore(replacement, create=True):
+        pass
+    replacement.replace(path)
+    worker_manager = workspace_arrays.WorkspaceFileManager.__new__(
+        workspace_arrays.WorkspaceFileManager
+    )
+    worker_manager.__setstate__(state)
+
+    with pytest.raises(
+        workspace_store.WorkspaceStoreConflictError,
+        match="identity changed",
+    ):
+        worker_manager._read_bounded_variable("data", slice(None))
+
+
 def test_workspace_raw_reads_reuse_active_store_handle(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -388,20 +567,23 @@ def test_workspace_compaction_keeps_current_state_and_reopens_store(
 ) -> None:
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
-        objects.create_group("obsolete").create_dataset(
-            "data", data=np.ones(2_000_000, dtype=np.float64)
-        )
-        objects.create_group("current").create_dataset(
-            "data", data=np.arange(10, dtype=np.float64)
-        )
+        with store.write_session() as h5_file:
+            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            objects.create_group("obsolete").create_dataset(
+                "data", data=np.ones(2_000_000, dtype=np.float64)
+            )
+            objects.create_group("current").create_dataset(
+                "data", data=np.arange(10, dtype=np.float64)
+            )
         store.publish(_manifest("obsolete"))
         store.publish(_manifest("current"))
         size_before = path.stat().st_size
+        workspace_id = store.workspace_id
 
         workspace_storage._compact_workspace_store(store)
 
         assert workspace_store.WorkspaceStore.active(path) is store
+        assert store.workspace_id == workspace_id
         assert store.h5_file.id.valid
         assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
             "current"
@@ -419,13 +601,13 @@ def test_workspace_store_active_waits_for_file_replacement(
     path = tmp_path / "workspace.itws"
     prepared_path = tmp_path / "prepared.itws"
     with workspace_store.WorkspaceStore(prepared_path, create=True) as prepared_store:
-        prepared_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
-            "prepared"
-        )
+        with prepared_store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("prepared")
         prepared_store.publish(_manifest("prepared"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+        with store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
         store.publish(_manifest("current"))
         replacement_started = threading.Event()
         allow_replacement = threading.Event()
@@ -494,15 +676,15 @@ def test_workspace_store_uses_prepared_recovery_if_original_cannot_reopen(
     path = tmp_path / "workspace.itws"
     prepared_path = tmp_path / "prepared.itws"
     with workspace_store.WorkspaceStore(prepared_path, create=True) as prepared_store:
-        prepared_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
-            "prepared"
-        )
+        with prepared_store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("prepared")
         prepared_store.publish(_manifest("prepared"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
         store.publish(_manifest())
 
-        def _deny_reopen(*, create: bool) -> None:
+        def _deny_reopen(*, create: bool, workspace_id: str | None = None) -> None:
+            del workspace_id
             if create:
                 raise AssertionError("Replacement recovery must not create a file")
             raise PermissionError(errno.EACCES, "reopen denied", path)
@@ -528,9 +710,8 @@ def test_workspace_store_retries_reopen_after_successful_replacement(
     path = tmp_path / "workspace.itws"
     prepared_path = tmp_path / "prepared.itws"
     with workspace_store.WorkspaceStore(prepared_path, create=True) as prepared_store:
-        prepared_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
-            "prepared"
-        )
+        with prepared_store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("prepared")
         prepared_store.publish(_manifest("prepared"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
@@ -539,8 +720,11 @@ def test_workspace_store_retries_reopen_after_successful_replacement(
         reopen_attempts = 0
         delays: list[float] = []
 
-        def _open_with_transient_denial(*, create: bool) -> None:
+        def _open_with_transient_denial(
+            *, create: bool, workspace_id: str | None = None
+        ) -> None:
             nonlocal reopen_attempts
+            del workspace_id
             reopen_attempts += 1
             if reopen_attempts < 3:
                 raise PermissionError(errno.EACCES, "reopen denied", path)
@@ -567,10 +751,12 @@ def test_workspace_compaction_retains_prepared_recovery_file(
     path = tmp_path / "workspace.itws"
     recovery_path: pathlib.Path | None = None
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+        with store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
         store.publish(_manifest("current"))
 
-        def _deny_reopen(*, create: bool) -> None:
+        def _deny_reopen(*, create: bool, workspace_id: str | None = None) -> None:
+            del workspace_id
             if create:
                 raise AssertionError("Replacement recovery must not create a file")
             raise PermissionError(errno.EACCES, "reopen denied", path)
@@ -602,25 +788,25 @@ def test_workspace_compaction_does_not_overwrite_external_replacement(
     path = tmp_path / "workspace.itws"
     external_path = tmp_path / "external.itws"
     with workspace_store.WorkspaceStore(external_path, create=True) as external_store:
-        external_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
-            "external"
-        )
+        with external_store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("external")
         external_store.publish(_manifest("external"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+        with store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
         store.publish(_manifest("current"))
-        original_close = store._close_handle
+        original_release = store._release_handle
         replacement_installed = False
 
-        def _close_and_replace_document() -> None:
+        def _release_and_replace_document() -> None:
             nonlocal replacement_installed
-            original_close()
+            original_release()
             if not replacement_installed:
                 replacement_installed = True
                 external_path.replace(path)
 
-        monkeypatch.setattr(store, "_close_handle", _close_and_replace_document)
+        monkeypatch.setattr(store, "_release_handle", _release_and_replace_document)
 
         with pytest.raises(workspace_store.WorkspaceStoreConflictError):
             workspace_storage._compact_workspace_store(store)
@@ -642,13 +828,13 @@ def test_workspace_compaction_rejects_replacement_after_identity_check(
     path = tmp_path / "workspace.itws"
     external_path = tmp_path / "external.itws"
     with workspace_store.WorkspaceStore(external_path, create=True) as external_store:
-        external_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
-            "external"
-        )
+        with external_store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("external")
         external_store.publish(_manifest("external"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+        with store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
         store.publish(_manifest("current"))
         original_require_identity = store._require_path_identity
 
@@ -677,20 +863,25 @@ def test_workspace_compaction_preserves_leased_payloads(
 ) -> None:
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
-        objects.create_group("leased")
-        objects.create_group("current")
+        with store.write_session() as h5_file:
+            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            objects.create_group("leased")
+            objects.create_group("current")
         store.publish(_manifest("leased"))
         store.publish(_manifest("current"))
         store.acquire_object("leased")
 
         workspace_storage._compact_workspace_store(store)
 
-        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
-        assert set(objects) == {"current", "leased"}
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "current",
+            "leased",
+        }
         store.release_object("leased")
         assert not store.collect_garbage(max_objects=1)
-        assert set(objects) == {"current"}
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "current"
+        }
 
 
 def test_workspace_compaction_preserves_live_legacy_group(
@@ -699,11 +890,11 @@ def test_workspace_compaction_preserves_live_legacy_group(
     path = tmp_path / "workspace.itws"
     dataset = xr.Dataset({"data": ("x", np.arange(5, dtype=np.float64))})
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        workspace_arrays._write_workspace_dataset_group_to_file(
-            store.h5_file, "legacy/imagetool", dataset, compression_mode="none"
-        )
-        objects = store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
-        objects.create_group("current")
+        with store.write_session() as h5_file:
+            workspace_arrays._write_workspace_dataset_group_to_file(
+                h5_file, "legacy/imagetool", dataset, compression_mode="none"
+            )
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
         store.publish(_manifest("current"))
         opened = workspace_arrays.open_workspace_dataset(
             path, "legacy/imagetool", chunks={}
@@ -724,17 +915,18 @@ def test_workspace_store_switch_keeps_preserved_lazy_readers(
     target_path = tmp_path / "target.itws"
     dataset = xr.Dataset({"data": ("x", np.arange(5, dtype=np.float64))})
     with workspace_store.WorkspaceStore(source_path, create=True) as source_store:
-        for group_path in (
-            source_store.object_path("old"),
-            source_store.object_path("current"),
-            "/legacy/imagetool",
-        ):
-            workspace_arrays._write_workspace_dataset_group_to_file(
-                source_store.h5_file,
-                group_path,
-                dataset,
-                compression_mode="none",
-            )
+        with source_store.write_session() as h5_file:
+            for group_path in (
+                source_store.object_path("old"),
+                source_store.object_path("current"),
+                "/legacy/imagetool",
+            ):
+                workspace_arrays._write_workspace_dataset_group_to_file(
+                    h5_file,
+                    group_path,
+                    dataset,
+                    compression_mode="none",
+                )
         source_store.publish(_manifest("current"))
         old_reader = workspace_arrays.open_workspace_dataset(
             source_path, source_store.object_path("old"), chunks={}
@@ -775,8 +967,14 @@ def test_workspace_store_switch_keeps_preserved_lazy_readers(
             source_store.switch_path(target_path)
             source_path.unlink()
 
-            assert float(old_reader["data"].sum().compute()) == 10.0
-            assert float(legacy_reader["data"].sum().compute()) == 10.0
+            import dask
+
+            with (
+                source_store.computation_session(),
+                dask.config.set(scheduler="processes"),
+            ):
+                assert float(old_reader["data"].sum().compute()) == 10.0
+                assert float(legacy_reader["data"].sum().compute()) == 10.0
         finally:
             old_reader.close()
             legacy_reader.close()
@@ -810,21 +1008,23 @@ def test_workspace_store_conflict_keeps_lazy_data_for_save_as(
     dataset = xr.Dataset({"data": ("x", np.arange(5, dtype=np.float64))})
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        workspace_arrays._write_workspace_dataset_group_to_file(
-            store.h5_file,
-            store.object_path("current"),
-            dataset,
-            compression_mode="none",
-        )
+        with store.write_session() as h5_file:
+            workspace_arrays._write_workspace_dataset_group_to_file(
+                h5_file,
+                store.object_path("current"),
+                dataset,
+                compression_mode="none",
+            )
         store.publish(_manifest("current"))
         opened = workspace_arrays.open_workspace_dataset(
             path, store.object_path("current"), chunks={}
         )
         try:
             with workspace_store.WorkspaceStore(replacement, create=True) as other:
-                other.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
-                    "external"
-                )
+                with other.write_session() as h5_file:
+                    h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
+                        "external"
+                    )
                 other.publish(_manifest("external"))
             replacement.replace(path)
 

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import errno
+import hashlib
+import json
 import threading
 import typing
 
@@ -31,6 +33,463 @@ def _manifest(*object_ids: str) -> dict[str, object]:
         ],
         "root_order": list(range(len(object_ids))),
     }
+
+
+def test_workspace_file_access_retry_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+    waits = 0
+    failed_attempts = 0
+
+    def _temporarily_blocked() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise BlockingIOError(errno.EAGAIN, "busy")
+        return "opened"
+
+    def _waited() -> None:
+        nonlocal waits
+        waits += 1
+
+    def _failed() -> None:
+        nonlocal failed_attempts
+        failed_attempts += 1
+
+    monkeypatch.setattr(workspace_store.time, "sleep", lambda _delay: None)
+    assert (
+        workspace_store._wait_for_hdf5_access(
+            _temporarily_blocked,
+            on_wait=_waited,
+            before_attempt=_waited,
+            after_failed_attempt=_failed,
+        )
+        == "opened"
+    )
+    assert attempts == 2
+    assert waits == 3
+    assert failed_attempts == 1
+
+    attempts = 0
+    waits = 0
+    assert (
+        workspace_store._retry_file_access(_temporarily_blocked, on_wait=_waited)
+        == "opened"
+    )
+    assert attempts == 2
+    assert waits == 1
+
+    permission_error = PermissionError(errno.EACCES, "denied")
+    monkeypatch.setattr(workspace_store, "_FILE_ACCESS_RETRY_DELAYS", ())
+    with pytest.raises(PermissionError, match="denied"):
+        workspace_store._retry_file_access(
+            lambda: (_ for _ in ()).throw(permission_error)
+        )
+
+    with pytest.raises(OSError, match="invalid"):
+        workspace_store._wait_for_hdf5_access(
+            lambda: (_ for _ in ()).throw(OSError(errno.EINVAL, "invalid"))
+        )
+
+
+def test_workspace_store_manifest_validation_contract() -> None:
+    class _Dataset:
+        def __init__(self, raw: object, checksum: object) -> None:
+            self._raw = raw
+            self.attrs = {"sha256": checksum}
+
+        def asstr(self):
+            return self
+
+        def __getitem__(self, _key):
+            return self._raw
+
+    class _Group(dict):
+        def __init__(
+            self, dataset: _Dataset | None, objects: set[str] | None = None
+        ) -> None:
+            super().__init__()
+            if dataset is not None:
+                self[workspace_store._WORKSPACE_MANIFEST_DATASET] = dataset
+            self.file = set() if objects is None else objects
+
+    def _group(manifest: object, *, objects: set[str] | None = None) -> _Group:
+        raw = json.dumps(manifest)
+        checksum = hashlib.sha256(raw.encode()).hexdigest().encode()
+        return _Group(_Dataset(raw, checksum), objects)
+
+    with pytest.raises(ValueError, match="no manifest"):
+        workspace_store.WorkspaceStore._read_manifest(_Group(None))
+    with pytest.raises(TypeError, match="not text"):
+        workspace_store.WorkspaceStore._read_manifest(_Group(_Dataset(1, "unused")))
+    with pytest.raises(ValueError, match="checksum"):
+        workspace_store.WorkspaceStore._read_manifest(
+            _Group(_Dataset(json.dumps(_manifest()), "wrong"))
+        )
+    with pytest.raises(TypeError, match="not an object"):
+        workspace_store.WorkspaceStore._read_manifest(_group([]))
+    with pytest.raises(ValueError, match="unsupported schema"):
+        workspace_store.WorkspaceStore._read_manifest(
+            _group({"schema_version": 4, "nodes": []})
+        )
+    with pytest.raises(TypeError, match="not a list"):
+        workspace_store.WorkspaceStore._read_manifest(
+            _group({"schema_version": 5, "nodes": {}})
+        )
+    with pytest.raises(TypeError, match="not an object"):
+        workspace_store.WorkspaceStore._read_manifest(
+            _group({"schema_version": 5, "nodes": [None]})
+        )
+    with pytest.raises(TypeError, match="no payload object"):
+        workspace_store.WorkspaceStore._read_manifest(
+            _group({"schema_version": 5, "nodes": [{}]})
+        )
+    with pytest.raises(ValueError, match="not canonical"):
+        workspace_store.WorkspaceStore._read_manifest(
+            _group(
+                {
+                    "schema_version": 5,
+                    "nodes": [{"payload_object_id": "data", "payload_path": "/bad"}],
+                }
+            )
+        )
+    with pytest.raises(ValueError, match="object is missing"):
+        workspace_store.WorkspaceStore._read_manifest(_group(_manifest("data")))
+
+
+def test_workspace_store_value_validation_and_closed_state(
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with pytest.raises(ValueError, match="only when create is true"):
+        workspace_store.WorkspaceStore(path, workspace_id="invalid")
+    for object_id in ("", "nested/object"):
+        with pytest.raises(ValueError, match="one path component"):
+            workspace_store.WorkspaceStore.object_path(object_id)
+
+    assert workspace_store.WorkspaceStore.manifest_object_ids({"nodes": {}}) == set()
+    assert workspace_store.WorkspaceStore.manifest_object_ids(
+        {"nodes": [None, {}, {"payload_object_id": ""}, {"payload_object_id": "ok"}]}
+    ) == {"ok"}
+
+    store = workspace_store.WorkspaceStore(path, create=True)
+    store.close()
+    assert workspace_store.WorkspaceStore.active(path) is None
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = store.h5_file
+    with pytest.raises(RuntimeError, match="no readable handle"):
+        _ = store.read_h5_file
+    with pytest.raises(RuntimeError, match="closed"), store.read_session():
+        pass
+    with pytest.raises(RuntimeError, match="closed"):
+        store.require_current_path()
+    with pytest.raises(RuntimeError, match="closed"):
+        store.replace_from(path, lambda _source, _target: None)
+
+
+def test_workspace_store_identity_helpers_decode_bytes() -> None:
+    class _File:
+        def __init__(self, value: object) -> None:
+            self.attrs = {workspace_store._WORKSPACE_ID_ATTR: value}
+            self.flush_count = 0
+
+        def flush(self) -> None:
+            self.flush_count += 1
+
+    existing = _File(b"workspace-id")
+    assert (
+        workspace_store.WorkspaceStore._ensure_workspace_id(existing) == "workspace-id"
+    )
+    assert workspace_store.WorkspaceStore._workspace_id_from_file(existing) == (
+        "workspace-id"
+    )
+
+    missing = _File(None)
+    generated = workspace_store.WorkspaceStore._ensure_workspace_id(missing)
+    assert generated
+    assert missing.attrs[workspace_store._WORKSPACE_ID_ATTR] == generated
+    assert missing.flush_count == 1
+    assert workspace_store.WorkspaceStore._workspace_id_from_file(_File("")) is None
+    assert (
+        workspace_store.WorkspaceStore._workspace_id_from_file(_File(b"bytes-id"))
+        == "bytes-id"
+    )
+
+
+def test_hdf5_error_filters_cover_platform_independent_messages() -> None:
+    sharing_error = OSError("sharing violation")
+    sharing_error.winerror = 32
+    assert workspace_store._is_hdf5_file_contention_error(sharing_error)
+    assert workspace_store._is_hdf5_file_lock_unavailable_error(
+        OSError("HDF5 locking is disabled")
+    )
+    assert workspace_store._is_hdf5_file_lock_unavailable_error(
+        OSError(errno.ENOSYS, "unsupported")
+    )
+
+
+def test_workspace_store_rejects_non_lock_open_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        monkeypatch.setattr(
+            workspace_store.h5py,
+            "File",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                OSError(errno.EINVAL, "invalid HDF5 open")
+            ),
+        )
+        with pytest.raises(OSError, match="invalid HDF5 open"):
+            store._open_with_lock_detection("r")
+
+
+def test_workspace_store_switches_when_required_locking_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    source_path = tmp_path / "source.itws"
+    target_path = tmp_path / "target.itws"
+    with workspace_store.WorkspaceStore(target_path, create=True):
+        pass
+    with workspace_store.WorkspaceStore(source_path, create=True) as source:
+        monkeypatch.setattr(
+            workspace_store,
+            "_wait_for_hdf5_access",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                OSError(errno.ENOSYS, "locking is not supported")
+            ),
+        )
+
+        source.switch_path(target_path)
+
+        assert source.path == target_path.resolve()
+        assert not source.locking_supported
+
+
+def test_workspace_store_conflicted_guards(tmp_path) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared = tmp_path / "prepared.itws"
+    with workspace_store.WorkspaceStore(prepared, create=True):
+        pass
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store._mark_conflicted()
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            store.require_current_path()
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            store.reopen()
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            store.replace_from(prepared, lambda _source, _target: None)
+
+
+def test_workspace_store_missing_path_and_recovery_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        identity = typing.cast("tuple[int, int]", store._path_identity)
+        path.unlink()
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            store._require_path_identity(identity)
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            store._require_path_state((*identity, 0, 0))
+
+        monkeypatch.setattr(
+            workspace_store.h5py,
+            "File",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("unreadable")),
+        )
+        with pytest.raises(OSError, match="unreadable"):
+            store._use_recovery_source(tmp_path / "missing-recovery.itws")
+        assert store.conflicted
+
+
+def test_workspace_store_flush_accepts_tuple_vfd_handle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class _Id:
+        @staticmethod
+        def get_vfd_handle():
+            return (123, object())
+
+    class _File:
+        id = _Id()
+
+        @staticmethod
+        def flush() -> None:
+            pass
+
+    synced: list[int] = []
+    store = workspace_store.WorkspaceStore(tmp_path / "workspace.itws", create=True)
+    store._release_handle()
+    store._h5_file = _File()
+    monkeypatch.setattr(workspace_store.os, "fsync", synced.append)
+    try:
+        store.flush(durable=True)
+    finally:
+        store._h5_file = None
+        store.close()
+    assert synced == [123]
+
+
+def test_workspace_store_rejects_duplicate_owner_and_invalid_switch(
+    tmp_path,
+) -> None:
+    import h5py
+
+    source_path = tmp_path / "source.itws"
+    target_path = tmp_path / "target.itws"
+    invalid_path = tmp_path / "invalid.itws"
+    with workspace_store.WorkspaceStore(source_path, create=True) as source:
+        with pytest.raises(RuntimeError, match="active store"):
+            workspace_store.WorkspaceStore(source_path)
+
+        with h5py.File(invalid_path, "w"):
+            pass
+        with pytest.raises(ValueError, match="no stable identity"):
+            source.switch_path(invalid_path)
+
+        with (
+            workspace_store.WorkspaceStore(target_path, create=True),
+            pytest.raises(RuntimeError, match="active store"),
+        ):
+            source.switch_path(target_path)
+
+
+def test_workspace_store_write_open_failure_restores_idle_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared = tmp_path / ".workspace.itws.write-test"
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store._locking_supported = False
+
+        def _prepare() -> pathlib.Path:
+            prepared.write_bytes(b"not-hdf5")
+            return prepared
+
+        monkeypatch.setattr(store, "_prepare_copy_on_write", _prepare)
+        with pytest.raises(OSError, match="file signature"), store.write_session():
+            pass
+
+        assert not store.write_in_progress
+        assert store._write_target_path is None
+        assert not prepared.exists()
+
+        store._path_identity = None
+        with (
+            pytest.raises(RuntimeError, match="no path identity"),
+            store.write_session(),
+        ):
+            pass
+        assert not store.write_in_progress
+
+
+def test_workspace_store_replace_conflict_callbacks_quarantine_writes(
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared = tmp_path / "prepared.itws"
+    with workspace_store.WorkspaceStore(prepared, create=True):
+        pass
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            store.replace_from(
+                prepared,
+                lambda _source, _target: None,
+                before_close=lambda: (_ for _ in ()).throw(
+                    workspace_store.WorkspaceStoreConflictError("changed")
+                ),
+            )
+        assert store.conflicted
+
+
+def test_workspace_store_replace_detects_path_change_after_failure(
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared = tmp_path / "prepared.itws"
+    with workspace_store.WorkspaceStore(prepared, create=True):
+        pass
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+
+        def _remove_then_fail(_source, target) -> None:
+            target.unlink()
+            raise RuntimeError("replace failed")
+
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            store.replace_from(prepared, _remove_then_fail)
+        assert store.conflicted
+
+
+def test_workspace_store_replace_failure_keeps_recovery_error_quarantined(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared = tmp_path / "prepared.itws"
+    with workspace_store.WorkspaceStore(prepared, create=True):
+        pass
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        monkeypatch.setattr(
+            store,
+            "_reopen_after_file_operation",
+            lambda: (_ for _ in ()).throw(OSError("cannot reopen")),
+        )
+        monkeypatch.setattr(
+            store,
+            "_use_recovery_source",
+            lambda _path: (_ for _ in ()).throw(OSError("cannot recover")),
+        )
+
+        with pytest.raises(RuntimeError, match="replace failed"):
+            store.replace_from(
+                prepared,
+                lambda _source, _target: (_ for _ in ()).throw(
+                    RuntimeError("replace failed")
+                ),
+            )
+        assert store.conflicted
+
+
+def test_workspace_store_reports_reopen_failure_after_successful_replace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    prepared = tmp_path / "prepared.itws"
+    with workspace_store.WorkspaceStore(prepared, create=True):
+        pass
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        monkeypatch.setattr(
+            store,
+            "_reopen_after_file_operation",
+            lambda: (_ for _ in ()).throw(OSError("cannot reopen")),
+        )
+
+        with pytest.raises(workspace_store.WorkspaceStoreReopenError):
+            store.replace_from(prepared, lambda source, target: source.replace(target))
+
+
+def test_workspace_store_rejects_invalid_gc_limit_and_clears_staging(
+    tmp_path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with pytest.raises(ValueError, match="must be positive"):
+            store.collect_garbage(max_objects=0)
+
+        store.clear_staging()
+        with store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_STAGING_GROUP].create_group("orphan")
+        store.clear_staging()
+        assert len(store.h5_file[workspace_store._WORKSPACE_STAGING_GROUP]) == 0
 
 
 def test_workspace_store_publishes_valid_generations(tmp_path: pathlib.Path) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -527,6 +527,42 @@ def test_workspace_compaction_does_not_overwrite_external_replacement(
             )
 
 
+def test_workspace_compaction_rejects_replacement_after_identity_check(
+    monkeypatch, tmp_path: pathlib.Path
+) -> None:
+    path = tmp_path / "workspace.itws"
+    external_path = tmp_path / "external.itws"
+    with workspace_store.WorkspaceStore(external_path, create=True) as external_store:
+        external_store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
+            "external"
+        )
+        external_store.publish(_manifest("external"))
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+        store.publish(_manifest("current"))
+        original_require_identity = store._require_path_identity
+
+        def _replace_after_identity_check(expected: tuple[int, int]) -> None:
+            original_require_identity(expected)
+            external_path.replace(path)
+
+        monkeypatch.setattr(
+            store, "_require_path_identity", _replace_after_identity_check
+        )
+
+        with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+            workspace_storage._compact_workspace_store(store)
+
+        assert store.conflicted
+        assert store.current_generation().manifest == _manifest("current")
+        store.close()
+        with workspace_store.WorkspaceStore(path) as replacement_store:
+            assert replacement_store.current_generation().manifest == _manifest(
+                "external"
+            )
+
+
 def test_workspace_compaction_preserves_leased_payloads(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -654,3 +690,60 @@ def test_workspace_store_rejects_replaced_document_path(
         assert workspace_store.WorkspaceStore.active(path) is store
         with pytest.raises(workspace_store.WorkspaceStoreConflictError):
             _ = store.h5_file
+
+
+def test_workspace_store_conflict_keeps_lazy_data_for_save_as(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    replacement = tmp_path / "replacement.itws"
+    recovered = tmp_path / "recovered.itws"
+    dataset = xr.Dataset({"data": ("x", np.arange(5, dtype=np.float64))})
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        workspace_arrays._write_workspace_dataset_group_to_file(
+            store.h5_file,
+            store.object_path("current"),
+            dataset,
+            compression_mode="none",
+        )
+        store.publish(_manifest("current"))
+        opened = workspace_arrays.open_workspace_dataset(
+            path, store.object_path("current"), chunks={}
+        )
+        try:
+            with workspace_store.WorkspaceStore(replacement, create=True) as other:
+                other.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
+                    "external"
+                )
+                other.publish(_manifest("external"))
+            replacement.replace(path)
+
+            with pytest.raises(workspace_store.WorkspaceStoreConflictError):
+                store.publish(_manifest("current"))
+
+            assert store.conflicted
+            assert float(opened["data"].sum().compute()) == 10.0
+            plan = workspace_storage._WorkspaceGenerationPlan(
+                manifest=_manifest("current"),
+                objects=(
+                    workspace_storage._WorkspaceObjectWrite(
+                        "current",
+                        source_file=str(path),
+                        source_path=store.object_path("current"),
+                    ),
+                ),
+            )
+            with workspace_store.WorkspaceStore(recovered, create=True) as target:
+                workspace_storage._write_workspace_generation(
+                    target, plan, compression_mode="none"
+                )
+
+            store.switch_path(recovered)
+            assert not store.conflicted
+            assert float(opened["data"].sum().compute()) == 10.0
+        finally:
+            opened.close()
+
+    with workspace_store.WorkspaceStore(path) as replacement_store:
+        assert replacement_store.current_generation().manifest == _manifest("external")

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -248,6 +248,11 @@ def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None
         workspace_id = store.workspace_id
         assert store.serialized_object_ids == {"old-object"}
         assert store.serialized_legacy_group_paths == {"/legacy"}
+        assert store.has_serialized_readers
+        store.clear_serialized_reader_pins()
+        assert not store.has_serialized_readers
+        assert store.serialized_object_ids == set()
+        assert store.serialized_legacy_group_paths == set()
 
     assert workspace_id
     with h5py.File(path, "r") as h5_file:
@@ -796,8 +801,16 @@ def test_workspace_store_gc_preserves_serialized_reader_objects(
 
     with workspace_store.WorkspaceStore(path) as reopened:
         assert reopened.serialized_object_ids == {"first"}
+        assert reopened.has_serialized_readers
         assert reopened.current_generation().sequence > first_generation.sequence
         workspace_id = reopened.workspace_id
+        reopened.clear_serialized_reader_pins()
+        assert not reopened.has_serialized_readers
+        assert not reopened.collect_garbage(max_objects=10)
+        assert set(reopened.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "second",
+            "third",
+        }
 
     copied_path = tmp_path / "copied-workspace.itws"
     shutil.copy2(path, copied_path)

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -237,6 +237,7 @@ def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None
             object_id="old-object",
             legacy_group_path="/legacy",
         )
+        old_pins = store.serialized_reader_pin_snapshot()
         assert store.serialized_object_ids == {"old-object"}
         assert store.serialized_legacy_group_paths == {"/legacy"}
     assert path.read_bytes() == unchanged
@@ -255,10 +256,7 @@ def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None
             object_id="kept-object",
             legacy_group_path="/kept-legacy",
         )
-        store.release_serialized_reader_pins(
-            object_ids={"old-object"},
-            legacy_group_paths={"/legacy"},
-        )
+        store.release_serialized_reader_pins(old_pins)
         assert store.serialized_object_ids == {"kept-object"}
         assert store.serialized_legacy_group_paths == {"/kept-legacy"}
         store.clear_serialized_reader_pins()
@@ -281,6 +279,26 @@ def test_hdf5_error_filters_cover_platform_independent_messages() -> None:
     assert workspace_store._is_hdf5_file_lock_unavailable_error(
         OSError(errno.ENOSYS, "unsupported")
     )
+
+
+def test_hdf5_access_does_not_retry_when_locking_is_unavailable() -> None:
+    attempts = 0
+    waits = 0
+
+    def _open() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise OSError(errno.ENOSYS, "unable to lock file: function not implemented")
+
+    def _wait() -> None:
+        nonlocal waits
+        waits += 1
+
+    with pytest.raises(OSError, match="unable to lock file"):
+        workspace_store._wait_for_hdf5_access(_open, on_wait=_wait)
+
+    assert attempts == 1
+    assert waits == 0
 
 
 def test_workspace_store_rejects_non_lock_open_errors(
@@ -731,7 +749,7 @@ def test_workspace_store_detects_unavailable_required_locking(
 
     def _open_file(*args, **kwargs):
         if kwargs.get("locking") is True:
-            raise OSError(errno.ENOSYS, "file locking is not supported")
+            raise OSError(errno.ENOSYS, "unable to lock file: not supported")
         return original_file(*args, **kwargs)
 
     monkeypatch.setattr(workspace_store.h5py, "File", _open_file)
@@ -829,6 +847,69 @@ def test_workspace_store_gc_preserves_serialized_reader_objects(
     with workspace_store.WorkspaceStore(copied_path) as copied:
         assert copied.workspace_id == workspace_id
         assert copied.serialized_object_ids == set()
+
+
+def test_workspace_reader_export_waits_for_compaction_boundary(tmp_path) -> None:
+    path = tmp_path / "workspace.itws"
+    export_started = threading.Event()
+    export_finished = threading.Event()
+    export_errors: list[Exception] = []
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session() as h5_file:
+            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("obsolete")
+
+        def _export_reader() -> None:
+            export_started.set()
+            try:
+                store.pin_serialized_reader_reference(
+                    object_id="obsolete",
+                    legacy_group_path=None,
+                )
+            except Exception as exc:
+                export_errors.append(exc)
+            finally:
+                export_finished.set()
+
+        with store.lock:
+            export_thread = threading.Thread(target=_export_reader)
+            export_thread.start()
+            assert export_started.wait(timeout=2)
+            assert not export_finished.wait(timeout=0.05)
+            with store.write_session() as h5_file:
+                del h5_file[f"{workspace_store._WORKSPACE_OBJECTS_GROUP}/obsolete"]
+
+        export_thread.join(timeout=2)
+        assert not export_thread.is_alive()
+        assert len(export_errors) == 1
+        assert isinstance(
+            export_errors[0], workspace_store.WorkspaceReaderUnavailableError
+        )
+        assert not store.has_serialized_readers
+
+
+def test_workspace_reader_export_rejects_unavailable_targets(tmp_path) -> None:
+    path = tmp_path / "workspace.itws"
+    store = workspace_store.WorkspaceStore(path, create=True)
+
+    with pytest.raises(
+        workspace_store.WorkspaceReaderUnavailableError,
+        match="payload was compacted",
+    ):
+        store.pin_serialized_reader_reference(
+            object_id=None,
+            legacy_group_path="/missing-legacy",
+        )
+
+    store.close()
+    with pytest.raises(
+        workspace_store.WorkspaceReaderUnavailableError,
+        match="workspace changed",
+    ):
+        store.pin_serialized_reader_reference(
+            object_id=None,
+            legacy_group_path=None,
+        )
 
 
 def test_workspace_store_gc_removes_malformed_generation_names(
@@ -1272,7 +1353,9 @@ def test_workspace_worker_reports_inaccessible_shared_path(
 ) -> None:
     path = tmp_path / "workspace.itws"
     group_path = workspace_store.WorkspaceStore.object_path("payload")
-    with workspace_store.WorkspaceStore(path, create=True):
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session() as h5_file:
+            h5_file.require_group(group_path)
         manager = workspace_arrays.WorkspaceFileManager(
             path, object_id="payload", group_path=group_path
         )
@@ -1387,7 +1470,9 @@ def test_workspace_worker_rejects_different_file_at_shared_path(
     path = tmp_path / "workspace.itws"
     replacement = tmp_path / "replacement.itws"
     group_path = workspace_store.WorkspaceStore.object_path("payload")
-    with workspace_store.WorkspaceStore(path, create=True):
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session() as h5_file:
+            h5_file.require_group(group_path)
         manager = workspace_arrays.WorkspaceFileManager(
             path, object_id="payload", group_path=group_path
         )
@@ -1742,9 +1827,28 @@ def test_workspace_compaction_preserves_leased_and_serialized_payloads(
             "serialized",
         }
 
+        confirmed_pins = store.serialized_reader_pin_snapshot()
+        workspace_store.WorkspaceStore.pin_serialized_reader(
+            workspace_id=store.workspace_id,
+            path=path,
+            object_id="serialized",
+            legacy_group_path=None,
+        )
         workspace_storage._compact_workspace_store(
             store,
-            discard_serialized_object_ids={"serialized"},
+            discard_serialized_reader_pins=confirmed_pins,
+        )
+
+        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            "current",
+            "leased",
+            "serialized",
+        }
+
+        discarded_pins = store.serialized_reader_pin_snapshot()
+        workspace_storage._compact_workspace_store(
+            store,
+            discard_serialized_reader_pins=discarded_pins,
         )
 
         assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
@@ -1752,7 +1856,7 @@ def test_workspace_compaction_preserves_leased_and_serialized_payloads(
             "leased",
         }
         assert store.serialized_object_ids == {"serialized"}
-        store.release_serialized_reader_pins(object_ids={"serialized"})
+        store.release_serialized_reader_pins(discarded_pins)
         assert not store.has_serialized_readers
         store.release_object("leased")
         assert not store.collect_garbage(max_objects=1)

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import errno
+import gc
 import hashlib
 import json
+import shutil
 import threading
 import typing
 
@@ -229,6 +231,14 @@ def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None
     unchanged = path.read_bytes()
     with workspace_store.WorkspaceStore(path) as store:
         assert store.workspace_id is None
+        workspace_store.WorkspaceStore.pin_serialized_reader(
+            workspace_id=None,
+            path=path,
+            object_id="old-object",
+            legacy_group_path="/legacy",
+        )
+        assert store.serialized_object_ids == {"old-object"}
+        assert store.serialized_legacy_group_paths == {"/legacy"}
     assert path.read_bytes() == unchanged
     with h5py.File(path, "r") as h5_file:
         assert workspace_store._WORKSPACE_ID_ATTR not in h5_file.attrs
@@ -236,6 +246,8 @@ def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None
     with workspace_store.WorkspaceStore(path) as store:
         store.publish(_manifest())
         workspace_id = store.workspace_id
+        assert store.serialized_object_ids == {"old-object"}
+        assert store.serialized_legacy_group_paths == {"/legacy"}
 
     assert workspace_id
     with h5py.File(path, "r") as h5_file:
@@ -754,7 +766,7 @@ def test_workspace_store_gc_retains_two_generations_and_leases(
         }
 
 
-def test_workspace_store_gc_can_defer_obsolete_object_deletion(
+def test_workspace_store_gc_preserves_serialized_reader_objects(
     tmp_path: pathlib.Path,
 ) -> None:
     path = tmp_path / "workspace.itws"
@@ -763,34 +775,35 @@ def test_workspace_store_gc_can_defer_obsolete_object_deletion(
             objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
             for object_id in ("first", "second", "third"):
                 objects.create_group(object_id)
-        store.publish(_manifest("first"))
+        first_generation = store.publish(_manifest("first"))
+        workspace_store.WorkspaceStore.pin_serialized_reader(
+            workspace_id=None,
+            path=path,
+            object_id="first",
+            legacy_group_path=None,
+        )
         store.publish(_manifest("second"))
         store.publish(_manifest("third"))
 
-        assert store.collect_garbage(max_objects=1, delete_objects=False)
+        assert not store.collect_garbage(max_objects=1)
         assert len(store.generations()) == 2
         assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
             "first",
             "second",
             "third",
         }
+        assert store.serialized_object_ids == {"first"}
 
-        checks = iter((True, False))
-        assert store.collect_garbage(
-            max_objects=1,
-            can_delete_objects=lambda: next(checks),
-        )
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
-            "first",
-            "second",
-            "third",
-        }
+    with workspace_store.WorkspaceStore(path) as reopened:
+        assert reopened.serialized_object_ids == {"first"}
+        assert reopened.current_generation().sequence > first_generation.sequence
+        workspace_id = reopened.workspace_id
 
-        assert not store.collect_garbage(max_objects=1)
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
-            "second",
-            "third",
-        }
+    copied_path = tmp_path / "copied-workspace.itws"
+    shutil.copy2(path, copied_path)
+    with workspace_store.WorkspaceStore(copied_path) as copied:
+        assert copied.workspace_id == workspace_id
+        assert copied.serialized_object_ids == set()
 
 
 def test_workspace_store_gc_removes_malformed_generation_names(
@@ -1168,10 +1181,11 @@ def test_workspace_lazy_array_uses_process_localcluster_without_copy(
                     processes=True,
                     dashboard_address=None,
                 ) as cluster,
-                distributed.Client(cluster),
+                distributed.Client(cluster, set_as_default=False) as client,
             ):
-                result = opened["data"].sum().compute()
+                result = client.compute(opened["data"].sum()).result()
             assert float(result) == 435.0
+            assert store.serialized_object_ids == {object_id}
             assert set(tmp_path.iterdir()) == {path}
         finally:
             opened.close()
@@ -1675,7 +1689,7 @@ def test_workspace_compaction_rejects_replacement_after_identity_check(
             )
 
 
-def test_workspace_compaction_preserves_leased_payloads(
+def test_workspace_compaction_preserves_leased_and_serialized_payloads(
     tmp_path: pathlib.Path,
 ) -> None:
     path = tmp_path / "workspace.itws"
@@ -1683,25 +1697,34 @@ def test_workspace_compaction_preserves_leased_payloads(
         with store.write_session() as h5_file:
             objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
             objects.create_group("leased")
+            objects.create_group("serialized")
             objects.create_group("current")
         store.publish(_manifest("leased"))
         store.publish(_manifest("current"))
         store.acquire_object("leased")
+        workspace_store.WorkspaceStore.pin_serialized_reader(
+            workspace_id=store.workspace_id,
+            path=path,
+            object_id="serialized",
+            legacy_group_path=None,
+        )
 
         workspace_storage._compact_workspace_store(store)
 
         assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
             "current",
             "leased",
+            "serialized",
         }
         store.release_object("leased")
         assert not store.collect_garbage(max_objects=1)
         assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
-            "current"
+            "current",
+            "serialized",
         }
 
 
-def test_workspace_compaction_preserves_live_legacy_group(
+def test_workspace_compaction_preserves_serialized_legacy_group(
     tmp_path: pathlib.Path,
 ) -> None:
     path = tmp_path / "workspace.itws"
@@ -1713,13 +1736,22 @@ def test_workspace_compaction_preserves_live_legacy_group(
             )
             h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
         store.publish(_manifest("current"))
+        manager = workspace_arrays.WorkspaceFileManager(
+            path,
+            group_path="/legacy/imagetool",
+        )
+        manager.__getstate__()
+        del manager
+        gc.collect()
+        assert store.leased_legacy_group_paths == set()
+
+        workspace_storage._compact_workspace_store(store)
+
+        assert "legacy/imagetool" in store.h5_file
         opened = workspace_arrays.open_workspace_dataset(
             path, "legacy/imagetool", chunks={}
         )
         try:
-            workspace_storage._compact_workspace_store(store)
-
-            assert "legacy/imagetool" in store.h5_file
             assert float(opened["data"].sum().compute()) == 10.0
         finally:
             opened.close()

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -82,6 +82,119 @@ def test_workspace_store_limits_writable_handle_to_write_session(
         assert store.h5_file.mode == "r"
 
 
+def test_workspace_store_uses_copy_on_write_without_filesystem_locks(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store._locking_supported = False
+        with store.write_session() as h5_file:
+            assert h5_file.filename != str(path)
+            h5_file.attrs["copy_on_write"] = True
+
+        assert store.h5_file.attrs["copy_on_write"]
+        assert set(tmp_path.iterdir()) == {path}
+
+
+def test_workspace_store_discards_failed_copy_on_write(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store._locking_supported = False
+
+        def _fail_write() -> None:
+            with store.write_session() as h5_file:
+                h5_file.attrs["must_not_publish"] = True
+                raise RuntimeError("injected failure")
+
+        with pytest.raises(RuntimeError, match="injected failure"):
+            _fail_write()
+
+        assert "must_not_publish" not in store.h5_file.attrs
+        assert set(tmp_path.iterdir()) == {path}
+
+
+def test_workspace_store_rejects_changed_copy_on_write_source(
+    tmp_path: pathlib.Path,
+) -> None:
+    import h5py
+
+    path = tmp_path / "workspace.itws"
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        store._locking_supported = False
+
+        def _write_while_source_changes() -> None:
+            with store.write_session() as staged:
+                staged.attrs["staged"] = True
+                with h5py.File(path, "r+", locking=False) as external:
+                    external.attrs["external"] = True
+                    external.create_dataset("external_payload", data=np.arange(1000))
+                    external.flush()
+
+        with pytest.raises(
+            workspace_store.WorkspaceStoreConflictError,
+            match="changed during save",
+        ):
+            _write_while_source_changes()
+
+        assert "staged" not in store.h5_file.attrs
+        assert store.h5_file.attrs["external"]
+        assert set(tmp_path.iterdir()) == {path}
+
+
+def test_workspace_store_fast_path_does_not_copy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+
+        def _unexpected_copy() -> pathlib.Path:
+            raise AssertionError("locking-supported writes must not copy the workspace")
+
+        monkeypatch.setattr(store, "_prepare_copy_on_write", _unexpected_copy)
+        with store.write_session() as h5_file:
+            h5_file.attrs["direct"] = True
+
+        assert store.h5_file.attrs["direct"]
+
+
+def test_workspace_store_detects_unavailable_required_locking(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    original_file = workspace_store.h5py.File
+
+    def _open_file(*args, **kwargs):
+        if kwargs.get("locking") is True:
+            raise OSError(errno.ENOSYS, "file locking is not supported")
+        return original_file(*args, **kwargs)
+
+    monkeypatch.setattr(workspace_store.h5py, "File", _open_file)
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        assert not store.locking_supported
+        with store.write_session() as h5_file:
+            assert h5_file.filename != str(path)
+            h5_file.attrs["safe_fallback"] = True
+
+        assert store.h5_file.attrs["safe_fallback"]
+
+
+def test_hdf5_contention_filter_does_not_treat_permissions_as_overlap() -> None:
+    permission_error = PermissionError(errno.EACCES, "access denied")
+    lock_error = BlockingIOError(errno.EAGAIN, "resource temporarily unavailable")
+
+    assert not workspace_store._is_hdf5_file_contention_error(permission_error)
+    assert workspace_store._is_hdf5_file_contention_error(lock_error)
+
+
 def test_workspace_store_gc_retains_two_generations_and_leases(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -395,6 +508,37 @@ def test_workspace_store_shares_lazy_reader_and_generation_writer(
             opened.close()
 
 
+def test_standalone_lazy_reader_attaches_when_workspace_store_opens(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    object_id = "payload"
+    dataset = xr.Dataset({"data": ("x", np.arange(5, dtype=np.float64))})
+    plan = workspace_storage._WorkspaceGenerationPlan(
+        manifest=_manifest(object_id),
+        objects=(workspace_storage._WorkspaceObjectWrite(object_id, dataset=dataset),),
+    )
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        workspace_storage._write_workspace_generation(
+            store, plan, compression_mode="none"
+        )
+
+    opened = workspace_arrays.open_workspace_dataset(
+        path,
+        workspace_store.WorkspaceStore.object_path(object_id),
+        chunks={},
+    )
+    try:
+        assert float(opened["data"].sum().compute()) == 10.0
+        with workspace_store.WorkspaceStore(path) as store:
+            assert object_id in store.leased_object_ids
+            with store.write_session() as h5_file:
+                h5_file.attrs["attached_reader"] = True
+            assert float(opened["data"].sum().compute()) == 10.0
+    finally:
+        opened.close()
+
+
 def test_workspace_lazy_array_uses_bounded_process_reads(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -418,10 +562,7 @@ def test_workspace_lazy_array_uses_bounded_process_reads(
             path, store.object_path(object_id), chunks={"x": 2}
         )
         try:
-            with (
-                store.computation_session(),
-                dask.config.set(scheduler="processes"),
-            ):
+            with dask.config.set(scheduler="processes"):
                 result = opened["data"].sum().compute()
             assert float(result) == 435.0
             assert store.h5_file.mode == "r"
@@ -460,7 +601,6 @@ def test_workspace_lazy_array_uses_process_localcluster_without_copy(
                     dashboard_address=None,
                 ) as cluster,
                 distributed.Client(cluster),
-                store.computation_session(),
             ):
                 result = opened["data"].sum().compute()
             assert float(result) == 435.0
@@ -469,37 +609,55 @@ def test_workspace_lazy_array_uses_process_localcluster_without_copy(
             opened.close()
 
 
-def test_workspace_computation_session_blocks_background_write(
+def test_workspace_writer_waits_only_for_active_hdf5_reader(
     tmp_path: pathlib.Path,
 ) -> None:
+    import h5py
+
     path = tmp_path / "workspace.itws"
     write_started = threading.Event()
+    write_waiting = threading.Event()
     write_finished = threading.Event()
     errors: list[BaseException] = []
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
-        value = xr.DataArray([1.0])
-        value.encoding["source"] = str(path)
 
         def _write() -> None:
             write_started.set()
             try:
-                store.clear_staging()
+                with store.write_session(on_contention=write_waiting.set) as h5_file:
+                    h5_file.attrs["overlap_test"] = True
             except BaseException as exc:
                 errors.append(exc)
             finally:
                 write_finished.set()
 
-        with workspace_arrays.workspace_computation_session(value):
+        with h5py.File(path, "r", locking="best-effort"):
             writer = threading.Thread(target=_write)
             writer.start()
             assert write_started.wait(2)
-            assert not write_finished.wait(0.05)
+            assert write_waiting.wait(2)
+            assert not write_finished.is_set()
+            assert store.generations() == ()
 
         writer.join(2)
         assert not writer.is_alive()
         assert write_finished.is_set()
         assert errors == []
+        assert store.h5_file.attrs["overlap_test"]
+
+
+def test_workspace_writer_does_not_report_wait_without_overlap(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "workspace.itws"
+    waiting = threading.Event()
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session(on_contention=waiting.set) as h5_file:
+            h5_file.attrs["direct_write"] = True
+
+        assert not waiting.is_set()
 
 
 def test_workspace_worker_reports_inaccessible_shared_path(
@@ -523,6 +681,97 @@ def test_workspace_worker_reports_inaccessible_shared_path(
         match="same readable file on every worker",
     ):
         worker_manager._read_bounded_variable("data", slice(None))
+
+
+def test_workspace_worker_waits_for_overlapping_writer(
+    tmp_path: pathlib.Path,
+) -> None:
+    import subprocess
+    import sys
+
+    path = tmp_path / "workspace.itws"
+    group_path = workspace_store.WorkspaceStore.object_path("payload")
+    dataset = xr.Dataset({"data": ("x", np.arange(4, dtype=np.float64))})
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session() as h5_file:
+            workspace_arrays._write_workspace_dataset_group_to_file(
+                h5_file,
+                group_path,
+                dataset,
+                compression_mode="none",
+            )
+        manager = workspace_arrays.WorkspaceFileManager(
+            path,
+            object_id="payload",
+            group_path=group_path,
+        )
+        state = manager.__getstate__()
+        code = """
+import sys
+from erlab.interactive.imagetool.manager._workspace import _arrays
+m = _arrays.WorkspaceFileManager.__new__(_arrays.WorkspaceFileManager)
+m.__setstate__((
+    "erlab-workspace-bounded-reader-v1",
+    sys.argv[1], sys.argv[1], sys.argv[2], "payload", sys.argv[3]
+))
+print("ready", flush=True)
+print(float(m._read_bounded_variable("data", slice(None)).sum()), flush=True)
+"""
+        with store.write_session():
+            reader = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    code,
+                    str(path),
+                    typing.cast("str", state[3]),
+                    group_path,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if reader.stdout is None:
+                raise RuntimeError("Worker stdout is unavailable")
+            assert reader.stdout.readline().strip() == "ready"
+            assert reader.poll() is None
+
+        stdout, stderr = reader.communicate(timeout=5)
+        assert reader.returncode == 0, stderr
+        assert float(stdout.strip()) == 6.0
+
+
+def test_workspace_store_closes_cached_handles_before_fork(
+    tmp_path: pathlib.Path,
+) -> None:
+    import multiprocessing
+
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("fork is unavailable")
+
+    path = tmp_path / "workspace.itws"
+    context = multiprocessing.get_context("fork")
+    child_ready = context.Event()
+    child_release = context.Event()
+
+    def _wait_in_child() -> None:
+        child_ready.set()
+        child_release.wait(5)
+
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        _ = store.h5_file
+        process = context.Process(target=_wait_in_child)
+        process.start()
+        try:
+            assert child_ready.wait(2)
+            with store.write_session() as h5_file:
+                h5_file.attrs["written_after_fork"] = True
+        finally:
+            child_release.set()
+            process.join(5)
+        assert process.exitcode == 0
+        assert store.h5_file.attrs["written_after_fork"]
 
 
 def test_workspace_worker_rejects_different_file_at_shared_path(
@@ -969,10 +1218,7 @@ def test_workspace_store_switch_keeps_preserved_lazy_readers(
 
             import dask
 
-            with (
-                source_store.computation_session(),
-                dask.config.set(scheduler="processes"),
-            ):
+            with dask.config.set(scheduler="processes"):
                 assert float(old_reader["data"].sum().compute()) == 10.0
                 assert float(legacy_reader["data"].sum().compute()) == 10.0
         finally:

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -25,6 +25,7 @@ import erlab.interactive.imagetool._itool as itool_mod
 import erlab.interactive.imagetool._mainwindow as imagetool_mainwindow
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._server as imagetool_manager_server
+import erlab.interactive.imagetool.viewer as imagetool_viewer
 import erlab.interactive.imagetool.viewer_linking as imagetool_viewer_linking
 import erlab.interactive.imagetool.viewer_state as imagetool_viewer_state
 from erlab.interactive._figurecomposer import (
@@ -7593,6 +7594,50 @@ def test_imagetool_keeps_repeatable_xarray_resource_closer(qtbot) -> None:
     assert close_calls == [None, None]
     win.close()
     assert close_calls == [None, None, None]
+
+
+def test_repeatable_xarray_resource_closer_handles_wrapper_cycles() -> None:
+    first = xr.DataArray([1.0])
+    second = xr.DataArray([2.0])
+    first.set_close(second.close)
+    second.set_close(first.close)
+
+    assert imagetool_viewer._repeatable_xarray_resource_closer(first) is None
+
+    second.set_close(None)
+    assert callable(imagetool_viewer._repeatable_xarray_resource_closer(first))
+
+
+def test_imagetool_closes_lazy_input_after_auto_compute(qtbot) -> None:
+    da = pytest.importorskip("dask.array")
+    close_calls: list[None] = []
+    dataset = xr.Dataset(
+        {
+            "data": (
+                ("x", "y"),
+                da.from_array(
+                    np.arange(6, dtype=np.float32).reshape(2, 3), chunks=(1, 3)
+                ),
+            )
+        }
+    )
+    dataset.set_close(lambda: close_calls.append(None))
+    data = dataset["data"]
+    data.set_close(dataset.close)
+
+    win = ImageTool(data, auto_compute=True)
+    qtbot.addWidget(win)
+
+    assert win.slicer_area._data.chunks is None
+    assert close_calls == [None]
+    win.close()
+
+
+def test_imagetool_rejects_canceled_input_preparation(monkeypatch) -> None:
+    monkeypatch.setattr(imagetool_viewer, "_prepare_input_data", lambda *_args: None)
+
+    with pytest.raises(ValueError, match="was canceled"):
+        ImageTool(xr.DataArray([1.0]))
 
 
 def test_set_data_rad2deg_converts_angle_coords(qtbot) -> None:

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -7538,6 +7538,63 @@ def test_owned_values_copy_handles_dask_and_array_fallback() -> None:
     np.testing.assert_array_equal(fallback, np.array([1, 2, 3]))
 
 
+def test_dask_refresh_defers_only_while_workspace_write_is_active(
+    qtbot,
+    monkeypatch,
+) -> None:
+    da = pytest.importorskip("dask.array")
+    data = xr.DataArray(
+        da.from_array(np.arange(6, dtype=np.float32).reshape(2, 3), chunks=(1, 3)),
+        dims=("x", "y"),
+    )
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    writing = True
+    monkeypatch.setattr(
+        "erlab.interactive.imagetool.viewer._workspace_write_in_progress",
+        lambda _value: writing,
+    )
+
+    area._handle_refresh_dask(0, None)
+
+    assert area._workspace_dask_refresh_scheduled
+    assert area._workspace_pending_dask_refresh == (0, None)
+
+    writing = False
+    refreshes: list[tuple[int | tuple[int, ...], tuple[int, ...] | None]] = []
+    monkeypatch.setattr(
+        area,
+        "_handle_refresh_dask",
+        lambda cursor, axes: refreshes.append((cursor, axes)),
+    )
+    area._retry_workspace_dask_refresh()
+
+    assert refreshes == [(0, None)]
+    area._workspace_pending_dask_refresh = None
+    win.close()
+
+
+def test_imagetool_keeps_repeatable_xarray_resource_closer(qtbot) -> None:
+    close_calls: list[None] = []
+    dataset = xr.Dataset(
+        {"data": (("x", "y"), np.arange(6, dtype=np.float32).reshape(2, 3))}
+    )
+    dataset.set_close(lambda: close_calls.append(None))
+    data = dataset["data"]
+    data.set_close(dataset.close)
+
+    win = ImageTool(data, auto_compute=False)
+    qtbot.addWidget(win)
+
+    win.slicer_area._close_data_resource_cache()
+    win.slicer_area._close_data_resource_cache()
+
+    assert close_calls == [None, None]
+    win.close()
+    assert close_calls == [None, None, None]
+
+
 def test_set_data_rad2deg_converts_angle_coords(qtbot) -> None:
     data = xr.DataArray(
         np.arange(15, dtype=np.float32).reshape((3, 5)),

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -1038,16 +1038,12 @@ def test_options_get_set():
     assert options["colors/cmap/name"] == AppOptions().colors.cmap.name
     assert options["io/workspace/compression"] == "zstd1"
     assert options["io/workspace/compress"] is True
-    assert options["io/workspace/use_incremental"] is True
-    assert options["io/workspace/incremental_save_on_remote"] is False
     assert options["io/default_directory"] == ""
     assert options["io/recent_workspace_limit"] == 20
     assert options["figure/dpi"] is None
 
     options["colors/cmap/name"] = "viridis"
     options["io/workspace/compression"] = "blosclz3"
-    options["io/workspace/use_incremental"] = False
-    options["io/workspace/incremental_save_on_remote"] = True
     options["io/default_directory"] = "~/data"
     options["io/recent_workspace_limit"] = 35
     options["figure/stylesheets"] = ["classic", "missing-style"]
@@ -1056,15 +1052,11 @@ def test_options_get_set():
     assert options["colors/cmap/name"] == "viridis"
     assert options["io/workspace/compression"] == "blosclz3"
     assert options["io/workspace/compress"] is True
-    assert options["io/workspace/use_incremental"] is False
-    assert options["io/workspace/incremental_save_on_remote"] is True
     assert options["io/default_directory"] == "~/data"
     assert options["io/recent_workspace_limit"] == 35
     assert options["figure/stylesheets"] == ["classic", "missing-style"]
     assert options["figure/dpi"] == pytest.approx(150.0)
     assert options.model.io.workspace.compression == "blosclz3"
-    assert not options.model.io.workspace.use_incremental
-    assert options.model.io.workspace.incremental_save_on_remote
     assert options.model.io.recent_workspace_limit == 35
     assert options.model.figure.stylesheets == ["classic", "missing-style"]
     assert options.model.figure.dpi == pytest.approx(150.0)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -4364,6 +4364,13 @@ def test_tool_window_resolves_references_with_missing_placeholder_variables() ->
         data_items[erlab.interactive.utils._SAVED_TOOL_DATA_NAME],
         xr.DataArray(0, name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME),
     )
+    primary_only = erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(
+        ds,
+        source_parent_data=None,
+        reference_resolver=None,
+        variable_names={erlab.interactive.utils._SAVED_TOOL_DATA_NAME},
+    )
+    assert tuple(primary_only) == (erlab.interactive.utils._SAVED_TOOL_DATA_NAME,)
 
     with pytest.raises(ValueError, match="could not be resolved"):
         erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(


### PR DESCRIPTION
## Summary

- Keep the published workspace file under single-writer ownership.
- Open lazy xarray data through private immutable, read-only reader generations.
- Serialize full and incremental writes with one per-path lock.
- Retry transient Windows sharing failures and detect external publication changes.
- Retarget Save As references transactionally without reopening or copying saved data.
- Preserve the current incremental save fast path.

## Root cause

Long-lived xarray and HDF5 readers could retain handles to the published `.itws` file. Windows does not permit `os.replace` while another handle denies delete sharing. The manager could therefore block its own full save. The exact failure depended on which workspace payloads were still lazy and which readers were alive. This made the error appear intermittent.

The new ownership model separates published files from live readers. Full saves publish a prepared file only after all manager-owned public handles are closed. Lazy data uses a private immutable generation instead.

## User impact

Full saves no longer depend on the lifetime of lazy workspace readers. Access failures and external changes keep the open edits and show an actionable message. Save As rolls back all live reference metadata if any dependent tool update fails.

Incremental saves still update the existing file in place. They do not copy or replace the file. Same-path full saves do not reopen or copy live data after publication.

## Performance

A 16 MiB local comparison remained in the same full-save timing range as current main. Incremental saves were faster in the sample. Regression coverage also fails if the incremental path calls `copyfile` or `os.replace`.

Private reader generation creation occurs when workspace data is first opened. It is not part of the save path.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/workspace` — 437 passed before the final rollback-only hardening.
- Final focused reader, publication, Save As rollback, and compaction tests — 95 passed.
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run mypy ...`
- `uv run python -m scripts.ci_test_groups --check-partition`
- `git diff --check`
