### PR TITLE
Add configurable export settings to Figure Composer

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -172,16 +172,8 @@ If {guilabel}`DPI` in Settings has {guilabel}`Override stylesheet` enabled, that
 is used for new figures instead of the stylesheet default.
 
 Use the {guilabel}`Export` tab to set the DPI, background transparency, bounding box,
-and padding for one figure. Choose {guilabel}`Use Defaults` for a value to inherit the
-workspace or user export setting. These controls affect only the {guilabel}`Export`
-button and the export action in the plot window. They do not change the plot preview or
-copied Python code.
-
-Set user export defaults in {guilabel}`Settings`. Select
-{guilabel}`Figure Composer`, then use the rows that start with
-{guilabel}`Export`. You can also select {guilabel}`Export Settings…` in the
-{guilabel}`Export` tab to open these settings directly. Open a managed figure to edit
-workspace overrides. A per-figure value takes priority over both settings scopes.
+and padding that are applied when exporting the figure. Choose {guilabel}`Use Defaults`
+for a value to inherit the workspace or user export setting.
 
 To add custom Matplotlib stylesheets:
 

--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -171,6 +171,17 @@ settings, as well as the styling of all figure elements.
 If {guilabel}`DPI` in Settings has {guilabel}`Override stylesheet` enabled, that value
 is used for new figures instead of the stylesheet default.
 
+Use the {guilabel}`Export` tab to set the DPI, background transparency, bounding box,
+and padding for one figure. Choose {guilabel}`Use Defaults` for a value to inherit the
+workspace or user export setting. These controls affect only the {guilabel}`Export`
+button and the export action in the plot window. They do not change the plot preview or
+copied Python code.
+
+Set user export defaults in {guilabel}`Settings`. Select
+{guilabel}`Figure Composer`, then use the rows that start with
+{guilabel}`Export`. Open Settings from ImageTool Manager to add workspace overrides. A
+per-figure value takes priority over both settings scopes.
+
 To add custom Matplotlib stylesheets:
 
 1. Open the shared settings window: on macOS, choose {menuselection}`Preferences…` from

--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -179,8 +179,9 @@ copied Python code.
 
 Set user export defaults in {guilabel}`Settings`. Select
 {guilabel}`Figure Composer`, then use the rows that start with
-{guilabel}`Export`. Open Settings from ImageTool Manager to add workspace overrides. A
-per-figure value takes priority over both settings scopes.
+{guilabel}`Export`. You can also select {guilabel}`Export Settings…` in the
+{guilabel}`Export` tab to open these settings directly. Open a managed figure to edit
+workspace overrides. A per-figure value takes priority over both settings scopes.
 
 To add custom Matplotlib stylesheets:
 

--- a/docs/source/user-guide/interactive/options.md
+++ b/docs/source/user-guide/interactive/options.md
@@ -24,8 +24,8 @@ Use the sidebar to switch between setting groups:
 - {guilabel}`I/O` controls the default loader and the default folder used by
   manager file dialogs and new Data Explorer windows.
 - {guilabel}`ktool` controls defaults for newly opened momentum-conversion tools.
-- {guilabel}`Figure Composer` controls default Matplotlib stylesheets and optional
-  default DPI for newly created figures.
+- {guilabel}`Figure Composer` controls default Matplotlib stylesheets, figure DPI,
+  and export settings.
 
 Rows in the {guilabel}`User` scope include a reset action that restores the application
 default for that setting. Broadly resetting all user settings still asks for
@@ -36,5 +36,6 @@ available. Workspace settings are sparse overrides saved inside the manager's `.
 workspace file, so they travel with that workspace. Turn on {guilabel}`Override` for a
 row to store a workspace value; turn it off, or use the row action, to inherit the user
 setting again. Clearing all workspace overrides asks for confirmation. Workspace
-overrides affect newly opened tools and new Figure Composer defaults, but do not mutate
-tools that are already open.
+Most workspace overrides affect newly opened tools and new Figure Composer defaults.
+Figure export defaults are resolved when you export. They apply to open figures that
+still inherit those values.

--- a/docs/source/user-guide/interactive/options.md
+++ b/docs/source/user-guide/interactive/options.md
@@ -24,18 +24,13 @@ Use the sidebar to switch between setting groups:
 - {guilabel}`I/O` controls the default loader and the default folder used by
   manager file dialogs and new Data Explorer windows.
 - {guilabel}`ktool` controls defaults for newly opened momentum-conversion tools.
-- {guilabel}`Figure Composer` controls default Matplotlib stylesheets, figure DPI,
-  and export settings.
+- {guilabel}`Figure Composer` controls default Matplotlib stylesheets, figure DPI, and
+  export settings.
 
 Rows in the {guilabel}`User` scope include a reset action that restores the application
 default for that setting. Broadly resetting all user settings still asks for
 confirmation.
 
 When Settings is opened from ImageTool Manager, a {guilabel}`Workspace` scope is also
-available. Workspace settings are sparse overrides saved inside the manager's `.itws`
-workspace file, so they travel with that workspace. Turn on {guilabel}`Override` for a
-row to store a workspace value; turn it off, or use the row action, to inherit the user
-setting again. Clearing all workspace overrides asks for confirmation. Workspace
-Most workspace overrides affect newly opened tools and new Figure Composer defaults.
-Figure export defaults are resolved when you export. They apply to open figures that
-still inherit those values.
+available. Workspace settings are local overrides saved inside the manager's `.itws`
+workspace file. Turn on the checkbox to store a value.

--- a/src/erlab/interactive/_figurecomposer/_defaults.py
+++ b/src/erlab/interactive/_figurecomposer/_defaults.py
@@ -15,6 +15,7 @@ if typing.TYPE_CHECKING:
 
     from matplotlib.figure import Figure
 
+    from erlab.interactive._figurecomposer._model._state import FigureExportState
     from erlab.interactive._figurecomposer._tool import FigureComposerTool
     from erlab.interactive._options.schema import AppOptions
 
@@ -146,6 +147,53 @@ def _default_export_transparent() -> bool:
 def _default_export_bbox_inches() -> str | None:
     value = _styled_rcparams_value("savefig.bbox")
     return None if value is None else str(value)
+
+
+def _default_export_pad_inches() -> float | typing.Literal["layout"]:
+    value = _styled_rcparams_value("savefig.pad_inches")
+    if value == "layout":
+        return "layout"
+    return float(value)
+
+
+def _resolved_export_kwargs(export: FigureExportState) -> dict[str, typing.Any]:
+    """Resolve user, workspace, and per-figure export settings."""
+    configured = _current_options().figure.export
+
+    dpi = _default_export_dpi() if configured.dpi == "style" else configured.dpi
+    transparent = (
+        _default_export_transparent()
+        if configured.transparent == "style"
+        else configured.transparent == "true"
+    )
+    bbox_inches = (
+        _default_export_bbox_inches()
+        if configured.bbox_inches == "style"
+        else None
+        if configured.bbox_inches == "standard"
+        else "tight"
+    )
+    pad_inches = (
+        _default_export_pad_inches()
+        if configured.pad_inches == "style"
+        else configured.pad_inches
+    )
+
+    if export.dpi != "inherit":
+        dpi = export.dpi
+    if export.transparent != "inherit":
+        transparent = export.transparent
+    if export.bbox_inches != "inherit":
+        bbox_inches = None if export.bbox_inches == "standard" else "tight"
+    if export.pad_inches != "inherit":
+        pad_inches = export.pad_inches
+
+    return {
+        "dpi": dpi,
+        "transparent": transparent,
+        "bbox_inches": bbox_inches,
+        "pad_inches": pad_inches,
+    }
 
 
 @contextlib.contextmanager

--- a/src/erlab/interactive/_figurecomposer/_model/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_model/_state.py
@@ -10,9 +10,6 @@ from collections.abc import Mapping
 import pydantic
 
 from erlab.interactive._figurecomposer._defaults import (
-    _default_export_bbox_inches,
-    _default_export_dpi,
-    _default_export_transparent,
     _default_figsize,
     _default_figure_dpi,
     _default_layout,
@@ -330,15 +327,12 @@ class FigureAxesSelectionState(pydantic.BaseModel):
 
 
 class FigureExportState(pydantic.BaseModel):
-    """Default export settings for the composer."""
+    """Per-figure overrides for explicit Figure Composer exports."""
 
-    dpi: float | typing.Literal["figure"] = pydantic.Field(
-        default_factory=_default_export_dpi
-    )
-    transparent: bool = pydantic.Field(default_factory=_default_export_transparent)
-    bbox_inches: str | None = pydantic.Field(
-        default_factory=_default_export_bbox_inches
-    )
+    dpi: float | typing.Literal["inherit", "figure"] = "inherit"
+    transparent: bool | typing.Literal["inherit"] = "inherit"
+    bbox_inches: typing.Literal["inherit", "standard", "tight"] = "inherit"
+    pad_inches: float | typing.Literal["inherit", "layout"] = "inherit"
 
     model_config = pydantic.ConfigDict(extra="forbid")
 
@@ -346,13 +340,47 @@ class FigureExportState(pydantic.BaseModel):
     @classmethod
     def _validate_export_dpi(
         cls, value: typing.Any
-    ) -> float | typing.Literal["figure"]:
-        if value == "figure":
-            return "figure"
+    ) -> float | typing.Literal["inherit", "figure"]:
+        if isinstance(value, str) and value in {"inherit", "figure"}:
+            return typing.cast('typing.Literal["inherit", "figure"]', value)
         dpi = float(value)
         if dpi <= 0:
             raise ValueError("export dpi must be positive")
         return dpi
+
+    @pydantic.field_validator("transparent", mode="before")
+    @classmethod
+    def _validate_export_transparent(
+        cls, value: typing.Any
+    ) -> bool | typing.Literal["inherit"]:
+        if value == "inherit":
+            return "inherit"
+        if isinstance(value, bool):
+            return value
+        raise ValueError("export transparency must be inherited or boolean")
+
+    @pydantic.field_validator("bbox_inches", mode="before")
+    @classmethod
+    def _validate_export_bbox_inches(
+        cls, value: typing.Any
+    ) -> typing.Literal["inherit", "standard", "tight"]:
+        if value is None:
+            return "standard"
+        if isinstance(value, str) and value in {"inherit", "standard", "tight"}:
+            return typing.cast('typing.Literal["inherit", "standard", "tight"]', value)
+        raise ValueError("export bounding box must be inherited, standard, or tight")
+
+    @pydantic.field_validator("pad_inches", mode="before")
+    @classmethod
+    def _validate_export_pad_inches(
+        cls, value: typing.Any
+    ) -> float | typing.Literal["inherit", "layout"]:
+        if isinstance(value, str) and value in {"inherit", "layout"}:
+            return typing.cast('typing.Literal["inherit", "layout"]', value)
+        padding = float(value)
+        if padding < 0.0:
+            raise ValueError("export padding must be nonnegative")
+        return padding
 
 
 class FigureOperationKind(enum.StrEnum):

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -192,6 +192,7 @@ if typing.TYPE_CHECKING:
     import xarray as xr
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 
+    from erlab.interactive._options import OptionDialog
     from erlab.interactive._options.schema import AppOptions
 
 
@@ -371,6 +372,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     ) -> None:
         super().__init__()
         self._options_getter: Callable[[], AppOptions] | None = None
+        self._settings_opener: Callable[[], OptionDialog] | None = None
+        self._settings_dialog: OptionDialog | None = None
         self._updating_controls = False
         self._rendering = False
         self._auto_redraw_dirty = False
@@ -480,6 +483,24 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def set_options_getter(self, getter: Callable[[], AppOptions] | None) -> None:
         self._options_getter = getter
+
+    def set_settings_opener(self, opener: Callable[[], OptionDialog] | None) -> None:
+        """Set the manager-owned settings dialog opener."""
+        self._settings_opener = opener
+
+    @QtCore.Slot()
+    def _open_export_settings(self) -> None:
+        if self._settings_opener is not None:
+            dialog = self._settings_opener()
+        else:
+            dialog = self._settings_dialog
+            if dialog is None or not erlab.interactive.utils.qt_is_valid(dialog):
+                dialog = erlab.interactive._options.OptionDialog(self)
+                self._settings_dialog = dialog
+        dialog.select_setting("figure/export/dpi")
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
 
     def _plot_slices_cache_for_render(
         self,
@@ -1395,6 +1416,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.layout_panel.layout_mode_requested.connect(self._layout_mode_requested)
         self.export_panel = FigureExportPanel(self.editor_tabs)
         self.export_panel.state_requested.connect(self._export_state_requested)
+        self.export_panel.settings_requested.connect(self._open_export_settings)
         self.axes_selector.sigAddRowRequested.connect(
             functools.partial(self._grow_subplot_grid, "row")
         )

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -52,6 +52,7 @@ import erlab.interactive._qt_state as _qt_state
 from erlab.interactive._figurecomposer._defaults import (
     _figure_draw_context,
     _figure_style_context,
+    _resolved_export_kwargs,
     _styled_rcparams_value,
     figure_options_context,
 )
@@ -102,6 +103,7 @@ from erlab.interactive._figurecomposer._model._sources import (
 from erlab.interactive._figurecomposer._model._state import (
     FigureAxesSelectionState,
     FigureDataSelectionState,
+    FigureExportState,
     FigureMethodFamily,
     FigureOperationKind,
     FigureOperationState,
@@ -147,6 +149,7 @@ from erlab.interactive._figurecomposer._ui._axes_widgets import (
     _GridSpecViewWidget,
     _subplot_target_preview_descriptor,
 )
+from erlab.interactive._figurecomposer._ui._export_panel import FigureExportPanel
 from erlab.interactive._figurecomposer._ui._figure_window import (
     _FigureComposerDisplayWindow,
 )
@@ -435,6 +438,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             source_data=initial_source_data,
             changed_callback=self._document_changed,
         )
+        self._output_recipe_payload = self._output_recipe_state(self._document.recipe)
         self._figure_window: _FigureComposerDisplayWindow | None = None
         self._subplot_adjust_dialog: QtWidgets.QDialog | None = None
         self._axes_customize_dialog: QtWidgets.QDialog | None = None
@@ -459,11 +463,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         """Publish each committed document mutation through the manager boundary."""
         if not erlab.interactive.utils.qt_is_valid(self):
             return
-        self._notify_provenance_changed()
+        output_recipe_payload = self._output_recipe_state(self._document.recipe)
+        output_recipe_changed = output_recipe_payload != self._output_recipe_payload
+        self._output_recipe_payload = output_recipe_payload
+        if output_recipe_changed or source_payloads_changed:
+            self._notify_provenance_changed()
         if recipe_changed:
             self.sigStateChanged.emit()
         if source_payloads_changed:
             self.sigDataChanged.emit()
+
+    @staticmethod
+    def _output_recipe_state(recipe: FigureRecipeState) -> dict[str, typing.Any]:
+        """Return recipe state that affects rendering and generated code."""
+        return recipe.model_dump(mode="python", exclude={"export"})
 
     def set_options_getter(self, getter: Callable[[], AppOptions] | None) -> None:
         self._options_getter = getter
@@ -598,6 +611,13 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         window = getattr(self, "_figure_window", None)
         if window is not None and erlab.interactive.utils.qt_is_valid(window):
             window.toolbar.set_history_buttons()
+
+    def _status_assignment_affects_provenance(
+        self, target_state: FigureRecipeState
+    ) -> bool:
+        return self._output_recipe_state(target_state) != self._output_recipe_state(
+            self._document.recipe
+        )
 
     def _disconnect_figure_window(self, window: _FigureComposerDisplayWindow) -> None:
         with contextlib.suppress(TypeError, RuntimeError):
@@ -1373,6 +1393,8 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.layout_panel = FigureLayoutPanel(self.editor_tabs)
         self.layout_panel.setup_requested.connect(self._layout_setup_requested)
         self.layout_panel.layout_mode_requested.connect(self._layout_mode_requested)
+        self.export_panel = FigureExportPanel(self.editor_tabs)
+        self.export_panel.state_requested.connect(self._export_state_requested)
         self.axes_selector.sigAddRowRequested.connect(
             functools.partial(self._grow_subplot_grid, "row")
         )
@@ -1392,6 +1414,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self.editor_tabs.setTabToolTip(
             recipe_index,
             "Ordered plotting steps and controls for the selected step.",
+        )
+        export_index = self.editor_tabs.addTab(self.export_panel, "Export")
+        self.editor_tabs.setTabToolTip(
+            export_index,
+            "Settings used only when the figure is exported to a file.",
         )
         self.editor_tabs.setCurrentWidget(self.operation_panel)
 
@@ -1435,6 +1462,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self.layout_panel.set_setup(
                 setup, reserved_names=self._document.source_names()
             )
+            self.export_panel.set_export(self._document.recipe.export)
             self._refresh_source_list()
             self._rebuild_axes_grid()
             self._refresh_operation_list()
@@ -3178,6 +3206,19 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         setup = typing.cast("FigureSubplotsState", setup_object)
         self._commit_layout_setup(setup)
 
+    @QtCore.Slot(object)
+    def _export_state_requested(self, export_object: object) -> None:
+        if self._updating_controls or self._closing:
+            return
+        export = FigureExportState.model_validate(export_object)
+        if export == self._document.recipe.export:
+            return
+        changed = self._document.replace_recipe(
+            self._document.recipe.model_copy(update={"export": export})
+        )
+        if changed:
+            self._write_state()
+
     def _commit_layout_setup(self, setup: FigureSubplotsState) -> bool:
         if self._updating_controls or self._closing:
             return False
@@ -3476,18 +3517,23 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def _undo_recorded_state(self) -> None:
         """Move recipe and source-data history to the previous state."""
+        target_state = self._prev_states[-2]
+        output_changes = self._history_transition_affects_provenance(target_state)
         self._next_states.append(self._prev_states.pop())
         self._next_source_data_states.append(self._prev_source_data_states.pop())
-        self._restore_source_data_history_state(self._prev_source_data_states[-1])
-        self.tool_status = self._prev_states[-1]
+        if output_changes:
+            self._restore_source_data_history_state(self._prev_source_data_states[-1])
+        self.tool_status = target_state
 
     def _redo_recorded_state(self) -> None:
         """Move recipe and source-data history to the next state."""
         next_state = self._next_states.pop()
         next_source_data = self._next_source_data_states.pop()
+        output_changes = self._history_transition_affects_provenance(next_state)
         self._prev_states.append(next_state)
         self._prev_source_data_states.append(next_source_data)
-        self._restore_source_data_history_state(next_source_data)
+        if output_changes:
+            self._restore_source_data_history_state(next_source_data)
         self.tool_status = next_state
 
     @QtCore.Slot(str, bool)
@@ -4270,9 +4316,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         ):
             figure.savefig(
                 filename,
-                dpi=self._document.recipe.export.dpi,
-                transparent=self._document.recipe.export.transparent,
-                bbox_inches=self._document.recipe.export.bbox_inches,
+                **_resolved_export_kwargs(self._document.recipe.export),
             )
 
     @property
@@ -4303,14 +4347,20 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._ensure_primary_source_data()
             self._normalize_operation_source_selections()
             self._apply_recipe_to_controls()
+        source_data_changed = self._document.source_revision != previous_source_revision
+        output_recipe_changed = self._output_recipe_state(
+            self._document.recipe
+        ) != self._output_recipe_state(previous_recipe)
+        refresh_requested = (
+            self._document.recipe == previous_recipe and not source_data_changed
+        )
+        if output_recipe_changed or source_data_changed or refresh_requested:
             self._sync_figure_window_to_recipe_setup()
             if self._dataset_restore_in_progress:
                 self._mark_preview_pixmap_stale()
             else:
                 _render_preview(self)
-        recipe_changed = self._document.recipe != previous_recipe
-        source_data_changed = self._document.source_revision != previous_source_revision
-        if recipe_changed or source_data_changed:
+        if output_recipe_changed or source_data_changed:
             self.sigInfoChanged.emit()
 
     def set_source_data(self, source_data: Mapping[str, xr.DataArray]) -> None:

--- a/src/erlab/interactive/_figurecomposer/_ui/_export_panel.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_export_panel.py
@@ -1,0 +1,159 @@
+"""Explicit-export settings for Figure Composer."""
+
+from __future__ import annotations
+
+from qtpy import QtCore, QtWidgets
+
+from erlab.interactive._figurecomposer._model._state import FigureExportState
+from erlab.interactive._options.parameters import SavefigNumberWidget
+
+
+class FigureExportPanel(QtWidgets.QWidget):
+    """Edit per-figure savefig overrides without requesting a redraw."""
+
+    state_requested = QtCore.Signal(object)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("figureComposerExportPage")
+        self._syncing = False
+        self._build_ui()
+        self.set_export(FigureExportState())
+
+    def _build_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(8)
+
+        description = QtWidgets.QLabel(self)
+        description.setWordWrap(True)
+        description.setText(
+            "These settings apply only when you export this figure. "
+            "Inherited values come from the workspace or user settings."
+        )
+        layout.addWidget(description)
+
+        form = QtWidgets.QFormLayout()
+        form.setContentsMargins(0, 0, 0, 0)
+        form.setHorizontalSpacing(12)
+        form.setVerticalSpacing(8)
+        form.setFieldGrowthPolicy(
+            QtWidgets.QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
+        )
+
+        self.dpi_control = SavefigNumberWidget(
+            special_values=(
+                ("Use defaults", "inherit"),
+                ("Use figure DPI", "figure"),
+            ),
+            value="inherit",
+            minimum=1.0,
+            maximum=10000.0,
+            decimals=1,
+            step=10.0,
+            custom_value=100.0,
+            parent=self,
+        )
+        self.dpi_control.setObjectName("figureComposerExportDpiControl")
+        self.dpi_control.setToolTip(
+            "Resolution passed to savefig for explicit exports."
+        )
+        form.addRow("DPI", self.dpi_control)
+
+        self.transparent_combo = QtWidgets.QComboBox(self)
+        self.transparent_combo.setObjectName("figureComposerExportTransparentCombo")
+        self.transparent_combo.addItem("Use defaults", "inherit")
+        self.transparent_combo.addItem("Enabled", True)
+        self.transparent_combo.addItem("Disabled", False)
+        self.transparent_combo.setToolTip(
+            "Background transparency passed to savefig for explicit exports."
+        )
+        form.addRow("Transparent background", self.transparent_combo)
+
+        self.bbox_combo = QtWidgets.QComboBox(self)
+        self.bbox_combo.setObjectName("figureComposerExportBboxCombo")
+        self.bbox_combo.addItem("Use defaults", "inherit")
+        self.bbox_combo.addItem("Standard", "standard")
+        self.bbox_combo.addItem("Tight", "tight")
+        self.bbox_combo.setToolTip(
+            "Bounding box passed to savefig. Tight crops to the figure contents."
+        )
+        form.addRow("Bounding box", self.bbox_combo)
+
+        self.padding_control = SavefigNumberWidget(
+            special_values=(
+                ("Use defaults", "inherit"),
+                ("Use layout", "layout"),
+            ),
+            value="inherit",
+            minimum=0.0,
+            maximum=100.0,
+            decimals=3,
+            step=0.05,
+            custom_value=0.1,
+            suffix="in",
+            parent=self,
+        )
+        self.padding_control.setObjectName("figureComposerExportPaddingControl")
+        self.padding_control.setToolTip(
+            "Padding passed to savefig when the bounding box is tight."
+        )
+        form.addRow("Padding", self.padding_control)
+        layout.addLayout(form)
+
+        action_layout = QtWidgets.QHBoxLayout()
+        self.use_defaults_button = QtWidgets.QPushButton("Use Defaults", self)
+        self.use_defaults_button.setObjectName("figureComposerExportUseDefaultsButton")
+        self.use_defaults_button.setToolTip("Remove all per-figure export overrides.")
+        action_layout.addWidget(self.use_defaults_button)
+        action_layout.addStretch(1)
+        layout.addLayout(action_layout)
+        layout.addStretch(1)
+
+        self.dpi_control.sigValueChanged.connect(self._control_changed)
+        self.transparent_combo.currentIndexChanged.connect(self._control_changed)
+        self.bbox_combo.currentIndexChanged.connect(self._control_changed)
+        self.padding_control.sigValueChanged.connect(self._control_changed)
+        self.use_defaults_button.clicked.connect(self._use_defaults)
+
+    def set_export(self, export: FigureExportState) -> None:
+        """Project one immutable export snapshot into the controls."""
+        self._syncing = True
+        try:
+            self.dpi_control.set_value(export.dpi)
+            self._set_combo_data(self.transparent_combo, export.transparent)
+            self._set_combo_data(self.bbox_combo, export.bbox_inches)
+            self.padding_control.set_value(export.pad_inches)
+        finally:
+            self._syncing = False
+
+    @staticmethod
+    def _set_combo_data(combo: QtWidgets.QComboBox, value: object) -> None:
+        index = combo.findData(value)
+        if index < 0:
+            raise ValueError(f"Unsupported export control value {value!r}")
+        combo.setCurrentIndex(index)
+
+    def export_state(self) -> FigureExportState:
+        """Return the validated per-figure export state shown by the controls."""
+        return FigureExportState.model_validate(
+            {
+                "dpi": self.dpi_control.get_value(),
+                "transparent": self.transparent_combo.currentData(),
+                "bbox_inches": self.bbox_combo.currentData(),
+                "pad_inches": self.padding_control.get_value(),
+            }
+        )
+
+    @QtCore.Slot()
+    @QtCore.Slot(int)
+    @QtCore.Slot(object)
+    def _control_changed(self, _value: object = None) -> None:
+        if not self._syncing:
+            self.state_requested.emit(self.export_state())
+
+    @QtCore.Slot()
+    def _use_defaults(self) -> None:
+        export = FigureExportState()
+        self.set_export(export)
+        self.state_requested.emit(export)

--- a/src/erlab/interactive/_figurecomposer/_ui/_export_panel.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_export_panel.py
@@ -12,6 +12,7 @@ class FigureExportPanel(QtWidgets.QWidget):
     """Edit per-figure savefig overrides without requesting a redraw."""
 
     state_requested = QtCore.Signal(object)
+    settings_requested = QtCore.Signal()
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent)
@@ -24,14 +25,6 @@ class FigureExportPanel(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(8, 8, 8, 8)
         layout.setSpacing(8)
-
-        description = QtWidgets.QLabel(self)
-        description.setWordWrap(True)
-        description.setText(
-            "These settings apply only when you export this figure. "
-            "Inherited values come from the workspace or user settings."
-        )
-        layout.addWidget(description)
 
         form = QtWidgets.QFormLayout()
         form.setContentsMargins(0, 0, 0, 0)
@@ -106,6 +99,12 @@ class FigureExportPanel(QtWidgets.QWidget):
         self.use_defaults_button.setObjectName("figureComposerExportUseDefaultsButton")
         self.use_defaults_button.setToolTip("Remove all per-figure export overrides.")
         action_layout.addWidget(self.use_defaults_button)
+        self.settings_button = QtWidgets.QPushButton("Export Settings…", self)
+        self.settings_button.setObjectName("figureComposerExportSettingsButton")
+        self.settings_button.setToolTip(
+            "Open the user and workspace defaults for figure exports."
+        )
+        action_layout.addWidget(self.settings_button)
         action_layout.addStretch(1)
         layout.addLayout(action_layout)
         layout.addStretch(1)
@@ -115,6 +114,7 @@ class FigureExportPanel(QtWidgets.QWidget):
         self.bbox_combo.currentIndexChanged.connect(self._control_changed)
         self.padding_control.sigValueChanged.connect(self._control_changed)
         self.use_defaults_button.clicked.connect(self._use_defaults)
+        self.settings_button.clicked.connect(self.settings_requested)
 
     def set_export(self, export: FigureExportState) -> None:
         """Project one immutable export snapshot into the controls."""

--- a/src/erlab/interactive/_options/__init__.py
+++ b/src/erlab/interactive/_options/__init__.py
@@ -13,6 +13,8 @@ from erlab.interactive._options.parameters import (
     ColorListParameter,
     DirectoryPathParameter,
     FigureDpiOverrideParameter,
+    SavefigDpiParameter,
+    SavefigPaddingParameter,
     StylesheetListParameter,
     _CustomColorMapParameter,
 )
@@ -31,6 +33,14 @@ pyqtgraph.parametertree.registerParameterType(
 
 pyqtgraph.parametertree.registerParameterType(
     "figure_dpi_override", FigureDpiOverrideParameter, override=True
+)
+
+pyqtgraph.parametertree.registerParameterType(
+    "savefig_dpi", SavefigDpiParameter, override=True
+)
+
+pyqtgraph.parametertree.registerParameterType(
+    "savefig_padding", SavefigPaddingParameter, override=True
 )
 
 pyqtgraph.parametertree.registerParameterType(

--- a/src/erlab/interactive/_options/parameters.py
+++ b/src/erlab/interactive/_options/parameters.py
@@ -4,6 +4,8 @@ This module defines custom parameter types for use in the options dialog of the
 ImageTool. It includes list-style parameters and a custom colormap parameter.
 """
 
+from collections.abc import Callable
+
 import pyqtgraph as pg
 import pyqtgraph.parametertree
 from qtpy import QtCore, QtGui, QtWidgets
@@ -264,6 +266,174 @@ class FigureDpiOverrideParameter(
 
     def __init__(self, **opts):
         opts.setdefault("type", "figure_dpi_override")
+        super().__init__(**opts)
+
+
+class SavefigNumberWidget(QtWidgets.QWidget):
+    """Widget for a savefig value that accepts named modes or a number."""
+
+    sigValueChanged = QtCore.Signal(object)
+    _CUSTOM_VALUE = "__custom_savefig_value__"
+
+    def __init__(
+        self,
+        *,
+        special_values: tuple[tuple[str, str], ...],
+        value: float | str,
+        minimum: float,
+        maximum: float,
+        decimals: int,
+        step: float,
+        custom_value: float,
+        suffix: str = "",
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.mode_combo = QtWidgets.QComboBox(self)
+        self.mode_combo.setObjectName("savefigNumberModeCombo")
+        for label, stored_value in special_values:
+            self.mode_combo.addItem(label, stored_value)
+        self.mode_combo.addItem("Custom", self._CUSTOM_VALUE)
+
+        self.value_spin = QtWidgets.QDoubleSpinBox(self)
+        self.value_spin.setObjectName("savefigNumberSpin")
+        self.value_spin.setRange(minimum, maximum)
+        self.value_spin.setDecimals(decimals)
+        self.value_spin.setSingleStep(step)
+        self.value_spin.setValue(custom_value)
+        self.value_spin.setKeyboardTracking(False)
+        if suffix:
+            self.value_spin.setSuffix(f" {suffix}")
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        layout.addWidget(self.mode_combo)
+        layout.addWidget(self.value_spin)
+        layout.addStretch(1)
+
+        self.mode_combo.currentIndexChanged.connect(self._mode_changed)
+        self.value_spin.valueChanged.connect(self._number_changed)
+        self.set_value(value)
+
+    def get_value(self) -> float | str:
+        value = self.mode_combo.currentData()
+        if value == self._CUSTOM_VALUE:
+            return float(self.value_spin.value())
+        return str(value)
+
+    def set_value(self, value: float | str) -> None:
+        index = self.mode_combo.findData(value)
+        custom = index < 0
+        if custom:
+            numeric = float(value)
+            index = self.mode_combo.findData(self._CUSTOM_VALUE)
+        combo_was_blocked = self.mode_combo.blockSignals(True)
+        spin_was_blocked = self.value_spin.blockSignals(True)
+        try:
+            if custom:
+                self.value_spin.setValue(numeric)
+            self.mode_combo.setCurrentIndex(index)
+            self.value_spin.setEnabled(custom)
+        finally:
+            self.value_spin.blockSignals(spin_was_blocked)
+            self.mode_combo.blockSignals(combo_was_blocked)
+
+    @QtCore.Slot(int)
+    def _mode_changed(self, _index: int) -> None:
+        self.value_spin.setEnabled(self.mode_combo.currentData() == self._CUSTOM_VALUE)
+        self.sigValueChanged.emit(self.get_value())
+
+    @QtCore.Slot(float)
+    def _number_changed(self, _value: float) -> None:
+        if self.mode_combo.currentData() == self._CUSTOM_VALUE:
+            self.sigValueChanged.emit(self.get_value())
+
+
+class SavefigDpiWidget(SavefigNumberWidget):
+    """Widget for a global savefig DPI default."""
+
+    def __init__(
+        self,
+        value: float | str = "style",
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(
+            special_values=(
+                ("Use stylesheet", "style"),
+                ("Use figure DPI", "figure"),
+            ),
+            value=value,
+            minimum=1.0,
+            maximum=10000.0,
+            decimals=1,
+            step=10.0,
+            custom_value=100.0,
+            parent=parent,
+        )
+        self.setObjectName("savefigDpiWidget")
+
+
+class SavefigPaddingWidget(SavefigNumberWidget):
+    """Widget for a global savefig padding default."""
+
+    def __init__(
+        self,
+        value: float | str = "style",
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(
+            special_values=(
+                ("Use stylesheet", "style"),
+                ("Use layout", "layout"),
+            ),
+            value=value,
+            minimum=0.0,
+            maximum=100.0,
+            decimals=3,
+            step=0.05,
+            custom_value=0.1,
+            suffix="in",
+            parent=parent,
+        )
+        self.setObjectName("savefigPaddingWidget")
+
+
+class _SavefigNumberParameterItem(
+    pyqtgraph.parametertree.parameterTypes.WidgetParameterItem
+):
+    widget_class: Callable[[], SavefigNumberWidget]
+
+    def makeWidget(self) -> SavefigNumberWidget:
+        widget = self.widget_class()
+        widget.sigChanged = widget.sigValueChanged  # type: ignore[attr-defined]
+        widget.value = widget.get_value  # type: ignore[attr-defined]
+        widget.setValue = widget.set_value  # type: ignore[attr-defined]
+        self.hideWidget = False
+        return widget
+
+
+class SavefigDpiParameterItem(_SavefigNumberParameterItem):
+    widget_class = SavefigDpiWidget
+
+
+class SavefigDpiParameter(pyqtgraph.parametertree.parameterTypes.SimpleParameter):
+    itemClass = SavefigDpiParameterItem
+
+    def __init__(self, **opts):
+        opts.setdefault("type", "savefig_dpi")
+        super().__init__(**opts)
+
+
+class SavefigPaddingParameterItem(_SavefigNumberParameterItem):
+    widget_class = SavefigPaddingWidget
+
+
+class SavefigPaddingParameter(pyqtgraph.parametertree.parameterTypes.SimpleParameter):
+    itemClass = SavefigPaddingParameterItem
+
+    def __init__(self, **opts):
+        opts.setdefault("type", "savefig_padding")
         super().__init__(**opts)
 
 

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -56,6 +56,7 @@ __all__ = [
     "AppOptions",
     "ColorMapOptions",
     "ColorOptions",
+    "FigureExportOptions",
     "FigureOptions",
     "IOOptions",
     "WorkspaceCompressionMode",
@@ -411,6 +412,85 @@ class ColorOptions(BaseModel):
         return v
 
 
+class FigureExportOptions(BaseModel):
+    """Figure Composer export defaults."""
+
+    dpi: float | typing.Literal["style", "figure"] = Field(
+        default="style",
+        title="DPI",
+        description=(
+            "Default resolution for exported figures. Use the active stylesheet "
+            "value, the figure DPI, or a custom value."
+        ),
+        json_schema_extra=_workspace_extra(ui_type="savefig_dpi"),
+    )
+    transparent: typing.Literal["style", "true", "false"] = Field(
+        default="style",
+        title="Transparent background",
+        description=(
+            "Default background transparency for exported figures. Use the active "
+            "stylesheet value, enable transparency, or disable it."
+        ),
+        json_schema_extra=_workspace_extra(
+            ui_type="list",
+            ui_choices=[
+                {"label": "Use stylesheet", "value": "style"},
+                {"label": "Enabled", "value": "true"},
+                {"label": "Disabled", "value": "false"},
+            ],
+        ),
+    )
+    bbox_inches: typing.Literal["style", "standard", "tight"] = Field(
+        default="style",
+        title="Bounding box",
+        description=(
+            "Default bounding box for exported figures. Tight crops the output to "
+            "the figure contents."
+        ),
+        json_schema_extra=_workspace_extra(
+            ui_type="list",
+            ui_choices=[
+                {"label": "Use stylesheet", "value": "style"},
+                {"label": "Standard", "value": "standard"},
+                {"label": "Tight", "value": "tight"},
+            ],
+        ),
+    )
+    pad_inches: float | typing.Literal["style", "layout"] = Field(
+        default="style",
+        title="Padding",
+        description=(
+            "Default padding around tight exported figures. Use the active "
+            "stylesheet value, the layout engine, or a custom value in inches."
+        ),
+        json_schema_extra=_workspace_extra(ui_type="savefig_padding"),
+    )
+
+    @field_validator("dpi", mode="before")
+    @classmethod
+    def validate_dpi(
+        cls, value: typing.Any
+    ) -> float | typing.Literal["style", "figure"]:
+        if isinstance(value, str) and value in {"style", "figure"}:
+            return typing.cast('typing.Literal["style", "figure"]', value)
+        dpi = float(value)
+        if dpi <= 0.0:
+            raise ValueError("export dpi must be positive")
+        return dpi
+
+    @field_validator("pad_inches", mode="before")
+    @classmethod
+    def validate_pad_inches(
+        cls, value: typing.Any
+    ) -> float | typing.Literal["style", "layout"]:
+        if isinstance(value, str) and value in {"style", "layout"}:
+            return typing.cast('typing.Literal["style", "layout"]', value)
+        padding = float(value)
+        if padding < 0.0:
+            raise ValueError("export padding must be nonnegative")
+        return padding
+
+
 class FigureOptions(BaseModel):
     """Figure Composer defaults."""
 
@@ -436,6 +516,11 @@ class FigureOptions(BaseModel):
             ui_type="figure_dpi_override",
             ui_step=10.0,
         ),
+    )
+    export: FigureExportOptions = Field(
+        default_factory=FigureExportOptions,
+        title="Export",
+        description="Defaults used when Figure Composer exports a figure.",
     )
 
     @field_validator("stylesheets", mode="before")

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -19,6 +19,9 @@ from erlab.interactive._options.parameters import (
     ColorListWidget,
     DirectoryPathWidget,
     FigureDpiOverrideWidget,
+    SavefigDpiWidget,
+    SavefigNumberWidget,
+    SavefigPaddingWidget,
     StylesheetListWidget,
 )
 from erlab.interactive._options.schema import AppOptions
@@ -609,14 +612,26 @@ class OptionDialog(QtWidgets.QDialog):
             return StylesheetListWidget(parent=self)
         if ui_type == "figure_dpi_override":
             return FigureDpiOverrideWidget(parent=self)
+        if ui_type == "savefig_dpi":
+            return SavefigDpiWidget(parent=self)
+        if ui_type == "savefig_padding":
+            return SavefigPaddingWidget(parent=self)
         if ui_type == "directory_path":
             return DirectoryPathWidget(parent=self)
         if ui_type == "choice_slider":
             return _ChoiceSlider(extra.get("ui_choices", ()), self)
         if ui_type == "list" or "ui_limits" in extra:
             combo = QtWidgets.QComboBox(self)
-            for choice in extra.get("ui_limits", ()):
-                combo.addItem(str(choice), choice)
+            choices = extra.get("ui_choices")
+            if isinstance(choices, list):
+                for choice in choices:
+                    combo.addItem(
+                        str(choice.get("label", choice.get("value"))),
+                        choice.get("value"),
+                    )
+            else:
+                for choice in extra.get("ui_limits", ()):
+                    combo.addItem(str(choice), choice)
             return combo
         if _is_bool_path(path):
             return QtWidgets.QCheckBox(self)
@@ -686,7 +701,7 @@ class OptionDialog(QtWidgets.QDialog):
             control.sigDpiChanged.connect(
                 lambda _value, row=row: self._control_changed(row)
             )
-        elif isinstance(control, _ChoiceSlider):
+        elif isinstance(control, SavefigNumberWidget | _ChoiceSlider):
             control.sigValueChanged.connect(
                 lambda _value, row=row: self._control_changed(row)
             )
@@ -799,6 +814,8 @@ class OptionDialog(QtWidgets.QDialog):
             return control.get_stylesheets()
         if isinstance(control, FigureDpiOverrideWidget):
             return control.get_dpi()
+        if isinstance(control, SavefigNumberWidget):
+            return control.get_value()
         if isinstance(control, DirectoryPathWidget):
             return control.get_path()
         if isinstance(control, QtWidgets.QLineEdit):
@@ -845,6 +862,9 @@ class OptionDialog(QtWidgets.QDialog):
             return
         if isinstance(control, FigureDpiOverrideWidget):
             control.set_dpi(value)
+            return
+        if isinstance(control, SavefigNumberWidget):
+            control.set_value(value)
             return
         if isinstance(control, DirectoryPathWidget):
             control.set_path(None if value is None else str(value))

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -416,6 +416,29 @@ class OptionDialog(QtWidgets.QDialog):
         self.reset_session_baseline()
         super().showEvent(event)
 
+    def select_setting(self, path: str) -> None:
+        """Show and focus one setting in the current scope."""
+        category = path.partition("/")[0]
+        for index in range(self.category_list.count()):
+            item = self.category_list.item(index)
+            if item is None:
+                continue
+            if item.data(QtCore.Qt.ItemDataRole.UserRole) == category:
+                self.category_list.setCurrentRow(index)
+                break
+        else:
+            raise KeyError(path)
+
+        row = self._rows.get((self._current_scope, path))
+        if row is None:
+            raise KeyError(path)
+        page = self.page_stack.currentWidget()
+        if page is not None:
+            scroll = page.findChild(QtWidgets.QScrollArea)
+            if scroll is not None:
+                scroll.ensureWidgetVisible(row)
+        row.control.setFocus(QtCore.Qt.FocusReason.ShortcutFocusReason)
+
     @staticmethod
     def _find_workspace_manager(parent: QtWidgets.QWidget | None) -> typing.Any | None:
         current: QtCore.QObject | None = parent

--- a/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
@@ -54,6 +54,7 @@ class _FigureComposerWorkflowController(QtCore.QObject):
         tool._refresh_reload_data_action()
         if isinstance(tool, FigureComposerTool):
             tool.set_options_getter(lambda: self._host.effective_interactive_options)
+            tool.set_settings_opener(self._host.open_settings)
             self._install_figure_source_refresh_callbacks(node.uid, tool)
 
     def _figure_operations_from_image_targets(

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2005,8 +2005,8 @@ class ImageToolManager(_ImageToolManagerBase):
     def _stop_servers(self) -> None:
         self._widgets_controller._stop_servers()
 
-    def open_settings(self) -> None:
-        self._widgets_controller.open_settings()
+    def open_settings(self) -> erlab.interactive._options.OptionDialog:
+        return self._widgets_controller.open_settings()
 
     def open_new_manager_instance(self) -> None:
         self._widgets_controller.open_new_manager_instance()

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -1914,10 +1914,12 @@ class _WidgetsController:
                     )
                 watcher_server.deleteLater()
 
-    def open_settings(self) -> None:
+    def open_settings(self) -> erlab.interactive._options.OptionDialog:
         """Open the settings dialog for the ImageTool manager."""
         dialog = self._manager._additional_windows.get("settings")
-        if dialog is None or not erlab.interactive.utils.qt_is_valid(dialog):
+        if not isinstance(
+            dialog, erlab.interactive._options.OptionDialog
+        ) or not erlab.interactive.utils.qt_is_valid(dialog):
             dialog = erlab.interactive._options.OptionDialog(self._manager)
             self._manager._additional_windows["settings"] = dialog
 
@@ -1929,6 +1931,7 @@ class _WidgetsController:
         dialog.show()
         dialog.raise_()
         dialog.activateWindow()
+        return dialog
 
     def open_new_manager_instance(self) -> None:
         """Open another ImageTool Manager window."""

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -3344,7 +3344,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             if not hasattr(self, "_provenance_change_depth"):
                 setter(self, status)
                 return
-            with self._provenance_mutation():
+            with self._provenance_mutation(
+                changed=self._status_assignment_affects_provenance(status)
+            ):
                 setter(self, status)
 
         type(cls).__setattr__(
@@ -3687,6 +3689,14 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if hasattr(self, "redo_action") and qt_is_valid(self.redo_action):
             self.redo_action.setEnabled(self.redoable)
 
+    def _status_assignment_affects_provenance(self, target_state: M) -> bool:
+        """Return whether applying a complete state changes provenance output."""
+        return True
+
+    def _history_transition_affects_provenance(self, target_state: M) -> bool:
+        """Return whether moving to a history state changes provenance output."""
+        return self._status_assignment_affects_provenance(target_state)
+
     @property
     def _dataset_restore_in_progress(self) -> bool:
         """Return whether saved dataset state is currently being applied."""
@@ -3837,7 +3847,8 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if not self.undoable:
             return
         with self._coalesce_provenance_changes():
-            self._notify_provenance_changed()
+            if self._history_transition_affects_provenance(self._prev_states[-2]):
+                self._notify_provenance_changed()
             with self._history_suppressed():
                 self._undo_recorded_state()
         self._update_history_actions()
@@ -3855,7 +3866,8 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if not self.redoable:
             return
         with self._coalesce_provenance_changes():
-            self._notify_provenance_changed()
+            if self._history_transition_affects_provenance(self._next_states[-1]):
+                self._notify_provenance_changed()
             with self._history_suppressed():
                 self._redo_recorded_state()
         self._update_history_actions()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_export.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_export.py
@@ -1,0 +1,293 @@
+import numpy as np
+import pytest
+import xarray as xr
+from matplotlib.figure import Figure
+from qtpy import QtWidgets
+
+import erlab.interactive._figurecomposer._defaults as figurecomposer_defaults
+import erlab.interactive._figurecomposer._tool as figurecomposer_tool_module
+import erlab.interactive.utils
+from erlab.interactive._figurecomposer import FigureComposerTool, FigureExportState
+from erlab.interactive._figurecomposer._defaults import figure_options_context
+from erlab.interactive._figurecomposer._ui._export_panel import FigureExportPanel
+from erlab.interactive._options.core import model_with_workspace_overrides
+from erlab.interactive._options.schema import AppOptions
+
+
+def _data() -> xr.DataArray:
+    return xr.DataArray(
+        np.arange(4.0),
+        dims=("x",),
+        coords={"x": np.arange(4.0)},
+        name="data",
+    )
+
+
+def test_figure_export_state_inherits_and_migrates_legacy_values() -> None:
+    assert FigureExportState() == FigureExportState(
+        dpi="inherit",
+        transparent="inherit",
+        bbox_inches="inherit",
+        pad_inches="inherit",
+    )
+    assert FigureExportState.model_validate(
+        {
+            "dpi": 300.0,
+            "transparent": False,
+            "bbox_inches": None,
+        }
+    ) == FigureExportState(
+        dpi=300.0,
+        transparent=False,
+        bbox_inches="standard",
+        pad_inches="inherit",
+    )
+
+    with pytest.raises(ValueError, match="padding must be nonnegative"):
+        FigureExportState(pad_inches=-0.1)
+    with pytest.raises(ValueError, match="dpi must be positive"):
+        FigureExportState(dpi=0.0)
+    with pytest.raises(ValueError, match="transparency"):
+        FigureExportState.model_validate({"transparent": "invalid"})
+    with pytest.raises(ValueError, match="bounding box"):
+        FigureExportState.model_validate({"bbox_inches": "invalid"})
+
+
+def test_default_export_padding_accepts_layout(monkeypatch) -> None:
+    monkeypatch.setattr(
+        figurecomposer_defaults,
+        "_styled_rcparams_value",
+        lambda _key: "layout",
+    )
+
+    assert figurecomposer_defaults._default_export_pad_inches() == "layout"
+
+
+def test_export_kwargs_follow_style_user_workspace_and_figure_precedence() -> None:
+    user_options = AppOptions.model_validate(
+        {
+            "figure": {
+                "export": {
+                    "dpi": 180.0,
+                    "transparent": "false",
+                    "bbox_inches": "standard",
+                    "pad_inches": 0.1,
+                }
+            }
+        }
+    )
+    workspace_options = model_with_workspace_overrides(
+        user_options,
+        {
+            "figure/export/dpi": 240.0,
+            "figure/export/bbox_inches": "tight",
+        },
+    )
+
+    with figure_options_context(workspace_options):
+        assert figurecomposer_defaults._resolved_export_kwargs(FigureExportState()) == {
+            "dpi": 240.0,
+            "transparent": False,
+            "bbox_inches": "tight",
+            "pad_inches": 0.1,
+        }
+        assert figurecomposer_defaults._resolved_export_kwargs(
+            FigureExportState(
+                dpi="figure",
+                transparent=True,
+                bbox_inches="standard",
+                pad_inches="layout",
+            )
+        ) == {
+            "dpi": "figure",
+            "transparent": True,
+            "bbox_inches": None,
+            "pad_inches": "layout",
+        }
+
+
+def test_export_panel_edits_and_resets_per_figure_state(qtbot) -> None:
+    panel = FigureExportPanel()
+    qtbot.addWidget(panel)
+    requested: list[FigureExportState] = []
+    panel.state_requested.connect(requested.append)
+
+    panel.dpi_control.mode_combo.setCurrentIndex(
+        panel.dpi_control.mode_combo.count() - 1
+    )
+    panel.dpi_control.value_spin.setValue(320.0)
+    panel.transparent_combo.setCurrentIndex(panel.transparent_combo.findData(True))
+    panel.bbox_combo.setCurrentIndex(panel.bbox_combo.findData("tight"))
+    panel.padding_control.mode_combo.setCurrentIndex(
+        panel.padding_control.mode_combo.findData("layout")
+    )
+
+    assert requested[-1] == FigureExportState(
+        dpi=320.0,
+        transparent=True,
+        bbox_inches="tight",
+        pad_inches="layout",
+    )
+
+    panel.use_defaults_button.click()
+
+    assert requested[-1] == FigureExportState()
+    assert panel.export_state() == FigureExportState()
+
+
+def test_export_panel_rejects_an_unknown_control_value(qtbot) -> None:
+    panel = FigureExportPanel()
+    qtbot.addWidget(panel)
+
+    with pytest.raises(ValueError, match="Unsupported export control value"):
+        panel._set_combo_data(panel.bbox_combo, "unknown")
+
+
+def test_export_only_edits_and_history_do_not_render_or_invalidate_cache(
+    qtbot, monkeypatch
+) -> None:
+    tool = FigureComposerTool(_data())
+    qtbot.addWidget(tool)
+    tool._reset_history_stack()
+    assert tool.editor_tabs.indexOf(tool.export_panel) >= 0
+
+    render_calls: list[object] = []
+    monkeypatch.setattr(
+        figurecomposer_tool_module,
+        "_render_preview",
+        lambda owner: render_calls.append(owner),
+    )
+    info_changes: list[None] = []
+    state_changes: list[None] = []
+    tool.sigInfoChanged.connect(lambda: info_changes.append(None))
+    tool.sigStateChanged.connect(lambda: state_changes.append(None))
+    initial_generation = tool.preview_pixmap_generation
+    initial_stale = tool.preview_pixmap_stale
+    initial_provenance_revision = tool.provenance_revision
+    code_before = tool.generated_code()
+
+    export = FigureExportState(
+        dpi=300.0,
+        transparent=True,
+        bbox_inches="tight",
+        pad_inches=0.2,
+    )
+    tool.export_panel.state_requested.emit(export)
+
+    assert tool.tool_status.export == export
+    assert tool.generated_code() == code_before
+    assert render_calls == []
+    assert info_changes == []
+    assert state_changes == [None]
+    assert tool.preview_pixmap_generation == initial_generation
+    assert tool.preview_pixmap_stale is initial_stale
+    assert tool.provenance_revision == initial_provenance_revision
+    assert tool.undoable
+
+    tool.undo()
+
+    assert tool.tool_status.export == FigureExportState()
+    assert tool.export_panel.export_state() == FigureExportState()
+    assert render_calls == []
+    assert tool.provenance_revision == initial_provenance_revision
+
+    tool.redo()
+
+    assert tool.tool_status.export == export
+    assert tool.export_panel.export_state() == export
+    assert render_calls == []
+    assert tool.provenance_revision == initial_provenance_revision
+
+
+def test_export_state_request_ignores_sync_and_unchanged_state(qtbot) -> None:
+    tool = FigureComposerTool(_data())
+    qtbot.addWidget(tool)
+    state_changes: list[None] = []
+    tool.sigStateChanged.connect(lambda: state_changes.append(None))
+
+    tool.export_panel.state_requested.emit(FigureExportState())
+    tool._updating_controls = True
+    tool.export_panel.state_requested.emit(FigureExportState(dpi=300.0))
+    tool._updating_controls = False
+
+    assert tool.tool_status.export == FigureExportState()
+    assert state_changes == []
+
+
+def test_explicit_export_resolves_workspace_and_figure_settings(
+    qtbot, monkeypatch
+) -> None:
+    tool = FigureComposerTool(_data())
+    qtbot.addWidget(tool)
+    user_options = AppOptions.model_validate(
+        {
+            "figure": {
+                "export": {
+                    "dpi": 180.0,
+                    "transparent": "false",
+                    "bbox_inches": "tight",
+                    "pad_inches": 0.2,
+                }
+            }
+        }
+    )
+    effective_options = model_with_workspace_overrides(
+        user_options,
+        {
+            "figure/export/dpi": 240.0,
+            "figure/export/transparent": "true",
+        },
+    )
+    tool.set_options_getter(lambda: effective_options)
+    tool.export_panel.state_requested.emit(
+        FigureExportState(
+            dpi="figure",
+            bbox_inches="standard",
+            pad_inches="layout",
+        )
+    )
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getSaveFileName",
+        lambda *args, **kwargs: ("figure.png", ""),
+    )
+    saved: list[tuple[str, dict[str, object]]] = []
+
+    def savefig(_figure: Figure, filename: str, **kwargs: object) -> None:
+        saved.append((filename, kwargs))
+
+    monkeypatch.setattr(Figure, "savefig", savefig)
+
+    tool.export_figure()
+
+    assert saved == [
+        (
+            "figure.png",
+            {
+                "dpi": "figure",
+                "transparent": True,
+                "bbox_inches": None,
+                "pad_inches": "layout",
+            },
+        )
+    ]
+
+
+def test_figure_export_state_round_trips_saved_tool(qtbot) -> None:
+    tool = FigureComposerTool(_data())
+    qtbot.addWidget(tool)
+    export = FigureExportState(
+        dpi=360.0,
+        transparent=False,
+        bbox_inches="tight",
+        pad_inches=0.15,
+    )
+    tool.export_panel.state_requested.emit(export)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(tool.to_dataset())
+    assert isinstance(restored, FigureComposerTool)
+    qtbot.addWidget(restored)
+
+    assert restored.tool_status.export == export
+    assert restored.export_panel.export_state() == export

--- a/tests/interactive/imagetool/manager/figurecomposer/test_export.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_export.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from matplotlib.figure import Figure
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 import erlab.interactive._figurecomposer._defaults as figurecomposer_defaults
 import erlab.interactive._figurecomposer._tool as figurecomposer_tool_module
@@ -12,6 +12,7 @@ from erlab.interactive._figurecomposer._defaults import figure_options_context
 from erlab.interactive._figurecomposer._ui._export_panel import FigureExportPanel
 from erlab.interactive._options.core import model_with_workspace_overrides
 from erlab.interactive._options.schema import AppOptions
+from erlab.interactive._options.ui import OptionDialog
 
 
 def _data() -> xr.DataArray:
@@ -110,7 +111,9 @@ def test_export_panel_edits_and_resets_per_figure_state(qtbot) -> None:
     panel = FigureExportPanel()
     qtbot.addWidget(panel)
     requested: list[FigureExportState] = []
+    settings_requested: list[None] = []
     panel.state_requested.connect(requested.append)
+    panel.settings_requested.connect(lambda: settings_requested.append(None))
 
     panel.dpi_control.mode_combo.setCurrentIndex(
         panel.dpi_control.mode_combo.count() - 1
@@ -130,9 +133,51 @@ def test_export_panel_edits_and_resets_per_figure_state(qtbot) -> None:
     )
 
     panel.use_defaults_button.click()
+    panel.settings_button.click()
 
     assert requested[-1] == FigureExportState()
     assert panel.export_state() == FigureExportState()
+    assert settings_requested == [None]
+
+
+def test_export_settings_button_opens_figure_export_settings(qtbot) -> None:
+    tool = FigureComposerTool(_data())
+    qtbot.addWidget(tool)
+
+    tool.export_panel.settings_button.click()
+
+    dialog = tool._settings_dialog
+    assert isinstance(dialog, OptionDialog)
+    assert dialog.isVisible()
+    current_category = dialog.category_list.currentItem()
+    assert current_category is not None
+    assert current_category.data(QtCore.Qt.ItemDataRole.UserRole) == "figure"
+    assert dialog.focusWidget() is dialog._rows[("user", "figure/export/dpi")].control
+
+    tool.export_panel.settings_button.click()
+    assert tool._settings_dialog is dialog
+
+
+def test_export_settings_button_uses_manager_dialog(qtbot) -> None:
+    tool = FigureComposerTool(_data())
+    dialog = OptionDialog()
+    qtbot.addWidget(tool)
+    qtbot.addWidget(dialog)
+    opener_calls: list[None] = []
+
+    def open_settings() -> OptionDialog:
+        opener_calls.append(None)
+        return dialog
+
+    tool.set_settings_opener(open_settings)
+    tool.export_panel.settings_button.click()
+
+    assert opener_calls == [None]
+    assert tool._settings_dialog is None
+    assert dialog.isVisible()
+    current_category = dialog.category_list.currentItem()
+    assert current_category is not None
+    assert current_category.data(QtCore.Qt.ItemDataRole.UserRole) == "figure"
 
 
 def test_export_panel_rejects_an_unknown_control_value(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -2058,6 +2058,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
         "figureComposerSourcesPage",
         "figureComposerLayoutPage",
         "figureComposerRecipePage",
+        "figureComposerExportPage",
     ]
     assert editor_tabs.currentWidget() is tool.operation_panel
     assert isinstance(tool.layout_panel.layout(), QtWidgets.QGridLayout)

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -3030,9 +3030,11 @@ def test_figure_composer_defaults_follow_stylesheet_rcparams(
             expected_export_dpi = float(expected_export_dpi)
         expected_transparent = bool(mpl.rcParams["savefig.transparent"])
         expected_bbox = mpl.rcParams["savefig.bbox"]
+        expected_padding = mpl.rcParams["savefig.pad_inches"]
 
     setup = FigureSubplotsState()
     export = FigureExportState()
+    resolved_export = figurecomposer_defaults._resolved_export_kwargs(export)
 
     assert setup.figsize == expected_figsize
     assert setup.dpi == expected_dpi
@@ -3041,9 +3043,18 @@ def test_figure_composer_defaults_follow_stylesheet_rcparams(
     assert setup.sharey == "row"
     assert setup.width_ratios == ()
     assert setup.height_ratios == ()
-    assert export.dpi == expected_export_dpi
-    assert export.transparent is expected_transparent
-    assert export.bbox_inches == expected_bbox
+    assert export == FigureExportState(
+        dpi="inherit",
+        transparent="inherit",
+        bbox_inches="inherit",
+        pad_inches="inherit",
+    )
+    assert resolved_export == {
+        "dpi": expected_export_dpi,
+        "transparent": expected_transparent,
+        "bbox_inches": expected_bbox,
+        "pad_inches": expected_padding,
+    }
 
 
 def test_figure_composer_default_dpi_option_overrides_stylesheet(

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -19,10 +19,13 @@ from erlab.interactive._options.parameters import (
     ColorListWidget,
     DirectoryPathWidget,
     FigureDpiOverrideWidget,
+    SavefigDpiWidget,
+    SavefigPaddingWidget,
     StylesheetListWidget,
 )
 from erlab.interactive._options.schema import (
     AppOptions,
+    FigureExportOptions,
     IOOptions,
     WorkspaceOptions,
     normalize_workspace_compression_mode,
@@ -294,6 +297,58 @@ def test_stylesheet_editor_fits_settings_page(dialog: OptionDialog, qtbot):
     )
 
     qtbot.waitUntil(lambda: page.horizontalScrollBar().maximum() == 0)
+
+
+def test_user_figure_export_settings_save_immediately(dialog: OptionDialog) -> None:
+    dpi = typing.cast(
+        "SavefigDpiWidget",
+        _control(
+            dialog,
+            "user",
+            "figure/export/dpi",
+            SavefigDpiWidget,
+        ),
+    )
+    padding = typing.cast(
+        "SavefigPaddingWidget",
+        _control(
+            dialog,
+            "user",
+            "figure/export/pad_inches",
+            SavefigPaddingWidget,
+        ),
+    )
+    transparent = typing.cast(
+        "QtWidgets.QComboBox",
+        _control(
+            dialog,
+            "user",
+            "figure/export/transparent",
+            QtWidgets.QComboBox,
+        ),
+    )
+    bbox = typing.cast(
+        "QtWidgets.QComboBox",
+        _control(
+            dialog,
+            "user",
+            "figure/export/bbox_inches",
+            QtWidgets.QComboBox,
+        ),
+    )
+
+    dpi.mode_combo.setCurrentIndex(dpi.mode_combo.count() - 1)
+    dpi.value_spin.setValue(300.0)
+    transparent.setCurrentIndex(transparent.findData("true"))
+    bbox.setCurrentIndex(bbox.findData("tight"))
+    padding.mode_combo.setCurrentIndex(padding.mode_combo.findData("layout"))
+
+    assert options.model.figure.export == FigureExportOptions(
+        dpi=300.0,
+        transparent="true",
+        bbox_inches="tight",
+        pad_inches="layout",
+    )
 
 
 def test_stylesheet_names_normalize_saved_values() -> None:
@@ -760,6 +815,42 @@ def test_workspace_figure_dpi_override_supports_unset_and_numeric(qtbot):
     assert manager.overrides[path] is None
 
 
+def test_workspace_figure_export_setting_overrides_user_default(qtbot) -> None:
+    path = "figure/export/dpi"
+    options.model = options.model.model_copy(
+        update={
+            "figure": options.model.figure.model_copy(
+                update={
+                    "export": options.model.figure.export.model_copy(
+                        update={"dpi": 180.0}
+                    )
+                }
+            )
+        }
+    )
+    manager = _WorkspaceManagerStub()
+    qtbot.addWidget(manager)
+    dialog = OptionDialog(manager)
+    qtbot.addWidget(dialog)
+    dialog.scope_tabs.setCurrentIndex(1)
+
+    control = typing.cast(
+        "SavefigDpiWidget",
+        _control(dialog, "workspace", path, SavefigDpiWidget),
+    )
+    override = _override(dialog, path)
+
+    assert not control.isEnabled()
+    assert control.get_value() == pytest.approx(180.0)
+    override.setChecked(True)
+    control.value_spin.setValue(240.0)
+
+    assert manager.overrides[path] == pytest.approx(240.0)
+    assert manager.effective_interactive_options.figure.export.dpi == pytest.approx(
+        240.0
+    )
+
+
 def test_workspace_control_change_without_override_is_ignored(qtbot):
     manager = _WorkspaceManagerStub()
     qtbot.addWidget(manager)
@@ -983,6 +1074,10 @@ def test_workspace_override_helpers_filter_to_curated_subset() -> None:
     assert "io/workspace/compression" in paths
     assert "io/workspace/compress" not in paths
     assert "figure/dpi" in paths
+    assert "figure/export/dpi" in paths
+    assert "figure/export/transparent" in paths
+    assert "figure/export/bbox_inches" in paths
+    assert "figure/export/pad_inches" in paths
     assert "ktool/show_angle_scale_controls" not in paths
     assert normalize_workspace_option_overrides(
         {
@@ -1041,6 +1136,7 @@ def test_options_get_set():
     assert options["io/default_directory"] == ""
     assert options["io/recent_workspace_limit"] == 20
     assert options["figure/dpi"] is None
+    assert options["figure/export/dpi"] == "style"
 
     options["colors/cmap/name"] = "viridis"
     options["io/workspace/compression"] = "blosclz3"
@@ -1048,6 +1144,8 @@ def test_options_get_set():
     options["io/recent_workspace_limit"] = 35
     options["figure/stylesheets"] = ["classic", "missing-style"]
     options["figure/dpi"] = 150.0
+    options["figure/export/dpi"] = 300.0
+    options["figure/export/transparent"] = "true"
 
     assert options["colors/cmap/name"] == "viridis"
     assert options["io/workspace/compression"] == "blosclz3"
@@ -1056,10 +1154,14 @@ def test_options_get_set():
     assert options["io/recent_workspace_limit"] == 35
     assert options["figure/stylesheets"] == ["classic", "missing-style"]
     assert options["figure/dpi"] == pytest.approx(150.0)
+    assert options["figure/export/dpi"] == pytest.approx(300.0)
+    assert options["figure/export/transparent"] == "true"
     assert options.model.io.workspace.compression == "blosclz3"
     assert options.model.io.recent_workspace_limit == 35
     assert options.model.figure.stylesheets == ["classic", "missing-style"]
     assert options.model.figure.dpi == pytest.approx(150.0)
+    assert options.model.figure.export.dpi == pytest.approx(300.0)
+    assert options.model.figure.export.transparent == "true"
 
     options["io/workspace/compress"] = False
     assert options["io/workspace/compression"] == "none"
@@ -1108,6 +1210,22 @@ def test_legacy_workspace_compress_setting_migrates(
 def test_figure_dpi_option_validates(value: object) -> None:
     with pytest.raises(pydantic.ValidationError):
         AppOptions.model_validate({"figure": {"dpi": value}})
+
+
+@pytest.mark.parametrize(
+    "export",
+    [
+        {"dpi": 0.0},
+        {"dpi": "invalid"},
+        {"pad_inches": -0.1},
+        {"pad_inches": "invalid"},
+        {"transparent": "invalid"},
+        {"bbox_inches": "invalid"},
+    ],
+)
+def test_figure_export_options_validate(export: dict[str, object]) -> None:
+    with pytest.raises(pydantic.ValidationError):
+        FigureExportOptions.model_validate(export)
 
 
 def test_option_manager_uses_configured_settings_path(monkeypatch, tmp_path):

--- a/tests/interactive/test_options_parameters.py
+++ b/tests/interactive/test_options_parameters.py
@@ -13,6 +13,8 @@ from erlab.interactive._options.parameters import (
     DirectoryPathWidget,
     FigureDpiOverrideParameter,
     FigureDpiOverrideWidget,
+    SavefigDpiParameter,
+    SavefigDpiWidget,
     StylesheetListParameter,
     StylesheetListWidget,
     _stylesheet_names,
@@ -155,6 +157,22 @@ def test_figure_dpi_override_parameter_item_widget(qtbot) -> None:
 
     widget.override_check.setChecked(False)
     assert param.value() is None
+
+
+def test_savefig_dpi_parameter_item_widget(qtbot) -> None:
+    param = SavefigDpiParameter(name="dpi", value="style")
+    item = param.makeTreeItem(0)
+    widget = item.widget
+    qtbot.addWidget(widget)
+
+    assert isinstance(widget, SavefigDpiWidget)
+    assert not item.hideWidget
+    assert widget.value() == "style"
+
+    widget.mode_combo.setCurrentIndex(widget.mode_combo.count() - 1)
+    assert param.value() == pytest.approx(100.0)
+    widget.value_spin.setValue(300.0)
+    assert param.value() == pytest.approx(300.0)
 
 
 def test_directory_path_widget_initialization(qtbot) -> None:

--- a/tests/interactive/test_options_tree.py
+++ b/tests/interactive/test_options_tree.py
@@ -51,7 +51,18 @@ def test_make_parameter_defaults_and_missing_child_continue() -> None:
 
 def test_make_parameter_round_trips_figure_options() -> None:
     options = AppOptions.model_validate(
-        {"figure": {"stylesheets": ["classic", "missing-style"], "dpi": 150.0}}
+        {
+            "figure": {
+                "stylesheets": ["classic", "missing-style"],
+                "dpi": 150.0,
+                "export": {
+                    "dpi": 300.0,
+                    "transparent": "true",
+                    "bbox_inches": "tight",
+                    "pad_inches": "layout",
+                },
+            }
+        }
     )
     param = make_parameter(options)
 
@@ -61,10 +72,22 @@ def test_make_parameter_round_trips_figure_options() -> None:
     dpi_param = param.child("figure").child("dpi")
     assert dpi_param.opts["type"] == "figure_dpi_override"
     assert dpi_param.value() == 150.0
+    export_param = param.child("figure").child("export")
+    assert export_param.child("dpi").opts["type"] == "savefig_dpi"
+    assert export_param.child("dpi").value() == 300.0
+    assert export_param.child("transparent").opts["limits"] == {
+        "Use stylesheet": "style",
+        "Enabled": "true",
+        "Disabled": "false",
+    }
+    assert export_param.child("bbox_inches").value() == "tight"
+    assert export_param.child("pad_inches").opts["type"] == "savefig_padding"
+    assert export_param.child("pad_inches").value() == "layout"
 
     opts = parameter_to_options(param)
     assert opts.figure.stylesheets == ["classic", "missing-style"]
     assert opts.figure.dpi == 150.0
+    assert opts.figure.export == options.figure.export
 
 
 def test_make_parameter_round_trips_default_directory() -> None:


### PR DESCRIPTION
## Summary

- Add per-figure export controls for DPI, transparency, bounding box, and padding.
- Add user and workspace export defaults with inheritance support.
- Resolve export settings only when saving figures.
- Keep export-only changes out of previews and generated Python code.
- Document export settings and their precedence.

## Testing

- Added coverage for export defaults, stylesheet resolution, settings persistence, and the new Export tab.
- Existing Figure Composer UI tests updated for the additional tab.