### PR TITLE
feat(analysis.gold): add adaptive Fermi-edge ranges

### DIFF
--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -18,6 +18,10 @@ description: Conduct, teach, and automate reproducible ARPES analysis with ERLab
 - Put all input paths, physical parameters, fit choices, and calibration values in
   visible cells. Do not rely on hidden kernel or GUI state.
 - Use public ERLabPy and xarray-lmfit APIs in copied or generated code.
+- Treat a static normal-emission estimate as a candidate, regardless of agent
+  confidence. For publication or quantitative momentum conversion, require an approved
+  calibration. If none exists, open ImageTool or KTool for the user and wait for the
+  accepted values before momentum conversion.
 
 ## Coordinate compatible skills
 
@@ -64,6 +68,13 @@ analysis notebook executable when no optional Qt binding is installed.
 - Load files with `erlab.io.load` and an explicit `Path`. Select a loader explicitly
   when automatic loader selection is ambiguous.
 - Keep loader settings, scan identifiers, and concatenation choices in the notebook.
+- Build an alignment table before combining scans. Include the sample or cleavage,
+  acquisition order, motor coordinates, analyzer mode, photon energy, and log notes.
+  Put files in one alignment group only when the sample geometry did not change.
+- Use the user-specified experimental log as the authority when it conflicts with
+  embedded analyzer metadata. Compare scalar angle coordinates with raw attributes and
+  the log. Restore a missing or incorrect scalar coordinate before conversion and
+  record the source value.
 - Use a semantic raw variable such as `raw_data` or `gold_reference`. Do not overwrite it
   with corrected or converted data.
 - Stop and report missing files, unsupported layouts, or incomplete acquisition
@@ -75,7 +86,9 @@ analysis notebook executable when no optional Qt binding is installed.
 2. Record package versions, input paths, loader settings, and physical parameters.
 3. Load the data once and keep an unchanged raw-data variable.
 4. Inspect `dims`, `coords`, `attrs`, units, coordinate order, monotonicity, finite
-   values, and sampling. Plot representative raw slices.
+   values, and sampling. Plot representative raw slices. For weak or anisotropic data,
+   also prepare energy-averaged, coordinate-aware smoothed, normalized, and derivative
+   views. Keep the raw view beside them.
 5. Establish the Fermi level. Read
    [references/fermi-calibration.md](references/fermi-calibration.md) only when the
    energy zero is unverified, a reference must be fit, residual curvature must be
@@ -109,14 +122,54 @@ momentum axes are calibrated.
 - Execute once from a clean kernel. Repeat only when randomness, in-place mutation,
   calibration-file writes, or other rerun-sensitive behavior is present.
 
+### Reproducibility acceptance gate
+
+Treat the delivered `.ipynb` as the primary executable artifact, not as a report that
+points at a separate analysis. Before delivery, inspect its code cells and reject the
+notebook unless all of the following are true:
+
+- The notebook visibly loads the raw experimental files and authoritative metadata,
+  defines every physical calibration, performs every substantive transformation and
+  fit, constructs each final figure from explicit figure objects, and saves the stated
+  numerical products.
+- Paths, scan groups, accepted GUI-derived values, fit windows, smoothing widths,
+  normalization rules, masks, and uncertainty choices appear in executable cells.
+- `display(Image(...))`, saved PNG or PDF files, and cached NetCDF files are only
+  optional summaries or acceleration paths. They must not replace the code that
+  generates the displayed result from raw data.
+- Do not use `%run`, `runpy`, `exec(open(...))`, subprocess calls, or imports of local
+  build scripts as the primary analysis path. A helper script may generate notebook
+  cells, but its substantive source must be materialized in those cells.
+- A `REBUILD_FROM_RAW = False` switch does not make a report notebook reproducible.
+  The raw-to-result path must be present and runnable without changing hidden source
+  files or relying on outputs created by a previous kernel or external pipeline.
+- Execute the notebook top to bottom in a clean kernel with pre-existing derived
+  figures hidden or absent when practical. Confirm that the execution regenerates the
+  numerical products and inline figures, then inspect the rendered results.
+
+Fail the handoff rather than call a notebook reproducible when any substantive step is
+available only in an external script or pre-rendered artifact.
+
 ## Decision rules
 
 - Prefer an approved reference calibration over inference from sample data.
+- Reuse one `(alpha_normal, beta_normal)` pair for all photon energies in one unchanged
+  sample alignment. Do not fit independent normal-emission offsets by photon energy.
+- Do not transfer offsets across an alignment change, even when the sample name and
+  motor readbacks appear similar.
 - Treat implicit zero offsets as defaults, not measured normal-emission values.
 - Do not infer an angle-dependent Fermi correction from sample bands.
 - For `gold.poly`, use reliable `sample_temp` metadata. Use `fast=True` when that
   temperature is missing or unreliable, and supply a unit-checked resolution estimate.
 - Do not use symmetrized data to justify a normal-emission calibration.
+- Do not use intensity maxima or apparent brightness symmetry to locate normal
+  emission. Matrix elements can suppress one side of the same contour.
+- Exclude analyzer-acceptance boundaries and detector masks from derivatives,
+  correlations, and center estimates. The center of a circular acceptance mask is not
+  the sample normal-emission angle.
+- Compare photon energies only through identified corresponding features. Bulk bands
+  can change with out-of-plane momentum, and matrix elements can reveal different
+  bands. Do not align complete images or all detected ridges as if they were one band.
 - Do not interpret optimizer success alone as a valid physical fit.
 - Use Voigt spectral peaks by default. Tie their Gaussian sigma parameters to one
   instrumental-width parameter with expressions.
@@ -130,15 +183,19 @@ momentum axes are calibrated.
 
 ## Interactive tools
 
-- Use optional GUI tools only when they are available and visual interaction will
-  reduce uncertainty. Do not install Qt only to use a diagnostic GUI unless the user
-  requests it.
+- Use optional GUI tools when they are available and visual interaction will reduce
+  uncertainty. Do not install Qt only to use a diagnostic GUI unless the user requests
+  it.
 - Use ImageTool when exploration or region selection benefits from linked views.
 - Use `goldtool` when Fermi-edge windows or model choices need visual adjustment.
 - Use `ktool` when normal emission, geometry, or momentum-conversion candidates need
   interactive comparison.
 - Use `ftool` when 1D or sequence fits need visual initialization or propagation.
 - Use Figure Composer when visual figure construction is useful.
+- Make KTool or ImageTool a required user handoff for publication or quantitative
+  momentum conversion when no approved normal-emission calibration exists. Do this
+  even when the agent considers one static-image candidate obvious. Open the tool, tell
+  the user what to select, and wait for the displayed angles or copied code.
 - Reproduce every accepted GUI operation with explicit notebook code. Do not deliver a
   notebook that depends on an open GUI or clipboard state.
 

--- a/skills/arpes-analysis/references/curve-analysis.md
+++ b/skills/arpes-analysis/references/curve-analysis.md
@@ -207,6 +207,13 @@ Independent fits do not preserve band identity. When peaks cross or exchange int
 - stop a trace when the feature disappears;
 - show gaps in the overlay instead of connecting rejected points.
 
+Photon-energy sequences need an additional check. Bulk bands can disperse with
+out-of-plane momentum, and matrix elements can replace one visible peak with another.
+Do not treat all peaks or derivative ridges at different photon energies as one band.
+Track only a branch that remains identifiable from its dispersion and neighboring raw
+cuts. Show the selected points and rejected alternatives. Stop the trace when identity
+is not supported.
+
 Do not smooth fitted centers before validating the individual fits. If smoothing is a
 separate requested analysis, plot unsmoothed centers and residuals as well.
 

--- a/skills/arpes-analysis/references/fermi-calibration.md
+++ b/skills/arpes-analysis/references/fermi-calibration.md
@@ -41,6 +41,11 @@ Check:
 - whether a reference and sample used compatible analyzer geometry, slit or lens mode,
   pass energy, detector region, and acquisition correction.
 
+Compare the embedded photon energy, temperature, and fixed-angle metadata with the
+authoritative experimental log before fitting. Use the source that the user specifies.
+Record every overwritten value. Photon energy affects both the expected kinetic Fermi
+level and momentum conversion, so do not postpone this check.
+
 Choose the first fit window carefully. A poorly conditioned first fit can contaminate
 the polynomial fit even when later angle bins contain a clear edge.
 
@@ -220,6 +225,10 @@ If a nominally flat edge is curved or slanted, do not derive an angular correcti
 sample bands. Matrix elements, gaps, dispersing states, and the density of states can
 produce a false edge trajectory.
 
+Exclude detector and analyzer-acceptance boundaries from edge diagnostics. A circular
+deflector-map mask is an analyzer boundary. Its shape and center do not measure sample
+normal emission or Fermi-edge curvature.
+
 Retain the angle-energy diagnostic and request a compatible reference spectrum. You may
 report a scalar fit to an integrated EDC as an approximate global energy offset, but:
 
@@ -227,6 +236,13 @@ report a scalar fit to an integrated EDC as an approximate global energy offset,
 - do not remove the observed angle dependence;
 - state that the remaining curvature can bias near-Fermi analysis;
 - do not use the approximate result for a publication claim without approval.
+
+If the user explicitly requests a feasibility test without a reference, keep it as a
+separate sample-derived diagnostic. Require the same smooth response in multiple
+independent maps, exclude visible bands and acceptance boundaries, and validate the
+model on a held-out map. Show raw and scalar-aligned data beside the diagnostic result.
+Label it `sample-derived`, not `reference-calibrated`. Do not apply it to quantitative
+publication figures without user approval.
 
 ## Handle photon-energy scans
 
@@ -237,6 +253,14 @@ energy.
 For a flat edge, create one integrated EDC per photon energy and fit each EDC. Preserve
 the `hv` coordinate when collecting centers and standard errors. Plot both against
 photon energy before applying a correction.
+
+Plot the fitted center uncertainty and the residual from the expected kinetic-energy
+trend. Treat an isolated point as an outlier candidate even when the optimizer reports
+success. Inspect its raw EDC, fit, residual, acquisition window, and neighboring photon
+energies. Do not connect or smooth through the point without marking it. Decide whether
+the point is a failed edge fit, an analyzer-energy offset, or a photon-energy anomaly.
+Keep it missing when the edge cannot be identified. When a clear local edge is present,
+distinguish the per-slice energy correction from the separate trend anomaly.
 
 Apply a photon-energy-dependent shift only where fits are successful, uncertainties are
 finite, and the edge is visible. `correct_with_edge` accepts a center `DataArray` that

--- a/skills/arpes-analysis/references/momentum-conversion.md
+++ b/skills/arpes-analysis/references/momentum-conversion.md
@@ -6,11 +6,14 @@ geometry values in visible notebook cells.
 ## Contents
 
 - [Check prerequisites](#check-prerequisites)
+- [Group scans by sample alignment](#group-scans-by-sample-alignment)
 - [Use an existing calibration](#use-an-existing-calibration)
+- [Prepare visual diagnostics](#prepare-visual-diagnostics)
+- [Compare photon energies safely](#compare-photon-energies-safely)
 - [Infer normal emission visually](#infer-normal-emission-visually)
 - [Recognize underdetermined data](#recognize-underdetermined-data)
 - [Apply and validate the conversion](#apply-and-validate-the-conversion)
-- [Use ktool without losing reproducibility](#use-ktool-without-losing-reproducibility)
+- [Use KTool for user confirmation](#use-ktool-for-user-confirmation)
 
 ## Check prerequisites
 
@@ -24,6 +27,18 @@ Inspect:
 - explicit offset attributes and any reference dataset;
 - whether the measured angular range includes normal emission.
 
+Compare each scalar angle coordinate with the raw analyzer attribute and the
+experimental log. A loader can emit a default scalar zero when the acquisition used a
+nonzero fixed angle. Restore the authoritative value before conversion:
+
+```python
+fixed_beta = float(experimental_log_row["DA"])
+data_with_geometry = energy_corrected_data.assign_coords(beta=fixed_beta)
+```
+
+Use the user's stated metadata authority. Record the original coordinate, replacement
+value, and source. Do not replace a swept coordinate with one scalar value.
+
 `data.kspace.offsets` returns zero for missing offset attributes. Check the attributes
 before treating zero as a calibration:
 
@@ -35,6 +50,27 @@ stored_offset_keys = {
 ```
 
 An empty `stored_offset_keys` set means that the displayed zeros are defaults.
+
+## Group scans by sample alignment
+
+Build an alignment table before selecting a normal-emission calibration. Include:
+
+- the sample, cleavage, and termination;
+- file identifier and acquisition order;
+- photon energy and polarization;
+- sample-position and sample-angle motor values;
+- analyzer lens, slit, pass energy, and acquisition mode;
+- log notes that report a realignment, sample motion, or geometry change.
+
+Use one `(alpha_normal, beta_normal)` pair for every photon energy in one unchanged
+sample alignment. Normal emission does not change when only photon energy changes. Do
+not fit one offset pair per photon energy.
+
+Split the alignment group when the sample was moved or realigned. A shared sample name
+or similar motor readbacks do not prove that two acquisitions have the same alignment.
+Prefer a reference map
+acquired immediately before or after the scan series. Do not use a later map when the
+log says that the angle changed in between.
 
 ## Use an existing calibration
 
@@ -49,6 +85,11 @@ data_for_conversion.kspace.set_normal_like(reference_data)
 
 Verify that the reference and target use compatible configurations and angle meanings.
 Do not copy a raw offset dictionary between incompatible configurations.
+
+Search saved KTool code, a saved workspace, or the notebook for an approved `set_normal`
+operation before inferring new values. Report that source directly. Do not describe a
+recovered human calibration as an agent visual deduction. A cursor position alone is not
+an approved calibration unless its purpose is documented or the user confirms it.
 
 When the normal-emission angles are already approved, set them directly:
 
@@ -68,23 +109,85 @@ data_for_conversion.kspace.set_normal(
 
 Use `set_normal`. Do not derive offset signs by hand.
 
+## Prepare visual diagnostics
+
+Matrix elements can make one side of a band much brighter than the other. Determine
+the center from band positions and contour geometry, not from intensity maxima.
+
+Prepare all of these views before proposing a center:
+
+1. Keep a raw, unsymmetrized angle-space view.
+2. Average a finite energy window that is wide enough for the count rate and energy
+   resolution. Record the full width.
+3. Apply coordinate-aware smoothing in physical angle and energy units. Do not apply a
+   derivative to a visibly noisy image.
+4. Add a normalized or local-contrast view to reduce broad matrix-element modulation.
+5. Add a derivative, minimum-gradient, or curvature view only after averaging and
+   smoothing.
+6. Show the raw and processed views together. A processed view cannot be the only
+   evidence.
+
+Use coordinate-aware ERLabPy smoothing:
+
+```python
+diagnostic_map = energy_corrected_data.qsel(
+    eV=diagnostic_energy,
+    eV_width=diagnostic_energy_width,
+)
+smoothed_map = era.image.gaussian_filter(
+    diagnostic_map,
+    sigma={"alpha": alpha_smoothing, "beta": beta_smoothing},
+)
+```
+
+Choose smoothing widths from the coordinate steps and feature widths. Do not copy one
+numeric width between instruments without inspection.
+
+Find the analyzer acceptance mask before normalization or differentiation. Crop the
+boundary or erode the valid-data mask by more than the smoothing kernel radius. Do not
+use a circular detector or deflector boundary as a symmetry feature. Its center is set
+by analyzer acceptance and is unrelated to sample normal emission.
+
+## Compare photon energies safely
+
+For one unchanged sample alignment, a feature at fixed in-plane momentum changes its
+emission angle as photon energy changes. Corresponding contours can contract or expand
+about the common normal-emission angle. Use this as supporting geometry evidence.
+
+Compare only a feature that can be identified as the same branch or contour at both
+photon energies. Use energy averaging, smoothing, and a raw-data check for each view.
+Bulk bands can move with out-of-plane momentum. Matrix elements can hide one band and
+reveal another. Therefore:
+
+- do not correlate complete images as if all bands were unchanged;
+- do not combine all derivative ridges into one alignment score;
+- do not join peaks only because they form a smooth numerical path;
+- do not force a match through a photon energy where the feature disappears;
+- show the selected corresponding feature and rejected alternatives.
+
+If no corresponding feature remains identifiable, mark the comparison as
+underdetermined and use the interactive user-confirmation workflow.
+
 ## Infer normal emission visually
 
-Use visual inference only when no approved calibration exists and the data contains
-enough physical information.
+Use visual inference to propose a KTool starting position when no approved calibration
+exists and the data contains enough physical information. Do not treat agent confidence
+as approval for publication or quantitative momentum conversion.
 
 1. Plot several raw angle-space constant-energy slices or representative projections.
 2. Use the same axis directions, color normalization, and aspect for all slices.
 3. Save the diagnostic figure and inspect the rendered pixels with the available image
    viewer.
-4. Identify a tentative center from a known zone-center feature, a consistent mirror or
-   rotational center, or a cut known to pass through normal emission.
+4. Identify a tentative center from a known zone-center feature, a consistent contour
+   center, or a cut known to pass through normal emission. Do not use apparent mirror
+   brightness or an intensity maximum.
 5. Test a small grid of nearby `(alpha, beta)` candidates. Use coordinate step sizes to
    define the grid rather than arbitrary precision.
 6. Convert unsymmetrized previews for several energies.
 7. Draw zero-momentum guides. Add a Brillouin-zone overlay when verified lattice vectors
    and orientation are available.
-8. Accept the center only when several raw and converted views support the same choice.
+8. Use the supported center only as the initial KTool value. Obtain user confirmation
+   before a publication or quantitative conversion.
 
 If the agent cannot inspect rendered images, save the diagnostics and request user
 review. Do not replace visual evidence with an unverified numerical guess.
@@ -105,7 +208,9 @@ candidate_map = candidate_data.kspace.convert().qsel(
 
 Do not use an n-fold-symmetrized image as evidence for the center. Symmetrization can
 make an incorrect center look plausible. A quantitative symmetry score can support the
-visual review, but it must not override contradictory raw data or known geometry.
+visual review, but it must not override contradictory raw data or known geometry. Do
+not accept a score that depends on the analyzer mask, unrelated photon-energy bands, or
+noisy derivative contours.
 
 Record the accepted values and evidence in a markdown cell next to the diagnostics:
 
@@ -128,6 +233,9 @@ Request user input instead of selecting a value when:
 - magnetic or other symmetry-breaking behavior invalidates the assumed symmetry;
 - configuration, work function, photon energy, or required scalar angles are missing;
 - the Brillouin-zone orientation is unknown and materially changes the conclusion.
+
+For publication or quantitative momentum conversion, also request user confirmation
+when no approved calibration exists, even if the agent sees only one candidate.
 
 Retain the diagnostic cells and candidate figure. Show the user the proposed values and
 the source of the ambiguity. Resume the notebook after confirmation.
@@ -180,9 +288,23 @@ eplt.plot_in_plane_bz(
 )
 ```
 
-## Use ktool without losing reproducibility
+## Use KTool for user confirmation
 
-Use `ktool` when interactive adjustment is more effective:
+Use KTool as the acceptance step when no approved normal-emission calibration exists.
+Use ImageTool first when linked raw and processed views help the user select the region:
+
+```python
+import erlab.interactive as eri
+
+eri.itool(
+    [raw_diagnostic_map, processed_diagnostic_map],
+    link=True,
+    link_colors=False,
+)
+```
+
+Open KTool with the energy-corrected, unsymmetrized source data. A static estimate can
+seed the controls:
 
 ```python
 import erlab.interactive as eri
@@ -194,6 +316,24 @@ eri.ktool(
 )
 ```
 
-Inspect the unsymmetrized preview. Use Brillouin-zone and high-symmetry overlays only
-when their lattice inputs are verified. Copy the accepted generated code back into the
-notebook and rerun it without depending on the open tool or clipboard.
+When a standalone process must keep the window open, pass `execute=True`. In a notebook
+with an active Qt event loop, use the default or `execute=False` so the user can continue
+to interact with the notebook.
+
+Tell the user to:
+
+1. inspect several energy slices and integration widths;
+2. adjust `alpha` and `beta` normal emission;
+3. ignore the circular analyzer-acceptance boundary;
+4. use a Brillouin-zone overlay only with verified lattice vectors and orientation;
+5. report the displayed angles or use **Copy to clipboard** and return the generated
+   code.
+
+Keep the tool open and wait for the user. Do not continue to final momentum conversion
+while the selection is pending. If interactive display is unavailable, save the raw
+and processed diagnostics and ask the user for the accepted values.
+
+After confirmation, copy the accepted public code into the notebook. Record the values
+as `user-selected in KTool`, include the source file and alignment group, close the GUI,
+and rerun the conversion from a clean kernel. Do not make the notebook depend on an
+open tool, clipboard state, or saved workspace.

--- a/skills/arpes-analysis/references/momentum-conversion.md
+++ b/skills/arpes-analysis/references/momentum-conversion.md
@@ -8,7 +8,6 @@ geometry values in visible notebook cells.
 - [Check prerequisites](#check-prerequisites)
 - [Group scans by sample alignment](#group-scans-by-sample-alignment)
 - [Use an existing calibration](#use-an-existing-calibration)
-- [Prepare visual diagnostics](#prepare-visual-diagnostics)
 - [Compare photon energies safely](#compare-photon-energies-safely)
 - [Infer normal emission visually](#infer-normal-emission-visually)
 - [Recognize underdetermined data](#recognize-underdetermined-data)
@@ -108,45 +107,6 @@ data_for_conversion.kspace.set_normal(
 ```
 
 Use `set_normal`. Do not derive offset signs by hand.
-
-## Prepare visual diagnostics
-
-Matrix elements can make one side of a band much brighter than the other. Determine
-the center from band positions and contour geometry, not from intensity maxima.
-
-Prepare all of these views before proposing a center:
-
-1. Keep a raw, unsymmetrized angle-space view.
-2. Average a finite energy window that is wide enough for the count rate and energy
-   resolution. Record the full width.
-3. Apply coordinate-aware smoothing in physical angle and energy units. Do not apply a
-   derivative to a visibly noisy image.
-4. Add a normalized or local-contrast view to reduce broad matrix-element modulation.
-5. Add a derivative, minimum-gradient, or curvature view only after averaging and
-   smoothing.
-6. Show the raw and processed views together. A processed view cannot be the only
-   evidence.
-
-Use coordinate-aware ERLabPy smoothing:
-
-```python
-diagnostic_map = energy_corrected_data.qsel(
-    eV=diagnostic_energy,
-    eV_width=diagnostic_energy_width,
-)
-smoothed_map = era.image.gaussian_filter(
-    diagnostic_map,
-    sigma={"alpha": alpha_smoothing, "beta": beta_smoothing},
-)
-```
-
-Choose smoothing widths from the coordinate steps and feature widths. Do not copy one
-numeric width between instruments without inspection.
-
-Find the analyzer acceptance mask before normalization or differentiation. Crop the
-boundary or erode the valid-data mask by more than the smoothing kernel radius. Do not
-use a circular detector or deflector boundary as a symmetry feature. Its center is set
-by analyzer acceptance and is unrelated to sample normal emission.
 
 ## Compare photon energies safely
 
@@ -324,9 +284,8 @@ Tell the user to:
 
 1. inspect several energy slices and integration widths;
 2. adjust `alpha` and `beta` normal emission;
-3. ignore the circular analyzer-acceptance boundary;
-4. use a Brillouin-zone overlay only with verified lattice vectors and orientation;
-5. report the displayed angles or use **Copy to clipboard** and return the generated
+3. use a Brillouin-zone overlay only with verified lattice vectors and orientation;
+4. report the displayed angles or use **Copy to clipboard** and return the generated
    code.
 
 Keep the tool open and wait for the user. Do not continue to final momentum conversion

--- a/skills/arpes-analysis/references/publication-plotting.md
+++ b/skills/arpes-analysis/references/publication-plotting.md
@@ -16,6 +16,13 @@ figure code in the notebook and save from explicit figure objects.
 - Show raw or minimally processed intensity for primary evidence.
 - Show derivative, curvature, normalized, or symmetrized data as processed data. Label
   the operation and keep a raw comparison nearby.
+- Average a documented physical energy or momentum window before differentiation when
+  one-pixel slices are noisy. Apply coordinate-aware smoothing before curvature or
+  derivative processing. Do not publish a processed panel that is visibly dominated by
+  pixel noise.
+- Use normalization to reduce broad detector gain or matrix-element modulation only
+  when the selected normalization region is visible and documented. Do not interpret a
+  normalized intensity change as spectral-weight transfer without separate evidence.
 - Use a sequential colormap for intensity and a diverging colormap centered at zero for
   signed differences or residuals.
 - Use identical color limits when panels are compared quantitatively.
@@ -23,6 +30,14 @@ figure code in the notebook and save from explicit figure objects.
   evidence. Record any nonlinear normalization in code.
 - Preserve physical axis directions and units. Mark the Fermi level and high-symmetry
   points explicitly.
+- Crop or mask detector gaps and analyzer-acceptance boundaries before derivatives and
+  contour extraction. Keep a raw panel that shows the excluded region.
+
+When comparing samples, doping, terminations, or photon energies, separate band-position
+comparisons from intensity comparisons. Match photon energy, polarization, analyzer
+mode, integration widths, smoothing widths, and color normalization before comparing
+intensity. If these conditions differ, use normalized panels only for band geometry and
+state that matrix elements prevent a quantitative intensity comparison.
 
 ## Plot cuts and constant-energy maps
 

--- a/skills/arpes-analysis/references/publication-plotting.md
+++ b/skills/arpes-analysis/references/publication-plotting.md
@@ -17,9 +17,9 @@ figure code in the notebook and save from explicit figure objects.
 - Show derivative, curvature, normalized, or symmetrized data as processed data. Label
   the operation and keep a raw comparison nearby.
 - Average a documented physical energy or momentum window before differentiation when
-  one-pixel slices are noisy. Apply coordinate-aware smoothing before curvature or
-  derivative processing. Do not publish a processed panel that is visibly dominated by
-  pixel noise.
+  one-pixel slices are noisy. The window sizes used must be explitly provided to the
+  user. Apply coordinate-aware smoothing before curvature or derivative processing. Do
+  not publish a processed panel that is visibly dominated by pixel noise.
 - Use normalization to reduce broad detector gain or matrix-element modulation only
   when the selected normalization region is visible and documented. Do not interpret a
   normalized intensity change as spectral-weight transfer without separate evidence.

--- a/src/erlab/analysis/gold.py
+++ b/src/erlab/analysis/gold.py
@@ -3,6 +3,7 @@
 __all__ = [
     "correct_with_edge",
     "edge",
+    "guess_edge_fit_range",
     "poly",
     "poly_from_edge",
     "quick_fit",
@@ -24,7 +25,7 @@ import matplotlib.pyplot as plt
 import matplotlib.transforms
 import numpy as np
 import numpy.typing as npt
-import scipy.interpolate
+import scipy
 import xarray as xr
 
 import erlab
@@ -35,6 +36,9 @@ else:
     import lazy_loader as _lazy
 
     joblib = _lazy.load("joblib")
+
+
+_FWHM_TO_SIGMA = 1 / np.sqrt(8 * np.log(2))
 
 
 def _eval_edge(modelresult: lmfit.model.ModelResult, *, evalute_at: npt.NDArray):
@@ -90,6 +94,575 @@ def _range_limits_for_coord(
     coord_sel = coord.sel({coord.dims[0]: _range_slice_for_coord(coord, value_range)})
     values = np.asarray(coord_sel.values, dtype=float)
     return float(np.min(values)), float(np.max(values))
+
+
+def _edge_sigma(*, temp: float, resolution: float, fast: bool) -> float:
+    if fast:
+        return float(
+            (resolution + 3.5255 * erlab.constants.kb_eV * temp) * _FWHM_TO_SIGMA
+        )
+    return float(
+        np.hypot(
+            resolution * _FWHM_TO_SIGMA,
+            np.pi * erlab.constants.kb_eV * temp / np.sqrt(3),
+        )
+    )
+
+
+def _edge_model_and_params(
+    *,
+    temp: float,
+    resolution: float,
+    vary_temp: bool,
+    bkg_slope: bool,
+    fast: bool,
+) -> tuple[lmfit.Model, lmfit.Parameters]:
+    if fast:
+        model = erlab.analysis.fit.models.StepEdgeModel()
+        params = lmfit.create_params(
+            sigma={
+                "value": _edge_sigma(temp=temp, resolution=resolution, fast=True),
+                "min": 0,
+            }
+        )
+    else:
+        model = erlab.analysis.fit.models.FermiEdgeModel()
+        params = lmfit.create_params(
+            temp={"value": temp, "vary": vary_temp, "min": 0},
+            resolution={"value": resolution, "min": 0},
+        )
+    if not bkg_slope:
+        params["back1"] = lmfit.Parameter("back1", value=0, vary=False)
+    return model, params
+
+
+def _estimate_local_noise(
+    y: npt.NDArray, *, sigma: float, dx: float
+) -> tuple[npt.NDArray, float]:
+    """Estimate local point noise with a rolling second-difference MAD."""
+    noise_residual = 2 * y[2:-2] - y[:-4] - y[4:]
+    noise_window_size = min(
+        max(2 * int(np.ceil(8 * sigma / dx)) + 1, 25),
+        noise_residual.size,
+    )
+    noise_floor = np.finfo(float).eps * max(float(np.max(np.abs(y))), 1.0)
+
+    noise_centers = np.clip(np.arange(y.size) - 2, 0, noise_residual.size - 1)
+    noise_starts, noise_window_indices = np.unique(
+        np.clip(
+            noise_centers - noise_window_size // 2,
+            0,
+            noise_residual.size - noise_window_size,
+        ),
+        return_inverse=True,
+    )
+    window_noise = np.empty(noise_starts.size)
+    for window_index, noise_start in enumerate(noise_starts):
+        local_residual = noise_residual[noise_start : noise_start + noise_window_size]
+        residual_median = float(np.median(local_residual))
+        window_noise[window_index] = (
+            1.4826 * np.median(np.abs(local_residual - residual_median)) / np.sqrt(6)
+        )
+    return window_noise[noise_window_indices], noise_floor
+
+
+def _find_falling_edge_candidates(
+    x: npt.NDArray,
+    y: npt.NDArray,
+    *,
+    sigma: float,
+    dx: float,
+    local_noise: npt.NDArray,
+    noise_floor: float,
+) -> list[tuple[float, float]]:
+    """Find falling-edge candidates with multiscale Gaussian derivatives."""
+    local_median = scipy.ndimage.median_filter(y, size=5, mode="nearest")
+    outliers = np.abs(y - local_median) > 6 * np.maximum(local_noise, noise_floor)
+    detection_y = y.copy()
+    detection_y[outliers] = local_median[outliers]
+
+    signal_span = float(np.percentile(detection_y, 98) - np.percentile(detection_y, 2))
+    candidates: list[tuple[float, float]] = []
+    for scale in (0.5, 1.0, 2.0, 4.0):
+        filter_sigma = max(scale * sigma / dx, 1.0)
+        margin = max(3, int(np.ceil(3 * filter_sigma)))
+
+        response = -scipy.ndimage.gaussian_filter1d(
+            detection_y, filter_sigma, order=1, mode="nearest"
+        )
+
+        impulse = np.zeros(2 * margin + 1)
+        impulse[margin] = 1.0
+        kernel = scipy.ndimage.gaussian_filter1d(
+            impulse, filter_sigma, order=1, mode="constant"
+        )
+        response_noise_factor = float(np.linalg.norm(kernel))
+
+        interior_response = response[3:-3]
+        left_neighbor = response[2:-4]
+        right_neighbor = response[4:-2]
+        # Select the right sample when adjacent response values are equal.
+        is_local_maximum = (interior_response >= left_neighbor) & (
+            interior_response > right_neighbor
+        )
+        peak_indices = np.flatnonzero(is_local_maximum) + 3
+
+        for candidate_index in peak_indices:
+            side_points = min(
+                max(round(2 * filter_sigma), 3),
+                candidate_index,
+                x.size - candidate_index - 1,
+            )
+            occupied = detection_y[candidate_index - side_points : candidate_index]
+            unoccupied = detection_y[
+                candidate_index + 1 : candidate_index + side_points + 1
+            ]
+            contrast = float(np.median(occupied) - np.median(unoccupied))
+            prominence = float(response[candidate_index])
+            point_noise = float(local_noise[candidate_index])
+            contrast_noise = point_noise * np.sqrt(np.pi / side_points)
+            # Keep a practical contrast floor so a noiseless background slope cannot
+            # qualify as an edge.
+            if prominence > max(
+                point_noise * response_noise_factor, noise_floor
+            ) and contrast > max(
+                3 * contrast_noise,
+                0.01 * signal_span,
+                noise_floor,
+            ):
+                denominator = (
+                    response[candidate_index - 1]
+                    - 2 * response[candidate_index]
+                    + response[candidate_index + 1]
+                )
+                offset = 0.0
+                if denominator != 0:
+                    offset = float(
+                        np.clip(
+                            0.5
+                            * (
+                                response[candidate_index - 1]
+                                - response[candidate_index + 1]
+                            )
+                            / denominator,
+                            -1.0,
+                            1.0,
+                        )
+                    )
+                candidates.append(
+                    (
+                        float(x[candidate_index] + offset * dx),
+                        point_noise,
+                    )
+                )
+    return candidates
+
+
+def _guess_edge_fit_range(
+    x: npt.NDArray,
+    y: npt.NDArray,
+    *,
+    temp: float,
+    resolution: float,
+    fast: bool,
+    bkg_slope: bool = True,
+) -> tuple[float, float]:
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    finite = np.isfinite(x) & np.isfinite(y)
+    x, y = x[finite], y[finite]
+    if x.size < 12:
+        raise ValueError("At least 12 finite points are required")
+
+    order = np.argsort(x)
+    x, y = x[order], y[order]
+    if np.any(np.diff(x) <= 0):
+        raise ValueError("Energy coordinates must be unique")
+
+    uniform_x = np.linspace(x[0], x[-1], x.size)
+    uniform_y = np.interp(uniform_x, x, y)
+    uniform_dx = float(uniform_x[1] - uniform_x[0])
+    sigma = max(_edge_sigma(temp=temp, resolution=resolution, fast=fast), uniform_dx)
+    local_noise, noise_floor = _estimate_local_noise(
+        uniform_y, sigma=sigma, dx=uniform_dx
+    )
+    candidates = _find_falling_edge_candidates(
+        uniform_x,
+        uniform_y,
+        sigma=sigma,
+        dx=uniform_dx,
+        local_noise=local_noise,
+        noise_floor=noise_floor,
+    )
+    if not candidates:
+        raise ValueError("No falling edge was detected")
+
+    # The Fermi edge is the terminal valid falling edge. Do not require agreement
+    # across scales because a broad edge can be visible only at a coarse scale.
+    center, point_noise = max(candidates, key=lambda item: item[0])
+
+    if not np.isfinite(center):
+        raise ValueError("No falling edge was detected")
+
+    trial_x_mean = float(np.mean(x))
+    trial_x_scale = float(np.std(x))
+
+    def fit_trial(lower_index: int) -> dict[str, float] | None:
+        fit_x = x[lower_index:]
+        fit_y = y[lower_index:]
+        normalized_x = (fit_x - trial_x_mean) / trial_x_scale
+
+        model = erlab.analysis.fit.models.StepEdgeModel()
+        center_value = (center - trial_x_mean) / trial_x_scale
+        sigma_value = sigma / trial_x_scale
+        step = erlab.analysis.fit.functions.step_broad(
+            normalized_x,
+            center=center_value,
+            sigma=sigma_value,
+            amplitude=1.0,
+        )
+        if bkg_slope:
+            linear_design = np.column_stack(
+                (
+                    1 - step,
+                    normalized_x * (1 - step),
+                    step,
+                    normalized_x * step,
+                )
+            )
+            parameter_names = ("back0", "back1", "dos0", "dos1")
+        else:
+            linear_design = np.column_stack((1 - step, step, normalized_x * step))
+            parameter_names = ("back0", "dos0", "dos1")
+        coefficients, _, rank, _ = np.linalg.lstsq(
+            linear_design,
+            fit_y,
+            rcond=None,
+        )
+        if rank == linear_design.shape[1]:
+            params = model.make_params(
+                center=center_value,
+                sigma=sigma_value,
+                **dict(zip(parameter_names, coefficients, strict=True)),
+            )
+        else:
+            params = model.guess(
+                fit_y,
+                x=normalized_x,
+                center=center_value,
+                sigma=sigma_value,
+            )
+        if not bkg_slope:
+            params["back1"].set(value=0.0, vary=False)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                fit_result = model.fit(
+                    fit_y,
+                    params,
+                    x=normalized_x,
+                    method="least_squares",
+                )
+        except (
+            FloatingPointError,
+            np.linalg.LinAlgError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ):
+            return None
+
+        fit_center = float(
+            fit_result.best_values["center"] * trial_x_scale + trial_x_mean
+        )
+        fit_sigma = abs(float(fit_result.best_values["sigma"] * trial_x_scale))
+        if not fit_result.success or not np.isfinite(fit_center + fit_sigma):
+            return None
+
+        lower = float(x[lower_index])
+        if not (
+            lower <= fit_center <= x[-1]
+            and 0.05 * sigma <= fit_sigma <= 3 * sigma
+            and fit_center - lower >= 3 * fit_sigma
+            and x[-1] - fit_center >= 0.5 * fit_sigma
+        ):
+            return None
+        return {
+            "lower": lower,
+            "center": fit_center,
+            "sigma": fit_sigma,
+        }
+
+    def trials_are_stable(trials: list[dict[str, float]]) -> bool:
+        centers = [trial["center"] for trial in trials]
+        widths = [trial["sigma"] for trial in trials]
+        return bool(
+            max(centers) - min(centers) <= 0.5 * sigma
+            and max(widths) / min(widths) <= 3
+        )
+
+    trial_sequence: list[dict[str, float] | None] = []
+    previous_lower_index: int | None = None
+    for width in (4.0, 6.0, 8.0, 10.0, 12.0, 16.0, 20.0, 24.0, 32.0):
+        lower = max(float(x[0]), center - width * sigma)
+        lower_index = min(
+            int(np.searchsorted(x, lower, side="left")),
+            x.size - 12,
+        )
+        if lower_index == previous_lower_index:
+            continue
+        previous_lower_index = lower_index
+        trial_sequence.append(fit_trial(lower_index))
+
+        recent_trials = trial_sequence[-3:]
+        accepted_trials = [trial for trial in recent_trials if trial is not None]
+        if len(accepted_trials) == 3 and trials_are_stable(accepted_trials):
+            return accepted_trials[1]["lower"], float(x[-1])
+
+    # If three consecutive trials do not stabilize, use the longest shorter
+    # plateau. This keeps locally cropped EDCs usable. A complete rejection falls
+    # through to the previous single-fit range heuristic below.
+    best_score: tuple[int, int] | None = None
+    best_trial: dict[str, float] | None = None
+    for start in range(len(trial_sequence)):
+        accepted_trials = []
+        for trial in trial_sequence[start:]:
+            if trial is None:
+                break
+            accepted_trials.append(trial)
+            if not trials_are_stable(accepted_trials):
+                break
+            score = (len(accepted_trials), -start)
+            if best_score is None or score > best_score:
+                best_score = score
+                best_trial = accepted_trials[(len(accepted_trials) - 1) // 2]
+    if best_trial is not None:
+        return best_trial["lower"], float(x[-1])
+
+    # A balanced local range prevents occupied-side peaks from dominating the
+    # provisional step fit, including when little unoccupied data is available.
+    seed_lower = max(float(x[0]), 2 * center - float(x[-1]))
+    seed_start = int(np.searchsorted(x, seed_lower, side="left"))
+    if x.size - seed_start < 12:
+        return float(x[0]), float(x[-1])
+
+    occupied = y[seed_start : np.searchsorted(x, center, side="left")]
+    unoccupied = y[np.searchsorted(x, center, side="right") :]
+    contrast_points = min(occupied.size, unoccupied.size)
+    if contrast_points < 3:
+        return float(x[0]), float(x[-1])
+    terminal_contrast = float(
+        np.median(occupied[-contrast_points:]) - np.median(unoccupied[:contrast_points])
+    )
+    if terminal_contrast <= max(
+        3 * point_noise * np.sqrt(np.pi / contrast_points), noise_floor
+    ):
+        raise ValueError("No falling edge was detected")
+
+    fit_x = x[seed_start:]
+    fit_y = y[seed_start:]
+    x_mean = float(np.mean(fit_x))
+    x_scale = float(np.std(fit_x))
+    y_offset = float(np.percentile(fit_y, 2))
+    y_scale = max(float(np.percentile(fit_y, 98) - y_offset), np.finfo(float).eps)
+    normalized_x = (fit_x - x_mean) / x_scale
+    normalized_y = (fit_y - y_offset) / y_scale
+
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    params = model.guess(normalized_y, x=normalized_x)
+    params["center"].set(
+        value=(center - x_mean) / x_scale,
+        min=float(normalized_x[0]),
+        max=float(normalized_x[-1]),
+    )
+    params["sigma"].set(
+        value=sigma / x_scale,
+        min=0.0,
+        max=0.5 * float(np.ptp(normalized_x)),
+    )
+    if not bkg_slope:
+        params["back1"].set(value=0.0, vary=False)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            fit_result = model.fit(
+                normalized_y,
+                params,
+                x=normalized_x,
+                method="least_squares",
+            )
+        fit_center = float(fit_result.best_values["center"] * x_scale + x_mean)
+        fit_sigma = float(fit_result.best_values["sigma"] * x_scale)
+    except (FloatingPointError, np.linalg.LinAlgError, TypeError, ValueError):
+        return float(x[0]), float(x[-1])
+
+    if not fit_result.success or not np.isfinite(fit_center + fit_sigma):
+        return float(x[0]), float(x[-1])
+
+    # Four fitted widths contain the transition. The nominal-width floor also keeps
+    # two nominal widths of occupied baseline when the provisional fit is too narrow.
+    lower = max(float(x[0]), min(center, fit_center) - max(4 * fit_sigma, 6 * sigma))
+    lower_index = min(int(np.searchsorted(x, lower, side="left")), x.size - 12)
+    return float(x[lower_index]), float(x[-1])
+
+
+def _guess_edge_fit_range_or_default(
+    x: npt.NDArray,
+    y: npt.NDArray,
+    *,
+    temp: float,
+    resolution: float,
+    fast: bool,
+    bkg_slope: bool = True,
+) -> tuple[float, float]:
+    x = np.asarray(x, dtype=float)
+    finite_x = x[np.isfinite(x)]
+    if finite_x.size == 0:
+        raise ValueError("Energy coordinates must contain finite values")
+    fallback = float(np.min(finite_x)), float(np.max(finite_x))
+    try:
+        return _guess_edge_fit_range(
+            x,
+            y,
+            temp=temp,
+            resolution=resolution,
+            fast=fast,
+            bkg_slope=bkg_slope,
+        )
+    except (FloatingPointError, np.linalg.LinAlgError, ValueError):
+        return fallback
+
+
+def guess_edge_fit_range(
+    edc: xr.DataArray,
+    *,
+    energy_dim: str = "eV",
+    temp: float | None = None,
+    resolution: float = 0.02,
+    bkg_slope: bool = True,
+    fast: bool = False,
+) -> tuple[float, float]:
+    r"""Estimate the energy range for fitting one Fermi edge.
+
+    The returned bounds are ordered from low to high energy and can be used as
+    ``edc.sel(eV=slice(*bounds))`` when the energy coordinate is increasing.
+
+    Parameters
+    ----------
+    edc
+        One energy distribution curve.
+    energy_dim
+        Name of the energy dimension.
+    temp
+        Sample temperature in kelvins. If `None`, infer it from `edc`. The fast model
+        uses 10 K when the temperature is not available.
+    resolution
+        Initial energy-resolution FWHM in electronvolts.
+    bkg_slope
+        If `True`, include a linear background above the Fermi level.
+    fast
+        If `True`, use the nominal width of a broadened step edge. Otherwise, use the
+        combined thermal and resolution width of a Fermi edge.
+
+    Returns
+    -------
+    lower, upper
+        Estimated energy bounds in the units of the energy coordinate.
+
+    Notes
+    -----
+    The estimator uses the following steps:
+
+    1. It calculates a nominal edge standard deviation. For a Fermi edge model, this is
+
+       .. math::
+
+           \sigma_0 = \max\left[\Delta x, \sqrt{\left(\frac{R}{\sqrt{8\ln 2}}\right)^2 +
+           \left(\frac{\pi k_\mathrm{B}T}{\sqrt{3}}\right)^2}\right].
+
+       For the step function, it uses
+
+       .. math::
+
+           \sigma_0 = \max\left[\Delta x, \frac{R + 3.5255 k_\mathrm{B}T}{\sqrt{8\ln
+           2}}\right].
+
+       Here, :math:`R` is the resolution FWHM and :math:`\Delta x` is the energy
+       spacing.
+
+    2. It estimates the local point noise from the second-difference residual
+
+       .. math::
+
+           r_i = 2y_i-y_{i-2}-y_{i+2}, \qquad \hat\sigma_{n,i} =
+           \frac{1.4826}{\sqrt{6}}\operatorname{MAD}(r).
+
+       The MAD uses a rolling window of approximately :math:`16\sigma_0`, with a
+       25-sample minimum when that many residual samples are available. The factors
+       1.4826 and :math:`\sqrt{6}` correct the MAD for Gaussian noise and the variance
+       of the second difference, respectively.
+
+    3. It replaces samples that differ from a five-sample median by more than six local
+       noise levels in the detection copy. This replacement does not modify the data
+       used for fits.
+
+    4. It performs a multiscale search for local maxima of negative Gaussian derivatives
+       with widths of :math:`\{0.5,1,2,4\}\sigma_0`. A candidate must have derivative
+       prominence above the propagated local noise. It must also have a falling-side
+       contrast above three contrast-noise levels and 1% of the robust signal span. A
+       quadratic interpolation refines its position. The highest-energy valid candidate
+       becomes the edge anchor.
+
+    5. It fits broadened step models with lower bounds at offsets of
+       :math:`\{4,6,8,10,12,16,20,24,32\}\sigma_0` below the anchor. The anchor and
+       nominal width initialize each fit. The linear coefficients are initialized
+       conditionally on the broadened step :math:`s(x)`:
+
+       .. math::
+
+           y(x) = [1-s(x)](b_0+b_1x) + s(x)(d_0+d_1x).
+
+       When ``bkg_slope=False``, the fit fixes :math:`b_1=0`.
+
+    6. A trial is accepted when the fitted center remains inside the fit domain and
+       the fitted width is between :math:`0.05\sigma_0` and :math:`3\sigma_0`. The
+       domain must contain at least three fitted widths below the center and half a
+       fitted width above it.
+
+    7. The estimator returns the middle lower bound of the first three consecutive
+       accepted fits whose centers span at most :math:`0.5\sigma_0` and whose widths
+       differ by at most a factor of three. If this plateau is unavailable, it uses the
+       longest shorter plateau, then a local single-step fallback. The fallback can
+       return the full input range when the available support is insufficient. The upper
+       bound is the highest input energy.
+
+    Raises
+    ------
+    ValueError
+        If the input is not one-dimensional, lacks required temperature metadata, has
+        insufficient data, or has no qualifying falling edge.
+    """
+    if edc.dims != (energy_dim,):
+        raise ValueError(f"Expected a 1D DataArray along {energy_dim!r}")
+
+    if temp is None:
+        temp = edc.qinfo.get_value("sample_temp")
+        if temp is None:
+            if fast:
+                temp = 10.0
+            else:
+                raise ValueError(
+                    "Temperature not found in data attributes, please provide manually"
+                )
+
+    return _guess_edge_fit_range(
+        np.asarray(edc[energy_dim]),
+        np.asarray(edc),
+        temp=float(temp),
+        resolution=float(resolution),
+        fast=fast,
+        bkg_slope=bkg_slope,
+    )
 
 
 def correct_with_edge(
@@ -245,6 +818,7 @@ def edge(
     along: str = "alpha",
     angle_range: tuple[float, float],
     eV_range: tuple[float, float],
+    adaptive: bool = False,
     bin_size: tuple[int, int] = (1, 1),
     temp: float | None = None,
     vary_temp: bool = False,
@@ -281,6 +855,10 @@ def edge(
         The range of values along the ``along`` dimension to consider.
     eV_range
         The range of eV values to consider.
+    adaptive
+        If `True`, estimate and use a separate energy range for each EDC within
+        `eV_range`. If no valid falling edge is detected in one EDC, that EDC uses the
+        complete `eV_range`. Defaults to `False`.
     bin_size
         The bin size for coarsening the gold data, by default (1, 1).
     temp
@@ -345,11 +923,6 @@ def edge(
         }
     )
 
-    if normalize:
-        # Normalize energy coordinates
-        avgx, stdx = gold_sel.eV.values.mean(), gold_sel.eV.values.std()
-        gold_sel = gold_sel.assign_coords(eV=(gold_sel.eV - avgx) / stdx)
-
     if temp is None:
         temp = gold.qinfo.get_value("sample_temp")
         if temp is None:
@@ -360,28 +933,31 @@ def edge(
                     "Temperature not found in data attributes, please provide manually"
                 )
 
-    if normalize and temp is not None:
-        temp = float(temp / stdx)
+    if adaptive and kwargs.get("skipna") is False:
+        raise ValueError("adaptive fitting requires skipna=True")
 
-    if fast:
-        params = lmfit.create_params(
-            sigma=(resolution + 3.53 * erlab.constants.kb_eV * temp)
-            / np.sqrt(8 * np.log(2))
-        )
-        model_cls: lmfit.Model = erlab.analysis.fit.models.StepEdgeModel
+    if normalize:
+        # Normalize energy coordinates
+        avgx, stdx = gold_sel.eV.values.mean(), gold_sel.eV.values.std()
+        gold_sel = gold_sel.assign_coords(eV=(gold_sel.eV - avgx) / stdx)
+
+    if normalize:
+        fit_temp = float(temp / stdx)
+        fit_resolution = float(resolution / stdx)
     else:
-        params = lmfit.create_params(
-            temp={"value": float(temp), "vary": vary_temp}, resolution=resolution
-        )
-        model_cls = erlab.analysis.fit.models.FermiEdgeModel
+        fit_temp = float(temp)
+        fit_resolution = float(resolution)
 
-    model = model_cls()
+    model, params = _edge_model_and_params(
+        temp=fit_temp,
+        resolution=fit_resolution,
+        vary_temp=vary_temp,
+        bkg_slope=bkg_slope,
+        fast=fast,
+    )
 
     if parallel_kw is None:
         parallel_kw = {}
-
-    if not bkg_slope:
-        params["back1"] = lmfit.Parameter("back1", value=0, vary=False)
 
     if fixed_center is not None:
         fixed_center_fit = (
@@ -415,6 +991,33 @@ def edge(
                     "Using UFloat objects with std_dev==0 may give unexpected results."
                 ),
             )
+            if adaptive:
+                range_kwargs = {
+                    "temp": fit_temp,
+                    "resolution": fit_resolution,
+                    "bkg_slope": bkg_slope,
+                    "fast": fast,
+                }
+                if data.dims == ("eV",):
+                    lower, upper = _guess_edge_fit_range_or_default(
+                        np.asarray(data["eV"]),
+                        np.asarray(data),
+                        **range_kwargs,
+                    )
+                else:
+                    lower, upper = xr.apply_ufunc(
+                        _guess_edge_fit_range_or_default,
+                        data["eV"],
+                        data,
+                        input_core_dims=[["eV"], ["eV"]],
+                        output_core_dims=[[], []],
+                        vectorize=True,
+                        dask="parallelized",
+                        output_dtypes=[float, float],
+                        kwargs=range_kwargs,
+                    )
+                energy = data["eV"]
+                data = data.where((energy >= lower) & (energy <= upper))
             return data.xlm.modelfit(
                 "eV",
                 model=model,
@@ -639,6 +1242,7 @@ def poly(
     along: str = "alpha",
     angle_range: tuple[float, float],
     eV_range: tuple[float, float],
+    adaptive: bool = False,
     bin_size: tuple[int, int] = (1, 1),
     temp: float | None = None,
     vary_temp: bool = False,
@@ -663,6 +1267,7 @@ def poly(
             along=along,
             angle_range=angle_range,
             eV_range=eV_range,
+            adaptive=adaptive,
             bin_size=bin_size,
             temp=temp,
             vary_temp=vary_temp,
@@ -708,6 +1313,7 @@ def spline(
     along: str = "alpha",
     angle_range: tuple[float, float],
     eV_range: tuple[float, float],
+    adaptive: bool = False,
     bin_size: tuple[int, int] = (1, 1),
     temp: float | None = None,
     vary_temp: bool = False,
@@ -730,6 +1336,7 @@ def spline(
             along=along,
             angle_range=angle_range,
             eV_range=eV_range,
+            adaptive=adaptive,
             bin_size=bin_size,
             temp=temp,
             vary_temp=vary_temp,

--- a/src/erlab/analysis/gold.py
+++ b/src/erlab/analysis/gold.py
@@ -235,20 +235,18 @@ def _find_falling_edge_candidates(
                     - 2 * response[candidate_index]
                     + response[candidate_index + 1]
                 )
-                offset = 0.0
-                if denominator != 0:
-                    offset = float(
-                        np.clip(
-                            0.5
-                            * (
-                                response[candidate_index - 1]
-                                - response[candidate_index + 1]
-                            )
-                            / denominator,
-                            -1.0,
-                            1.0,
+                offset = float(
+                    np.clip(
+                        0.5
+                        * (
+                            response[candidate_index - 1]
+                            - response[candidate_index + 1]
                         )
+                        / denominator,
+                        -1.0,
+                        1.0,
                     )
+                )
                 candidates.append(
                     (
                         float(x[candidate_index] + offset * dx),
@@ -300,9 +298,6 @@ def _guess_edge_fit_range(
     # The Fermi edge is the terminal valid falling edge. Do not require agreement
     # across scales because a broad edge can be visible only at a coarse scale.
     center, point_noise = max(candidates, key=lambda item: item[0])
-
-    if not np.isfinite(center):
-        raise ValueError("No falling edge was detected")
 
     trial_x_mean = float(np.mean(x))
     trial_x_scale = float(np.std(x))

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -161,6 +161,7 @@ class EdgeFitTask(QtCore.QRunnable):
                         bkg_slope=self.params["Linear"],
                         resolution=self.params["Resolution"],
                         fast=self.params["Fast"],
+                        adaptive=self.params["Adaptive"],
                         method=self.params["Method"],
                         scale_covar=self.params["Scale cov"],
                         progress=False,
@@ -210,6 +211,7 @@ class _GoldEdgeState(_GoldStateBase):
     bin_y: int = pydantic.Field(default=1, alias="Bin y")
     resolution: float = pydantic.Field(default=0.02, alias="Resolution")
     fast: bool = pydantic.Field(default=False, alias="Fast")
+    adaptive: bool = pydantic.Field(default=False, alias="Adaptive")
     linear: bool = pydantic.Field(default=True, alias="Linear")
     method: str = pydantic.Field(default="least_squares", alias="Method")
     scale_cov: bool = pydantic.Field(default=True, alias="Scale cov")
@@ -423,6 +425,11 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
                     "checked": False,
                     "toolTip": "If checked, fit with a broadened step function "
                     "instead of Fermi-Dirac",
+                },
+                "Adaptive": {
+                    "qwtype": "chkbox",
+                    "checked": False,
+                    "toolTip": "Estimate a separate energy range for each EDC.",
                 },
                 "Linear": {
                     "qwtype": "chkbox",
@@ -757,6 +764,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             ("Bin x / y", f"{edge['Bin x']} / {edge['Bin y']}"),
             ("Resolution", f"{edge['Resolution']} eV"),
             ("Fast", self._bool_text(bool(edge["Fast"]))),
+            ("Adaptive", self._bool_text(bool(edge["Adaptive"]))),
             (
                 "Background above EF",
                 "Linear" if bool(edge["Linear"]) else "Constant",
@@ -1120,9 +1128,6 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         return data
 
     def _toggle_fast(self) -> None:
-        self.params_edge.widgets["T (K)"].setDisabled(
-            bool(self.params_edge.values["Fast"])
-        )
         self.params_edge.widgets["Fix T"].setDisabled(
             bool(self.params_edge.values["Fast"])
         )
@@ -1418,6 +1423,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             "bkg_slope": p0["Linear"],
             "resolution": p0["Resolution"],
             "fast": p0["Fast"],
+            "adaptive": p0["Adaptive"],
             "method": p0["Method"],
             "scale_covar_edge": p0["Scale cov"],
         }
@@ -1432,9 +1438,6 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
                     arg_dict["lam"] = None
                 else:
                     arg_dict["lam"] = p1["lambda"]
-
-        if p0["Fast"]:
-            del arg_dict["temp"]
 
         if mode == "poly" and not p1["Scale cov"]:
             arg_dict["scale_covar"] = False

--- a/tests/analysis/test_gold.py
+++ b/tests/analysis/test_gold.py
@@ -101,6 +101,125 @@ def test_guess_edge_fit_range(gold: xr.DataArray, fast: bool) -> None:
     assert 0 < selected.sizes["eV"] <= edc.sizes["eV"]
 
 
+def test_edge_model_params_fix_background_slope() -> None:
+    _, params = gold_mod._edge_model_and_params(
+        temp=10.0,
+        resolution=0.02,
+        vary_temp=False,
+        bkg_slope=False,
+        fast=True,
+    )
+
+    assert params["back1"].value == 0.0
+    assert params["back1"].vary is False
+
+
+@pytest.mark.parametrize(
+    ("eV", "message"),
+    [
+        (np.linspace(-0.1, 0.1, 11), "At least 12 finite points are required"),
+        (
+            np.array(
+                [
+                    -0.1,
+                    -0.08,
+                    -0.06,
+                    -0.04,
+                    -0.02,
+                    0.0,
+                    0.0,
+                    0.02,
+                    0.04,
+                    0.06,
+                    0.08,
+                    0.1,
+                ]
+            ),
+            "Energy coordinates must be unique",
+        ),
+    ],
+)
+def test_guess_edge_fit_range_validates_energy_coordinate(
+    eV: np.ndarray, message: str
+) -> None:
+    edc = xr.DataArray(np.ones(eV.size), coords={"eV": eV}, dims="eV")
+
+    with pytest.raises(ValueError, match=message):
+        gold_mod.guess_edge_fit_range(edc, temp=10.0, fast=True)
+
+
+def test_guess_edge_fit_range_uses_temperature_metadata() -> None:
+    eV = np.linspace(-0.2, 0.1, 151)
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = model.func(eV, 0.0, 0.01, 0.1, 0.0, 1.0, 0.0)
+    edc = xr.DataArray(
+        values,
+        coords={"eV": eV},
+        dims="eV",
+        attrs={"sample_temp": 20.0},
+    )
+
+    lower, upper = gold_mod.guess_edge_fit_range(edc, fast=False)
+
+    assert lower < 0.0 < upper
+
+
+def test_guess_edge_fit_range_temperature_fallback_and_validation() -> None:
+    eV = np.linspace(-0.2, 0.1, 151)
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = model.func(eV, 0.0, 0.01, 0.1, 0.0, 1.0, 0.0)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+
+    lower, upper = gold_mod.guess_edge_fit_range(edc, fast=True)
+    assert lower < 0.0 < upper
+
+    with pytest.raises(ValueError, match="Temperature not found"):
+        gold_mod.guess_edge_fit_range(edc, fast=False)
+
+
+def test_guess_edge_fit_range_requires_one_edc() -> None:
+    data = xr.DataArray(
+        np.ones((2, 12)),
+        coords={"alpha": [0.0, 1.0], "eV": np.linspace(-0.1, 0.1, 12)},
+        dims=("alpha", "eV"),
+    )
+
+    with pytest.raises(ValueError, match="Expected a 1D DataArray"):
+        gold_mod.guess_edge_fit_range(data, temp=10.0, fast=True)
+
+
+def test_guess_edge_fit_range_uses_model_guess_for_rank_deficient_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eV = np.linspace(-0.3, 0.15, 301)
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = model.func(eV, 0.0, 0.012, 0.15, 0.08, 1.2, -0.12)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+    original_lstsq = np.linalg.lstsq
+    forced_rank_deficiency = False
+
+    def rank_deficient_once(*args: typing.Any, **kwargs: typing.Any):
+        nonlocal forced_rank_deficiency
+        result = original_lstsq(*args, **kwargs)
+        if not forced_rank_deficiency:
+            forced_rank_deficiency = True
+            coefficients, residuals, rank, singular_values = result
+            return coefficients, residuals, rank - 1, singular_values
+        return result
+
+    monkeypatch.setattr(np.linalg, "lstsq", rank_deficient_once)
+
+    lower, upper = gold_mod.guess_edge_fit_range(
+        edc,
+        temp=0.0,
+        resolution=2.355 * 0.012,
+        fast=True,
+    )
+
+    assert forced_rank_deficiency
+    assert lower < 0.0 < upper
+
+
 def test_guess_edge_fit_range_finds_edge_outside_initial_tail() -> None:
     eV = np.linspace(-0.4, 0.2, 401)
     center = -0.12
@@ -137,6 +256,98 @@ def test_guess_edge_fit_range_falls_back_when_seed_fit_fails(
     bounds = gold_mod.guess_edge_fit_range(edc, **kwargs)
 
     assert bounds == pytest.approx((eV[0], eV[-1]))
+
+
+def test_guess_edge_fit_range_falls_back_for_unsuccessful_fits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eV = np.linspace(-0.3, 0.15, 301)
+    model_class = erlab.analysis.fit.models.StepEdgeModel
+    values = model_class().func(eV, 0.0, 0.012, 0.15, 0.08, 1.2, -0.12)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+
+    class FailedResult:
+        def __init__(self) -> None:
+            self.success = False
+            self.best_values = {"center": 0.0, "sigma": 0.01}
+
+    monkeypatch.setattr(model_class, "fit", lambda *_args, **_kwargs: FailedResult())
+
+    bounds = gold_mod.guess_edge_fit_range(
+        edc,
+        temp=0.0,
+        resolution=2.355 * 0.012,
+        bkg_slope=False,
+        fast=True,
+    )
+
+    assert bounds == pytest.approx((eV[0], eV[-1]))
+
+
+@pytest.mark.parametrize("candidate_index", [1, -2])
+def test_guess_edge_fit_range_uses_full_range_without_candidate_support(
+    monkeypatch: pytest.MonkeyPatch,
+    candidate_index: int,
+) -> None:
+    eV = np.linspace(-0.1, 0.1, 41)
+    values = np.where(eV <= 0.0, 1.0, 0.0)
+    monkeypatch.setattr(
+        gold_mod,
+        "_find_falling_edge_candidates",
+        lambda *_args, **_kwargs: [(float(eV[candidate_index]), 0.0)],
+    )
+
+    def fail_fit(*_args: typing.Any, **_kwargs: typing.Any) -> typing.NoReturn:
+        raise ValueError("synthetic trial fit failure")
+
+    monkeypatch.setattr(erlab.analysis.fit.models.StepEdgeModel, "fit", fail_fit)
+
+    bounds = gold_mod._guess_edge_fit_range(
+        eV,
+        values,
+        temp=0.0,
+        resolution=0.01,
+        fast=True,
+    )
+
+    assert bounds == pytest.approx((eV[0], eV[-1]))
+
+
+def test_guess_edge_fit_range_rejects_candidate_without_terminal_contrast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eV = np.linspace(-0.1, 0.1, 41)
+    values = np.ones(eV.size)
+    monkeypatch.setattr(
+        gold_mod,
+        "_find_falling_edge_candidates",
+        lambda *_args, **_kwargs: [(0.0, 0.0)],
+    )
+
+    def fail_fit(*_args: typing.Any, **_kwargs: typing.Any) -> typing.NoReturn:
+        raise ValueError("synthetic trial fit failure")
+
+    monkeypatch.setattr(erlab.analysis.fit.models.StepEdgeModel, "fit", fail_fit)
+
+    with pytest.raises(ValueError, match="No falling edge was detected"):
+        gold_mod._guess_edge_fit_range(
+            eV,
+            values,
+            temp=0.0,
+            resolution=0.01,
+            fast=True,
+        )
+
+
+def test_guess_edge_fit_range_default_requires_finite_energy() -> None:
+    with pytest.raises(ValueError, match="Energy coordinates must contain finite"):
+        gold_mod._guess_edge_fit_range_or_default(
+            np.full(12, np.nan),
+            np.ones(12),
+            temp=10.0,
+            resolution=0.02,
+            fast=True,
+        )
 
 
 def test_guess_edge_fit_range_rejects_rising_edge() -> None:
@@ -309,6 +520,20 @@ def test_edge_adaptive_falls_back_for_one_edc(
     full_count = gold.sel(eV=slice(-0.2, 0.2)).sizes["eV"]
     assert point_counts.sel(alpha=target_alpha) == full_count
     assert point_counts.min() < full_count
+
+
+def test_edge_adaptive_requires_skipna(gold: xr.DataArray) -> None:
+    with pytest.raises(ValueError, match="adaptive fitting requires skipna=True"):
+        edge(
+            gold,
+            angle_range=(-15, 15),
+            eV_range=(-0.2, 0.2),
+            adaptive=True,
+            temp=100.0,
+            fast=True,
+            progress=False,
+            skipna=False,
+        )
 
 
 @pytest.mark.parametrize("wrapper", [gold_mod.poly, gold_mod.spline])

--- a/tests/analysis/test_gold.py
+++ b/tests/analysis/test_gold.py
@@ -6,6 +6,7 @@ import pytest
 import xarray as xr
 from numpy.testing import assert_allclose
 
+import erlab
 import erlab.analysis.gold as gold_mod
 from erlab.analysis.gold import correct_with_edge, edge, poly, quick_fit, spline
 
@@ -87,6 +88,261 @@ def test_range_slice_for_coord_nonmonotonic_raises() -> None:
 
     with pytest.raises(ValueError, match=r"Coordinate `x` is not monotonic"):
         _ = gold_mod._range_slice_for_coord(coord, (-1.0, 1.0))
+
+
+@pytest.mark.parametrize("fast", [True, False], ids=["fast", "regular"])
+def test_guess_edge_fit_range(gold: xr.DataArray, fast: bool) -> None:
+    edc = gold.sel(eV=slice(-0.2, 0.2)).sel(alpha=0.0)
+
+    lower, upper = gold_mod.guess_edge_fit_range(edc, temp=100.0, fast=fast)
+    selected = edc.sel(eV=slice(lower, upper))
+
+    assert lower < 0.04 < upper
+    assert 0 < selected.sizes["eV"] <= edc.sizes["eV"]
+
+
+def test_guess_edge_fit_range_finds_edge_outside_initial_tail() -> None:
+    eV = np.linspace(-0.4, 0.2, 401)
+    center = -0.12
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = model.func(eV, center, 0.006, 0.15, 0.08, 1.2, -0.12)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+
+    lower, upper = gold_mod.guess_edge_fit_range(
+        edc,
+        temp=0.0,
+        resolution=2.355 * 0.006,
+        fast=True,
+    )
+
+    assert lower < center < upper
+    assert lower == pytest.approx(center - 6 * 0.006, abs=2 * (eV[1] - eV[0]))
+    assert upper == eV[-1]
+
+
+def test_guess_edge_fit_range_falls_back_when_seed_fit_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eV = np.linspace(-0.3, 0.15, 301)
+    model_class = erlab.analysis.fit.models.StepEdgeModel
+    values = model_class().func(eV, 0.0, 0.012, 0.15, 0.08, 1.2, -0.12)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+    kwargs = {"temp": 0.0, "resolution": 2.355 * 0.012, "fast": True}
+
+    def fail_fit(*_args: typing.Any, **_kwargs: typing.Any) -> typing.NoReturn:
+        raise ValueError("synthetic seed fit failure")
+
+    monkeypatch.setattr(model_class, "fit", fail_fit)
+
+    bounds = gold_mod.guess_edge_fit_range(edc, **kwargs)
+
+    assert bounds == pytest.approx((eV[0], eV[-1]))
+
+
+def test_guess_edge_fit_range_rejects_rising_edge() -> None:
+    eV = np.linspace(-0.3, 0.15, 301)
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = -model.func(eV, 0.0, 0.012, 0.15, 0.08, 1.2, -0.12)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+
+    with pytest.raises(ValueError, match="No falling edge was detected"):
+        gold_mod.guess_edge_fit_range(
+            edc,
+            temp=0.0,
+            resolution=2.355 * 0.012,
+            fast=True,
+        )
+
+
+def test_guess_edge_fit_range_uses_terminal_edge_after_occupied_peak() -> None:
+    eV = np.linspace(-0.4, 0.15, 551)
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = model.func(eV, 0.0, 0.012, 0.1, 0.0, 1.0, 0.0)
+    values += 5 * 0.01**2 / ((eV + 0.18) ** 2 + 0.01**2)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+
+    lower, upper = gold_mod.guess_edge_fit_range(
+        edc,
+        temp=0.0,
+        resolution=2.355 * 0.01,
+        fast=True,
+    )
+
+    assert -0.18 < lower < 0.0 < upper
+
+
+def test_guess_edge_fit_range_uses_multiscale_terminal_edge() -> None:
+    rng = np.random.default_rng(13)
+    eV = np.linspace(-0.5, 0.15, 501)
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = model.func(eV, 0.0, 0.013, 0.05, 0.0, 0.12, 0.0)
+    values += 0.5 * 0.03**2 / ((eV + 0.24) ** 2 + 0.03**2)
+    values += rng.normal(0.0, 0.03, eV.size)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+
+    lower, upper = gold_mod.guess_edge_fit_range(
+        edc,
+        temp=0.0,
+        resolution=2.355 * 0.013,
+        fast=True,
+    )
+
+    assert -0.15 < lower < 0.0 < upper
+
+
+def test_guess_edge_fit_range_estimates_width_from_broad_edge() -> None:
+    eV = np.linspace(-0.35, 0.2, 551)
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = model.func(eV, 0.0, 0.05, 0.1, 0.0, 1.0, 0.0)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+
+    lower, upper = gold_mod.guess_edge_fit_range(
+        edc,
+        temp=0.0,
+        resolution=2.355 * 0.005,
+        fast=True,
+    )
+
+    assert lower == pytest.approx(-0.2, abs=2 * (eV[1] - eV[0]))
+    assert upper == eV[-1]
+
+
+def test_guess_edge_fit_range_supports_edge_near_upper_bound() -> None:
+    eV = np.linspace(-0.2, 0.035, 96)
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = model.func(eV, 0.0, 0.012, 0.1, 0.0, 1.0, 0.0)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+
+    lower, upper = gold_mod.guess_edge_fit_range(
+        edc,
+        temp=0.0,
+        resolution=2.355 * 0.01,
+        fast=True,
+    )
+
+    assert lower < 0.0 < upper
+    assert upper == eV[-1]
+
+
+def test_guess_edge_fit_range_uses_full_range_with_short_occupied_side() -> None:
+    eV = np.linspace(-0.02, 0.2, 221)
+    model = erlab.analysis.fit.models.StepEdgeModel()
+    values = model.func(eV, 0.0, 0.006, 0.15, 0.08, 1.2, -0.12)
+    edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
+
+    bounds = gold_mod.guess_edge_fit_range(
+        edc,
+        temp=0.0,
+        resolution=2.355 * 0.006,
+        fast=True,
+    )
+
+    assert bounds == pytest.approx((eV[0], eV[-1]))
+
+
+@pytest.mark.parametrize("use_dask", [False, True], ids=["no_dask", "dask"])
+@pytest.mark.parametrize("normalize", [False, True], ids=["raw", "normalized"])
+def test_edge_adaptive_uses_per_edc_ranges(
+    gold: xr.DataArray, use_dask: bool, normalize: bool
+) -> None:
+    if use_dask:
+        gold = gold.chunk(alpha=1)
+
+    result = edge(
+        gold,
+        angle_range=(-15, 15),
+        eV_range=(-0.2, 0.2),
+        adaptive=True,
+        temp=100.0,
+        fast=True,
+        normalize=normalize,
+        progress=False,
+        return_full=True,
+        parallel_kw={"backend": "threading", "n_jobs": 1, "return_as": "list"},
+    )
+    if use_dask:
+        result = result.compute()
+
+    point_counts = result.modelfit_data.count("eV")
+    assert np.unique(point_counts).size > 1
+    assert point_counts.max() <= gold.sel(eV=slice(-0.2, 0.2)).sizes["eV"]
+    assert point_counts.min() < point_counts.max()
+
+
+@pytest.mark.parametrize("use_dask", [False, True], ids=["no_dask", "dask"])
+def test_edge_adaptive_falls_back_for_one_edc(
+    gold: xr.DataArray,
+    monkeypatch: pytest.MonkeyPatch,
+    use_dask: bool,
+) -> None:
+    original = gold_mod._guess_edge_fit_range
+    target_alpha = 0.0
+    target_values = np.asarray(gold.sel(alpha=target_alpha).sel(eV=slice(-0.2, 0.2)))
+
+    def fail_target_range(
+        x: np.ndarray, y: np.ndarray, **kwargs: typing.Any
+    ) -> tuple[float, float]:
+        if np.array_equal(y, target_values):
+            raise ValueError("synthetic range failure")
+        return original(x, y, **kwargs)
+
+    monkeypatch.setattr(gold_mod, "_guess_edge_fit_range", fail_target_range)
+    if use_dask:
+        gold = gold.chunk(alpha=1)
+
+    result = edge(
+        gold,
+        angle_range=(-15, 15),
+        eV_range=(-0.2, 0.2),
+        adaptive=True,
+        temp=100.0,
+        fast=True,
+        normalize=False,
+        progress=False,
+        return_full=True,
+        parallel_kw={"backend": "threading", "n_jobs": 1, "return_as": "list"},
+    )
+    if use_dask:
+        result = result.compute()
+
+    point_counts = result.modelfit_data.count("eV")
+    full_count = gold.sel(eV=slice(-0.2, 0.2)).sizes["eV"]
+    assert point_counts.sel(alpha=target_alpha) == full_count
+    assert point_counts.min() < full_count
+
+
+@pytest.mark.parametrize("wrapper", [gold_mod.poly, gold_mod.spline])
+def test_edge_model_wrapper_forwards_adaptive(
+    monkeypatch: pytest.MonkeyPatch,
+    wrapper: typing.Callable[..., typing.Any],
+) -> None:
+    beta = np.linspace(0.0, 10.0, 11)
+    eV = np.linspace(-0.2, 0.2, 51)
+    data = xr.DataArray(
+        np.ones((beta.size, eV.size)),
+        dims=("beta", "eV"),
+        coords={"beta": beta, "eV": eV},
+    )
+    center = xr.DataArray(np.linspace(0.0, 0.1, beta.size), coords={"beta": beta})
+    stderr = xr.ones_like(center)
+    received: dict[str, typing.Any] = {}
+
+    def stub_edge(*_args: typing.Any, **kwargs: typing.Any):
+        received.update(kwargs)
+        return center, stderr
+
+    monkeypatch.setattr(gold_mod, "edge", stub_edge)
+
+    wrapper(
+        data,
+        along="beta",
+        angle_range=(0.0, 10.0),
+        eV_range=(-0.2, 0.2),
+        adaptive=True,
+        plot=False,
+    )
+
+    assert received["adaptive"] is True
 
 
 @pytest.mark.parametrize(
@@ -326,6 +582,73 @@ def test_edge_fixed_center_with_normalize_returns_physical_center(gold) -> None:
     finite = np.isfinite(vals.values)
     assert finite.any()
     assert_allclose(vals.values[finite], 0.04, atol=1e-12)
+
+
+def test_edge_normalize_scales_energy_parameters(
+    gold: xr.DataArray, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    angle_range = (-15, 15)
+    eV_range = (-0.2, 0.2)
+    temp = 100.0
+    resolution = 0.02
+    gold_sel = gold.sel(alpha=slice(*angle_range), eV=slice(*eV_range))
+    stdx = float(gold_sel.eV.values.std())
+    received: dict[str, float] = {}
+    original = gold_mod._edge_model_and_params
+
+    def capture_energy_parameters(**kwargs: typing.Any):
+        received["temp"] = kwargs["temp"]
+        received["resolution"] = kwargs["resolution"]
+        return original(**kwargs)
+
+    monkeypatch.setattr(gold_mod, "_edge_model_and_params", capture_energy_parameters)
+
+    edge(
+        gold,
+        angle_range=angle_range,
+        eV_range=eV_range,
+        temp=temp,
+        resolution=resolution,
+        normalize=True,
+        progress=False,
+        parallel_kw={"backend": "threading", "n_jobs": 1, "return_as": "list"},
+    )
+
+    assert received["temp"] == pytest.approx(temp / stdx)
+    assert received["resolution"] == pytest.approx(resolution / stdx)
+
+
+@pytest.mark.parametrize("adaptive", [False, True], ids=["fixed", "adaptive"])
+def test_edge_is_invariant_to_energy_offset(gold: xr.DataArray, adaptive: bool) -> None:
+    offset = 71.0
+    kinetic = gold.assign_coords(eV=gold.eV + offset)
+    shifted = kinetic.assign_coords(eV=kinetic.eV - offset)
+    kwargs = {
+        "angle_range": (-15, 15),
+        "adaptive": adaptive,
+        "temp": 100.0,
+        "resolution": 0.02,
+        "fast": True,
+        "normalize": True,
+        "progress": False,
+        "parallel_kw": {
+            "backend": "threading",
+            "n_jobs": 1,
+            "return_as": "list",
+        },
+    }
+
+    kinetic_center, kinetic_stderr = typing.cast(
+        "tuple[xr.DataArray, xr.DataArray]",
+        edge(kinetic, eV_range=(70.8, 71.2), **kwargs),
+    )
+    shifted_center, shifted_stderr = typing.cast(
+        "tuple[xr.DataArray, xr.DataArray]",
+        edge(shifted, eV_range=(-0.2, 0.2), **kwargs),
+    )
+
+    assert_allclose(kinetic_center - offset, shifted_center, atol=1e-8)
+    assert_allclose(kinetic_stderr, shifted_stderr, atol=1e-8)
 
 
 def test_edge_range_selection_follows_descending_coordinate_order(gold) -> None:

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -146,6 +146,61 @@ def test_goldtool_can_save_and_load() -> None:
     assert GoldTool.can_save_and_load() is True
 
 
+def test_goldtool_adaptive_toggle_is_persisted_and_forwarded(
+    qtbot, gold, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    win: GoldTool = goldtool(gold, execute=False)
+    qtbot.addWidget(win)
+    adaptive_check = typing.cast(
+        "QtWidgets.QCheckBox", win.params_edge.widgets["Adaptive"]
+    )
+    assert not adaptive_check.isChecked()
+
+    adaptive_check.setChecked(True)
+    status = win.tool_status
+    assert status.edge_values.adaptive is True
+
+    adaptive_check.setChecked(False)
+    win.tool_status = status
+    assert adaptive_check.isChecked()
+
+    win._argnames["data"] = "gold"
+    provenance = win.current_provenance_spec()
+    assert provenance is not None
+    replay_kwargs: dict[str, typing.Any] = {}
+
+    def capture_poly(*_args: typing.Any, **kwargs: typing.Any) -> xr.Dataset:
+        replay_kwargs.update(kwargs)
+        return xr.Dataset()
+
+    monkeypatch.setattr(erlab.analysis.gold, "poly", capture_poly)
+    namespace = {"era": erlab.analysis, "gold": gold}
+    exec(  # noqa: S102
+        provenance.display_code(), {"__builtins__": {}}, namespace
+    )
+    assert replay_kwargs["adaptive"] is True
+
+    edge_kwargs: dict[str, typing.Any] = {}
+    edge_center = gold.mean("eV")
+    edge_stderr = xr.ones_like(edge_center)
+
+    def capture_edge(**kwargs: typing.Any):
+        edge_kwargs.update(kwargs)
+        return edge_center, edge_stderr
+
+    monkeypatch.setattr(erlab.analysis.gold, "edge", capture_edge)
+    typing.cast("QtWidgets.QSpinBox", win.params_edge.widgets["# CPU"]).setValue(1)
+    task = EdgeFitTask(
+        win.data,
+        win._along_dim,
+        *win.roi_limits_ordered,
+        dict(win.params_edge.values),
+    )
+    task.run()
+
+    assert edge_kwargs["adaptive"] is True
+
+
 def _seed_goldtool_poly_result(win: GoldTool, result: xr.Dataset) -> None:
     win.edge_center = result.modelfit_data.copy()
     win.edge_stderr = xr.ones_like(win.edge_center)
@@ -796,6 +851,7 @@ def test_edge_fit_task_aborted_before_run_skips_fit(gold, monkeypatch) -> None:
             "Linear": True,
             "Resolution": 0.01,
             "Fast": True,
+            "Adaptive": False,
             "Method": "leastsq",
             "Scale cov": True,
         },
@@ -833,6 +889,7 @@ def test_edge_fit_task_aborted_after_progress_skips_fit(gold, monkeypatch) -> No
             "Linear": True,
             "Resolution": 0.01,
             "Fast": True,
+            "Adaptive": False,
             "Method": "leastsq",
             "Scale cov": True,
         },
@@ -876,6 +933,7 @@ def test_edge_fit_task_aborted_during_parallel_setup_skips_fit(
             "Linear": True,
             "Resolution": 0.01,
             "Fast": True,
+            "Adaptive": False,
             "Method": "leastsq",
             "Scale cov": True,
         },
@@ -924,6 +982,7 @@ def test_edge_fit_task_aborted_after_fit_skips_finished_signal(
             "Linear": True,
             "Resolution": 0.01,
             "Fast": True,
+            "Adaptive": False,
             "Method": "leastsq",
             "Scale cov": True,
         },


### PR DESCRIPTION
## Summary

- add `guess_edge_fit_range` for one-dimensional falling Fermi edges
- estimate an independent fit range for each EDC when `adaptive=True`
- expose adaptive fitting through `gold.edge`, `gold.poly`, `gold.spline`, GoldTool state, and generated provenance code
- scale temperature and resolution consistently when the energy coordinate is normalized
- keep the temperature control available for the fast broadened-step model
- strengthen the ARPES analysis guidance for calibration, normal emission, momentum conversion, and processed-data validation

## Motivation

A fixed energy window can include occupied-side peaks or too little edge support. This can make otherwise valid EDC fits unstable. The adaptive path detects the terminal falling edge, rejects isolated outliers, checks physically plausible trial fits across several lower bounds, and selects a stable local range for each EDC.

The energy-normalization path also scaled the thermal term without scaling the resolution term. This made the initial line shape depend on the numeric energy scale. The updated implementation keeps both energy-width terms in the normalized coordinate system.

## User impact

Adaptive fitting is disabled by default. Existing calls keep their fixed fit range. Users can opt in with `adaptive=True` or with the Adaptive toggle in GoldTool.

## Validation

- `uv run pytest -q tests/analysis/test_gold.py tests/interactive/test_fermiedge.py` - 259 passed
- `uv run ruff check src/erlab/analysis/gold.py src/erlab/interactive/fermiedge.py tests/analysis/test_gold.py tests/interactive/test_fermiedge.py`
- `uv run ruff format --check src/erlab/analysis/gold.py src/erlab/interactive/fermiedge.py tests/analysis/test_gold.py tests/interactive/test_fermiedge.py`
- `uv run mypy src/erlab/analysis/gold.py src/erlab/interactive/fermiedge.py`
- `git diff --check`
