### PR TITLE
fix(imagetool): handle binned unindexed selections

### DIFF
--- a/src/erlab/interactive/imagetool/slicer.py
+++ b/src/erlab/interactive/imagetool/slicer.py
@@ -263,6 +263,11 @@ def qsel_args_from_indexers(
         Dimensions whose index slices should become ``qsel`` center and width
         arguments.
 
+    Notes
+    -----
+    Dimensions without indexes use temporary coordinates from zero to ``n - 1``.
+    This matches the positional selection behavior of :meth:`xarray.DataArray.qsel`.
+
     Returns
     -------
     dict
@@ -274,18 +279,31 @@ def qsel_args_from_indexers(
         If a requested dimension is missing or a binned selection cannot be expressed
         by the current coordinate values.
     """
+    for dim in indexers:
+        if dim not in data.dims:
+            raise ValueError(f"Dimension `{dim}` not found in data")
+
+    temporary_coords = {
+        dim: np.arange(data.sizes[dim]) for dim in indexers if dim not in data.indexes
+    }
+    selection_data = data.assign_coords(temporary_coords) if temporary_coords else data
+
     out: dict[Hashable, float] = {}
     binned_dim_set = set(binned_dims)
 
     for dim, selector in indexers.items():
-        if dim not in data.dims:
-            raise ValueError(f"Dimension `{dim}` not found in data")
-        coord_values = data[dim].values
+        coord_values = selection_data[dim].values
         inc = _get_inc(coord_values)
         order = 3 if inc == 0 else erlab.utils.array.effective_decimals(inc)
 
         if dim in binned_dim_set:
-            coord = data[dim][selector].values
+            if not isinstance(selector, slice):
+                raise ValueError(
+                    f"Bin selection for dimension `{dim}` must be an index slice"
+                )
+            coord = selection_data[dim][selector].values
+            if coord.size == 0:
+                raise ValueError(f"Bin selection for dimension `{dim}` is empty")
             center = float(np.round(coord.mean(), order))
             width = float(np.abs(np.round(coord[-1] - coord[0] + inc, order)))
 
@@ -298,7 +316,7 @@ def qsel_args_from_indexers(
                     -slice_obj.step if slice_obj.step is not None else None,
                 )
 
-            if not np.allclose(data[dim].sel({dim: slice_obj}).values, coord):
+            if not np.allclose(selection_data[dim].sel({dim: slice_obj}).values, coord):
                 raise ValueError(
                     "Bin does not contain the same values as the original data."
                 )

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -4917,6 +4917,42 @@ def test_image_open_in_new_window_preserves_spaced_qsel_dimension(qtbot) -> None
     win.close()
 
 
+def test_image_open_in_new_window_handles_binned_unindexed_dimension(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(60.0).reshape(3, 4, 5),
+        dims=("x", "y", "z"),
+        name="map",
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    image = win.slicer_area.images[0]
+    win.slicer_area.set_bin(axis=2, value=3, cursor=0)
+    expected = data.isel(z=slice(1, 4)).mean("z")
+
+    source_spec = image.make_tool_source_spec()
+    resolved = source_spec.apply(data)
+    xr.testing.assert_identical(resolved, expected)
+    np.testing.assert_allclose(image.current_data.values, expected.values)
+
+    image.open_in_new_window()
+    qtbot.wait_until(
+        lambda: isinstance(win.slicer_area._associated_tools_list[-1], ImageTool),
+        timeout=5000,
+    )
+    child = typing.cast("ImageTool", win.slicer_area._associated_tools_list[-1])
+
+    np.testing.assert_allclose(child.slicer_area.data.values, expected.values)
+    assert child.provenance_spec is not None
+    display_code = child.provenance_spec.display_code()
+    assert display_code is not None
+    namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
+    xr.testing.assert_identical(namespace["derived"], expected)
+
+    child.close()
+    win.close()
+
+
 def test_image_open_in_new_window_restores_nonuniform_public_dims(qtbot) -> None:
     data = xr.DataArray(
         np.arange(60.0).reshape(3, 4, 5),

--- a/tests/interactive/imagetool/test_slicer.py
+++ b/tests/interactive/imagetool/test_slicer.py
@@ -720,6 +720,38 @@ def test_qsel_args_from_indexers_validates_live_bin_coordinates() -> None:
         qsel_args_from_indexers(data, {"x": slice(2, 5)}, ("x",))
 
 
+@pytest.mark.parametrize("has_unindexed_coord", [False, True])
+def test_qsel_args_from_indexers_uses_positions_for_unindexed_dimension(
+    has_unindexed_coord: bool,
+) -> None:
+    data = xr.DataArray(
+        np.array([0.0, 10.0, 100.0, 1000.0, 10000.0]),
+        dims=("x",),
+    )
+    if has_unindexed_coord:
+        data = data.assign_coords(x=[10.0, 20.0, 30.0, 40.0, 50.0]).drop_indexes("x")
+    original = data.copy(deep=True)
+
+    args = qsel_args_from_indexers(data, {"x": slice(1, 4)}, ("x",))
+
+    assert args == {"x": 2.0, "x_width": 3.0}
+    np.testing.assert_allclose(
+        data.qsel(args).values,
+        data.isel(x=slice(1, 4)).mean("x").values,
+    )
+    xr.testing.assert_identical(data, original)
+
+
+def test_qsel_args_from_indexers_rejects_invalid_bin_indexers() -> None:
+    data = xr.DataArray(np.arange(5.0), dims=("x",))
+
+    with pytest.raises(ValueError, match="must be an index slice"):
+        qsel_args_from_indexers(data, {"x": 2}, ("x",))
+
+    with pytest.raises(ValueError, match="is empty"):
+        qsel_args_from_indexers(data, {"x": slice(2, 2)}, ("x",))
+
+
 def test_qsel_args_desc_uniform_descending_axis_emits_positive_width() -> None:
     data = xr.DataArray(
         np.arange(5, dtype=np.float32),


### PR DESCRIPTION
## Summary

- Treat dimensions without indexes as positional coordinates when ImageTool builds qsel provenance.
- Reject empty bins and non-slice bin indexers with clear errors.
- Add direct and end-to-end regression tests for binned unindexed selections.

## Root cause

ImageTool adds range coordinates to its internal slicer data. The source provenance still uses the original data, which can have dimensions without indexes. Bin validation applied a float label slice to an unindexed dimension. Xarray interpreted that slice as positional and raised a `TypeError`.

## User impact

Opening a binned selection in a new ImageTool window now works for data without explicit coordinates. Generated provenance code also replays the same public result. The fix does not mutate the source data or add synthetic display coordinates to public provenance.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run --group pyqt6 pytest -q tests/interactive/imagetool/test_slicer.py` - 44 passed
- `QT_QPA_PLATFORM=offscreen uv run --group pyside6 pytest -q tests/interactive/imagetool/test_slicer.py` - 44 passed
- Focused ImageTool regression tests under PyQt6 - 8 passed
- Focused ImageTool regression tests under PySide6 - 8 passed
- `uv run ruff format ...`
- `uv run ruff check ...`
- `uv run mypy src/erlab/interactive/imagetool/slicer.py`
- `git diff --check`
