### PR TITLE
Support nested ImageTools in manager actions

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -95,16 +95,16 @@ class _ActionsController:
             )
             return
 
-        if selected_tools or any(
-            not isinstance(target, int) for target in selected_images
-        ):
+        if selected_tools:
             return
 
+        selected_nodes = [
+            self._manager._node_for_target(target) for target in selected_images
+        ]
         dlg = self._rename_dialog
-        root_selected = typing.cast("list[int]", selected_images)
         dlg.set_names(
-            root_selected,
-            [self._manager._tool_graph.root_wrappers[i].name for i in root_selected],
+            [node.uid for node in selected_nodes],
+            [node.name for node in selected_nodes],
         )
         dlg.open()
 
@@ -850,15 +850,11 @@ class _ActionsController:
         return True
 
     def store_selected(self) -> None:
+        targets = self._manager._selected_imagetool_targets()
+        if not targets:
+            return
         self._manager.ensure_console_initialized()
-        dialog = _StoreDialog(
-            self._manager,
-            [
-                target
-                for target in self._manager._selected_imagetool_targets()
-                if isinstance(target, int)
-            ],
-        )
+        dialog = _StoreDialog(self._manager, targets)
         dialog.exec()
 
     def unwatch_selected(self) -> None:

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -2142,11 +2142,22 @@ class _JupyterConsoleWidget(qtconsole.inprocess.QtInProcessRichJupyterWidget):
             self.initialize_kernel()
         super().execute(source, hidden=hidden, interactive=interactive)
 
-    def store_data_as(self, tool_index: int, name: str) -> None:
+    def store_data_as(self, node_uid: str, name: str) -> None:
         """Store the data in an ImageTool with IPython to reuse in other scripts."""
         self.initialize_kernel()
+        tools = self._tools_namespace
+        if tools is None:  # pragma: no cover - manager consoles always inject tools
+            return
+        node = tools._manager._tool_graph.nodes.get(node_uid)
+        if node is None or not node.is_imagetool:
+            return
+        path = tools._node_path(node)
+        if not path:  # pragma: no cover - registered nodes always have tree paths
+            return
+        tool_expression = f"tools[{path[0]}]"
+        tool_expression += "".join(f".children[{child_row}]" for child_row in path[1:])
         store_commands = (
-            f"{name} = tools[{tool_index}].data",
+            f"{name} = {tool_expression}.data",
             f"get_ipython().run_line_magic('store', '{name}')",
             f"del {name}",
         )

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -1528,11 +1528,10 @@ class _DetailsPanelController:
                 selection_offloadable.append(target)
 
         something_selected = bool(imagetool_targets or selection_children)
-        root_imagetool_count = len(self._manager.tree_view.selected_imagetool_indices)
         total_selected = len(imagetool_targets) + len(selection_children)
         single_selected = total_selected == 1
-        multiple_root_imagetools_selected = (
-            root_imagetool_count > 1 and root_imagetool_count == total_selected
+        multiple_imagetools_selected = (
+            len(imagetool_targets) > 1 and len(imagetool_targets) == total_selected
         )
         multiple_selected = len(imagetool_targets) > 1
 
@@ -1541,7 +1540,7 @@ class _DetailsPanelController:
         self._manager.arrange_windows_action.setEnabled(total_selected >= 2)
         self._manager.remove_action.setEnabled(something_selected)
         self._manager.rename_action.setEnabled(
-            single_selected or multiple_root_imagetools_selected
+            single_selected or multiple_imagetools_selected
         )
         self._manager.duplicate_action.setEnabled(something_selected)
         self._manager.promote_action.setEnabled(promotable_child_uid is not None)
@@ -1559,9 +1558,7 @@ class _DetailsPanelController:
         self._manager.create_figure_action.setEnabled(
             bool(self._manager._selected_figure_source_targets())
         )
-        self._manager.store_action.setEnabled(
-            bool(self._manager.tree_view.selected_imagetool_indices)
-        )
+        self._manager.store_action.setEnabled(bool(imagetool_targets))
 
         reload_relevant = reload_candidates is not None
         self._manager.reload_action.setVisible(reload_relevant)

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -583,7 +583,7 @@ class _RenameDialog(QtWidgets.QDialog):
 
         self._layout = QtWidgets.QGridLayout(self)
 
-        self._new_name_lines: dict[int, QtWidgets.QLineEdit] = {}
+        self._new_name_lines: dict[str, QtWidgets.QLineEdit] = {}
 
         # Persistent button box; we re-add it when (re)building rows
         self._button_box = QtWidgets.QDialogButtonBox(
@@ -594,7 +594,7 @@ class _RenameDialog(QtWidgets.QDialog):
         self._button_box.accepted.connect(self.accept)
         self._button_box.rejected.connect(self.reject)
 
-    def set_names(self, indices: list[int], original_names: list[str]) -> None:
+    def set_names(self, target_uids: list[str], original_names: list[str]) -> None:
         # Clear current rows but keep the button box object
         while self._layout.count():
             item = self._layout.takeAt(0)
@@ -608,8 +608,19 @@ class _RenameDialog(QtWidgets.QDialog):
             v.deleteLater()
 
         # Rebuild rows
-        for i, (tool_idx, name) in enumerate(zip(indices, original_names, strict=True)):
-            lbl_from = QtWidgets.QLabel(f"{tool_idx}: {name}")
+        manager = self._manager()
+        if manager is None:  # pragma: no cover - dialog cannot outlive its parent
+            return
+
+        for i, (uid, name) in enumerate(zip(target_uids, original_names, strict=True)):
+            node = manager._node_for_target(uid)
+            path = manager._tool_graph.node_path(node)
+            display_index = (
+                ".".join(str(index) for index in path)
+                if path is not None
+                else node.uid[:8]
+            )
+            lbl_from = QtWidgets.QLabel(f"{display_index}: {name}")
             lbl_arrow = QtWidgets.QLabel("→")
             line_new = QtWidgets.QLineEdit(name)
             line_new.setPlaceholderText("New name")
@@ -617,7 +628,7 @@ class _RenameDialog(QtWidgets.QDialog):
             self._layout.addWidget(lbl_from, i, 0)
             self._layout.addWidget(lbl_arrow, i, 1)
             self._layout.addWidget(line_new, i, 2)
-            self._new_name_lines[tool_idx] = line_new
+            self._new_name_lines[uid] = line_new
 
         # Resize inputs to longest current text
         if self._new_name_lines:  # pragma: no branch
@@ -632,66 +643,107 @@ class _RenameDialog(QtWidgets.QDialog):
         # Re-add button box at the last row
         self._layout.addWidget(self._button_box, len(original_names), 0, 1, 3)
 
-    def new_names(self) -> list[tuple[int, str]]:
-        return [(idx, w.text()) for idx, w in self._new_name_lines.items()]
+    def new_names(self) -> list[tuple[str, str]]:
+        return [(uid, line.text()) for uid, line in self._new_name_lines.items()]
 
     def accept(self) -> None:
         manager = self._manager()
         if manager is not None:  # pragma: no branch
-            for index, new_name in self.new_names():
-                manager.rename_imagetool(index, new_name)
+            model = manager.tree_view._model
+            for uid, new_name in self.new_names():
+                index = model._row_index(uid)
+                if index.isValid():
+                    model.setData(index, new_name)
         super().accept()
 
 
 class _StoreDialog(QtWidgets.QDialog):
-    def __init__(self, manager: ImageToolManager, target_indices: list[int]) -> None:
+    def __init__(self, manager: ImageToolManager, targets: list[int | str]) -> None:
         super().__init__(manager)
         self.setWindowTitle("Store with IPython")
         self._manager = weakref.ref(manager)
-        self._target_indices: list[int] = target_indices
+        self._target_uids: list[str] = []
 
         self._layout = QtWidgets.QFormLayout()
         self.setLayout(self._layout)
 
         self._var_name_lines: list[QtWidgets.QLineEdit] = []
+        used_names: set[str] = set()
 
         self._layout.addRow("Data to store", QtWidgets.QLabel("Stored name"))
 
-        for tool_idx in target_indices:
-            data = manager.get_imagetool(tool_idx).slicer_area.displayed_data
-            wrapper = manager._tool_graph.root_wrappers[tool_idx]
-            default_name = data.name
-            if not erlab.utils.misc._is_valid_identifier(default_name):
-                if erlab.utils.misc._is_valid_identifier(wrapper.name):
-                    default_name = wrapper.name
-                else:
-                    default_name = f"data_{tool_idx}"
+        for target in targets:
+            node = manager._node_for_target(target)
+            if not node.is_imagetool:
+                raise TypeError(f"Target {target!r} is not an ImageTool")
+            data = manager.get_imagetool(target).slicer_area.displayed_data
+            self._target_uids.append(node.uid)
+            path = manager._tool_graph.node_path(node)
+            if path is None:  # pragma: no cover - registered targets have paths
+                uid_name = "".join(char if char.isalnum() else "_" for char in node.uid)
+                path_name = f"data_{uid_name[:8]}"
+            else:
+                path_name = "data_" + "_".join(str(index) for index in path)
+
+            if erlab.utils.misc._is_valid_identifier(data.name):
+                default_name = str(data.name)
+            elif erlab.utils.misc._is_valid_identifier(node.name):
+                default_name = node.name
+            else:
+                default_name = path_name
+
+            if default_name in used_names:
+                default_name = path_name
+            name_stem = default_name
+            suffix = 2
+            while default_name in used_names:
+                default_name = f"{name_stem}_{suffix}"
+                suffix += 1
+            used_names.add(default_name)
 
             line_new = QtWidgets.QLineEdit(str(default_name))
             line_new.setPlaceholderText("Enter variable name")
             line_new.setValidator(erlab.interactive.utils.IdentifierValidator())
-            self._layout.addRow(wrapper.label_text, line_new)
+            self._layout.addRow(node.display_text, line_new)
             self._var_name_lines.append(line_new)
 
-        button_box = QtWidgets.QDialogButtonBox(
+        self._button_box = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
             | QtWidgets.QDialogButtonBox.StandardButton.Cancel
         )
-        button_box.accepted.connect(self.accept)
-        button_box.rejected.connect(self.reject)
-        self._layout.addRow(button_box)
+        self._button_box.accepted.connect(self.accept)
+        self._button_box.rejected.connect(self.reject)
+        self._layout.addRow(self._button_box)
+        for line in self._var_name_lines:
+            line.textChanged.connect(self._update_accept_enabled)
+        self._update_accept_enabled()
 
-    def var_name_map(self) -> dict[int, str]:
+    def var_name_map(self) -> dict[str, str]:
         return {
-            idx: w.text()
-            for idx, w in zip(self._target_indices, self._var_name_lines, strict=True)
+            uid: line.text()
+            for uid, line in zip(self._target_uids, self._var_name_lines, strict=True)
         }
 
+    def _store_names_are_valid(self) -> bool:
+        names = [line.text() for line in self._var_name_lines]
+        return (
+            bool(names)
+            and all(line.hasAcceptableInput() for line in self._var_name_lines)
+            and len(names) == len(set(names))
+        )
+
+    def _update_accept_enabled(self, *_args: object) -> None:
+        button = self._button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        if button is not None:  # pragma: no branch - the dialog always has this button
+            button.setEnabled(self._store_names_are_valid())
+
     def accept(self) -> None:
+        if not self._store_names_are_valid():
+            return
         manager = self._manager()
         if manager is not None:
-            for idx, var_name in self.var_name_map().items():
-                manager.console._console_widget.store_data_as(idx, var_name)
+            for uid, var_name in self.var_name_map().items():
+                manager.console._console_widget.store_data_as(uid, var_name)
         super().accept()
 
 

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -185,19 +185,24 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                     type_rect, _, _ = self._compute_tool_type_info(option, child_node)
                     if type_rect is not None:
                         rect.setLeft(type_rect.right() + self.tool_type_rect_gap + 1)
-                    _, dask_rect, _, _ = self._compute_icons_info(option, child_node)
+                    _, dask_rect, link_rect, _ = self._compute_icons_info(
+                        option, child_node
+                    )
+                    icon_edge = self._right_badge_edge(dask_rect, link_rect)
                     status_rect, _, _ = self._compute_child_status_info(
                         option,
                         child_node,
-                        right_edge=self._right_badge_edge(dask_rect),
+                        right_edge=icon_edge,
                     )
                     if status_rect is None:
                         status_rect, _, _ = self._compute_dependency_status_info(
                             option,
                             child_node,
-                            right_edge=self._right_badge_edge(dask_rect),
+                            right_edge=icon_edge,
                         )
-                    right_badge_rect = self._leftmost_rect(status_rect, dask_rect)
+                    right_badge_rect = self._leftmost_rect(
+                        status_rect, dask_rect, link_rect
+                    )
                     if right_badge_rect is not None:
                         rect.setRight(right_badge_rect.left() - self.icon_right_pad)
             rect.setTop(rect.center().y() - editor.sizeHint().height() / 2)
@@ -289,7 +294,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         QtCore.QRect | None,
     ]:
         # Determine which icons should be visible
-        is_linked = isinstance(node, _ImageToolWrapper) and node.workspace_linked
+        is_linked = node.is_imagetool and node.workspace_linked
         is_watched: bool = (
             isinstance(node, _ImageToolWrapper) and node._watched_varname is not None
         )
@@ -378,6 +383,31 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             ),
             QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter,
         )
+
+    def _paint_link_icon(
+        self,
+        painter: QtGui.QPainter,
+        option: QtWidgets.QStyleOptionViewItem,
+        link_rect: QtCore.QRect,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+    ) -> None:
+        link_color: QtGui.QColor | None = None
+        if node.workspace_link_key is not None:
+            link_color = self.manager.color_for_workspace_link_key(
+                node.workspace_link_key
+            )
+        elif node.imagetool is not None:
+            proxy = node.slicer_area._linking_proxy
+            if proxy is not None:
+                link_color = self.manager.color_for_linker(proxy)
+        if link_color is None:
+            return
+        color_key = link_color.rgba()
+        link_icon = self._link_icon_cache.get(color_key)
+        if link_icon is None:
+            link_icon = qta.icon("mdi6.link-variant", color=link_color)
+            self._link_icon_cache[color_key] = link_icon
+        self._paint_icon(painter, option, link_rect, link_icon)
 
     @functools.cached_property
     def _dask_icon(self) -> QtGui.QIcon:
@@ -484,22 +514,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             self._paint_icon(painter, option, dask_rect, self._dask_icon)
 
         if link_rect:
-            link_color: QtGui.QColor | None = None
-            if tool_wrapper.workspace_link_key is not None:
-                link_color = self.manager.color_for_workspace_link_key(
-                    tool_wrapper.workspace_link_key
-                )
-            else:
-                proxy = tool_wrapper.slicer_area._linking_proxy
-                if proxy is not None:
-                    link_color = self.manager.color_for_linker(proxy)
-            if link_color is not None:
-                color_key = link_color.rgba()
-                link_icon = self._link_icon_cache.get(color_key)
-                if link_icon is None:
-                    link_icon = qta.icon("mdi6.link-variant", color=link_color)
-                    self._link_icon_cache[color_key] = link_icon
-                self._paint_icon(painter, option, link_rect, link_icon)
+            self._paint_link_icon(painter, option, link_rect, tool_wrapper)
 
         if watched_rect:
             palette = option.palette
@@ -584,6 +599,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         status_text: str | None = None
         status_color: QtGui.QColor | None = None
         dask_rect: QtCore.QRect | None = None
+        link_rect: QtCore.QRect | None = None
         try:
             child_node = self.manager._child_node(index.internalPointer())
         except KeyError:
@@ -592,18 +608,19 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             type_rect, type_text, type_color = self._compute_tool_type_info(
                 option, child_node
             )
-            _, dask_rect, _, _ = self._compute_icons_info(option, child_node)
+            _, dask_rect, link_rect, _ = self._compute_icons_info(option, child_node)
+            icon_edge = self._right_badge_edge(dask_rect, link_rect)
             status_rect, status_text, status_color = self._compute_child_status_info(
                 option,
                 child_node,
-                right_edge=self._right_badge_edge(dask_rect),
+                right_edge=icon_edge,
             )
             if status_rect is None:
                 status_rect, status_text, status_color = (
                     self._compute_dependency_status_info(
                         option,
                         child_node,
-                        right_edge=self._right_badge_edge(dask_rect),
+                        right_edge=icon_edge,
                     )
                 )
 
@@ -639,7 +656,7 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             text_rect = QtCore.QRect(option.rect)
             if type_rect is not None:
                 text_rect.setLeft(type_rect.right() + self.tool_type_rect_gap + 1)
-            right_badge_rect = self._leftmost_rect(status_rect, dask_rect)
+            right_badge_rect = self._leftmost_rect(status_rect, dask_rect, link_rect)
             if right_badge_rect is not None:
                 text_rect.setRight(right_badge_rect.left() - self.icon_right_pad)
 
@@ -657,6 +674,8 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
             )
             if dask_rect:
                 self._paint_icon(painter, option, dask_rect, self._dask_icon)
+            if link_rect and child_node is not None:
+                self._paint_link_icon(painter, option, link_rect, child_node)
             if status_rect and status_text and status_color:
                 _fill_rounded_rect(
                     painter,
@@ -848,6 +867,32 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
         option.widget = view
         return option
 
+    def _link_badge_at(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        link_rect: QtCore.QRect | None,
+        pos: QtCore.QPoint,
+    ) -> _RowBadge | None:
+        if (
+            link_rect is None
+            or not node.workspace_linked
+            or not link_rect.contains(pos)
+        ):
+            return None
+        proxy = None if node.imagetool is None else node.slicer_area._linking_proxy
+        if proxy is not None:
+            linker_index = self.manager.linker_index(proxy)
+            return _RowBadge(
+                "link",
+                link_rect,
+                f"Linked (#{linker_index}). Click to unlink this window.",
+            )
+        return _RowBadge(
+            "link",
+            link_rect,
+            "Linked. Click to unlink this window.",
+        )
+
     def _badge_at(
         self,
         option: QtWidgets.QStyleOptionViewItem,
@@ -858,8 +903,8 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
 
         The ordering here mirrors the visual layout. For top-level rows the badges are
         right-aligned; for child rows the tool-type badge is checked before right-side
-        dask and source status badges. Tooltip, cursor, and click paths all call this
-        method so any badge geometry change has one source of truth.
+        dask, link, and source status badges. Tooltip, cursor, and click paths all call
+        this method so any badge geometry change has one source of truth.
         """
         if not index.isValid():
             return None
@@ -894,26 +939,9 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                     dask_rect,
                     tooltip,
                 )
-            if (
-                link_rect is not None
-                and node.workspace_linked
-                and link_rect.contains(pos)
-            ):
-                proxy = (
-                    None if node.imagetool is None else node.slicer_area._linking_proxy
-                )
-                if proxy is not None:
-                    linker_index = self.manager.linker_index(proxy)
-                    return _RowBadge(
-                        "link",
-                        link_rect,
-                        f"Linked (#{linker_index}). Click to unlink this window.",
-                    )
-                return _RowBadge(
-                    "link",
-                    link_rect,
-                    "Linked. Click to unlink this window.",
-                )
+            link_badge = self._link_badge_at(node, link_rect, pos)
+            if link_badge is not None:
+                return link_badge
             if watched_rect is not None and watched_rect.contains(pos):
                 varname = str(node._watched_varname)
                 if node._watched_connected:
@@ -949,18 +977,19 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                 f"Tool type: {type_text}. Click to show this tool.",
             )
 
-        _, dask_rect, _, _ = self._compute_icons_info(option, child_node)
+        _, dask_rect, link_rect, _ = self._compute_icons_info(option, child_node)
+        icon_edge = self._right_badge_edge(dask_rect, link_rect)
         status_rect, _, _ = self._compute_child_status_info(
             option,
             child_node,
-            right_edge=self._right_badge_edge(dask_rect),
+            right_edge=icon_edge,
         )
         source_status = status_rect is not None
         if status_rect is None:
             status_rect, _, _ = self._compute_dependency_status_info(
                 option,
                 child_node,
-                right_edge=self._right_badge_edge(dask_rect),
+                right_edge=icon_edge,
             )
         if dask_rect is not None and dask_rect.contains(pos):
             tooltip = (
@@ -973,6 +1002,10 @@ class _ImageToolWrapperItemDelegate(QtWidgets.QStyledItemDelegate):
                 dask_rect,
                 tooltip,
             )
+
+        link_badge = self._link_badge_at(child_node, link_rect, pos)
+        if link_badge is not None:
+            return link_badge
 
         if status_rect is None or not status_rect.contains(pos):
             return None
@@ -2066,6 +2099,13 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
             case "link":
                 if isinstance(node, _ImageToolWrapper):
                     self._unlink_badge_target(node)
+                elif isinstance(node, str):
+                    try:
+                        child_node = self._model.manager._child_node(node)
+                    except KeyError:
+                        return
+                    if child_node.is_imagetool:
+                        self._unlink_badge_target(child_node)
             case "watched":
                 if isinstance(node, _ImageToolWrapper):
                     self._show_watched_badge_menu(node, badge.rect)
@@ -2106,8 +2146,10 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
             return
         tool._dask_menu.popup(viewport.mapToGlobal(badge_rect.bottomLeft()))
 
-    def _unlink_badge_target(self, wrapper: _ImageToolWrapper) -> None:
-        """Confirm and unlink only the ImageTool represented by ``wrapper``."""
+    def _unlink_badge_target(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> None:
+        """Confirm and unlink only the ImageTool represented by ``node``."""
         if (
             QtWidgets.QMessageBox.question(
                 self._model.manager,
@@ -2122,8 +2164,8 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
             return
 
         manager = self._model.manager
-        manager._actions_controller.unlink_imagetool_nodes((wrapper,))
-        self.refresh(wrapper.index)
+        manager._actions_controller.unlink_imagetool_nodes((node,))
+        self.refresh(node.index if isinstance(node, _ImageToolWrapper) else node.uid)
 
     def _show_watched_badge_menu(
         self, wrapper: _ImageToolWrapper, badge_rect: QtCore.QRect

--- a/tests/interactive/imagetool/manager/provenance/test_dependencies.py
+++ b/tests/interactive/imagetool/manager/provenance/test_dependencies.py
@@ -40,6 +40,7 @@ from erlab.interactive.imagetool._provenance._operations import (
 )
 from erlab.interactive.imagetool.dialogs import SelectionDialog
 from erlab.interactive.imagetool.manager import fetch, replace_data
+from erlab.interactive.imagetool.manager._dialogs import _RenameDialog
 from erlab.interactive.imagetool.manager._modelview import (
     _NODE_UID_ROLE,
     _ImageToolWrapperItemDelegate,
@@ -2252,6 +2253,7 @@ def test_manager_promote_action_enablement_and_menus(
 
 def test_manager_rename_action_enablement_for_child_selection(
     qtbot,
+    accept_dialog,
     test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -2276,6 +2278,16 @@ def test_manager_rename_action_enablement_for_child_selection(
             timeout=5000,
         )
         nested_uid = manager._child_node(child_uid)._childtool_indices[0]
+        child_tool.slicer_area.images[0].open_in_new_window()
+        qtbot.wait_until(
+            lambda: len(manager._child_node(child_uid)._childtool_indices) == 2,
+            timeout=5000,
+        )
+        nested_image_uid = next(
+            uid
+            for uid in manager._child_node(child_uid)._childtool_indices
+            if manager._is_imagetool_target(uid)
+        )
 
         manager.tree_view.clearSelection()
         select_child_tool(manager, child_uid)
@@ -2284,7 +2296,21 @@ def test_manager_rename_action_enablement_for_child_selection(
 
         select_tools(manager, [0])
         manager._update_actions()
-        assert not manager.rename_action.isEnabled()
+        assert manager.rename_action.isEnabled()
+
+        root_uid = parent.uid
+
+        def _rename_mixed_targets(dialog: _RenameDialog) -> None:
+            assert set(dialog._new_name_lines) == {root_uid, child_uid}
+            dialog._new_name_lines[root_uid].setText("renamed_root")
+            dialog._new_name_lines[child_uid].setText("renamed_child")
+
+        accept_dialog(
+            manager.rename_action.trigger,
+            pre_call=_rename_mixed_targets,
+        )
+        assert parent.name == "renamed_root"
+        assert manager._child_node(child_uid).name == "renamed_child"
 
         manager.tree_view.clearSelection()
         select_child_tool(manager, nested_uid)
@@ -2317,6 +2343,67 @@ def test_manager_rename_action_enablement_for_child_selection(
         select_child_tool(manager, nested_uid)
         manager._update_actions()
         assert not manager.rename_action.isEnabled()
+
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, child_uid)
+        select_child_tool(manager, nested_image_uid)
+        manager._update_actions()
+        assert manager.rename_action.isEnabled()
+
+        child_name = manager._child_node(child_uid).name
+        nested_image_name = manager._child_node(nested_image_uid).name
+
+        def _prepare_cancelled_rename(dialog: _RenameDialog) -> None:
+            assert set(dialog._new_name_lines) == {child_uid, nested_image_uid}
+            dialog._new_name_lines[child_uid].setText("cancelled_child")
+            dialog._new_name_lines[nested_image_uid].setText("cancelled_nested")
+
+        accept_dialog(
+            manager.rename_action.trigger,
+            pre_call=_prepare_cancelled_rename,
+            accept_call=lambda dialog: dialog.reject(),
+        )
+        assert manager._child_node(child_uid).name == child_name
+        assert manager._child_node(nested_image_uid).name == nested_image_name
+
+        def _rename_nested_targets(dialog: _RenameDialog) -> None:
+            dialog._new_name_lines[child_uid].setText("renamed_child_again")
+            dialog._new_name_lines[nested_image_uid].setText("renamed_nested")
+
+        accept_dialog(
+            manager.rename_action.trigger,
+            pre_call=_rename_nested_targets,
+        )
+        assert manager._child_node(child_uid).name == "renamed_child_again"
+        assert manager._child_node(nested_image_uid).name == "renamed_nested"
+
+
+def test_manager_batch_rename_tracks_uids_across_root_reindex(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        itool([test_data, test_data.copy(deep=True)], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        first = manager._tool_graph.root_wrappers[0]
+        second = manager._tool_graph.root_wrappers[1]
+        dialog = _RenameDialog(manager)
+        qtbot.addWidget(dialog)
+        dialog.set_names([first.uid, second.uid], [first.name, second.name])
+        dialog._new_name_lines[first.uid].setText("removed")
+        dialog._new_name_lines[second.uid].setText("surviving")
+
+        manager.remove_imagetool(0)
+        manager.reindex()
+        dialog.accept()
+
+        assert manager._tool_graph.root_wrappers[0].uid == second.uid
+        assert manager._tool_graph.root_wrappers[0].name == "surviving"
 
 
 def test_manager_promote_selected_cancel_keeps_nested_imagetool(

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from IPython.core.interactiveshell import InteractiveShell
+from IPython.external.pickleshare import PickleShareDB
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
@@ -45,7 +46,7 @@ from erlab.interactive.imagetool._provenance._operations import (
 from erlab.interactive.imagetool.manager import fetch
 from erlab.interactive.imagetool.manager._console import ToolNamespace
 from erlab.interactive.imagetool.manager._details_panel import _DetailsPanelController
-from erlab.interactive.imagetool.manager._dialogs import _ConcatDialog
+from erlab.interactive.imagetool.manager._dialogs import _ConcatDialog, _StoreDialog
 from erlab.interactive.imagetool.manager._tool_graph import _ManagerToolGraph
 
 from .helpers import (
@@ -80,6 +81,7 @@ def _record_reload_unavailable_dialog(monkeypatch: pytest.MonkeyPatch) -> list[s
 def test_manager_console(
     qtbot,
     accept_dialog,
+    tmp_path: pathlib.Path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -129,6 +131,7 @@ def test_manager_console(
             "lst = [1]\nalias = lst\nlst += [2]",
         )
         shell = manager.console._console_widget.kernel_manager.kernel.shell
+        shell.db = PickleShareDB(str(tmp_path / "ipython-store"))
         assert shell.user_ns["lst"] == [1, 2]
         assert shell.user_ns["alias"] is shell.user_ns["lst"]
 
@@ -146,7 +149,6 @@ def test_manager_console(
 
         # Test storing with ipython
         accept_dialog(manager.store_action.trigger)
-        manager.console._console_widget.execute(r"%store -d data_0 data_1")
 
         # Test setting data
         manager.console._console_widget.execute(
@@ -192,6 +194,158 @@ def test_manager_console(
         # Destroy console
         manager.console._console_widget.shutdown_kernel()
         InteractiveShell.clear_instance()
+
+
+def test_store_selected_supports_root_and_nested_child_imagetools(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    accept_dialog,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    class _StoreTreeTool(erlab.interactive.utils.ToolWindow):
+        tool_name = "dtool"
+
+    root_data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("x", "y"),
+        name="signal",
+    )
+    child_data = (root_data + 10.0).rename("signal")
+
+    with manager_context() as manager:
+        manager.show()
+        root_tool = itool(root_data, manager=False, execute=False)
+        assert isinstance(root_tool, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root_tool, show=False)
+        root_uid = manager._tool_graph.root_wrappers[0].uid
+
+        intermediate_uid = manager.add_childtool(_StoreTreeTool(), 0, show=False)
+        child_tool = itool(child_data, manager=False, execute=False)
+        assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child_tool, intermediate_uid, show=False
+        )
+
+        manager.tree_view.clearSelection()
+        manager._update_actions()
+        assert not manager.store_action.isEnabled()
+        initialize_calls: list[None] = []
+        with monkeypatch.context() as context:
+            context.setattr(
+                manager,
+                "ensure_console_initialized",
+                lambda: initialize_calls.append(None),
+            )
+            manager.store_selected()
+        assert initialize_calls == []
+
+        manager.ensure_console_initialized()
+        console_widget = manager.console._console_widget
+        console_widget.initialize_kernel()
+        shell = console_widget.kernel_manager.kernel.shell
+        shell.db = PickleShareDB(str(tmp_path / "ipython-store"))
+
+        select_child_tool(manager, child_uid)
+        manager._update_actions()
+        assert manager.store_action.isEnabled()
+
+        def _prepare_child_store(dialog: _StoreDialog) -> None:
+            assert dialog._target_uids == [child_uid]
+            assert dialog._var_name_lines[0].text() == "signal"
+            dialog._var_name_lines[0].setText("stored_nested_child")
+
+        accept_dialog(
+            manager.store_action.trigger,
+            pre_call=_prepare_child_store,
+        )
+        assert "stored_nested_child" not in shell.user_ns
+        console_widget.execute("%store -r stored_nested_child", hidden=True)
+        xr.testing.assert_identical(shell.user_ns["stored_nested_child"], child_data)
+
+        executed: list[str | None] = []
+        with monkeypatch.context() as context:
+            context.setattr(
+                console_widget,
+                "execute",
+                lambda source=None, **_kwargs: executed.append(source),
+            )
+            console_widget.store_data_as("missing", "missing_data")
+            console_widget.store_data_as(intermediate_uid, "tool_data")
+        assert executed == []
+
+        with pytest.raises(TypeError, match="not an ImageTool"):
+            _StoreDialog(manager, [intermediate_uid])
+
+        manager.tree_view.clearSelection()
+        select_tools(manager, [0])
+        select_child_tool(manager, child_uid)
+        manager._update_actions()
+        assert manager.store_action.isEnabled()
+
+        stored_names = {
+            root_uid: "stored_root",
+            child_uid: "stored_nested_child_mixed",
+        }
+
+        def _prepare_mixed_store(dialog: _StoreDialog) -> None:
+            assert dialog._target_uids == [root_uid, child_uid]
+            assert [line.text() for line in dialog._var_name_lines] == [
+                "signal",
+                "data_0_0_0",
+            ]
+            ok_button = dialog._button_box.button(
+                QtWidgets.QDialogButtonBox.StandardButton.Ok
+            )
+            assert ok_button is not None
+            dialog._var_name_lines[0].setText("duplicate_name")
+            dialog._var_name_lines[1].setText("duplicate_name")
+            assert not ok_button.isEnabled()
+            for uid, line in zip(
+                dialog._target_uids, dialog._var_name_lines, strict=True
+            ):
+                line.setText(stored_names[uid])
+            assert ok_button.isEnabled()
+
+        accept_dialog(
+            manager.store_action.trigger,
+            pre_call=_prepare_mixed_store,
+        )
+        console_widget.execute(
+            "%store -r stored_root stored_nested_child_mixed", hidden=True
+        )
+        xr.testing.assert_identical(shell.user_ns["stored_root"], root_data)
+        xr.testing.assert_identical(
+            shell.user_ns["stored_nested_child_mixed"], child_data
+        )
+
+        manager.tree_view.clearSelection()
+        select_child_tool(manager, child_uid)
+        manager._update_actions()
+        store_calls: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            console_widget,
+            "store_data_as",
+            lambda uid, name: store_calls.append((uid, name)),
+        )
+
+        invalid_dialog = _StoreDialog(manager, [0, child_uid])
+        qtbot.addWidget(invalid_dialog)
+        for line in invalid_dialog._var_name_lines:
+            line.setText("duplicate_name")
+        invalid_dialog.accept()
+        assert store_calls == []
+
+        accept_dialog(
+            manager.store_action.trigger,
+            pre_call=lambda dialog: dialog._var_name_lines[0].setText(
+                "cancelled_store"
+            ),
+            accept_call=lambda dialog: dialog.reject(),
+        )
+        assert store_calls == []
 
 
 def test_manager_console_show_event_defers_kernel_initialization(

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -5508,10 +5508,13 @@ def test_manager(
 
         # Batch renaming
         select_tools(manager, [1, 2])
+        selected_uids = {
+            index: manager._tool_graph.root_wrappers[index].uid for index in (1, 2)
+        }
 
         def _handle_renaming(dialog: _RenameDialog):
-            dialog._new_name_lines[1].setText("new_name_1")
-            dialog._new_name_lines[2].setText("new_name_2")
+            dialog._new_name_lines[selected_uids[1]].setText("new_name_1")
+            dialog._new_name_lines[selected_uids[2]].setText("new_name_2")
 
         accept_dialog(manager.rename_action.trigger, pre_call=_handle_renaming)
         assert manager._tool_graph.root_wrappers[1].name == "new_name_1"

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -616,6 +616,8 @@ def test_childtool_hover_preview_hides_missing_imageitem_pixmap(
         type_badge_text="",
         source_state="fresh",
         source_auto_update=False,
+        is_imagetool=False,
+        workspace_linked=False,
         imagetool=None,
         pending_workspace_tool_payload=None,
         tool_window=types.SimpleNamespace(
@@ -881,6 +883,130 @@ def test_link_selected_aligns_to_current_child_imagetool(
         )
         assert not child.slicer_area.undoable
         assert not target.slicer_area.undoable
+
+
+def test_linked_child_imagetool_badge_is_interactive(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.zeros((5, 5)), dims=("x", "y"))
+        tools: list[erlab.interactive.imagetool.ImageTool] = []
+        for _ in range(3):
+            tool = itool(data, manager=False, execute=False)
+            assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(tool, show=False)
+            tools.append(tool)
+
+        child = itool(data, manager=False, execute=False)
+        assert isinstance(child, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(
+            child,
+            0,
+            show=False,
+            source_spec=full_data(),
+            source_auto_update=True,
+        )
+        manager.link_imagetools(1, 2, child_uid, link_colors=False)
+
+        view = manager.tree_view
+        model = view._model
+        delegate = view._delegate
+        root_index = model._row_index(0)
+        child_index = model._row_index(child_uid)
+        view.expand(root_index)
+        qtbot.wait_until(lambda: not view.visualRect(child_index).isEmpty())
+
+        child_node = manager._child_node(child_uid)
+        option = delegate._option_for_index(view, child_index)
+        _, dask_rect, link_rect, _ = delegate._compute_icons_info(option, child_node)
+        assert dask_rect is None
+        assert link_rect is not None
+
+        status_rect, _, _ = delegate._compute_child_status_info(
+            option,
+            child_node,
+            right_edge=delegate._right_badge_edge(dask_rect, link_rect),
+        )
+        assert status_rect is not None
+        assert status_rect.right() < link_rect.left()
+        assert (
+            delegate._badge_at(option, child_index, link_rect.center()).kind == "link"
+        )
+        assert (
+            delegate._badge_at(option, child_index, status_rect.center()).kind
+            == "source_status"
+        )
+
+        editor = QtWidgets.QLineEdit(view)
+        qtbot.addWidget(editor)
+        delegate.updateEditorGeometry(editor, option, child_index)
+        assert editor.geometry().right() < status_rect.left()
+
+        with monkeypatch.context() as patch:
+            patch.setattr(child_node, "_source_auto_update", False)
+            patch.setattr(
+                manager,
+                "dependency_status_for_uid",
+                lambda uid: "changed" if uid == child_uid else None,
+            )
+            dependency_rect, _, _ = delegate._compute_dependency_status_info(
+                option,
+                child_node,
+                right_edge=delegate._right_badge_edge(dask_rect, link_rect),
+            )
+            assert dependency_rect is not None
+            assert dependency_rect.right() < link_rect.left()
+
+            dependency_editor = QtWidgets.QLineEdit(view)
+            qtbot.addWidget(dependency_editor)
+            delegate.updateEditorGeometry(dependency_editor, option, child_index)
+            assert dependency_editor.geometry().right() < dependency_rect.left()
+
+            dependency_canvas = QtGui.QPixmap(option.rect.size())
+            dependency_canvas.fill(QtGui.QColor("white"))
+            dependency_painter = QtGui.QPainter(dependency_canvas)
+            try:
+                delegate.paint(dependency_painter, option, child_index)
+            finally:
+                dependency_painter.end()
+
+        delegate._link_icon_cache.clear()
+        canvas = QtGui.QPixmap(option.rect.size())
+        canvas.fill(QtGui.QColor("white"))
+        painter = QtGui.QPainter(canvas)
+        try:
+            delegate.paint(painter, option, child_index)
+        finally:
+            painter.end()
+        link_key = child_node.workspace_link_key
+        assert link_key is not None
+        link_color = manager.color_for_workspace_link_key(link_key)
+        assert link_color.rgba() in delegate._link_icon_cache
+
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        click_tree_view_pos(view, link_rect.center())
+        assert child.slicer_area.is_linked
+        assert all(tool.slicer_area.is_linked for tool in tools[1:])
+
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+        )
+        click_tree_view_pos(view, link_rect.center())
+        assert not child.slicer_area.is_linked
+        assert not child_node.workspace_linked
+        assert all(tool.slicer_area.is_linked for tool in tools[1:])
+        assert delegate._compute_icons_info(option, child_node)[2] is None
 
 
 def test_link_badge_falls_back_to_live_linker(

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -147,6 +147,91 @@ def test_manager_workspace_restore_hidden_memory_link_group_keeps_payload_pendin
         assert link_color != option.palette.color(QtGui.QPalette.ColorRole.Mid)
 
 
+def test_manager_workspace_pending_child_link_badge_unlinks_without_materializing(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(25.0).reshape((5, 5)), dims=("x", "y"))
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        root.hide()
+
+        child_uids: list[str] = []
+        for offset in (100.0, 200.0):
+            child = itool(data + offset, manager=False, execute=False)
+            assert isinstance(child, erlab.interactive.imagetool.ImageTool)
+            child_uids.append(manager.add_imagetool_child(child, 0, show=False))
+            child.hide()
+        manager.link_imagetools(*child_uids, link_colors=False)
+
+        fname = tmp_path / "pending-child-link-badge.itws"
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        child_nodes = [manager._child_node(uid) for uid in child_uids]
+        assert all(node.imagetool is None for node in child_nodes)
+        assert all(
+            node.pending_workspace_memory_payload is not None for node in child_nodes
+        )
+        assert all(node.workspace_linked for node in child_nodes)
+
+        view = manager.tree_view
+        delegate = view._delegate
+        child_index = view._model._row_index(child_uids[0])
+        option = QtWidgets.QStyleOptionViewItem()
+        delegate.initStyleOption(option, child_index)
+        option.rect = QtCore.QRect(0, 0, 240, 25)
+        option.widget = view
+        _, _, link_rect, _ = delegate._compute_icons_info(option, child_nodes[0])
+        assert link_rect is not None
+        badge = delegate._badge_at(option, child_index, link_rect.center())
+        assert badge is not None
+        assert badge.kind == "link"
+
+        delegate._link_icon_cache.clear()
+        canvas = QtGui.QPixmap(option.rect.size())
+        canvas.fill(QtGui.QColor("white"))
+        painter = QtGui.QPainter(canvas)
+        try:
+            delegate.paint(painter, option, child_index)
+        finally:
+            painter.end()
+        link_key = child_nodes[0].workspace_link_key
+        assert link_key is not None
+        link_color = manager.color_for_workspace_link_key(link_key)
+        assert link_color.rgba() in delegate._link_icon_cache
+
+        def _fail_materialize_pending_payload(_node) -> bool:
+            pytest.fail("unlinking a child badge should not materialize hidden data")
+
+        monkeypatch.setattr(
+            manager._workspace_controller.loading.pending,
+            "_materialize_pending_workspace_payload",
+            _fail_materialize_pending_payload,
+        )
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+        )
+        view._handle_badge_click(child_index, badge)
+
+        assert all(node.imagetool is None for node in child_nodes)
+        assert all(
+            node.pending_workspace_memory_payload is not None for node in child_nodes
+        )
+        assert all(not node.workspace_linked for node in child_nodes)
+
+
 def test_manager_workspace_mixed_pending_link_badge_uses_group_color(
     qtbot,
     tmp_path,


### PR DESCRIPTION
## Summary

- Support renaming and storing root and nested ImageTools by stable node UID.
- Preserve nested tool paths when storing data in IPython.
- Enable link badges and unlink actions for managed child ImageTools.
- Validate stored variable names and prevent duplicates.

## Testing

- Added regression coverage for nested and mixed selections, batch rename after root reindexing, IPython storage, invalid targets, duplicate names, and link badge behavior.