### PR TITLE
fix(io.ssrl52): avoid implicit JIT during loading

### DIFF
--- a/src/erlab/io/plugins/ssrl52.py
+++ b/src/erlab/io/plugins/ssrl52.py
@@ -276,7 +276,11 @@ class SSRL52Loader(LoaderBase):
         if (
             "sample_workfunction" in data.attrs
             and "eV" in data.dims
-            and data["eV"].min() > 0
+            # Keep this reduction on NumPy. Xarray can dispatch floating-point
+            # reductions to Numbagg, which starts an uncached Numba/LLVM compilation
+            # on the calling thread. A macOS Qt worker can then exhaust its small
+            # native stack and fail in LLVMPY_FinalizeObject while loading this file.
+            and np.nanmin(data["eV"].values) > 0
         ):
             data = data.assign_coords(
                 eV=data["eV"] - float(data["hv"]) + data.attrs["sample_workfunction"]

--- a/tests/io/plugins/test_ssrl52.py
+++ b/tests/io/plugins/test_ssrl52.py
@@ -1,3 +1,6 @@
+import shutil
+
+import h5py
 import pytest
 import xarray as xr
 
@@ -38,6 +41,29 @@ def test_load(expected_dir, args, expected, chunks) -> None:
 
     xr.testing.assert_identical(
         loaded, xr.load_dataarray(expected_dir / expected, engine="h5netcdf")
+    )
+
+
+def test_load_legacy_compat_avoids_xarray_reduction(
+    data_dir, expected_dir, tmp_path, monkeypatch
+) -> None:
+    legacy_file = tmp_path / "legacy_ssrl52.h5"
+    shutil.copyfile(data_dir / "f_0002.h5", legacy_file)
+    with h5py.File(legacy_file, "r+") as file:
+        file.move("Data", "data")
+        file["data"].move("Count", "counts")
+        file["data"].move("Time", "exposure")
+
+    def unexpected_xarray_reduction(*_args, **_kwargs):
+        raise AssertionError("SSRL52 loading must not use DataArray.min()")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(xr.DataArray, "min", unexpected_xarray_reduction)
+        loaded = erlab.io.load(legacy_file)
+
+    xr.testing.assert_identical(
+        loaded,
+        xr.load_dataarray(expected_dir / "f_0002.h5", engine="h5netcdf"),
     )
 
 


### PR DESCRIPTION
## Summary

- Use a direct NumPy reduction for the SSRL 5-2 binding-energy check.
- Document why an xarray reduction is unsafe in this specific loader path.
- Add coverage for the legacy lowercase `/data`, `counts`, and `exposure` layout.

## Root cause

Xarray can dispatch a floating-point `DataArray.min()` call to Numbagg when the optional performance dependency is installed. The first call compiles a generalized ufunc through Numba and LLVM on the calling thread. In ImageTool Manager, this occurred on a macOS Qt file-loader worker with a small native stack. LLVM object finalization crossed the stack guard and terminated the application with `SIGBUS`.

The new NumPy reduction preserves the SSRL coordinate check without starting implicit JIT compilation. Xarray and Numbagg acceleration remain enabled elsewhere.

## User impact

Legacy SSRL 5-2 files can load without starting this hidden LLVM compilation in the manager worker. The change does not modify global xarray options or Qt worker configuration.

## Validation

- `uv run pytest -vv tests/io/plugins/test_ssrl52.py` — 10 passed
- `uv run ruff check src/erlab/io/plugins/ssrl52.py tests/io/plugins/test_ssrl52.py`
- `uv run ruff format --check src/erlab/io/plugins/ssrl52.py tests/io/plugins/test_ssrl52.py`
- `git diff --check`
- A fresh Numbagg-enabled trace completed the SSRL load with zero LLVM object-finalization calls; the previous path produced nine.
