### PR TITLE
fix(interactive): restore meshtool workspaces safely

### DIFF
--- a/src/erlab/interactive/_mesh.py
+++ b/src/erlab/interactive/_mesh.py
@@ -1,5 +1,6 @@
 __all__ = ["meshtool"]
 
+import contextlib
 import enum
 import importlib.resources
 import os
@@ -94,18 +95,36 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
     @tool_status.setter
     def tool_status(self, status: StateModel) -> None:
         self.data_name = status.data_name
-        self.p0_spin0.setValue(int(status.first_order_peaks[1][0]))
-        self.p0_spin1.setValue(int(status.first_order_peaks[1][1]))
-        self.p1_spin0.setValue(int(status.first_order_peaks[2][0]))
-        self.p1_spin1.setValue(int(status.first_order_peaks[2][1]))
+        with contextlib.ExitStack() as stack:
+            if self._dataset_restore_in_progress:
+                for widget in (
+                    self.p0_spin0,
+                    self.p0_spin1,
+                    self.p1_spin0,
+                    self.p1_spin1,
+                    self.order_spin,
+                    self.n_pad_spin,
+                    self.roi_hw_spin,
+                    self.k_spin,
+                    self.feather_spin,
+                    self.undo_edge_correction_check,
+                    self.method_combo,
+                ):
+                    stack.enter_context(QtCore.QSignalBlocker(widget))
+            self.p0_spin0.setValue(int(status.first_order_peaks[1][0]))
+            self.p0_spin1.setValue(int(status.first_order_peaks[1][1]))
+            self.p1_spin0.setValue(int(status.first_order_peaks[2][0]))
+            self.p1_spin1.setValue(int(status.first_order_peaks[2][1]))
 
-        self.order_spin.setValue(status.order)
-        self.n_pad_spin.setValue(status.n_pad)
-        self.roi_hw_spin.setValue(status.roi_hw)
-        self.k_spin.setValue(status.k)
-        self.feather_spin.setValue(status.feather)
-        self.undo_edge_correction_check.setChecked(status.undo_edge_correction)
-        self.method_combo.setCurrentText(status.method)
+            self.order_spin.setValue(status.order)
+            self.n_pad_spin.setValue(status.n_pad)
+            self.roi_hw_spin.setValue(status.roi_hw)
+            self.k_spin.setValue(status.k)
+            self.feather_spin.setValue(status.feather)
+            self.undo_edge_correction_check.setChecked(status.undo_edge_correction)
+            self.method_combo.setCurrentText(status.method)
+        if self._dataset_restore_in_progress:
+            self._update_target_pos()
 
     @property
     def tool_data(self) -> xr.DataArray:
@@ -370,6 +389,7 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
 
     def _restore_initial_preview(self) -> None:
         self.set_data_beforecalc(initial=True)
+        self._update_target_pos()
 
     @QtCore.Slot()
     def _update_target_pos(self) -> None:
@@ -400,6 +420,10 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
 
     @QtCore.Slot()
     def _update_higher_order_targets(self) -> None:
+        image = self.main_fft_image.image
+        if image is None:
+            return
+
         status = self.tool_status
         order: int = status.order
         first_order: list[list[int]] = status.first_order_peaks
@@ -407,7 +431,7 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
         higher_order = erlab.analysis.mesh.higher_order_peaks(
             first_order,
             order=order,
-            shape=self.main_fft_image.image.shape,
+            shape=image.shape,
             include_center=False,
             only_upper=False,
         )[2:]

--- a/tests/interactive/test_mesh.py
+++ b/tests/interactive/test_mesh.py
@@ -384,6 +384,12 @@ def test_meshtool_deferred_restore_queues_initial_preview(
 ) -> None:
     win: MeshTool = meshtool(meshy_data, data_name="mesh_input", execute=False)
     qtbot.addWidget(win)
+    win.p0_spin0.setValue(15)
+    win.p0_spin1.setValue(20)
+    win.p1_spin0.setValue(17)
+    win.p1_spin1.setValue(12)
+    win.order_spin.setValue(2)
+    win.undo_edge_correction_check.setChecked(True)
     win.cbar_fft.set_colormap("plasma", 0.7, reverse=True)
     win.cbar_fft.setSpanRegion((-1.0, 1.0))
     saved = win.to_dataset()
@@ -414,10 +420,24 @@ def test_meshtool_deferred_restore_queues_initial_preview(
     qtbot.addWidget(restored)
     assert isinstance(restored, MeshTool)
     assert calls == []
+    assert restored.main_fft_image.image is None
+    assert restored.tool_status == win.tool_status
 
     restored.show()
 
     qtbot.wait_until(lambda: calls == [(restored, True)], timeout=5000)
+    expected_higher = erlab.analysis.mesh.higher_order_peaks(
+        restored.tool_status.first_order_peaks,
+        order=restored.tool_status.order,
+        shape=restored.main_fft_image.image.shape,
+        include_center=False,
+        only_upper=False,
+    )[2:]
+    assert len(restored.higher_order_targets) == len(expected_higher)
+    for target, expected in zip(
+        restored.higher_order_targets, expected_higher, strict=True
+    ):
+        assert (target.pos().y(), target.pos().x()) == pytest.approx(expected)
     qtbot.wait_until(
         lambda: restored.cbar_fft.spanRegion() == pytest.approx((-1.0, 1.0))
     )


### PR DESCRIPTION
## Summary

- Restore MeshTool controls without emitting intermediate signals during deferred workspace loading.
- Wait for the FFT preview before higher-order target calculation.
- Rebuild saved target positions after the deferred preview is ready.
- Add regression coverage for non-default peaks, order, and edge correction.

## Root cause

The ImageTool Manager defers the MeshTool FFT preview when it opens a workspace. Restoring changed control values emitted signals before the preview initialized `main_fft_image.image`. The higher-order target update then tried to read the shape of `None`.

## User impact

MeshTool windows in `.itws` files now open with their saved state and targets. Normal interactive updates, undo, and redo keep their existing signal behavior.

## Validation

- `QT_QPA_PLATFORM=offscreen uv run pytest tests/interactive/test_mesh.py` with PyQt6: 9 passed
- `QT_QPA_PLATFORM=offscreen QT_API=pyside6 uv run pytest tests/interactive/test_mesh.py` with PySide6: 9 passed
- `uv run ruff format --check src/erlab/interactive/_mesh.py tests/interactive/test_mesh.py`
- `uv run ruff check src/erlab/interactive/_mesh.py tests/interactive/test_mesh.py`
- `git diff --check`