### PR TITLE
fix(imagetool): omit synthetic dimensions from 1D profiles

### DIFF
--- a/src/erlab/interactive/imagetool/_figurecomposer_adapter.py
+++ b/src/erlab/interactive/imagetool/_figurecomposer_adapter.py
@@ -282,6 +282,23 @@ class _PlotOperationBuilder:
             selected_dims = {self.selection_dim_name(axis) for axis in non_display_axes}
             selection_count = self.slicer_area.n_cursors
 
+        if qsel_kwargs is not None:
+            # Omit slicer-only dimensions, such as the synthetic 1D stack_dim.
+            public_dims = set(self.slicer_area.displayed_data.dims)
+            slicer_dims = {
+                self.selection_dim_name(axis)
+                for axis in range(self.slicer_area.data.ndim)
+            }
+            qsel_kwargs = {
+                key: value
+                for key, value in qsel_kwargs.items()
+                if (
+                    (dim := key.removesuffix("_width") if isinstance(key, str) else key)
+                    not in slicer_dims
+                    or dim in public_dims
+                )
+            }
+
         invalid_qsel_keys = (
             tuple(key for key in qsel_kwargs if not _qsel_key_is_editable(key))
             if qsel_kwargs is not None

--- a/src/erlab/interactive/imagetool/_provenance/_model.py
+++ b/src/erlab/interactive/imagetool/_provenance/_model.py
@@ -1098,7 +1098,7 @@ class ToolProvenanceOperation(pydantic.BaseModel):
     def __pydantic_on_complete__(cls) -> None:
         super().__pydantic_on_complete__()
 
-        if "op" not in cls.__dict__.get("__annotations__", {}):
+        if "op" not in inspect.get_annotations(cls):
             return
 
         op_field = cls.model_fields.get("op")
@@ -3829,22 +3829,32 @@ def compose_display_provenance(
         and parent_data.attrs.get(_PROMOTED_1D_SOURCE_ATTR, False)
         and source.kind == "selection"
     ):
-        saw_squeeze = False
+        saw_synthetic_cleanup = False
         for operation in source.operations:
             if _operation_is(operation, "qsel", "isel", "sel"):
-                if getattr(operation, "decoded_kwargs", {}):
-                    break
+                selection_kwargs = getattr(operation, "decoded_kwargs", {})
+                if selection_kwargs:
+                    selection_dims = {
+                        key.removesuffix("_width") if isinstance(key, str) else key
+                        for key in selection_kwargs
+                    }
+                    if not (
+                        parent_data.sizes.get("stack_dim") == 1
+                        and selection_dims == {"stack_dim"}
+                    ):
+                        break
+                    saw_synthetic_cleanup = True
                 continue
             if (
                 _operation_is(operation, "squeeze")
                 and getattr(operation, "dims", None) is None
                 and not getattr(operation, "drop", False)
             ):
-                saw_squeeze = True
+                saw_synthetic_cleanup = True
                 continue
             break
         else:
-            if saw_squeeze:
+            if saw_synthetic_cleanup:
                 return parent_spec
 
     source_kind = typing.cast(

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -1324,6 +1324,21 @@ class ItoolPlotItem(pg.PlotItem):
         selection_indexers = self.array_slicer.isel_args(
             cursor, self.display_axis, int_if_one=True
         )
+        public_dims = set(self.slicer_area.displayed_data.dims)
+        slicer_only_selection_dims = {
+            dim
+            for dim in selection_indexers
+            if (
+                dim in selection_data.dims
+                and dim not in public_dims
+                and selection_data.sizes[dim] == 1
+            )
+        }
+        selection_indexers = {
+            dim: indexer
+            for dim, indexer in selection_indexers.items()
+            if dim not in slicer_only_selection_dims
+        }
         if selection_indexers and selection_code.startswith(".qsel"):
             binned = self.array_slicer.get_binned(cursor)
             selection_binned_dims: list[Hashable] = []
@@ -1392,7 +1407,10 @@ class ItoolPlotItem(pg.PlotItem):
             operations.append(
                 TransposeOperation(dims=tuple(reversed(self.current_data.dims)))
             )
-        if squeeze and any(size == 1 for size in self.current_data.shape):
+        if squeeze and (
+            slicer_only_selection_dims
+            or any(size == 1 for size in self.current_data.shape)
+        ):
             operations.append(SqueezeOperation())
         return selection(*operations)
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
@@ -391,6 +391,39 @@ def test_manager_auto_names_figures_numerically(
         assert manager._child_node(unnamed_uid).display_text == "Figure 6"
 
 
+def test_imagetool_1d_profile_creates_figure_without_internal_stack_dim(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        data = xr.DataArray(
+            np.arange(5.0),
+            dims=("x",),
+            coords={"x": np.arange(5.0)},
+            name="cut",
+        )
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        source_tool = manager._tool_graph.root_wrappers[0]
+        assert source_tool.slicer_area.data.dims == ("x", "stack_dim")
+        source_tool.slicer_area.axes[1].plot_with_matplotlib()
+
+        qtbot.wait_until(
+            lambda: len(manager._tool_graph.figure_uids) == 1, timeout=5000
+        )
+        figure_uid = manager._tool_graph.figure_uids[0]
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        [operation] = figure_tool.tool_status.operations
+        assert operation.kind == FigureOperationKind.LINE
+        assert operation.line_x == "x"
+        assert operation.line_selection == {}
+        xr.testing.assert_equal(figure_tool.source_data()["cut"], data)
+
+
 def test_manager_duplicate_figure_assigns_unique_display_name_and_keeps_state(
     qtbot,
     manager_context: Callable[

--- a/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
+++ b/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
@@ -13,6 +13,7 @@ import erlab.interactive.imagetool._highdim as imagetool_highdim
 import erlab.interactive.imagetool.manager._lineage as manager_lineage
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
+from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
 from erlab.interactive._mesh import MeshTool
 from erlab.interactive.derivative import DerivativeTool
@@ -1166,6 +1167,48 @@ def test_manager_watched_1d_root_ftool_copy_code_omits_synthetic_squeeze(
         child_tool.copy_code()
 
         assert copied
+        _assert_modelfit_code_replays_source(copied[-1], "my_1d", data)
+
+
+def test_manager_watched_1d_profile_ftool_copy_code_omits_synthetic_selection(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(np.arange(5), dims=("x",), coords={"x": np.arange(5)})
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager._data_ingress.receive_data(
+            [data], {}, watched_var=("my_1d", "kernel-0")
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        parent_tool = manager.get_imagetool(0)
+        parent_tool.slicer_area.profiles[0].open_in_ftool()
+        qtbot.wait_until(
+            lambda: len(manager._tool_graph.root_wrappers[0]._childtool_indices) == 1,
+            timeout=5000,
+        )
+
+        child_uid = manager._tool_graph.root_wrappers[0]._childtool_indices[0]
+        child_tool = manager.get_childtool(child_uid)
+        assert isinstance(child_tool, Fit1DTool)
+
+        copied: list[str] = []
+        monkeypatch.setattr(
+            erlab.interactive.utils,
+            "copy_to_clipboard",
+            lambda text: copied.append(text) or text,
+        )
+        child_tool.copy_code()
+
+        assert copied
+        assert "stack_dim" not in copied[-1]
         _assert_modelfit_code_replays_source(copied[-1], "my_1d", data)
 
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -2197,6 +2197,7 @@ def test_figure_composer_operation_reports_uneditable_plot_slices_details(
         display_axis = (0, 1)
         slicer_area = types.SimpleNamespace(
             data=types.SimpleNamespace(ndim=3, dims=("alpha", "beta", "eV")),
+            displayed_data=types.SimpleNamespace(dims=("alpha", "beta", "eV")),
             n_cursors=1,
         )
         array_slicer = types.SimpleNamespace(_nonuniform_axes=set())

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -8470,6 +8470,46 @@ def test_profile_open_in_ftool_omits_noop_squeeze_source_binding(
     win.close()
 
 
+def test_1d_profile_ftool_copy_code_omits_slicer_only_selection(
+    qtbot, monkeypatch
+) -> None:
+    data = xr.DataArray(np.arange(5), dims=("x",), coords={"x": np.arange(5)})
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    profile = win.slicer_area.profiles[0]
+
+    source_spec = profile.make_tool_source_spec(squeeze=True)
+    assert source_spec.operations == (SqueezeOperation(),)
+    resolved = source_spec.apply(win.slicer_area.data)
+    assert resolved.coords["stack_dim"].ndim == 0
+    xr.testing.assert_identical(resolved.drop_vars("stack_dim"), data)
+
+    profile.open_in_ftool()
+    child = win.slicer_area._associated_tools_list[-1]
+    assert isinstance(child, erlab.interactive.utils.ToolWindow)
+
+    copied: list[str] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "copy_to_clipboard",
+        lambda text: copied.append(text) or text,
+    )
+    child.copy_code()
+
+    assert copied
+    assert "stack_dim" not in copied[-1]
+    namespace = _exec_generated_code(copied[-1], {"data": data.copy(deep=True)})
+    result = namespace["result"]
+    assert isinstance(result, xr.Dataset)
+    xr.testing.assert_identical(
+        result["modelfit_data"].rename(data.name),
+        data.astype(np.float64),
+    )
+
+    child.close()
+    win.close()
+
+
 def test_itool_guideline_undo_redo(qtbot) -> None:
     data = xr.DataArray(np.arange(25).reshape((5, 5)).astype(float), dims=["x", "y"])
     win = itool(data, execute=False)

--- a/tests/interactive/imagetool/test_module_split.py
+++ b/tests/interactive/imagetool/test_module_split.py
@@ -277,6 +277,7 @@ def test_plot_items_loads_figure_composer_only_for_action() -> None:
             _in_manager=True,
             _manager_instance=manager,
             data=types.SimpleNamespace(ndim=2, dims=("x", "y")),
+            displayed_data=types.SimpleNamespace(dims=("x", "y")),
             n_cursors=1,
             manual_limits={},
             colormap_properties={

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -7757,6 +7757,48 @@ def test_tool_provenance_compose_display_replay_omits_synthetic_1d_squeeze() -> 
     xr.testing.assert_identical(explicit_derived, watched_data.squeeze(drop=True))
 
 
+@pytest.mark.parametrize(
+    "operation",
+    [
+        QSelOperation(kwargs={"stack_dim": 0.0}),
+        IselOperation(kwargs={"stack_dim": 0}),
+    ],
+)
+def test_tool_provenance_compose_display_replay_omits_synthetic_1d_selection(
+    operation: ToolProvenanceOperation,
+) -> None:
+    parent = script(
+        start_label="Start from watched variable 'my_1d'",
+        seed_code="derived = my_1d",
+    )
+    parent_data = xr.DataArray(
+        np.arange(5).reshape((5, 1)),
+        dims=("x", "stack_dim"),
+        coords={"x": np.arange(5), "stack_dim": [0]},
+    )
+    parent_data = mark_promoted_1d_source(parent_data)
+
+    composed = compose_display_provenance(
+        parent,
+        selection(operation),
+        parent_data=parent_data,
+    )
+
+    assert composed is not None
+    code = composed.display_code()
+    assert code is not None
+    assert "stack_dim" not in code
+    watched_data = xr.DataArray(
+        np.arange(5),
+        dims=("x",),
+        coords={"x": np.arange(5)},
+    )
+    namespace = _exec_generated_code(code, {"my_1d": watched_data.copy(deep=True)})
+    derived = namespace["derived"]
+    assert isinstance(derived, xr.DataArray)
+    xr.testing.assert_identical(derived, watched_data)
+
+
 def test_model_fit_operation_replays_selected_parameter_as_dataarray() -> None:
     x = np.linspace(-1.0, 1.0, 11)
     y = np.array([0, 1])


### PR DESCRIPTION
## Summary

- Exclude slicer-only dimensions from Figure Composer line selections.
- Keep live derived tools connected to the internal 1D profile without exposing `stack_dim`.
- Remove legacy synthetic `qsel`, `isel`, and `sel` steps from copied provenance code.
- Execute generated Fit1D code in regression tests against the original public 1D data.

## Root cause

ImageTool promotes public 1D data to an internal two-dimensional array with a singleton `stack_dim`. Figure Composer and profile-derived tools used selections from this internal array. Their public operations then referred to `stack_dim`, although the original data did not contain that dimension.

## User impact

Adding a 1D profile to Figure Composer now opens and plots the profile.

Code copied from a derived tool, such as Fit1D, no longer contains `.qsel(stack_dim=...)`. The copied code runs against the original 1D variable.

The cleanup applies only to a marked promoted 1D source with a singleton synthetic dimension. Real user selections remain unchanged.

## Validation

- `QT_QPA_PLATFORM=offscreen QT_API=pyqt6 uv run pytest -q tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py` (484 passed)
- `QT_QPA_PLATFORM=offscreen QT_API=pyqt6 uv run pytest -q tests/interactive/imagetool/test_provenance.py tests/interactive/imagetool/test_imagetool.py tests/interactive/imagetool/manager/provenance/test_watched_tools.py` (757 passed)
- Focused Figure Composer regression under PySide6 (1 passed)
- Focused copied-code and provenance regressions under PySide6 (4 passed)
- `uv run mypy src`
- `uv run ruff check` on the changed files
- `uv run ruff format --check` on the changed files
- `git diff --check`
