### PR TITLE
Wait for manager close approval before installing updates

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -183,6 +183,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     menu_bar: QtWidgets.QMenuBar
     server: _ManagerServer
     sigLinkersChanged: QtCore.SignalInstance
+    _sigCloseResolved: QtCore.SignalInstance
     watcher_server: _WatcherServer
     _additional_windows: dict[str, QtWidgets.QWidget]
     _alert_dialogs: list[erlab.interactive.utils.MessageDialog]

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -216,6 +216,7 @@ class ImageToolManager(_ImageToolManagerBase):
     """
 
     sigLinkersChanged = QtCore.Signal()  #: :meta private:
+    _sigCloseResolved = QtCore.Signal(bool)  #: Emitted when a close request finishes.
     _sigReloadLinkers = QtCore.Signal()  #: Emitted when linker state needs refreshing
 
     _sigDataReplaced = QtCore.Signal()  #: :meta private:
@@ -1102,6 +1103,7 @@ class ImageToolManager(_ImageToolManagerBase):
             )
             if event is not None:
                 event.ignore()
+            self._sigCloseResolved.emit(False)
             return
         self._commit_note_editor()
         previous_closing_workspace_document = self._workspace_state.closing_document
@@ -1113,6 +1115,7 @@ class ImageToolManager(_ImageToolManagerBase):
             if save_choice == "cancel":
                 if event:
                     event.ignore()
+                self._sigCloseResolved.emit(False)
                 return
             if save_choice == "save":
                 if event:
@@ -1121,6 +1124,8 @@ class ImageToolManager(_ImageToolManagerBase):
                 def _close_after_save(save_succeeded: bool) -> None:
                     if save_succeeded and not self.is_workspace_modified:
                         self.close()
+                    else:
+                        self._sigCloseResolved.emit(False)
 
                 self._workspace_controller.save(on_finished=_close_after_save)
                 return
@@ -1139,6 +1144,7 @@ class ImageToolManager(_ImageToolManagerBase):
                 if self._standalone_app_windows:
                     if event:
                         event.ignore()
+                    self._sigCloseResolved.emit(False)
                     return
 
             logger.debug("Stopping servers...")
@@ -1202,6 +1208,7 @@ class ImageToolManager(_ImageToolManagerBase):
                 sys.excepthook = self._previous_excepthook
 
             super().closeEvent(event)
+            self._sigCloseResolved.emit(True)
         finally:
             self._workspace_state.closing_document = previous_closing_workspace_document
 

--- a/src/erlab/interactive/imagetool/manager/_updater_core.py
+++ b/src/erlab/interactive/imagetool/manager/_updater_core.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import platform
 import re
+import shutil
 import sys
 
 import requests
@@ -179,4 +180,19 @@ def add_update_tmp_dir(tmpdir: pathlib.Path) -> None:
     tmp_dir_list = tmp_dirs.strip().split(",") if tmp_dirs else []
     tmp_dirs_new = ",".join([*tmp_dir_list, str(tmpdir.resolve())])
     settings.setValue("update_tmp_dirs", tmp_dirs_new)
+    settings.sync()
+
+
+def remove_update_tmp_dir(tmpdir: pathlib.Path) -> None:
+    """Remove one temporary update directory and its cleanup registration."""
+    resolved = tmpdir.resolve()
+    shutil.rmtree(resolved, ignore_errors=True)
+
+    settings = _get_updater_settings()
+    tmp_dirs = settings.value("update_tmp_dirs", "")
+    tmp_dir_list = tmp_dirs.strip().split(",") if tmp_dirs else []
+    remaining = [
+        path for path in tmp_dir_list if pathlib.Path(path).resolve() != resolved
+    ]
+    settings.setValue("update_tmp_dirs", ",".join(remaining))
     settings.sync()

--- a/src/erlab/interactive/imagetool/manager/_updater_gui.py
+++ b/src/erlab/interactive/imagetool/manager/_updater_gui.py
@@ -22,10 +22,13 @@ from erlab.interactive.imagetool.manager._updater_core import (
     fetch_latest_release,
     get_full_changelog_from,
     get_install_root,
+    remove_update_tmp_dir,
     verify_sha256,
 )
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
     from erlab.interactive.imagetool.manager._base import _ImageToolManagerBase
 
 
@@ -313,9 +316,22 @@ class AutoUpdater(QtCore.QObject):
         install_root: pathlib.Path,
         parent: QtWidgets.QWidget | None,
     ):
+        tmpdir = extract_dir.parent
+        try:
+            launch_update = self._prepare_update_launcher(extract_dir, install_root)
+        except Exception as e:
+            remove_update_tmp_dir(tmpdir)
+            erlab.interactive.utils.MessageDialog.critical(
+                parent,
+                "Update",
+                "Failed to prepare updater.",
+                informative_text=str(e),
+            )
+            return
+
         manager = erlab.interactive.imagetool.manager._manager_instance
         if manager is None:
-            self._install_update(extract_dir, install_root, parent)
+            self._install_update(launch_update, tmpdir, parent)
             return
 
         def _continue_after_close(accepted: bool) -> None:
@@ -323,83 +339,80 @@ class AutoUpdater(QtCore.QObject):
             if accepted:
                 QtCore.QTimer.singleShot(
                     0,
-                    lambda: self._install_update(extract_dir, install_root, parent),
+                    lambda: self._install_update(launch_update, tmpdir, parent),
                 )
+            else:
+                remove_update_tmp_dir(tmpdir)
 
         manager._sigCloseResolved.connect(_continue_after_close)
         manager.close()
 
-    def _install_update(
-        self,
+    @staticmethod
+    def _prepare_update_launcher(
         extract_dir: pathlib.Path,
         install_root: pathlib.Path,
-        parent: QtWidgets.QWidget | None,
-    ) -> None:
+    ) -> Callable[[], subprocess.Popen[bytes]]:
         pid = os.getpid()
         tmpdir = extract_dir.parent
+
+        if sys.platform == "darwin":
+            new_app = next(extract_dir.glob("*.app"), None)
+            if new_app is None:
+                for path in extract_dir.iterdir():
+                    if path.is_dir() and (candidate := next(path.glob("*.app"), None)):
+                        new_app = candidate
+                        break
+            if new_app is None:
+                raise RuntimeError("`.app` bundle not found in extracted zip.")
+
+            app_binary = new_app / "Contents" / "MacOS" / new_app.stem
+            app_binary.chmod(app_binary.stat().st_mode | stat.S_IEXEC)
+
+            script_path = tmpdir / "apply_update.sh"
+            script_path.write_text(
+                _macos_helper_script(
+                    new_app=new_app.resolve(),
+                    old_app=install_root.resolve(),
+                    pid=pid,
+                ),
+                encoding="utf-8",
+            )
+            script_path.chmod(0o755)
+            return lambda: subprocess.Popen(
+                ["/bin/bash", str(script_path.resolve())], close_fds=True
+            )
+
+        if sys.platform.startswith("win"):
+            exe = next(extract_dir.rglob("*.exe"), None)
+            if exe is None:
+                raise RuntimeError("Installer .exe not found in extracted zip.")
+            return lambda: subprocess.Popen([str(exe), "/log"], cwd=str(extract_dir))
+
+        raise RuntimeError(
+            "Auto-update helper is not implemented for this OS and architecture."
+        )
+
+    def _install_update(
+        self,
+        launch_update: Callable[[], subprocess.Popen[bytes]],
+        tmpdir: pathlib.Path,
+        parent: QtWidgets.QWidget | None,
+    ) -> None:
+        try:
+            launch_update()
+        except Exception as e:
+            remove_update_tmp_dir(tmpdir)
+            erlab.interactive.utils.MessageDialog.critical(
+                parent,
+                "Update",
+                "Failed to start updater.",
+                informative_text=str(e),
+            )
+            return
+
         settings = _get_updater_settings()
         settings.setValue("version_before_update", self.current_version)
         settings.sync()
-
-        if sys.platform == "darwin":
-            new_app = None
-            for p in extract_dir.glob("*.app"):
-                new_app = p
-                break
-            if not new_app:
-                for p in extract_dir.iterdir():
-                    if p.is_dir():
-                        candidate = next(p.glob("*.app"), None)
-                        if candidate:
-                            new_app = candidate
-                            break
-            if not new_app:
-                raise RuntimeError("`.app` bundle not found in extracted zip.")
-
-            # Set executable permissions on extracted files
-            app_binary = new_app / "Contents" / "MacOS" / new_app.stem
-            st = app_binary.stat()
-            app_binary.chmod(st.st_mode | stat.S_IEXEC)
-
-            script = _macos_helper_script(
-                new_app=new_app.resolve(), old_app=install_root.resolve(), pid=pid
-            )
-
-            script_path = tmpdir / "apply_update.sh"
-            script_path.write_text(script, encoding="utf-8")
-            script_path.chmod(0o755)
-
-            try:
-                subprocess.Popen(
-                    ["/bin/bash", str(script_path.resolve())], close_fds=True
-                )
-            except Exception as e:
-                erlab.interactive.utils.MessageDialog.critical(
-                    parent,
-                    "Update",
-                    "Failed to start updater.",
-                    informative_text=str(e),
-                )
-                return
-
-        elif sys.platform.startswith("win"):
-            # Find installer .exe in extracted dir
-            exe = None
-            for p in extract_dir.rglob("*.exe"):
-                exe = p
-                break
-            if not exe:
-                raise RuntimeError("Installer .exe not found in extracted zip.")
-
-            # Start installer
-            subprocess.Popen([str(exe), "/log"], cwd=str(extract_dir))
-        else:
-            QtWidgets.QMessageBox.critical(
-                parent,
-                "Update",
-                "Auto-update helper not implemented for this OS and architecture.",
-            )
-            return
 
         # Quit current app; helper will take over and relaunch
         qapp = QtWidgets.QApplication.instance()

--- a/src/erlab/interactive/imagetool/manager/_updater_gui.py
+++ b/src/erlab/interactive/imagetool/manager/_updater_gui.py
@@ -313,6 +313,28 @@ class AutoUpdater(QtCore.QObject):
         install_root: pathlib.Path,
         parent: QtWidgets.QWidget | None,
     ):
+        manager = erlab.interactive.imagetool.manager._manager_instance
+        if manager is None:
+            self._install_update(extract_dir, install_root, parent)
+            return
+
+        def _continue_after_close(accepted: bool) -> None:
+            manager._sigCloseResolved.disconnect(_continue_after_close)
+            if accepted:
+                QtCore.QTimer.singleShot(
+                    0,
+                    lambda: self._install_update(extract_dir, install_root, parent),
+                )
+
+        manager._sigCloseResolved.connect(_continue_after_close)
+        manager.close()
+
+    def _install_update(
+        self,
+        extract_dir: pathlib.Path,
+        install_root: pathlib.Path,
+        parent: QtWidgets.QWidget | None,
+    ) -> None:
         pid = os.getpid()
         tmpdir = extract_dir.parent
         settings = _get_updater_settings()
@@ -378,12 +400,6 @@ class AutoUpdater(QtCore.QObject):
                 "Auto-update helper not implemented for this OS and architecture.",
             )
             return
-
-        # Close current manager
-        manager = erlab.interactive.imagetool.manager._manager_instance
-        if manager:
-            manager.remove_all_tools()
-            manager.close()
 
         # Quit current app; helper will take over and relaunch
         qapp = QtWidgets.QApplication.instance()

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -26,6 +26,7 @@ import erlab.interactive.imagetool.manager as manager_package
 import erlab.interactive.imagetool.manager.__main__ as manager_main
 import erlab.interactive.imagetool.manager._desktop as manager_desktop
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
+import erlab.interactive.imagetool.manager._updater_core as manager_updater_core
 import erlab.interactive.imagetool.manager._updater_gui as manager_updater_gui
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 from erlab.interactive._options.schema import AppOptions
@@ -161,17 +162,30 @@ def test_auto_updater_installs_only_after_manager_close(
 
     manager = _ManagerCloseStub()
     updater = manager_updater_gui.AutoUpdater("1.0.0")
-    install_calls: list[tuple[pathlib.Path, pathlib.Path, None]] = []
-    extract_dir = tmp_path / "extracted"
+    install_calls: list[tuple[Callable[[], object], pathlib.Path, None]] = []
+    cleanup_calls: list[pathlib.Path] = []
+    update_dir = tmp_path / "update"
+    extract_dir = update_dir / "extracted"
     install_root = tmp_path / "installed"
+
+    def launch_update() -> object:
+        return object()
 
     monkeypatch.setattr(manager_package, "_manager_instance", manager)
     monkeypatch.setattr(
         updater,
+        "_prepare_update_launcher",
+        lambda _extracted, _installed: launch_update,
+    )
+    monkeypatch.setattr(
+        updater,
         "_install_update",
-        lambda extracted, installed, parent: install_calls.append(
-            (extracted, installed, parent)
-        ),
+        lambda launch, tmpdir, parent: install_calls.append((launch, tmpdir, parent)),
+    )
+    monkeypatch.setattr(
+        manager_updater_gui,
+        "remove_update_tmp_dir",
+        cleanup_calls.append,
     )
 
     updater._apply_update(extract_dir, install_root, None)
@@ -191,10 +205,11 @@ def test_auto_updater_installs_only_after_manager_close(
     manager._sigCloseResolved.emit(False)
     QtWidgets.QApplication.processEvents()
     assert install_calls == (
-        [(extract_dir, install_root, None)]
+        [(launch_update, update_dir, None)]
         if close_outcome in {"accepted", "deferred"}
         else []
     )
+    assert cleanup_calls == ([update_dir] if close_outcome == "cancelled" else [])
 
 
 def test_auto_updater_cancel_preserves_open_workspace(
@@ -211,6 +226,8 @@ def test_auto_updater_cancel_preserves_open_workspace(
         qtbot.wait_until(lambda: manager.ntools == 1)
         updater = manager_updater_gui.AutoUpdater("1.0.0")
         install_calls: list[None] = []
+        cleanup_calls: list[pathlib.Path] = []
+        update_dir = tmp_path / "update"
 
         with monkeypatch.context() as patch:
             patch.setattr(
@@ -223,9 +240,19 @@ def test_auto_updater_cancel_preserves_open_workspace(
                 "_install_update",
                 lambda *_args: install_calls.append(None),
             )
+            patch.setattr(
+                updater,
+                "_prepare_update_launcher",
+                lambda *_args: lambda: object(),
+            )
+            patch.setattr(
+                manager_updater_gui,
+                "remove_update_tmp_dir",
+                cleanup_calls.append,
+            )
 
             updater._apply_update(
-                tmp_path / "extracted",
+                update_dir / "extracted",
                 tmp_path / "installed",
                 manager,
             )
@@ -234,6 +261,191 @@ def test_auto_updater_cancel_preserves_open_workspace(
             assert manager.isVisible()
             assert manager.ntools == 1
             assert install_calls == []
+            assert cleanup_calls == [update_dir]
+
+
+def test_manager_close_save_failure_resolves_as_cancelled(
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        close_results: list[bool] = []
+        manager._sigCloseResolved.connect(close_results.append)
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                manager._workspace_controller,
+                "_dirty_workspace_save_choice",
+                lambda _message: "save",
+            )
+
+            def fail_save(*, on_finished, **_kwargs) -> bool:
+                on_finished(False)
+                return False
+
+            patch.setattr(manager._workspace_controller, "save", fail_save)
+
+            assert not manager.close()
+
+        assert manager.isVisible()
+        assert close_results == [False]
+
+
+def test_manager_close_during_save_resolves_as_cancelled(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        close_results: list[bool] = []
+        manager._sigCloseResolved.connect(close_results.append)
+        manager._workspace_state.save_in_progress = True
+        try:
+            assert not manager.close()
+        finally:
+            manager._workspace_state.save_in_progress = False
+
+        assert manager.isVisible()
+        assert close_results == [False]
+
+
+def test_remove_update_tmp_dir_unregisters_and_removes(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    settings = QtCore.QSettings(
+        str(tmp_path / "updater.ini"),
+        QtCore.QSettings.Format.IniFormat,
+    )
+    keep_dir = tmp_path / "keep"
+    remove_dir = tmp_path / "remove"
+    keep_dir.mkdir()
+    remove_dir.mkdir()
+    (remove_dir / "update.zip").write_bytes(b"update")
+    settings.setValue("update_tmp_dirs", f"{keep_dir},{remove_dir}")
+    settings.sync()
+    monkeypatch.setattr(
+        manager_updater_core,
+        "_get_updater_settings",
+        lambda: settings,
+    )
+
+    manager_updater_core.remove_update_tmp_dir(remove_dir)
+
+    assert not remove_dir.exists()
+    assert keep_dir.exists()
+    assert settings.value("update_tmp_dirs") == str(keep_dir)
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32"])
+def test_auto_updater_prepares_platform_launcher(
+    platform: str,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    update_dir = tmp_path / "update"
+    extract_dir = update_dir / "extracted"
+    extract_dir.mkdir(parents=True)
+    install_root = tmp_path / "installed"
+    popen_calls: list[tuple[list[str], dict[str, object]]] = []
+
+    if platform == "darwin":
+        app_binary = (
+            extract_dir / "ImageTool Manager.app/Contents/MacOS/ImageTool Manager"
+        )
+        app_binary.parent.mkdir(parents=True)
+        app_binary.write_bytes(b"app")
+    else:
+        (extract_dir / "installer.exe").write_bytes(b"installer")
+
+    monkeypatch.setattr(manager_updater_gui.sys, "platform", platform)
+    monkeypatch.setattr(
+        manager_updater_gui.subprocess,
+        "Popen",
+        lambda command, **kwargs: popen_calls.append((command, kwargs)),
+    )
+
+    launch_update = manager_updater_gui.AutoUpdater._prepare_update_launcher(
+        extract_dir,
+        install_root,
+    )
+
+    assert popen_calls == []
+    launch_update()
+    assert len(popen_calls) == 1
+    if platform == "darwin":
+        assert (update_dir / "apply_update.sh").is_file()
+        assert popen_calls[0][0][0] == "/bin/bash"
+    else:
+        assert popen_calls[0][0][0].endswith("installer.exe")
+        assert popen_calls[0][1]["cwd"] == str(extract_dir)
+
+
+def test_auto_updater_preparation_failure_cleans_download(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    updater = manager_updater_gui.AutoUpdater("1.0.0")
+    update_dir = tmp_path / "update"
+    cleanup_calls: list[pathlib.Path] = []
+    errors: list[str] = []
+
+    monkeypatch.setattr(
+        updater,
+        "_prepare_update_launcher",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("invalid package")),
+    )
+    monkeypatch.setattr(
+        manager_updater_gui,
+        "remove_update_tmp_dir",
+        cleanup_calls.append,
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        lambda *_args, informative_text, **_kwargs: errors.append(informative_text),
+    )
+
+    updater._apply_update(
+        update_dir / "extracted",
+        tmp_path / "installed",
+        None,
+    )
+
+    assert cleanup_calls == [update_dir]
+    assert errors == ["invalid package"]
+
+
+def test_auto_updater_launch_failure_cleans_download(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    updater = manager_updater_gui.AutoUpdater("1.0.0")
+    update_dir = tmp_path / "update"
+    cleanup_calls: list[pathlib.Path] = []
+    errors: list[str] = []
+
+    monkeypatch.setattr(
+        manager_updater_gui,
+        "remove_update_tmp_dir",
+        cleanup_calls.append,
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        lambda *_args, informative_text, **_kwargs: errors.append(informative_text),
+    )
+
+    updater._install_update(
+        lambda: (_ for _ in ()).throw(RuntimeError("could not start")),
+        update_dir,
+        None,
+    )
+
+    assert cleanup_calls == [update_dir]
+    assert errors == ["could not start"]
 
 
 def test_manager_main_cache_directory_uses_qstandardpaths(

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -135,6 +135,107 @@ def test_update_workers_emit_failure_tracebacks(qapp, tmp_path, monkeypatch) -> 
     assert "zipfile.BadZipFile" in extract_failures[0][1]
 
 
+@pytest.mark.parametrize("close_outcome", ["accepted", "cancelled", "deferred"])
+def test_auto_updater_installs_only_after_manager_close(
+    close_outcome: str,
+    qtbot,
+    tmp_path,
+    monkeypatch,
+) -> None:
+    class _ManagerCloseStub(QtCore.QObject):
+        _sigCloseResolved = QtCore.Signal(bool)
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+            if close_outcome == "accepted":
+                self._sigCloseResolved.emit(True)
+            elif close_outcome == "cancelled":
+                self._sigCloseResolved.emit(False)
+
+        def remove_all_tools(self) -> None:
+            raise AssertionError("The updater must not remove workspace tools")
+
+    manager = _ManagerCloseStub()
+    updater = manager_updater_gui.AutoUpdater("1.0.0")
+    install_calls: list[tuple[pathlib.Path, pathlib.Path, None]] = []
+    extract_dir = tmp_path / "extracted"
+    install_root = tmp_path / "installed"
+
+    monkeypatch.setattr(manager_package, "_manager_instance", manager)
+    monkeypatch.setattr(
+        updater,
+        "_install_update",
+        lambda extracted, installed, parent: install_calls.append(
+            (extracted, installed, parent)
+        ),
+    )
+
+    updater._apply_update(extract_dir, install_root, None)
+
+    assert manager.close_calls == 1
+    if close_outcome == "accepted":
+        qtbot.wait_until(lambda: len(install_calls) == 1)
+    else:
+        QtWidgets.QApplication.processEvents()
+        assert install_calls == []
+
+    if close_outcome == "deferred":
+        manager._sigCloseResolved.emit(True)
+        qtbot.wait_until(lambda: len(install_calls) == 1)
+
+    manager._sigCloseResolved.emit(True)
+    manager._sigCloseResolved.emit(False)
+    QtWidgets.QApplication.processEvents()
+    assert install_calls == (
+        [(extract_dir, install_root, None)]
+        if close_outcome in {"accepted", "deferred"}
+        else []
+    )
+
+
+def test_auto_updater_cancel_preserves_open_workspace(
+    qtbot,
+    test_data,
+    tmp_path,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        test_data.qshow(manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1)
+        updater = manager_updater_gui.AutoUpdater("1.0.0")
+        install_calls: list[None] = []
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                manager._workspace_controller,
+                "_dirty_workspace_save_choice",
+                lambda _message: "cancel",
+            )
+            patch.setattr(
+                updater,
+                "_install_update",
+                lambda *_args: install_calls.append(None),
+            )
+
+            updater._apply_update(
+                tmp_path / "extracted",
+                tmp_path / "installed",
+                manager,
+            )
+            QtWidgets.QApplication.processEvents()
+
+            assert manager.isVisible()
+            assert manager.ntools == 1
+            assert install_calls == []
+
+
 def test_manager_main_cache_directory_uses_qstandardpaths(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Wait for the ImageTool manager to finish closing before applying an update.
- Prevent update installation when workspace closing is cancelled or deferred.
- Preserve open workspace tools and data when the user cancels the close request.
- Add coverage for accepted, cancelled, and deferred close outcomes.

## Testing

- Not run (not requested)