### PR TITLE
Add Figure Composer controls for method style arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "joblib>=1.3.2",
   "lazy-loader>=0.4",
   "lmfit>=1.3.2",
-  "matplotlib>=3.8.0",
+  "matplotlib>=3.11.0",
   "numba>=0.61.0,<0.63.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
   "numba>=0.63.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
   "numexpr>=2.11.0",

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
@@ -153,6 +153,7 @@ class MethodControlKind(enum.StrEnum):
     ASPECT_ARG = "aspect_arg"
     BOOL_ARG_COMBO = "bool_arg_combo"
     KWARG_COMBO = "kwarg_combo"
+    BOOL_KWARG_CHECK = "bool_kwarg_check"
     BOOL_KWARG_COMBO = "bool_kwarg_combo"
     OPTIONAL_BOOL_KWARG_COMBO = "optional_bool_kwarg_combo"
     INT_KWARG = "int_kwarg"
@@ -177,12 +178,15 @@ class MethodControlSpec:
     key: str | None = None
     options: tuple[str, ...] = ()
     option_labels: tuple[str, ...] = ()
+    aliases: tuple[str, ...] = ()
     default: typing.Any = None
     minimum: int | float | None = None
     maximum: int | float | None = None
     decimals: int | None = None
     step: int | float | None = None
     none_label: str | None = None
+    exclusive_group: str | None = None
+    none_is_unset: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -426,6 +430,9 @@ def _kwarg_combo(
     *,
     none_label: str | None = None,
     option_labels: Sequence[str] = (),
+    aliases: Sequence[str] = (),
+    exclusive_group: str | None = None,
+    none_is_unset: bool = False,
 ) -> MethodControlSpec:
     return MethodControlSpec(
         kind=MethodControlKind.KWARG_COMBO,
@@ -435,8 +442,11 @@ def _kwarg_combo(
         tooltip=tooltip,
         options=tuple(options),
         option_labels=tuple(option_labels),
+        aliases=tuple(aliases),
         default=default,
         none_label=none_label,
+        exclusive_group=exclusive_group,
+        none_is_unset=none_is_unset,
     )
 
 
@@ -455,6 +465,24 @@ def _bool_kwarg_combo(
         object_name=object_name,
         tooltip=tooltip,
         options=("True", "False"),
+        default=default,
+    )
+
+
+def _bool_kwarg_check(
+    label: str,
+    key: str,
+    object_name: str,
+    tooltip: str,
+    *,
+    default: bool,
+) -> MethodControlSpec:
+    return MethodControlSpec(
+        kind=MethodControlKind.BOOL_KWARG_CHECK,
+        label=label,
+        key=key,
+        object_name=object_name,
+        tooltip=tooltip,
         default=default,
     )
 
@@ -514,6 +542,7 @@ def _float_kwarg(
     maximum: float | None = None,
     decimals: int | None = None,
     step: float | None = None,
+    aliases: Sequence[str] = (),
 ) -> MethodControlSpec:
     return MethodControlSpec(
         kind=MethodControlKind.FLOAT_KWARG,
@@ -526,6 +555,7 @@ def _float_kwarg(
         maximum=maximum,
         decimals=decimals,
         step=step,
+        aliases=tuple(aliases),
     )
 
 
@@ -611,7 +641,12 @@ def _float_pair_kwarg(
 
 
 def _color_kwarg(
-    label: str, key: str, object_name: str, tooltip: str
+    label: str,
+    key: str,
+    object_name: str,
+    tooltip: str,
+    *,
+    aliases: Sequence[str] = (),
 ) -> MethodControlSpec:
     return MethodControlSpec(
         kind=MethodControlKind.COLOR_KWARG,
@@ -619,6 +654,7 @@ def _color_kwarg(
         key=key,
         object_name=object_name,
         tooltip=tooltip,
+        aliases=tuple(aliases),
     )
 
 
@@ -726,6 +762,138 @@ _FONT_WEIGHT_OPTIONS = (
     "extra bold",
     "black",
 )
+
+
+def _line_color_style_controls(
+    object_name_prefix: str, description: str
+) -> tuple[MethodControlSpec, ...]:
+    return (
+        _color_kwarg(
+            "Color",
+            "color",
+            f"{object_name_prefix}ColorEdit",
+            f"Matplotlib color for {description}.",
+            aliases=("c",),
+        ),
+        _kwarg_combo(
+            "Line style",
+            "linestyle",
+            LINE_STYLE_OPTIONS,
+            None,
+            f"{object_name_prefix}LineStyleCombo",
+            f"Matplotlib line style for {description}.",
+            none_label=LINE_STYLE_DEFAULT_LABEL,
+            aliases=("ls",),
+        ),
+    )
+
+
+def _title_location_control(object_name: str, tooltip: str) -> MethodControlSpec:
+    return _kwarg_combo(
+        "Location",
+        "loc",
+        ("center", "left", "right"),
+        "center",
+        object_name,
+        tooltip,
+    )
+
+
+_AXIS_LABEL_POSITION_GROUP = "axis_label_position"
+
+
+def _text_color_control(object_name: str, description: str) -> MethodControlSpec:
+    return _color_kwarg(
+        "Color",
+        "color",
+        object_name,
+        f"Matplotlib color for {description}.",
+        aliases=("c",),
+    )
+
+
+def _text_artist_controls(
+    object_name_prefix: str,
+    description: str,
+    *,
+    horizontalalignment_exclusive_group: str | None = None,
+) -> tuple[MethodControlSpec, ...]:
+    horizontalalignment_tooltip = f"Horizontal alignment for {description}."
+    if horizontalalignment_exclusive_group is not None:
+        horizontalalignment_tooltip += "\nSelecting this value clears Location."
+    return (
+        _text_color_control(f"{object_name_prefix}ColorEdit", description),
+        _kwarg_combo(
+            "Horizontal alignment",
+            "horizontalalignment",
+            ("left", "center", "right"),
+            None,
+            f"{object_name_prefix}HorizontalAlignmentCombo",
+            horizontalalignment_tooltip,
+            none_label="Unset",
+            aliases=("ha",),
+            exclusive_group=horizontalalignment_exclusive_group,
+            none_is_unset=True,
+        ),
+        _kwarg_combo(
+            "Vertical alignment",
+            "verticalalignment",
+            ("baseline", "bottom", "center", "center_baseline", "top"),
+            None,
+            f"{object_name_prefix}VerticalAlignmentCombo",
+            f"Vertical alignment for {description}.",
+            none_label="Unset",
+            aliases=("va",),
+            none_is_unset=True,
+        ),
+        _literal_kwarg(
+            "Rotation",
+            "rotation",
+            f"{object_name_prefix}RotationEdit",
+            (
+                f"Rotation for {description}.\n"
+                "Use an angle in degrees or a quoted value such as 'vertical'."
+            ),
+        ),
+        _kwarg_combo(
+            "Rotation mode",
+            "rotation_mode",
+            ("default", "anchor", "xtick", "ytick"),
+            None,
+            f"{object_name_prefix}RotationModeCombo",
+            f"Rotation and alignment order for {description}.",
+            none_label="Unset",
+        ),
+    )
+
+
+def _axis_label_controls(
+    axis: typing.Literal["x", "y"], object_name_prefix: str
+) -> tuple[MethodControlSpec, ...]:
+    if axis == "x":
+        location_options = ("center", "left", "right")
+    else:
+        location_options = ("center", "bottom", "top")
+    description = f"the {axis}-axis label"
+    return (
+        _kwarg_combo(
+            "Location",
+            "loc",
+            location_options,
+            "center",
+            f"{object_name_prefix}LocCombo",
+            (
+                f"{axis}-axis label location.\n"
+                "Selecting this value clears Horizontal alignment."
+            ),
+            exclusive_group=_AXIS_LABEL_POSITION_GROUP,
+        ),
+        *_text_artist_controls(
+            object_name_prefix,
+            description,
+            horizontalalignment_exclusive_group=_AXIS_LABEL_POSITION_GROUP,
+        ),
+    )
 
 
 def _label_subplots_text_controls(
@@ -937,6 +1105,7 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 "figureComposerAxesMethodTextEdit",
                 "Text string passed as the third ax.text argument.",
             ),
+            *_text_artist_controls("figureComposerAxesMethodText", "the text"),
         ),
     ),
     "plot": MethodSpec(
@@ -949,20 +1118,8 @@ AXES_METHODS: dict[str, MethodSpec] = {
         default_args=((0.0, 1.0),),
         controls=(
             _plot_data_args(),
-            _color_kwarg(
-                "Color",
-                "color",
-                "figureComposerAxesMethodPlotColorEdit",
-                "Matplotlib color for the plotted line.",
-            ),
-            _kwarg_combo(
-                "Line style",
-                "linestyle",
-                LINE_STYLE_OPTIONS,
-                None,
-                "figureComposerAxesMethodPlotLineStyleCombo",
-                "Matplotlib line style for the plotted line.",
-                none_label=LINE_STYLE_DEFAULT_LABEL,
+            *_line_color_style_controls(
+                "figureComposerAxesMethodPlot", "the plotted line"
             ),
             _float_kwarg(
                 "Line width",
@@ -973,6 +1130,7 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 minimum=0.0,
                 maximum=1_000_000.0,
                 step=0.5,
+                aliases=("lw",),
             ),
             _kwarg_combo(
                 "Marker",
@@ -992,18 +1150,21 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 minimum=0.0,
                 maximum=1_000_000.0,
                 step=0.5,
+                aliases=("ms",),
             ),
             _color_kwarg(
                 "Marker face",
                 "markerfacecolor",
                 "figureComposerAxesMethodPlotMarkerFaceColorEdit",
                 "Matplotlib marker face color.",
+                aliases=("mfc",),
             ),
             _color_kwarg(
                 "Marker edge",
                 "markeredgecolor",
                 "figureComposerAxesMethodPlotMarkerEdgeColorEdit",
                 "Matplotlib marker edge color.",
+                aliases=("mec",),
             ),
             _float_kwarg(
                 "Alpha",
@@ -1042,20 +1203,8 @@ AXES_METHODS: dict[str, MethodSpec] = {
         default_args=((0.0, 1.0), (0.0, 1.0)),
         controls=(
             _plot_data_args(),
-            _color_kwarg(
-                "Color",
-                "color",
-                "figureComposerAxesMethodErrorbarColorEdit",
-                "Matplotlib color for the errorbar line.",
-            ),
-            _kwarg_combo(
-                "Line style",
-                "linestyle",
-                LINE_STYLE_OPTIONS,
-                None,
-                "figureComposerAxesMethodErrorbarLineStyleCombo",
-                "Matplotlib line style for the errorbar line.",
-                none_label=LINE_STYLE_DEFAULT_LABEL,
+            *_line_color_style_controls(
+                "figureComposerAxesMethodErrorbar", "the errorbar line"
             ),
             _float_kwarg(
                 "Line width",
@@ -1066,6 +1215,7 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 minimum=0.0,
                 maximum=1_000_000.0,
                 step=0.5,
+                aliases=("lw",),
             ),
             _kwarg_combo(
                 "Marker",
@@ -1085,18 +1235,21 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 minimum=0.0,
                 maximum=1_000_000.0,
                 step=0.5,
+                aliases=("ms",),
             ),
             _color_kwarg(
                 "Marker face",
                 "markerfacecolor",
                 "figureComposerAxesMethodErrorbarMarkerFaceColorEdit",
                 "Matplotlib marker face color.",
+                aliases=("mfc",),
             ),
             _color_kwarg(
                 "Marker edge",
                 "markeredgecolor",
                 "figureComposerAxesMethodErrorbarMarkerEdgeColorEdit",
                 "Matplotlib marker edge color.",
+                aliases=("mec",),
             ),
             _float_kwarg(
                 "Cap size",
@@ -1159,6 +1312,9 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 "figureComposerAxesMethodXEdit",
                 "x coordinate for the vertical line.",
             ),
+            *_line_color_style_controls(
+                "figureComposerAxesMethodVLine", "the vertical line"
+            ),
         ),
     ),
     "axhline": MethodSpec(
@@ -1175,6 +1331,9 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 0,
                 "figureComposerAxesMethodYEdit",
                 "y coordinate for the horizontal line.",
+            ),
+            *_line_color_style_controls(
+                "figureComposerAxesMethodHLine", "the horizontal line"
             ),
         ),
     ),
@@ -1245,6 +1404,13 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 "figureComposerAxesMethodTickLabelsEdit",
                 "Optional comma-separated labels passed as set_ticks labels.",
             ),
+            _bool_kwarg_check(
+                "Minor",
+                "minor",
+                "figureComposerAxesMethodXTickMinorCheck",
+                "Set minor x-axis ticks instead of major ticks.",
+                default=False,
+            ),
         ),
     ),
     "set_yticks": MethodSpec(
@@ -1267,6 +1433,13 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 1,
                 "figureComposerAxesMethodTickLabelsEdit",
                 "Optional comma-separated labels passed as set_ticks labels.",
+            ),
+            _bool_kwarg_check(
+                "Minor",
+                "minor",
+                "figureComposerAxesMethodYTickMinorCheck",
+                "Set minor y-axis ticks instead of major ticks.",
+                default=False,
             ),
         ),
     ),
@@ -1317,14 +1490,11 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 "figureComposerAxesMethodTitleEdit",
                 "Title text passed to ax.set_title.",
             ),
-            _kwarg_combo(
-                "Location",
-                "loc",
-                ("center", "left", "right"),
-                "center",
+            _title_location_control(
                 "figureComposerAxesMethodTitleLocCombo",
                 "Horizontal title location.",
             ),
+            *_text_artist_controls("figureComposerAxesMethodTitle", "the title"),
             _float_kwarg(
                 "Padding",
                 "pad",
@@ -1352,14 +1522,7 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 "figureComposerAxesMethodXLabelEdit",
                 "x-axis label text passed to ax.set_xlabel.",
             ),
-            _kwarg_combo(
-                "Location",
-                "loc",
-                ("center", "left", "right"),
-                "center",
-                "figureComposerAxesMethodXLabelLocCombo",
-                "x-axis label location.",
-            ),
+            *_axis_label_controls("x", "figureComposerAxesMethodXLabel"),
             _float_kwarg(
                 "Label pad",
                 "labelpad",
@@ -1387,14 +1550,7 @@ AXES_METHODS: dict[str, MethodSpec] = {
                 "figureComposerAxesMethodYLabelEdit",
                 "y-axis label text passed to ax.set_ylabel.",
             ),
-            _kwarg_combo(
-                "Location",
-                "loc",
-                ("center", "bottom", "top"),
-                "center",
-                "figureComposerAxesMethodYLabelLocCombo",
-                "y-axis label location.",
-            ),
+            *_axis_label_controls("y", "figureComposerAxesMethodYLabel"),
             _float_kwarg(
                 "Label pad",
                 "labelpad",
@@ -1632,6 +1788,9 @@ FIGURE_METHODS: dict[str, MethodSpec] = {
                 "figureComposerFigureMethodTextEdit",
                 "Text string passed to fig.supxlabel.",
             ),
+            *_text_artist_controls(
+                "figureComposerFigureMethodText", "the figure x label"
+            ),
         ),
     ),
     "supylabel": MethodSpec(
@@ -1649,6 +1808,9 @@ FIGURE_METHODS: dict[str, MethodSpec] = {
                 "figureComposerFigureMethodTextEdit",
                 "Text string passed to fig.supylabel.",
             ),
+            *_text_artist_controls(
+                "figureComposerFigureMethodText", "the figure y label"
+            ),
         ),
     ),
     "suptitle": MethodSpec(
@@ -1665,6 +1827,9 @@ FIGURE_METHODS: dict[str, MethodSpec] = {
                 0,
                 "figureComposerFigureMethodTextEdit",
                 "Text string passed to fig.suptitle.",
+            ),
+            *_text_artist_controls(
+                "figureComposerFigureMethodText", "the figure title"
             ),
         ),
     ),
@@ -2126,6 +2291,11 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "Flattening order used to match titles to axes.",
                 option_labels=_FLATTEN_ORDER_LABELS,
             ),
+            _title_location_control(
+                "figureComposerERLabSetTitlesLocCombo",
+                "Horizontal title location.",
+            ),
+            *_text_artist_controls("figureComposerERLabSetTitles", "the titles"),
         ),
     ),
     "set_xlabels": MethodSpec(
@@ -2147,6 +2317,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "Flattening order used to match x labels to axes.",
                 option_labels=_FLATTEN_ORDER_LABELS,
             ),
+            *_axis_label_controls("x", "figureComposerERLabSetXLabels"),
         ),
     ),
     "set_ylabels": MethodSpec(
@@ -2168,6 +2339,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "Flattening order used to match y labels to axes.",
                 option_labels=_FLATTEN_ORDER_LABELS,
             ),
+            *_axis_label_controls("y", "figureComposerERLabSetYLabels"),
         ),
     ),
     "fermiline": MethodSpec(
@@ -2201,6 +2373,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                     "Optional Matplotlib color for the line.\n"
                     "Leave blank to let fermiline use the axes text color."
                 ),
+                aliases=("c",),
             ),
             _kwarg_combo(
                 "Line style",
@@ -2213,6 +2386,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                     "Leave unset to let fermiline use its default style."
                 ),
                 none_label=LINE_STYLE_DEFAULT_LABEL,
+                aliases=("ls",),
             ),
             _float_kwarg(
                 "Line width",
@@ -2223,6 +2397,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                     "Leave blank to let fermiline use its default width."
                 ),
                 minimum=0.0,
+                aliases=("lw",),
             ),
         ),
     ),
@@ -2326,6 +2501,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "figureComposerERLabCoreLevelsLineStyleCombo",
                 "Optional Matplotlib line style.",
                 none_label=LINE_STYLE_DEFAULT_LABEL,
+                aliases=("ls",),
             ),
             _float_kwarg(
                 "Line width",
@@ -2333,6 +2509,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "figureComposerERLabCoreLevelsLineWidthEdit",
                 "Optional line width.",
                 minimum=0.0,
+                aliases=("lw",),
             ),
         ),
     ),
@@ -2392,6 +2569,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
                 "Draw a bar over parsed labels.",
                 default=False,
             ),
+            *_text_artist_controls("figureComposerERLabMarkPoints", "the point labels"),
         ),
     ),
     "sizebar": MethodSpec(

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
@@ -47,6 +47,8 @@ from erlab.interactive._figurecomposer._operations._method._plot_editor import (
 )
 from erlab.interactive._figurecomposer._operations._method._state import (
     _aspect_value_from_text,
+    _canonical_method_control_aliases,
+    _canonical_method_control_kwargs,
     _default_method_args,
     _empty_text_as_none,
     _format_aspect_value,
@@ -69,6 +71,7 @@ from erlab.interactive._figurecomposer._operations._method._state import (
     _optional_literal_from_text,
     _string_tuple_from_text_or_none,
     _subplots_adjust_values,
+    _updated_method_control_kwargs,
 )
 from erlab.interactive._figurecomposer._subplot_adjust import (
     SUBPLOTS_ADJUST_SPINBOX_DECIMALS,
@@ -636,6 +639,20 @@ def _add_method_control_row(
             )
             combo.setObjectName(control.object_name)
             editor.add_form_row(layout, control.label, combo, control.tooltip)
+        case MethodControlKind.BOOL_KWARG_CHECK:
+            key = _control_key(control)
+            mixed = editor.batch_is_mixed(
+                operation,
+                lambda target: bool(_method_kwarg_value(target, key, control.default)),
+            )
+            check = editor.check_box(
+                bool(_method_kwarg_value(operation, key, control.default)),
+                _method_kwarg_update_callback(editor, key),
+                parent=layout.parentWidget(),
+                mixed=mixed,
+            )
+            check.setObjectName(control.object_name)
+            editor.add_form_row(layout, control.label, check, control.tooltip)
         case MethodControlKind.KWARG_COMBO:
             key = _control_key(control)
             kwarg_value_getter: Callable[[FigureOperationState], typing.Any]
@@ -1077,25 +1094,26 @@ def _method_float_pair_args(
 
 
 def _controlled_method_kwarg_keys(spec: MethodSpec) -> frozenset[str]:
-    keys = {
-        control.key
-        for control in spec.controls
-        if control.key is not None
-        and control.kind
-        in {
-            MethodControlKind.KWARG_COMBO,
-            MethodControlKind.BOOL_KWARG_COMBO,
-            MethodControlKind.OPTIONAL_BOOL_KWARG_COMBO,
-            MethodControlKind.INT_KWARG,
-            MethodControlKind.FLOAT_KWARG,
-            MethodControlKind.SUBPLOTS_ADJUST_KWARG,
-            MethodControlKind.TEXT_KWARG,
-            MethodControlKind.LITERAL_KWARG,
-            MethodControlKind.STRING_TUPLE_KWARG,
-            MethodControlKind.FLOAT_PAIR_KWARG,
-            MethodControlKind.COLOR_KWARG,
-        }
+    controlled_kinds = {
+        MethodControlKind.KWARG_COMBO,
+        MethodControlKind.BOOL_KWARG_CHECK,
+        MethodControlKind.BOOL_KWARG_COMBO,
+        MethodControlKind.OPTIONAL_BOOL_KWARG_COMBO,
+        MethodControlKind.INT_KWARG,
+        MethodControlKind.FLOAT_KWARG,
+        MethodControlKind.SUBPLOTS_ADJUST_KWARG,
+        MethodControlKind.TEXT_KWARG,
+        MethodControlKind.LITERAL_KWARG,
+        MethodControlKind.STRING_TUPLE_KWARG,
+        MethodControlKind.FLOAT_PAIR_KWARG,
+        MethodControlKind.COLOR_KWARG,
     }
+    keys: set[str] = set()
+    for control in spec.controls:
+        if control.key is None or control.kind not in controlled_kinds:
+            continue
+        keys.add(control.key)
+        keys.update(control.aliases)
     if any(control.kind == MethodControlKind.TICK_PARAMS for control in spec.controls):
         keys.update(TICK_PARAMS_CONTROLLED_KWARGS)
     if _is_axes_errorbar_method(spec):
@@ -1120,21 +1138,34 @@ def _update_current_extra_method_kwargs(
     editor: FigureOperationEditor, spec: MethodSpec, extra_kwargs: dict[str, typing.Any]
 ) -> None:
     controlled = _controlled_method_kwarg_keys(spec)
+    alias_control_keys = {
+        control.key
+        for control in spec.controls
+        if control.key is not None
+        and any(alias in extra_kwargs for alias in control.aliases)
+    }
+    extra_kwargs = _canonical_method_control_aliases(extra_kwargs, spec)
 
     def update_kwargs(
         _operation_index: int, operation: FigureOperationState
     ) -> FigureOperationState:
+        current_kwargs = _canonical_method_control_kwargs(operation.method_kwargs, spec)
         kwargs = {
-            key: value
-            for key, value in operation.method_kwargs.items()
-            if key in controlled
+            key: value for key, value in current_kwargs.items() if key in controlled
         }
-        kwargs.update(
-            {key: value for key, value in extra_kwargs.items() if key not in controlled}
-        )
+        for key, value in extra_kwargs.items():
+            if key not in controlled:
+                kwargs[key] = value
+            elif key in alias_control_keys:
+                kwargs = _updated_method_control_kwargs(kwargs, spec, key, value)
         return operation.model_copy(update={"method_kwargs": kwargs})
 
-    editor.request_transform(update_kwargs)
+    rebuild_editor = bool(alias_control_keys)
+    editor.request_transform(
+        update_kwargs,
+        rebuild_editor=rebuild_editor,
+        defer_editor_rebuild=rebuild_editor,
+    )
 
 
 def _update_current_tick_params_kwargs(
@@ -1529,14 +1560,26 @@ def _update_current_method_kwarg(
     def update_kwarg(
         _operation_index: int, operation: FigureOperationState
     ) -> FigureOperationState:
-        kwargs = dict(operation.method_kwargs)
-        if value is None:
-            kwargs.pop(key, None)
-        else:
-            kwargs[key] = value
+        spec = _method_spec(operation)
+        kwargs = _updated_method_control_kwargs(
+            operation.method_kwargs, spec, key, value
+        )
         return operation.model_copy(update={"method_kwargs": kwargs})
 
-    editor.request_transform(update_kwarg)
+    current = editor.current_operation()
+    rebuild_editor = (
+        value is not None
+        and current is not None
+        and any(
+            control.key == key and control.exclusive_group is not None
+            for control in _method_spec(current[1]).controls
+        )
+    )
+    editor.request_transform(
+        update_kwarg,
+        rebuild_editor=rebuild_editor,
+        defer_editor_rebuild=rebuild_editor,
+    )
 
 
 def _update_current_subplots_adjust_kwarg(

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_state.py
@@ -79,7 +79,9 @@ def _method_arg_value(
 def _method_kwarg_value(
     operation: FigureOperationState, key: str, default: typing.Any
 ) -> typing.Any:
-    return operation.method_kwargs.get(key, default)
+    return _canonical_method_control_kwargs(
+        operation.method_kwargs, _method_spec(operation)
+    ).get(key, default)
 
 
 def _normalized_method_control_value(
@@ -90,11 +92,73 @@ def _normalized_method_control_value(
     return value
 
 
+def _canonical_method_control_aliases(
+    method_kwargs: Mapping[str, typing.Any], spec: MethodSpec
+) -> dict[str, typing.Any]:
+    kwargs = dict(method_kwargs)
+    for control in spec.controls:
+        if control.key is None or not control.aliases:
+            continue
+        present_aliases = tuple(alias for alias in control.aliases if alias in kwargs)
+        if not present_aliases:
+            continue
+        if control.key not in kwargs:
+            kwargs[control.key] = kwargs[present_aliases[0]]
+        for alias in present_aliases:
+            kwargs.pop(alias)
+    return kwargs
+
+
+def _canonical_method_control_kwargs(
+    method_kwargs: Mapping[str, typing.Any], spec: MethodSpec
+) -> dict[str, typing.Any]:
+    kwargs = _canonical_method_control_aliases(method_kwargs, spec)
+    active_exclusive_groups: set[str] = set()
+    for control in spec.controls:
+        if control.key is None or control.key not in kwargs:
+            continue
+        if kwargs[control.key] is None and (
+            control.none_is_unset or control.exclusive_group is not None
+        ):
+            kwargs.pop(control.key)
+            continue
+        if control.exclusive_group is None:
+            continue
+        if control.exclusive_group in active_exclusive_groups:
+            kwargs.pop(control.key)
+            continue
+        active_exclusive_groups.add(control.exclusive_group)
+    return kwargs
+
+
+def _updated_method_control_kwargs(
+    method_kwargs: Mapping[str, typing.Any],
+    spec: MethodSpec,
+    key: str,
+    value: typing.Any,
+) -> dict[str, typing.Any]:
+    kwargs = _canonical_method_control_kwargs(method_kwargs, spec)
+    if value is None:
+        kwargs.pop(key, None)
+        return kwargs
+    control = next((control for control in spec.controls if control.key == key), None)
+    if control is not None and control.exclusive_group is not None:
+        for peer in spec.controls:
+            if (
+                peer.key is not None
+                and peer.key != key
+                and peer.exclusive_group == control.exclusive_group
+            ):
+                kwargs.pop(peer.key, None)
+    kwargs[key] = value
+    return kwargs
+
+
 def _method_kwargs(
     operation: FigureOperationState, spec: MethodSpec
 ) -> dict[str, typing.Any]:
     kwargs = dict(spec.default_kwargs)
-    kwargs.update(operation.method_kwargs)
+    kwargs.update(_canonical_method_control_kwargs(operation.method_kwargs, spec))
     for control in spec.controls:
         if control.key is not None and control.key in kwargs:
             kwargs[control.key] = _normalized_method_control_value(
@@ -259,6 +323,7 @@ def _control_accepts_value(control: MethodControlSpec, value: typing.Any) -> boo
         return str(value) in control.options
     if control.kind in {
         MethodControlKind.BOOL_ARG_COMBO,
+        MethodControlKind.BOOL_KWARG_CHECK,
         MethodControlKind.BOOL_KWARG_COMBO,
     }:
         return isinstance(value, bool)
@@ -270,9 +335,15 @@ def _control_accepts_value(control: MethodControlSpec, value: typing.Any) -> boo
 def _transfer_axis_label_loc(
     source_spec: MethodSpec, target_spec: MethodSpec, value: typing.Any
 ) -> typing.Any:
-    if source_spec.name == "set_xlabel" and target_spec.name == "set_ylabel":
+    if source_spec.name in {"set_xlabel", "set_xlabels"} and target_spec.name in {
+        "set_ylabel",
+        "set_ylabels",
+    }:
         return {"left": "bottom", "center": "center", "right": "top"}.get(value, value)
-    if source_spec.name == "set_ylabel" and target_spec.name == "set_xlabel":
+    if source_spec.name in {"set_ylabel", "set_ylabels"} and target_spec.name in {
+        "set_xlabel",
+        "set_xlabels",
+    }:
         return {"bottom": "left", "center": "center", "top": "right"}.get(value, value)
     return value
 
@@ -361,7 +432,10 @@ def _method_transfer_updates(
         and source_signature == target_signature
     )
     kwargs: dict[str, typing.Any] = {}
-    for key, value in operation.method_kwargs.items():
+    source_method_kwargs = _canonical_method_control_kwargs(
+        operation.method_kwargs, source_spec
+    )
+    for key, value in source_method_kwargs.items():
         target_control = target_kwargs.get(key)
         if target_control is None:
             if key not in source_kwargs and transfer_extra_kwargs:
@@ -374,6 +448,7 @@ def _method_transfer_updates(
             value = _transfer_axis_label_loc(source_spec, target_spec, value)
         if _control_accepts_value(target_control, value):
             kwargs[key] = value
+    kwargs = _canonical_method_control_kwargs(kwargs, target_spec)
 
     method_call_policy = None
     if operation.method_call_policy is not None:
@@ -448,6 +523,12 @@ def _method_transfer_updates(
 
 
 def _loaded_operation(operation: FigureOperationState) -> FigureOperationState:
+    updates: dict[str, typing.Any] = {}
+    kwargs = _canonical_method_control_kwargs(
+        operation.method_kwargs, _method_spec(operation)
+    )
+    if kwargs != operation.method_kwargs:
+        updates["method_kwargs"] = kwargs
     if operation.method_transform == "custom":
-        return operation.model_copy(update={"trusted": False})
-    return operation
+        updates["trusted"] = False
+    return operation.model_copy(update=updates) if updates else operation

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import xarray as xr
+from matplotlib.text import Text
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab.interactive._figurecomposer._rendering as figurecomposer_rendering
@@ -1043,6 +1044,82 @@ def test_figure_composer_method_selector_preserves_compatible_values(qtbot) -> N
     assert operation.method_kwargs == {}
 
 
+@pytest.mark.parametrize(
+    ("source_name", "target_name", "source_loc", "target_loc"),
+    [
+        ("set_xlabels", "set_ylabels", "right", "top"),
+        ("set_ylabels", "set_xlabels", "top", "right"),
+    ],
+)
+def test_figure_composer_erlab_label_method_selector_maps_location(
+    qtbot,
+    source_name: str,
+    target_name: str,
+    source_loc: str,
+    target_loc: str,
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.ERLAB,
+                    name=source_name,
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                    kwargs={"loc": source_loc, "color": "red", "fontsize": 12},
+                ).model_copy(update={"text_values": ("Momentum",)}),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_editor.select_section("method")
+
+    method_combo = tool.operation_editor.stack.currentWidget().findChild(
+        QtWidgets.QComboBox, "figureComposerERLabMethodCombo"
+    )
+    assert method_combo is not None
+    target_index = method_combo.findData(target_name)
+    assert target_index >= 0
+    _activate_combo_index(method_combo, target_index)
+
+    operation = tool.tool_status.operations[0]
+    assert operation.method_name == target_name
+    assert operation.text_values == ("Momentum",)
+    assert operation.method_kwargs == {
+        "loc": target_loc,
+        "color": "red",
+        "fontsize": 12,
+    }
+
+    figurecomposer_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+    assert not tool._operation_render_errors
+    position_index = 0 if target_name == "set_xlabels" else 1
+    label = (
+        tool.figure.axes[0].xaxis.label
+        if target_name == "set_xlabels"
+        else tool.figure.axes[0].yaxis.label
+    )
+    assert label.get_text() == "Momentum"
+    assert label.get_position()[position_index] == pytest.approx(1.0)
+    assert label.get_color() == "red"
+    assert label.get_fontsize() == pytest.approx(12.0)
+
+    namespace: dict[str, typing.Any] = {}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    generated_label = (
+        namespace["axs"][0, 0].xaxis.label
+        if target_name == "set_xlabels"
+        else namespace["axs"][0, 0].yaxis.label
+    )
+    assert generated_label.get_text() == "Momentum"
+    assert generated_label.get_position()[position_index] == pytest.approx(1.0)
+    assert generated_label.get_color() == "red"
+    assert generated_label.get_fontsize() == pytest.approx(12.0)
+
+
 def test_figure_composer_method_transfer_edge_contracts(
     qtbot,
     monkeypatch: pytest.MonkeyPatch,
@@ -1127,6 +1204,22 @@ def test_figure_composer_method_transfer_edge_contracts(
         )
         == "unchanged"
     )
+    assert (
+        method_state._transfer_axis_label_loc(
+            method_catalog.ERLAB_METHODS["set_xlabels"],
+            method_catalog.ERLAB_METHODS["set_ylabels"],
+            "right",
+        )
+        == "top"
+    )
+    assert (
+        method_state._transfer_axis_label_loc(
+            method_catalog.ERLAB_METHODS["set_ylabels"],
+            method_catalog.ERLAB_METHODS["set_xlabels"],
+            "top",
+        )
+        == "right"
+    )
 
     float_pair_updates = method_state._method_transfer_updates(
         FigureOperationState.method(
@@ -1151,6 +1244,42 @@ def test_figure_composer_method_transfer_edge_contracts(
         default_axis=None,
     )
     assert default_arg_updates["method_args"] == ("y",)
+
+    text_alias_updates = method_state._method_transfer_updates(
+        FigureOperationState.method(
+            family=FigureMethodFamily.AXES,
+            name="text",
+            args=(0.25, 0.75, "Panel"),
+            kwargs={
+                "c": "navy",
+                "ha": "left",
+                "va": "top",
+                "rotation": 30,
+                "rotation_mode": "anchor",
+            },
+        ),
+        method_catalog.AXES_METHODS["set_title"],
+        default_axis=None,
+    )
+    assert text_alias_updates["method_kwargs"] == {
+        "color": "navy",
+        "horizontalalignment": "left",
+        "verticalalignment": "top",
+        "rotation": 30,
+        "rotation_mode": "anchor",
+    }
+
+    axis_label_updates = method_state._method_transfer_updates(
+        FigureOperationState.method(
+            family=FigureMethodFamily.AXES,
+            name="set_title",
+            args=("Title",),
+            kwargs={"loc": "right", "ha": "left", "fontsize": 9},
+        ),
+        method_catalog.AXES_METHODS["set_xlabel"],
+        default_axis=None,
+    )
+    assert axis_label_updates["method_kwargs"] == {"loc": "right"}
 
     plot_operation = FigureOperationState.method(
         family=FigureMethodFamily.AXES,
@@ -1453,6 +1582,861 @@ def test_figure_composer_method_text_args_accept_real_newlines(qtbot) -> None:
 
     label_edit.setPlainText(r"h\nu")
     assert tool.tool_status.operations[0].method_args == (r"h\nu",)
+
+
+@pytest.mark.parametrize(
+    ("family", "name", "kwargs", "expected"),
+    [
+        (
+            FigureMethodFamily.AXES,
+            "plot",
+            {
+                "c": "red",
+                "ls": "--",
+                "lw": 2.0,
+                "ms": 4.0,
+                "mfc": "white",
+                "mec": "black",
+                "label": "data",
+            },
+            {
+                "color": "red",
+                "linestyle": "--",
+                "linewidth": 2.0,
+                "markersize": 4.0,
+                "markerfacecolor": "white",
+                "markeredgecolor": "black",
+                "label": "data",
+            },
+        ),
+        (
+            FigureMethodFamily.AXES,
+            "axvline",
+            {"color": "blue", "c": "red", "ls": ":"},
+            {"color": "blue", "linestyle": ":"},
+        ),
+        (
+            FigureMethodFamily.ERLAB,
+            "fermiline",
+            {"c": "green", "ls": "-.", "lw": 1.5},
+            {"color": "green", "linestyle": "-.", "linewidth": 1.5},
+        ),
+        (
+            FigureMethodFamily.ERLAB,
+            "plot_core_levels",
+            {"ls": "--", "lw": 0.5},
+            {"linestyle": "--", "linewidth": 0.5},
+        ),
+        (
+            FigureMethodFamily.FIGURE,
+            "suptitle",
+            {"c": "purple"},
+            {"color": "purple"},
+        ),
+        (
+            FigureMethodFamily.AXES,
+            "text",
+            {"ha": None, "verticalalignment": None},
+            {},
+        ),
+        (
+            FigureMethodFamily.AXES,
+            "set_xlabel",
+            {"loc": "right", "ha": "left", "fontsize": 9},
+            {"loc": "right", "fontsize": 9},
+        ),
+        (
+            FigureMethodFamily.AXES,
+            "set_ylabel",
+            {"loc": None, "ha": "right"},
+            {"horizontalalignment": "right"},
+        ),
+        (
+            FigureMethodFamily.ERLAB,
+            "set_xlabels",
+            {"loc": "left", "horizontalalignment": "right"},
+            {"loc": "left"},
+        ),
+        (
+            FigureMethodFamily.ERLAB,
+            "set_ylabels",
+            {"loc": "top", "ha": "left"},
+            {"loc": "top"},
+        ),
+    ],
+)
+def test_figure_composer_loaded_method_canonicalizes_control_aliases(
+    family, name, kwargs, expected
+) -> None:
+    operation = FigureOperationState.method(
+        family=family,
+        name=name,
+        kwargs=kwargs,
+    )
+    loaded = method_state._loaded_operation(operation)
+    assert loaded.method_kwargs == expected
+    assert (
+        method_state._method_kwargs(operation, method_catalog._method_spec(operation))
+        == expected
+    )
+
+    if name == "suptitle":
+        loaded = method_state._loaded_operation(
+            operation.model_copy(update={"method_transform": "custom", "trusted": True})
+        )
+        assert loaded.method_kwargs == expected
+        assert not loaded.trusted
+
+
+def test_figure_composer_loaded_method_preserves_semantic_none() -> None:
+    operation = FigureOperationState.method(
+        family=FigureMethodFamily.AXES,
+        name="margins",
+        kwargs={"tight": None},
+    )
+    loaded = method_state._loaded_operation(operation)
+    assert loaded.method_kwargs == {"tight": None}
+    assert (
+        method_state._method_kwargs(loaded, method_catalog.AXES_METHODS["margins"])[
+            "tight"
+        ]
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("family", "name"),
+    [
+        (FigureMethodFamily.AXES, "text"),
+        (FigureMethodFamily.AXES, "set_title"),
+        (FigureMethodFamily.AXES, "set_xlabel"),
+        (FigureMethodFamily.AXES, "set_ylabel"),
+        (FigureMethodFamily.FIGURE, "supxlabel"),
+        (FigureMethodFamily.FIGURE, "supylabel"),
+        (FigureMethodFamily.FIGURE, "suptitle"),
+        (FigureMethodFamily.ERLAB, "set_titles"),
+        (FigureMethodFamily.ERLAB, "set_xlabels"),
+        (FigureMethodFamily.ERLAB, "set_ylabels"),
+        (FigureMethodFamily.ERLAB, "mark_points"),
+    ],
+)
+def test_figure_composer_text_methods_share_artist_controls(family, name) -> None:
+    operation = FigureOperationState.method(family=family, name=name)
+    controls = {
+        control.key: control
+        for control in method_catalog._method_spec(operation).controls
+    }
+
+    assert {
+        "color",
+        "horizontalalignment",
+        "verticalalignment",
+        "rotation",
+        "rotation_mode",
+    } <= controls.keys()
+    assert controls["color"].aliases == ("c",)
+    assert controls["horizontalalignment"].aliases == ("ha",)
+    assert controls["verticalalignment"].aliases == ("va",)
+    if name in {"set_xlabel", "set_ylabel", "set_xlabels", "set_ylabels"}:
+        assert controls["loc"].exclusive_group is not None
+        assert (
+            controls["horizontalalignment"].exclusive_group
+            == controls["loc"].exclusive_group
+        )
+    else:
+        assert controls["horizontalalignment"].exclusive_group is None
+
+
+def test_figure_composer_text_controls_handle_constructor_aliases(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="text",
+                    args=(0.25, 0.75, "Panel"),
+                    kwargs={
+                        "c": "navy",
+                        "ha": "left",
+                        "va": "top",
+                        "rotation": 30,
+                        "rotation_mode": "anchor",
+                        "fontsize": 8,
+                    },
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_editor.select_section("method")
+    page = tool.operation_editor.stack.currentWidget()
+    color_edit = page.findChild(
+        QtWidgets.QLineEdit, "figureComposerAxesMethodTextColorEdit"
+    )
+    horizontal_combo = page.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodTextHorizontalAlignmentCombo",
+    )
+    vertical_combo = page.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodTextVerticalAlignmentCombo",
+    )
+    rotation_edit = page.findChild(
+        QtWidgets.QLineEdit, "figureComposerAxesMethodTextRotationEdit"
+    )
+    rotation_mode_combo = page.findChild(
+        QtWidgets.QComboBox, "figureComposerAxesMethodTextRotationModeCombo"
+    )
+    extra_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
+    assert color_edit is not None
+    assert horizontal_combo is not None
+    assert vertical_combo is not None
+    assert rotation_edit is not None
+    assert rotation_mode_combo is not None
+    assert extra_edit is not None
+    assert color_edit.text() == "navy"
+    assert horizontal_combo.currentData() == "left"
+    assert vertical_combo.currentData() == "top"
+    assert rotation_edit.text() == "30"
+    assert rotation_mode_combo.currentData() == "anchor"
+    assert extra_edit.text() == "fontsize=8"
+
+    extra_edit.setText('ha="right", va="bottom", fontsize=9')
+    extra_edit.editingFinished.emit()
+
+    assert tool.tool_status.operations[0].method_kwargs == {
+        "color": "navy",
+        "horizontalalignment": "right",
+        "verticalalignment": "bottom",
+        "rotation": 30,
+        "rotation_mode": "anchor",
+        "fontsize": 9,
+    }
+    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
+    rebuilt_page = tool.operation_editor.stack.currentWidget()
+    rebuilt_horizontal_combo = rebuilt_page.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodTextHorizontalAlignmentCombo",
+    )
+    rebuilt_vertical_combo = rebuilt_page.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodTextVerticalAlignmentCombo",
+    )
+    rebuilt_extra_edit = rebuilt_page.findChild(
+        QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit"
+    )
+    assert rebuilt_horizontal_combo is not None
+    assert rebuilt_vertical_combo is not None
+    assert rebuilt_extra_edit is not None
+    assert rebuilt_horizontal_combo.currentData() == "right"
+    assert rebuilt_vertical_combo.currentData() == "bottom"
+    assert rebuilt_extra_edit.text() == "fontsize=9"
+
+
+@pytest.mark.parametrize(
+    "alignment_kwargs",
+    [
+        {"ha": None, "va": None},
+        {"horizontalalignment": None, "verticalalignment": None},
+    ],
+)
+def test_figure_composer_loaded_text_none_alignments_are_unset(
+    qtbot, alignment_kwargs
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    recipe = FigureRecipeState.model_validate_json(
+        FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="text",
+                    args=(0.5, 0.5, "Text"),
+                    axes=FigureAxesSelectionState(axes=((0, 0),)),
+                    kwargs={**alignment_kwargs, "fontsize": 8},
+                ),
+            ),
+            primary_source="data",
+        ).model_dump_json()
+    )
+    tool = FigureComposerTool(data)
+    qtbot.addWidget(tool)
+    tool.tool_status = recipe
+    tool.operation_editor.select_section("method")
+
+    operation = tool.tool_status.operations[0]
+    assert operation.method_kwargs == {"fontsize": 8}
+    page = tool.operation_editor.stack.currentWidget()
+    horizontal_combo = page.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodTextHorizontalAlignmentCombo",
+    )
+    vertical_combo = page.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodTextVerticalAlignmentCombo",
+    )
+    assert horizontal_combo is not None
+    assert vertical_combo is not None
+    assert horizontal_combo.currentData() is None
+    assert vertical_combo.currentData() is None
+    assert not tool._operation_render_errors
+
+    namespace: dict[str, typing.Any] = {}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    artist = namespace["axs"][0, 0].texts[0]
+    assert artist.get_horizontalalignment() == "left"
+    assert artist.get_verticalalignment() == "baseline"
+    assert artist.get_fontsize() == pytest.approx(8.0)
+
+
+def test_figure_composer_constructor_method_controls_handle_aliases(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="axvline",
+                    args=(0.25,),
+                    kwargs={"c": "red", "ls": "--"},
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_editor.select_section("method")
+    page = tool.operation_editor.stack.currentWidget()
+    color_edit = page.findChild(
+        QtWidgets.QLineEdit, "figureComposerAxesMethodVLineColorEdit"
+    )
+    style_combo = page.findChild(
+        QtWidgets.QComboBox, "figureComposerAxesMethodVLineLineStyleCombo"
+    )
+    extra_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
+    assert color_edit is not None
+    assert style_combo is not None
+    assert extra_edit is not None
+    assert color_edit.text() == "red"
+    assert style_combo.currentData() == "--"
+    assert extra_edit.text() == ""
+
+    color_edit.setText("")
+    color_edit.editingFinished.emit()
+
+    assert tool.tool_status.operations[0].method_kwargs == {"linestyle": "--"}
+
+
+def test_figure_composer_extra_method_kwargs_canonicalize_aliases(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="axvline",
+                    args=(0.25,),
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_editor.select_section("method")
+    page = tool.operation_editor.stack.currentWidget()
+    extra_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
+    assert extra_edit is not None
+
+    extra_edit.setText('c="blue", ls=":", alpha=0.5')
+    extra_edit.editingFinished.emit()
+
+    assert tool.tool_status.operations[0].method_kwargs == {
+        "color": "blue",
+        "linestyle": ":",
+        "alpha": 0.5,
+    }
+    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
+    rebuilt_page = tool.operation_editor.stack.currentWidget()
+    color_edit = rebuilt_page.findChild(
+        QtWidgets.QLineEdit, "figureComposerAxesMethodVLineColorEdit"
+    )
+    style_combo = rebuilt_page.findChild(
+        QtWidgets.QComboBox, "figureComposerAxesMethodVLineLineStyleCombo"
+    )
+    rebuilt_extra_edit = rebuilt_page.findChild(
+        QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit"
+    )
+    assert color_edit is not None
+    assert style_combo is not None
+    assert rebuilt_extra_edit is not None
+    assert color_edit.text() == "blue"
+    assert style_combo.currentData() == ":"
+    assert rebuilt_extra_edit.text() == "alpha=0.5"
+
+
+def test_figure_composer_axis_label_position_controls_are_exclusive(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="set_xlabel",
+                    args=("Energy",),
+                    kwargs={"loc": "right", "fontsize": 8},
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+    tool.operation_editor.select_section("method")
+
+    page = tool.operation_editor.stack.currentWidget()
+    horizontal_combo = page.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodXLabelHorizontalAlignmentCombo",
+    )
+    assert horizontal_combo is not None
+    _activate_combo_text(horizontal_combo, "left")
+    assert tool.tool_status.operations[0].method_kwargs == {
+        "horizontalalignment": "left",
+        "fontsize": 8,
+    }
+
+    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
+    page = tool.operation_editor.stack.currentWidget()
+    location_combo = page.findChild(
+        QtWidgets.QComboBox, "figureComposerAxesMethodXLabelLocCombo"
+    )
+    assert location_combo is not None
+    _activate_combo_text(location_combo, "right")
+    assert tool.tool_status.operations[0].method_kwargs == {
+        "loc": "right",
+        "fontsize": 8,
+    }
+
+    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
+    page = tool.operation_editor.stack.currentWidget()
+    extra_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
+    assert extra_edit is not None
+    extra_edit.setText('ha="left", fontsize=9')
+    extra_edit.editingFinished.emit()
+    assert tool.tool_status.operations[0].method_kwargs == {
+        "horizontalalignment": "left",
+        "fontsize": 9,
+    }
+
+    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
+    page = tool.operation_editor.stack.currentWidget()
+    horizontal_combo = page.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodXLabelHorizontalAlignmentCombo",
+    )
+    extra_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
+    assert horizontal_combo is not None
+    assert extra_edit is not None
+    assert horizontal_combo.currentData() == "left"
+    assert extra_edit.text() == "fontsize=9"
+
+    namespace: dict[str, typing.Any] = {}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    assert namespace["fig"].axes[0].xaxis.label.get_horizontalalignment() == "left"
+
+    extra_edit.setText("ha=None, fontsize=10")
+    extra_edit.editingFinished.emit()
+    assert tool.tool_status.operations[0].method_kwargs == {"fontsize": 10}
+
+    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
+    page = tool.operation_editor.stack.currentWidget()
+    horizontal_combo = page.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodXLabelHorizontalAlignmentCombo",
+    )
+    extra_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
+    assert horizontal_combo is not None
+    assert extra_edit is not None
+    assert horizontal_combo.currentData() is None
+    assert extra_edit.text() == "fontsize=10"
+
+    namespace = {}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    assert namespace["fig"].axes[0].xaxis.label.get_horizontalalignment() == "center"
+
+
+@pytest.mark.parametrize("rotation_mode", ["xtick", "ytick"])
+def test_figure_composer_text_rotation_modes_require_matplotlib_311(
+    rotation_mode,
+) -> None:
+    operation = FigureOperationState.method(
+        family=FigureMethodFamily.AXES,
+        name="text",
+        args=(0.5, 0.5, "Text"),
+        kwargs={"rotation": 45, "rotation_mode": rotation_mode},
+    )
+    spec = method_catalog.AXES_METHODS["text"]
+    kwargs = method_state._method_kwargs(operation, spec)
+    figure, axis = plt.subplots()
+    try:
+        artist = axis.text(*operation.method_args, **kwargs)
+        assert artist.get_rotation_mode() == rotation_mode
+    finally:
+        plt.close(figure)
+
+
+def test_figure_composer_method_controls_restore_literal_kwargs(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    axes = FigureAxesSelectionState(axes=((0, 0),))
+    recipe = FigureRecipeState.model_validate_json(
+        FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="text",
+                    args=(0.1, 0.9, "Panel"),
+                    axes=axes,
+                    kwargs={
+                        "c": "tab:purple",
+                        "ha": "left",
+                        "va": "top",
+                        "rotation": 30,
+                        "rotation_mode": "anchor",
+                        "fontsize": 8,
+                    },
+                ),
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="axvline",
+                    args=(0.25,),
+                    axes=axes,
+                    kwargs={"c": "red", "ls": "--", "alpha": 0.4},
+                ),
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="axhline",
+                    args=(0.75,),
+                    axes=axes,
+                    kwargs={"color": "blue", "linestyle": ":"},
+                ),
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="set_xticks",
+                    args=((0.0, 0.5), ("zero", "half")),
+                    axes=axes,
+                    kwargs={"minor": True, "fontsize": 8},
+                ),
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="set_yticks",
+                    args=((0.0, 0.5),),
+                    axes=axes,
+                    kwargs={"minor": False},
+                ),
+                FigureOperationState.method(
+                    family=FigureMethodFamily.ERLAB,
+                    name="set_titles",
+                    axes=axes,
+                    kwargs={
+                        "order": "F",
+                        "loc": "right",
+                        "c": "navy",
+                        "ha": "right",
+                        "va": "top",
+                        "rotation": 15,
+                        "rotation_mode": "anchor",
+                        "fontsize": 9,
+                    },
+                ).model_copy(update={"text_values": ("Title",)}),
+                FigureOperationState.method(
+                    family=FigureMethodFamily.ERLAB,
+                    name="set_xlabels",
+                    axes=axes,
+                    kwargs={"loc": "right", "c": "green"},
+                ).model_copy(update={"text_values": ("X",)}),
+                FigureOperationState.method(
+                    family=FigureMethodFamily.ERLAB,
+                    name="set_ylabels",
+                    axes=axes,
+                    kwargs={"loc": "top", "color": "orange"},
+                ).model_copy(update={"text_values": ("Y",)}),
+                FigureOperationState.method(
+                    family=FigureMethodFamily.FIGURE,
+                    name="suptitle",
+                    args=("Super",),
+                    kwargs={
+                        "c": "black",
+                        "ha": "left",
+                        "va": "top",
+                        "rotation": 10,
+                        "rotation_mode": "anchor",
+                    },
+                ),
+            ),
+            primary_source="data",
+        ).model_dump_json()
+    )
+    tool = FigureComposerTool(data)
+    qtbot.addWidget(tool)
+    tool.tool_status = recipe
+
+    def select_method(row: int) -> QtWidgets.QWidget:
+        tool.operation_panel.operation_list.setCurrentItem(
+            tool.operation_panel.operation_list.topLevelItem(row)
+        )
+        tool.operation_editor.select_section("method")
+        page = tool.operation_editor.stack.currentWidget()
+        assert page is not None
+        return page
+
+    def line_edit(page: QtWidgets.QWidget, name: str) -> QtWidgets.QLineEdit:
+        edit = page.findChild(QtWidgets.QLineEdit, name)
+        assert edit is not None
+        return edit
+
+    def combo_box(page: QtWidgets.QWidget, name: str) -> QtWidgets.QComboBox:
+        combo = page.findChild(QtWidgets.QComboBox, name)
+        assert combo is not None
+        return combo
+
+    page = select_method(0)
+    text_color = line_edit(page, "figureComposerAxesMethodTextColorEdit")
+    assert text_color.text() == "tab:purple"
+    assert (
+        combo_box(
+            page, "figureComposerAxesMethodTextHorizontalAlignmentCombo"
+        ).currentData()
+        == "left"
+    )
+    assert (
+        combo_box(
+            page, "figureComposerAxesMethodTextVerticalAlignmentCombo"
+        ).currentData()
+        == "top"
+    )
+    assert line_edit(page, "figureComposerAxesMethodTextRotationEdit").text() == "30"
+    assert (
+        combo_box(page, "figureComposerAxesMethodTextRotationModeCombo").currentData()
+        == "anchor"
+    )
+    assert line_edit(page, "figureComposerAxesMethodKwEdit").text() == "fontsize=8"
+    assert tool.tool_status.operations[0].method_kwargs == {
+        "color": "tab:purple",
+        "horizontalalignment": "left",
+        "verticalalignment": "top",
+        "rotation": 30,
+        "rotation_mode": "anchor",
+        "fontsize": 8,
+    }
+
+    page = select_method(1)
+    assert line_edit(page, "figureComposerAxesMethodVLineColorEdit").text() == "red"
+    vline_style = combo_box(page, "figureComposerAxesMethodVLineLineStyleCombo")
+    assert vline_style.currentData() == "--"
+    assert line_edit(page, "figureComposerAxesMethodKwEdit").text() == "alpha=0.4"
+    _activate_combo_text(vline_style, "-.")
+    assert tool.tool_status.operations[1].method_kwargs == {
+        "color": "red",
+        "linestyle": "-.",
+        "alpha": 0.4,
+    }
+
+    page = select_method(2)
+    assert line_edit(page, "figureComposerAxesMethodHLineColorEdit").text() == "blue"
+    assert (
+        combo_box(page, "figureComposerAxesMethodHLineLineStyleCombo").currentData()
+        == ":"
+    )
+    assert line_edit(page, "figureComposerAxesMethodKwEdit").text() == ""
+
+    page = select_method(3)
+    x_minor = page.findChild(
+        QtWidgets.QCheckBox, "figureComposerAxesMethodXTickMinorCheck"
+    )
+    assert x_minor is not None
+    assert x_minor.isChecked()
+    assert line_edit(page, "figureComposerAxesMethodKwEdit").text() == "fontsize=8"
+    x_minor.setChecked(False)
+    assert tool.tool_status.operations[3].method_kwargs == {
+        "minor": False,
+        "fontsize": 8,
+    }
+
+    page = select_method(4)
+    y_minor = page.findChild(
+        QtWidgets.QCheckBox, "figureComposerAxesMethodYTickMinorCheck"
+    )
+    assert y_minor is not None
+    assert not y_minor.isChecked()
+    assert line_edit(page, "figureComposerAxesMethodKwEdit").text() == ""
+    y_minor.setChecked(True)
+    assert tool.tool_status.operations[4].method_kwargs == {"minor": True}
+
+    page = select_method(5)
+    title_loc = combo_box(page, "figureComposerERLabSetTitlesLocCombo")
+    assert title_loc.currentText() == "right"
+    assert line_edit(page, "figureComposerERLabSetTitlesColorEdit").text() == "navy"
+    assert (
+        combo_box(
+            page, "figureComposerERLabSetTitlesHorizontalAlignmentCombo"
+        ).currentData()
+        == "right"
+    )
+    assert (
+        combo_box(
+            page, "figureComposerERLabSetTitlesVerticalAlignmentCombo"
+        ).currentData()
+        == "top"
+    )
+    assert line_edit(page, "figureComposerERLabSetTitlesRotationEdit").text() == "15"
+    assert (
+        combo_box(page, "figureComposerERLabSetTitlesRotationModeCombo").currentData()
+        == "anchor"
+    )
+    assert line_edit(page, "figureComposerERLabMethodKwEdit").text() == "fontsize=9"
+    _activate_combo_text(title_loc, "left")
+    assert tool.tool_status.operations[5].method_kwargs == {
+        "order": "F",
+        "loc": "left",
+        "color": "navy",
+        "horizontalalignment": "right",
+        "verticalalignment": "top",
+        "rotation": 15,
+        "rotation_mode": "anchor",
+        "fontsize": 9,
+    }
+
+    page = select_method(6)
+    assert combo_box(page, "figureComposerERLabSetXLabelsLocCombo").currentText() == (
+        "right"
+    )
+    assert line_edit(page, "figureComposerERLabSetXLabelsColorEdit").text() == "green"
+    assert line_edit(page, "figureComposerERLabMethodKwEdit").text() == ""
+
+    page = select_method(7)
+    assert combo_box(page, "figureComposerERLabSetYLabelsLocCombo").currentText() == (
+        "top"
+    )
+    assert line_edit(page, "figureComposerERLabSetYLabelsColorEdit").text() == "orange"
+    assert line_edit(page, "figureComposerERLabMethodKwEdit").text() == ""
+
+    page = select_method(8)
+    assert line_edit(page, "figureComposerFigureMethodTextColorEdit").text() == (
+        "black"
+    )
+    assert (
+        combo_box(
+            page, "figureComposerFigureMethodTextHorizontalAlignmentCombo"
+        ).currentData()
+        == "left"
+    )
+    assert (
+        combo_box(
+            page, "figureComposerFigureMethodTextVerticalAlignmentCombo"
+        ).currentData()
+        == "top"
+    )
+    assert line_edit(page, "figureComposerFigureMethodTextRotationEdit").text() == "10"
+    assert (
+        combo_box(page, "figureComposerFigureMethodTextRotationModeCombo").currentData()
+        == "anchor"
+    )
+    assert line_edit(page, "figureComposerFigureMethodKwEdit").text() == ""
+
+    code = tool.generated_code()
+    namespace: dict[str, typing.Any] = {}
+    exec(code, namespace)  # noqa: S102
+    axis = namespace["axs"][0, 0]
+    assert axis.texts[0].get_color() == "tab:purple"
+    assert axis.texts[0].get_horizontalalignment() == "left"
+    assert axis.texts[0].get_verticalalignment() == "top"
+    assert axis.texts[0].get_rotation() == pytest.approx(30.0)
+    assert axis.texts[0].get_rotation_mode() == "anchor"
+    assert axis.lines[0].get_linestyle() == "-."
+    assert axis.lines[1].get_color() == "blue"
+    assert axis.get_title(loc="left") == "Title"
+    title = next(
+        artist
+        for artist in axis.get_children()
+        if isinstance(artist, Text) and artist.get_text() == "Title"
+    )
+    assert title.get_horizontalalignment() == "right"
+    assert title.get_verticalalignment() == "top"
+    assert title.get_rotation() == pytest.approx(15.0)
+    assert title.get_rotation_mode() == "anchor"
+    assert axis.xaxis.label.get_color() == "green"
+    assert axis.yaxis.label.get_color() == "orange"
+    assert axis.yaxis.get_minor_locator().locs == pytest.approx((0.0, 0.5))
+    figure_title = namespace["fig"].texts[-1]
+    assert figure_title.get_color() == "black"
+    assert figure_title.get_horizontalalignment() == "left"
+    assert figure_title.get_verticalalignment() == "top"
+    assert figure_title.get_rotation() == pytest.approx(10.0)
+    assert figure_title.get_rotation_mode() == "anchor"
+
+
+def test_figure_composer_batch_minor_tick_control_updates_selected_steps(
+    qtbot,
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [0.0, 1.0], "ky": [0.0, 1.0]},
+        name="data",
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="set_xticks",
+                    args=((0.0, 0.5),),
+                    kwargs={"minor": True},
+                ),
+                FigureOperationState.method(
+                    family=FigureMethodFamily.AXES,
+                    name="set_xticks",
+                    args=((0.0, 1.0),),
+                    kwargs={"minor": False},
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    _select_operation_rows(tool, (0, 1))
+    tool.operation_editor.select_section("method")
+    minor_check = tool.operation_editor.stack.currentWidget().findChild(
+        QtWidgets.QCheckBox, "figureComposerAxesMethodXTickMinorCheck"
+    )
+    assert minor_check is not None
+    assert minor_check.isTristate()
+    assert minor_check.checkState() == QtCore.Qt.CheckState.PartiallyChecked
+
+    minor_check.setChecked(True)
+    assert tool.tool_status.operations[0].method_kwargs == {"minor": True}
+    assert tool.tool_status.operations[1].method_kwargs == {"minor": True}
+    assert tool.tool_status.operations[0].method_args == ((0.0, 0.5),)
+    assert tool.tool_status.operations[1].method_args == ((0.0, 1.0),)
+    assert _selected_operation_rows(tool) == (0, 1)
 
 
 def test_figure_composer_batch_incompatible_methods_disable_editor(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
@@ -477,14 +477,26 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     text_edit = tool.findChild(
         QtWidgets.QPlainTextEdit, "figureComposerAxesMethodTextEdit"
     )
+    horizontal_alignment_combo = tool.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodTextHorizontalAlignmentCombo",
+    )
+    vertical_alignment_combo = tool.findChild(
+        QtWidgets.QComboBox,
+        "figureComposerAxesMethodTextVerticalAlignmentCombo",
+    )
     kwargs_edit = tool.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
     assert method_combo is not None
     assert transform_combo is not None
     assert text_edit is not None
+    assert horizontal_alignment_combo is not None
+    assert vertical_alignment_combo is not None
     assert kwargs_edit is not None
     assert method_combo.currentData() == "text"
     assert text_edit.toPlainText() == "Panel"
-    assert kwargs_edit.text() == 'ha="left", va="top"'
+    assert horizontal_alignment_combo.currentData() == "left"
+    assert vertical_alignment_combo.currentData() == "top"
+    assert kwargs_edit.text() == ""
 
     tool.operation_panel.operation_list.setCurrentItem(
         tool.operation_panel.operation_list.topLevelItem(4)
@@ -638,6 +650,8 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     fig.canvas.draw()
     assert fig.axes[0].texts[0].get_text() == "Panel"
     assert fig.axes[0].texts[0].get_transform() == fig.axes[0].transAxes
+    assert fig.axes[0].texts[0].get_horizontalalignment() == "left"
+    assert fig.axes[0].texts[0].get_verticalalignment() == "top"
     assert fig.axes[0].lines[0].get_color() == "red"
     assert fig.axes[0].axison is False
     assert fig.axes[1].lines[0].get_color() == "red"
@@ -665,8 +679,8 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
 
     code = tool.generated_code()
     assert (
-        'axs[0, 0].text(0.1, 0.9, "Panel", ha="left", va="top", '
-        "transform=axs[0, 0].transAxes)"
+        'axs[0, 0].text(0.1, 0.9, "Panel", horizontalalignment="left", '
+        'verticalalignment="top", transform=axs[0, 0].transAxes)'
     ) in code
     assert (
         'for ax in axs.flat:\n    ax.axvline(0.5, color="red", linestyle="--")' in code
@@ -697,6 +711,8 @@ def test_figure_composer_axes_methods_render_and_codegen(qtbot) -> None:
     namespace["fig"].canvas.draw()
     axs = namespace["axs"]
     assert axs[0, 0].texts[0].get_text() == "Panel"
+    assert axs[0, 0].texts[0].get_horizontalalignment() == "left"
+    assert axs[0, 0].texts[0].get_verticalalignment() == "top"
     assert axs[0, 0].axison is False
     assert [tick.get_text() for tick in axs[0, 1].get_xticklabels()] == [
         "left",

--- a/uv.lock
+++ b/uv.lock
@@ -1033,7 +1033,7 @@ requires-dist = [
     { name = "joblib", specifier = ">=1.3.2" },
     { name = "lazy-loader", specifier = ">=0.4" },
     { name = "lmfit", specifier = ">=1.3.2" },
-    { name = "matplotlib", specifier = ">=3.8.0" },
+    { name = "matplotlib", specifier = ">=3.11.0" },
     { name = "nexusformat", marker = "extra == 'io'", specifier = ">=1.0.6" },
     { name = "numba", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=0.63.0" },
     { name = "numba", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = ">=0.61.0,<0.63.0" },


### PR DESCRIPTION
## Summary

- Add reusable Figure Composer controls for line color and style, minor ticks, title location, and text alignment and rotation.
- Parse saved literal keyword arguments and Matplotlib shorthand forms such as `c`, `ls`, `ha`, and `va`.
- Keep mutually exclusive arguments synchronized when users change a method or a control.
- Require Matplotlib 3.11 so all supported collaborators use the same rotation behavior.

## Why

Existing workspaces can store these options as literal values or shorthand keyword arguments. The editor must convert both forms into controls without losing values or producing duplicate arguments.

## User impact

Users can edit common line, tick, title, and text properties directly in Figure Composer. Existing workspaces continue to load and generate canonical method calls.

## Checks

- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `uv run mypy src/erlab/interactive/_figurecomposer/_operations/_method`
- `uv lock --check`
- PyQt6 method tests: 79 passed
- PySide6 method tests: 79 passed