### PR TITLE
test(manager): stabilize Qt test teardown

### DIFF
--- a/tests/interactive/imagetool/manager/test_registry_server.py
+++ b/tests/interactive/imagetool/manager/test_registry_server.py
@@ -878,6 +878,7 @@ def test_manager_registry_heartbeat_controller_edge_paths(
             for record in caplog.records
         )
 
+        controller._in_flight_generation = None
         controller.stop()
         controller.request_refresh("ignored.itws", coalesce_if_busy=True)
         assert not controller.is_busy

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -4096,13 +4096,13 @@ def test_workspace_save_worker_start_and_finish_error_branches(
         def close(self) -> None:
             self.closed = True
 
-    with manager_context() as manager:
+    with manager_context() as manager, monkeypatch.context() as worker_patch:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         controller = manager._workspace_controller
 
         start_errors: list[str] = []
         snapshot = Snapshot()
-        monkeypatch.setattr(
+        worker_patch.setattr(
             workspace_controller.QtCore.QThreadPool,
             "globalInstance",
             staticmethod(lambda: None),
@@ -4121,7 +4121,7 @@ def test_workspace_save_worker_start_and_finish_error_branches(
                 raise RuntimeError("cannot start")
 
         snapshot = Snapshot()
-        monkeypatch.setattr(
+        worker_patch.setattr(
             workspace_controller.QtCore.QThreadPool,
             "globalInstance",
             staticmethod(lambda: RaisingPool()),
@@ -4148,17 +4148,17 @@ def test_workspace_save_worker_start_and_finish_error_branches(
         errors: list[tuple[str, str]] = []
         status_messages: list[tuple[typing.Any, ...]] = []
         pool = RecordingPool()
-        monkeypatch.setattr(
+        worker_patch.setattr(
             workspace_controller.QtCore.QThreadPool,
             "globalInstance",
             staticmethod(lambda: pool),
         )
-        monkeypatch.setattr(
+        worker_patch.setattr(
             manager,
             "_show_operation_error",
             lambda title, text: errors.append((title, text)),
         )
-        monkeypatch.setattr(
+        worker_patch.setattr(
             manager._status_bar,
             "showMessage",
             lambda *args: status_messages.append(args),


### PR DESCRIPTION
## Summary

- Restore workspace-save test patches before the ImageTool Manager is deleted.
- Clear synthetic heartbeat state before the registry test stops its Qt thread.

## Root cause

Compatibility #212 failed with exit code 139 in the PySide6 jobs for Python
3.11, 3.12, and 3.14. The workspace-save test patched methods on the manager
and its status bar. The manager context deleted those Qt objects before the
fixture-level `monkeypatch` cleanup restored their attributes. PySide6 then
entered `PyObject_SetAttr` on a deleted wrapper and caused a segmentation fault.

The coverage shard later timed out in the registry heartbeat edge-path test.
The test assigned a synthetic in-flight generation, but it did not clear that
state before it called the real thread shutdown path. The controller therefore
used its timeout and orphan-thread path even though no heartbeat operation was
running.

## Changes

- Use a scoped `monkeypatch.context()` inside `manager_context()`.
- Clear the synthetic in-flight generation before the heartbeat test calls
  `stop()`.

## Impact

The tests now release Qt objects and threads through their normal shutdown
paths. Runtime behavior is unchanged.

## Validation

- PySide6 and PyQt6 workspace-save worker error-path tests.
- PySide6 and PyQt6 registry heartbeat edge-path tests.
- PyQt6 registry heartbeat test with xdist and coverage enabled.
- Pre-commit Ruff checks for both changed files.

Related failures:

- https://github.com/kmnhan/erlabpy/actions/runs/31062554005
- https://github.com/kmnhan/erlabpy/actions/runs/31067041797/job/92506846941
