### PR TITLE
feat(analysis.gold): replace fast with step edge flag

### DIFF
--- a/skills/arpes-analysis/SKILL.md
+++ b/skills/arpes-analysis/SKILL.md
@@ -159,8 +159,9 @@ available only in an external script or pre-rendered artifact.
   motor readbacks appear similar.
 - Treat implicit zero offsets as defaults, not measured normal-emission values.
 - Do not infer an angle-dependent Fermi correction from sample bands.
-- For `gold.poly`, use reliable `sample_temp` metadata. Use `fast=True` when that
-  temperature is missing or unreliable, and supply a unit-checked resolution estimate.
+- For `gold.poly`, use reliable `sample_temp` metadata. Use
+  `use_step_edge=True` when that temperature is missing or unreliable, and supply a
+  unit-checked resolution estimate.
 - Do not use symmetrized data to justify a normal-emission calibration.
 - Do not use intensity maxima or apparent brightness symmetry to locate normal
   emission. Matrix elements can suppress one side of the same contour.

--- a/skills/arpes-analysis/references/fermi-calibration.md
+++ b/skills/arpes-analysis/references/fermi-calibration.md
@@ -67,8 +67,8 @@ Do not increase the degree only to reduce residuals.
 
 Read the temperature from `sample_temp` metadata. Use the full Fermi-Dirac model only
 when this value is present, finite, physically credible, and consistent with the
-experimental record. If it is missing or unreliable, use `fast=True` so the edge fits
-use the Gaussian-broadened step model.
+experimental record. If it is missing or unreliable, use `use_step_edge=True` so the
+edge fits use the Gaussian-broadened step model.
 
 Supply a realistic initial energy resolution in electronvolts. This can improve
 convergence. Confirm the units before passing a metadata value; do not assume that an
@@ -91,7 +91,7 @@ temperature_is_reliable = (
 )
 
 edge_fit_kwargs = {
-    "fast": not temperature_is_reliable,
+    "use_step_edge": not temperature_is_reliable,
     "resolution": initial_energy_resolution,
 }
 if temperature_is_reliable:

--- a/src/erlab/analysis/gold.py
+++ b/src/erlab/analysis/gold.py
@@ -96,8 +96,32 @@ def _range_limits_for_coord(
     return float(np.min(values)), float(np.max(values))
 
 
-def _edge_sigma(*, temp: float, resolution: float, fast: bool) -> float:
-    if fast:
+def _parse_deprecated_fast(use_step_edge: bool, kwargs: dict[str, typing.Any]) -> bool:
+    if "fast" not in kwargs:
+        return use_step_edge
+
+    fast = bool(kwargs.pop("fast"))
+    warnings.warn(
+        "The `fast` argument is deprecated and will be removed in a future version. "
+        "Use `use_step_edge` instead.",
+        FutureWarning,
+        stacklevel=3,
+    )
+    if use_step_edge and not fast:
+        raise TypeError("`use_step_edge` and deprecated `fast` have conflicting values")
+    return use_step_edge or fast
+
+
+def _raise_unexpected_kwargs(function_name: str, kwargs: dict[str, typing.Any]) -> None:
+    if kwargs:
+        argument = next(iter(kwargs))
+        raise TypeError(
+            f"{function_name}() got an unexpected keyword argument {argument!r}"
+        )
+
+
+def _edge_sigma(*, temp: float, resolution: float, use_step_edge: bool) -> float:
+    if use_step_edge:
         return float(
             (resolution + 3.5255 * erlab.constants.kb_eV * temp) * _FWHM_TO_SIGMA
         )
@@ -115,13 +139,15 @@ def _edge_model_and_params(
     resolution: float,
     vary_temp: bool,
     bkg_slope: bool,
-    fast: bool,
+    use_step_edge: bool,
 ) -> tuple[lmfit.Model, lmfit.Parameters]:
-    if fast:
+    if use_step_edge:
         model = erlab.analysis.fit.models.StepEdgeModel()
         params = lmfit.create_params(
             sigma={
-                "value": _edge_sigma(temp=temp, resolution=resolution, fast=True),
+                "value": _edge_sigma(
+                    temp=temp, resolution=resolution, use_step_edge=True
+                ),
                 "min": 0,
             }
         )
@@ -262,7 +288,7 @@ def _guess_edge_fit_range(
     *,
     temp: float,
     resolution: float,
-    fast: bool,
+    use_step_edge: bool,
     bkg_slope: bool = True,
 ) -> tuple[float, float]:
     x = np.asarray(x, dtype=float)
@@ -280,7 +306,10 @@ def _guess_edge_fit_range(
     uniform_x = np.linspace(x[0], x[-1], x.size)
     uniform_y = np.interp(uniform_x, x, y)
     uniform_dx = float(uniform_x[1] - uniform_x[0])
-    sigma = max(_edge_sigma(temp=temp, resolution=resolution, fast=fast), uniform_dx)
+    sigma = max(
+        _edge_sigma(temp=temp, resolution=resolution, use_step_edge=use_step_edge),
+        uniform_dx,
+    )
     local_noise, noise_floor = _estimate_local_noise(
         uniform_y, sigma=sigma, dx=uniform_dx
     )
@@ -507,7 +536,7 @@ def _guess_edge_fit_range_or_default(
     *,
     temp: float,
     resolution: float,
-    fast: bool,
+    use_step_edge: bool,
     bkg_slope: bool = True,
 ) -> tuple[float, float]:
     x = np.asarray(x, dtype=float)
@@ -521,7 +550,7 @@ def _guess_edge_fit_range_or_default(
             y,
             temp=temp,
             resolution=resolution,
-            fast=fast,
+            use_step_edge=use_step_edge,
             bkg_slope=bkg_slope,
         )
     except (FloatingPointError, np.linalg.LinAlgError, ValueError):
@@ -535,7 +564,8 @@ def guess_edge_fit_range(
     temp: float | None = None,
     resolution: float = 0.02,
     bkg_slope: bool = True,
-    fast: bool = False,
+    use_step_edge: bool = False,
+    **kwargs,
 ) -> tuple[float, float]:
     r"""Estimate the energy range for fitting one Fermi edge.
 
@@ -549,15 +579,17 @@ def guess_edge_fit_range(
     energy_dim
         Name of the energy dimension.
     temp
-        Sample temperature in kelvins. If `None`, infer it from `edc`. The fast model
-        uses 10 K when the temperature is not available.
+        Sample temperature in kelvins. If `None`, infer it from `edc`. The broadened
+        step model uses 10 K when the temperature is not available.
     resolution
         Initial energy-resolution FWHM in electronvolts.
     bkg_slope
         If `True`, include a linear background above the Fermi level.
-    fast
-        If `True`, use the nominal width of a broadened step edge. Otherwise, use the
-        combined thermal and resolution width of a Fermi edge.
+    use_step_edge
+        If `True`, use the nominal width of a broadened step edge. If `False`, use the
+        combined thermal and resolution width of a Fermi edge. Defaults to `False`.
+    **kwargs
+        Deprecated arguments. Use `use_step_edge` instead of ``fast``.
 
     Returns
     -------
@@ -636,14 +668,21 @@ def guess_edge_fit_range(
     ValueError
         If the input is not one-dimensional, lacks required temperature metadata, has
         insufficient data, or has no qualifying falling edge.
+
+    .. versionchanged:: 3.27.0
+
+        Added `use_step_edge`. The old ``fast`` argument is deprecated.
     """
+    use_step_edge = _parse_deprecated_fast(use_step_edge, kwargs)
+    _raise_unexpected_kwargs("guess_edge_fit_range", kwargs)
+
     if edc.dims != (energy_dim,):
         raise ValueError(f"Expected a 1D DataArray along {energy_dim!r}")
 
     if temp is None:
         temp = edc.qinfo.get_value("sample_temp")
         if temp is None:
-            if fast:
+            if use_step_edge:
                 temp = 10.0
             else:
                 raise ValueError(
@@ -655,7 +694,7 @@ def guess_edge_fit_range(
         np.asarray(edc),
         temp=float(temp),
         resolution=float(resolution),
-        fast=fast,
+        use_step_edge=use_step_edge,
         bkg_slope=bkg_slope,
     )
 
@@ -819,7 +858,7 @@ def edge(
     vary_temp: bool = False,
     bkg_slope: bool = True,
     resolution: float = 0.02,
-    fast: bool = False,
+    use_step_edge: bool = False,
     method: str = "least_squares",
     scale_covar: bool = True,
     normalize: bool = True,
@@ -866,8 +905,8 @@ def edge(
         background above the Fermi level is fit with a constant. Defaults to `True`.
     resolution
         The initial resolution value to use for fitting, by default `0.02`.
-    fast
-        Whether to use the Gaussian-broadeded step function to fit the edge, by default
+    use_step_edge
+        Whether to use the Gaussian-broadened step function to fit the edge, by default
         `False`.
     method
         The fitting method to use, by default ``"least_squares"``.
@@ -893,7 +932,8 @@ def edge(
         because dropping NaNs requires computing all fit results. If ``return_full`` is
         `True`, this option is ignored.
     **kwargs
-        Additional keyword arguments to fitting.
+        Additional keyword arguments to fitting. The old ``fast`` argument is accepted
+        with a deprecation warning. Use `use_step_edge` instead.
 
     Returns
     -------
@@ -904,7 +944,13 @@ def edge(
         A dataset containing the full fit results, returned when `return_full` is
         `True`.
 
+    .. versionchanged:: 3.27.0
+
+        Added `use_step_edge`. The old ``fast`` argument is deprecated.
+
     """
+    use_step_edge = _parse_deprecated_fast(use_step_edge, kwargs)
+
     if any(b != 1 for b in bin_size):
         gold_binned = gold.coarsen(
             {along: bin_size[0], "eV": bin_size[1]}, boundary="trim"
@@ -921,7 +967,7 @@ def edge(
     if temp is None:
         temp = gold.qinfo.get_value("sample_temp")
         if temp is None:
-            if fast:
+            if use_step_edge:
                 temp = 10.0
             else:
                 raise ValueError(
@@ -948,7 +994,7 @@ def edge(
         resolution=fit_resolution,
         vary_temp=vary_temp,
         bkg_slope=bkg_slope,
-        fast=fast,
+        use_step_edge=use_step_edge,
     )
 
     if parallel_kw is None:
@@ -991,7 +1037,7 @@ def edge(
                     "temp": fit_temp,
                     "resolution": fit_resolution,
                     "bkg_slope": bkg_slope,
-                    "fast": fast,
+                    "use_step_edge": use_step_edge,
                 }
                 if data.dims == ("eV",):
                     lower, upper = _guess_edge_fit_range_or_default(
@@ -1243,7 +1289,7 @@ def poly(
     vary_temp: bool = False,
     bkg_slope: bool = True,
     resolution: float = 0.02,
-    fast: bool = False,
+    use_step_edge: bool = False,
     method: str = "least_squares",
     normalize: bool = True,
     degree: int = 4,
@@ -1254,7 +1300,11 @@ def poly(
     fig: matplotlib.figure.Figure | None = None,
     scale_covar: bool = True,
     scale_covar_edge: bool = True,
+    **kwargs,
 ) -> xr.Dataset | tuple[xr.Dataset, xr.DataArray]:
+    use_step_edge = _parse_deprecated_fast(use_step_edge, kwargs)
+    _raise_unexpected_kwargs("poly", kwargs)
+
     center_arr, center_stderr = typing.cast(
         "tuple[xr.DataArray, xr.DataArray]",
         edge(
@@ -1268,7 +1318,7 @@ def poly(
             vary_temp=vary_temp,
             bkg_slope=bkg_slope,
             resolution=resolution,
-            fast=fast,
+            use_step_edge=use_step_edge,
             method=method,
             normalize=normalize,
             parallel_kw=parallel_kw,
@@ -1314,7 +1364,7 @@ def spline(
     vary_temp: bool = False,
     bkg_slope: bool = True,
     resolution: float = 0.02,
-    fast: bool = False,
+    use_step_edge: bool = False,
     method: str = "least_squares",
     lam: float | None = None,
     correct: bool = False,
@@ -1323,7 +1373,11 @@ def spline(
     plot: bool = True,
     fig: matplotlib.figure.Figure | None = None,
     scale_covar_edge: bool = True,
+    **kwargs,
 ) -> scipy.interpolate.BSpline | tuple[scipy.interpolate.BSpline, xr.DataArray]:
+    use_step_edge = _parse_deprecated_fast(use_step_edge, kwargs)
+    _raise_unexpected_kwargs("spline", kwargs)
+
     center_arr, center_stderr = typing.cast(
         "tuple[xr.DataArray, xr.DataArray]",
         edge(
@@ -1337,7 +1391,7 @@ def spline(
             vary_temp=vary_temp,
             bkg_slope=bkg_slope,
             resolution=resolution,
-            fast=fast,
+            use_step_edge=use_step_edge,
             method=method,
             parallel_kw=parallel_kw,
             scale_covar=scale_covar_edge,
@@ -1666,11 +1720,12 @@ def resolution(
     eV_range_fit: tuple[float, float] | None = None,
     bin_size: tuple[int, int] = (1, 1),
     degree: int = 4,
-    fast: bool = False,
+    use_step_edge: bool = False,
     method: str = "leastsq",
     plot: bool = True,
     parallel_kw: dict | None = None,
     scale_covar: bool = True,
+    **kwargs,
 ) -> lmfit.model.ModelResult:  # pragma: no cover
     """Fit a Fermi edge and obtain the resolution from the corrected data.
 
@@ -1685,6 +1740,8 @@ def resolution(
         FutureWarning,
         stacklevel=1,
     )
+    use_step_edge = _parse_deprecated_fast(use_step_edge, kwargs)
+    _raise_unexpected_kwargs("resolution", kwargs)
 
     pol, gold_corr = typing.cast(
         "tuple[xr.Dataset, xr.DataArray]",
@@ -1695,7 +1752,7 @@ def resolution(
             bin_size=bin_size,
             degree=degree,
             correct=True,
-            fast=fast,
+            use_step_edge=use_step_edge,
             method=method,
             plot=plot,
             parallel_kw=parallel_kw,

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -61,7 +61,7 @@ LMFIT_METHODS = [
 
 logger = logging.getLogger(__name__)
 
-_GOLDTOOL_STATE_SCHEMA_VERSION = 2
+_GOLDTOOL_STATE_SCHEMA_VERSION = 3
 
 
 def _disconnect_signal(signal: typing.Any) -> None:
@@ -160,7 +160,7 @@ class EdgeFitTask(QtCore.QRunnable):
                         vary_temp=not self.params["Fix T"],
                         bkg_slope=self.params["Linear"],
                         resolution=self.params["Resolution"],
-                        fast=self.params["Fast"],
+                        use_step_edge=self.params["Step edge"],
                         adaptive=self.params["Adaptive"],
                         method=self.params["Method"],
                         scale_covar=self.params["Scale cov"],
@@ -210,7 +210,11 @@ class _GoldEdgeState(_GoldStateBase):
     bin_x: int = pydantic.Field(default=1, alias="Bin x")
     bin_y: int = pydantic.Field(default=1, alias="Bin y")
     resolution: float = pydantic.Field(default=0.02, alias="Resolution")
-    fast: bool = pydantic.Field(default=False, alias="Fast")
+    use_step_edge: bool = pydantic.Field(
+        default=False,
+        validation_alias=pydantic.AliasChoices("Step edge", "Fast"),
+        serialization_alias="Step edge",
+    )
     adaptive: bool = pydantic.Field(default=False, alias="Adaptive")
     linear: bool = pydantic.Field(default=True, alias="Linear")
     method: str = pydantic.Field(default="least_squares", alias="Method")
@@ -420,7 +424,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
                     "singleStep": 0.001,
                     "decimals": 5,
                 },
-                "Fast": {
+                "Step edge": {
                     "qwtype": "chkbox",
                     "checked": False,
                     "toolTip": "If checked, fit with a broadened step function "
@@ -459,8 +463,8 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         ).setCurrentIndex(1)
 
         typing.cast(
-            "QtWidgets.QCheckBox", self.params_edge.widgets["Fast"]
-        ).stateChanged.connect(self._toggle_fast)
+            "QtWidgets.QCheckBox", self.params_edge.widgets["Step edge"]
+        ).stateChanged.connect(self._toggle_step_edge)
 
         self.params_poly = erlab.interactive.utils.ParameterGroup(
             {
@@ -696,7 +700,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
         self.params_roi.modify_roi(*self._clamp_roi_limits_to_bounds(status.roi_limits))
         self.params_roi.update_pos()
-        self._toggle_fast()
+        self._toggle_step_edge()
         self._sync_spline_lambda_enabled()
 
         if status.fit_snapshot is not None:
@@ -763,7 +767,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             ),
             ("Bin x / y", f"{edge['Bin x']} / {edge['Bin y']}"),
             ("Resolution", f"{edge['Resolution']} eV"),
-            ("Fast", self._bool_text(bool(edge["Fast"]))),
+            ("Step edge", self._bool_text(bool(edge["Step edge"]))),
             ("Adaptive", self._bool_text(bool(edge["Adaptive"]))),
             (
                 "Background above EF",
@@ -1085,7 +1089,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
                     self.params_spl, request.spline_values.model_dump(by_alias=True)
                 )
                 self.params_tab.setCurrentIndex(request.tab_index)
-            self._toggle_fast()
+            self._toggle_step_edge()
             self._sync_spline_lambda_enabled()
         self._reset_history_stack()
 
@@ -1127,9 +1131,9 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             data = data.copy().T
         return data
 
-    def _toggle_fast(self) -> None:
+    def _toggle_step_edge(self) -> None:
         self.params_edge.widgets["Fix T"].setDisabled(
-            bool(self.params_edge.values["Fast"])
+            bool(self.params_edge.values["Step edge"])
         )
 
     def iterated(self, n: int, *, task: EdgeFitTask | None = None) -> None:
@@ -1422,7 +1426,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             "vary_temp": not p0["Fix T"],
             "bkg_slope": p0["Linear"],
             "resolution": p0["Resolution"],
-            "fast": p0["Fast"],
+            "use_step_edge": p0["Step edge"],
             "adaptive": p0["Adaptive"],
             "method": p0["Method"],
             "scale_covar_edge": p0["Scale cov"],

--- a/tests/analysis/test_gold.py
+++ b/tests/analysis/test_gold.py
@@ -1,3 +1,4 @@
+import inspect
 import typing
 
 import matplotlib.pyplot as plt
@@ -90,11 +91,45 @@ def test_range_slice_for_coord_nonmonotonic_raises() -> None:
         _ = gold_mod._range_slice_for_coord(coord, (-1.0, 1.0))
 
 
-@pytest.mark.parametrize("fast", [True, False], ids=["fast", "regular"])
-def test_guess_edge_fit_range(gold: xr.DataArray, fast: bool) -> None:
+@pytest.mark.parametrize(
+    "func",
+    [
+        gold_mod.guess_edge_fit_range,
+        gold_mod.edge,
+        gold_mod.poly,
+        gold_mod.spline,
+        gold_mod.resolution,
+    ],
+)
+def test_gold_fit_api_exposes_use_step_edge(func: typing.Callable) -> None:
+    parameters = inspect.signature(func).parameters
+
+    assert "use_step_edge" in parameters
+    assert "fast" not in parameters
+
+
+@pytest.mark.parametrize("fast", [False, True])
+def test_guess_edge_fit_range_warns_for_deprecated_fast(
+    gold: xr.DataArray, fast: bool
+) -> None:
     edc = gold.sel(eV=slice(-0.2, 0.2)).sel(alpha=0.0)
 
-    lower, upper = gold_mod.guess_edge_fit_range(edc, temp=100.0, fast=fast)
+    with pytest.warns(FutureWarning, match="Use `use_step_edge` instead"):
+        legacy_bounds = gold_mod.guess_edge_fit_range(edc, temp=100.0, fast=fast)
+    current_bounds = gold_mod.guess_edge_fit_range(edc, temp=100.0, use_step_edge=fast)
+
+    assert legacy_bounds == current_bounds
+
+
+@pytest.mark.parametrize(
+    "use_step_edge", [True, False], ids=["use_step_edge", "regular"]
+)
+def test_guess_edge_fit_range(gold: xr.DataArray, use_step_edge: bool) -> None:
+    edc = gold.sel(eV=slice(-0.2, 0.2)).sel(alpha=0.0)
+
+    lower, upper = gold_mod.guess_edge_fit_range(
+        edc, temp=100.0, use_step_edge=use_step_edge
+    )
     selected = edc.sel(eV=slice(lower, upper))
 
     assert lower < 0.04 < upper
@@ -107,7 +142,7 @@ def test_edge_model_params_fix_background_slope() -> None:
         resolution=0.02,
         vary_temp=False,
         bkg_slope=False,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert params["back1"].value == 0.0
@@ -145,7 +180,7 @@ def test_guess_edge_fit_range_validates_energy_coordinate(
     edc = xr.DataArray(np.ones(eV.size), coords={"eV": eV}, dims="eV")
 
     with pytest.raises(ValueError, match=message):
-        gold_mod.guess_edge_fit_range(edc, temp=10.0, fast=True)
+        gold_mod.guess_edge_fit_range(edc, temp=10.0, use_step_edge=True)
 
 
 def test_guess_edge_fit_range_uses_temperature_metadata() -> None:
@@ -159,7 +194,7 @@ def test_guess_edge_fit_range_uses_temperature_metadata() -> None:
         attrs={"sample_temp": 20.0},
     )
 
-    lower, upper = gold_mod.guess_edge_fit_range(edc, fast=False)
+    lower, upper = gold_mod.guess_edge_fit_range(edc, use_step_edge=False)
 
     assert lower < 0.0 < upper
 
@@ -170,11 +205,11 @@ def test_guess_edge_fit_range_temperature_fallback_and_validation() -> None:
     values = model.func(eV, 0.0, 0.01, 0.1, 0.0, 1.0, 0.0)
     edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
 
-    lower, upper = gold_mod.guess_edge_fit_range(edc, fast=True)
+    lower, upper = gold_mod.guess_edge_fit_range(edc, use_step_edge=True)
     assert lower < 0.0 < upper
 
     with pytest.raises(ValueError, match="Temperature not found"):
-        gold_mod.guess_edge_fit_range(edc, fast=False)
+        gold_mod.guess_edge_fit_range(edc, use_step_edge=False)
 
 
 def test_guess_edge_fit_range_requires_one_edc() -> None:
@@ -185,7 +220,7 @@ def test_guess_edge_fit_range_requires_one_edc() -> None:
     )
 
     with pytest.raises(ValueError, match="Expected a 1D DataArray"):
-        gold_mod.guess_edge_fit_range(data, temp=10.0, fast=True)
+        gold_mod.guess_edge_fit_range(data, temp=10.0, use_step_edge=True)
 
 
 def test_guess_edge_fit_range_uses_model_guess_for_rank_deficient_initialization(
@@ -213,7 +248,7 @@ def test_guess_edge_fit_range_uses_model_guess_for_rank_deficient_initialization
         edc,
         temp=0.0,
         resolution=2.355 * 0.012,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert forced_rank_deficiency
@@ -231,7 +266,7 @@ def test_guess_edge_fit_range_finds_edge_outside_initial_tail() -> None:
         edc,
         temp=0.0,
         resolution=2.355 * 0.006,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert lower < center < upper
@@ -246,7 +281,7 @@ def test_guess_edge_fit_range_falls_back_when_seed_fit_fails(
     model_class = erlab.analysis.fit.models.StepEdgeModel
     values = model_class().func(eV, 0.0, 0.012, 0.15, 0.08, 1.2, -0.12)
     edc = xr.DataArray(values, coords={"eV": eV}, dims="eV")
-    kwargs = {"temp": 0.0, "resolution": 2.355 * 0.012, "fast": True}
+    kwargs = {"temp": 0.0, "resolution": 2.355 * 0.012, "use_step_edge": True}
 
     def fail_fit(*_args: typing.Any, **_kwargs: typing.Any) -> typing.NoReturn:
         raise ValueError("synthetic seed fit failure")
@@ -278,7 +313,7 @@ def test_guess_edge_fit_range_falls_back_for_unsuccessful_fits(
         temp=0.0,
         resolution=2.355 * 0.012,
         bkg_slope=False,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert bounds == pytest.approx((eV[0], eV[-1]))
@@ -307,7 +342,7 @@ def test_guess_edge_fit_range_uses_full_range_without_candidate_support(
         values,
         temp=0.0,
         resolution=0.01,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert bounds == pytest.approx((eV[0], eV[-1]))
@@ -335,7 +370,7 @@ def test_guess_edge_fit_range_rejects_candidate_without_terminal_contrast(
             values,
             temp=0.0,
             resolution=0.01,
-            fast=True,
+            use_step_edge=True,
         )
 
 
@@ -346,7 +381,7 @@ def test_guess_edge_fit_range_default_requires_finite_energy() -> None:
             np.ones(12),
             temp=10.0,
             resolution=0.02,
-            fast=True,
+            use_step_edge=True,
         )
 
 
@@ -361,7 +396,7 @@ def test_guess_edge_fit_range_rejects_rising_edge() -> None:
             edc,
             temp=0.0,
             resolution=2.355 * 0.012,
-            fast=True,
+            use_step_edge=True,
         )
 
 
@@ -376,7 +411,7 @@ def test_guess_edge_fit_range_uses_terminal_edge_after_occupied_peak() -> None:
         edc,
         temp=0.0,
         resolution=2.355 * 0.01,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert -0.18 < lower < 0.0 < upper
@@ -395,7 +430,7 @@ def test_guess_edge_fit_range_uses_multiscale_terminal_edge() -> None:
         edc,
         temp=0.0,
         resolution=2.355 * 0.013,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert -0.15 < lower < 0.0 < upper
@@ -411,7 +446,7 @@ def test_guess_edge_fit_range_estimates_width_from_broad_edge() -> None:
         edc,
         temp=0.0,
         resolution=2.355 * 0.005,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert lower == pytest.approx(-0.2, abs=2 * (eV[1] - eV[0]))
@@ -428,7 +463,7 @@ def test_guess_edge_fit_range_supports_edge_near_upper_bound() -> None:
         edc,
         temp=0.0,
         resolution=2.355 * 0.01,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert lower < 0.0 < upper
@@ -445,7 +480,7 @@ def test_guess_edge_fit_range_uses_full_range_with_short_occupied_side() -> None
         edc,
         temp=0.0,
         resolution=2.355 * 0.006,
-        fast=True,
+        use_step_edge=True,
     )
 
     assert bounds == pytest.approx((eV[0], eV[-1]))
@@ -465,7 +500,7 @@ def test_edge_adaptive_uses_per_edc_ranges(
         eV_range=(-0.2, 0.2),
         adaptive=True,
         temp=100.0,
-        fast=True,
+        use_step_edge=True,
         normalize=normalize,
         progress=False,
         return_full=True,
@@ -507,7 +542,7 @@ def test_edge_adaptive_falls_back_for_one_edc(
         eV_range=(-0.2, 0.2),
         adaptive=True,
         temp=100.0,
-        fast=True,
+        use_step_edge=True,
         normalize=False,
         progress=False,
         return_full=True,
@@ -523,7 +558,10 @@ def test_edge_adaptive_falls_back_for_one_edc(
 
 
 def test_edge_adaptive_requires_skipna(gold: xr.DataArray) -> None:
-    with pytest.raises(ValueError, match="adaptive fitting requires skipna=True"):
+    with (
+        pytest.warns(FutureWarning, match="Use `use_step_edge` instead"),
+        pytest.raises(ValueError, match="adaptive fitting requires skipna=True"),
+    ):
         edge(
             gold,
             angle_range=(-15, 15),
@@ -537,7 +575,7 @@ def test_edge_adaptive_requires_skipna(gold: xr.DataArray) -> None:
 
 
 @pytest.mark.parametrize("wrapper", [gold_mod.poly, gold_mod.spline])
-def test_edge_model_wrapper_forwards_adaptive(
+def test_edge_model_wrapper_forwards_options(
     monkeypatch: pytest.MonkeyPatch,
     wrapper: typing.Callable[..., typing.Any],
 ) -> None:
@@ -558,24 +596,29 @@ def test_edge_model_wrapper_forwards_adaptive(
 
     monkeypatch.setattr(gold_mod, "edge", stub_edge)
 
-    wrapper(
-        data,
-        along="beta",
-        angle_range=(0.0, 10.0),
-        eV_range=(-0.2, 0.2),
-        adaptive=True,
-        plot=False,
-    )
+    with pytest.warns(FutureWarning, match="Use `use_step_edge` instead"):
+        wrapper(
+            data,
+            along="beta",
+            angle_range=(0.0, 10.0),
+            eV_range=(-0.2, 0.2),
+            adaptive=True,
+            fast=True,
+            plot=False,
+        )
 
     assert received["adaptive"] is True
+    assert received["use_step_edge"] is True
 
 
 @pytest.mark.parametrize(
     "parallel_kw", [None, {"return_as": "list"}], ids=["generator", "list"]
 )
-@pytest.mark.parametrize("fast", [True, False], ids=["fast", "regular"])
+@pytest.mark.parametrize(
+    "use_step_edge", [True, False], ids=["use_step_edge", "regular"]
+)
 @pytest.mark.parametrize("use_dask", [False, True], ids=["no_dask", "dask"])
-def test_poly(gold, parallel_kw: dict, fast: bool, use_dask: bool) -> None:
+def test_poly(gold, parallel_kw: dict, use_step_edge: bool, use_dask: bool) -> None:
     if use_dask:
         gold = gold.chunk(alpha=1)
     if parallel_kw:
@@ -587,7 +630,7 @@ def test_poly(gold, parallel_kw: dict, fast: bool, use_dask: bool) -> None:
         angle_range=(-15, 15),
         eV_range=(-0.2, 0.2),
         temp=100.0,
-        fast=fast,
+        use_step_edge=use_step_edge,
         vary_temp=False,
         degree=2,
         plot=True,
@@ -622,9 +665,11 @@ def test_poly(gold, parallel_kw: dict, fast: bool, use_dask: bool) -> None:
 @pytest.mark.parametrize(
     "parallel_kw", [None, {"return_as": "list"}], ids=["generator", "list"]
 )
-@pytest.mark.parametrize("fast", [True, False], ids=["fast", "regular"])
+@pytest.mark.parametrize(
+    "use_step_edge", [True, False], ids=["use_step_edge", "regular"]
+)
 @pytest.mark.parametrize("use_dask", [False, True], ids=["no_dask", "dask"])
-def test_poly_nd(gold, parallel_kw: dict, fast: bool, use_dask: bool) -> None:
+def test_poly_nd(gold, parallel_kw: dict, use_step_edge: bool, use_dask: bool) -> None:
     gold_nd = gold.expand_dims(
         {"beta": np.array([-1.0, 0.0, 1.0]), "hv": np.array([20.0, 21.0])}
     )
@@ -639,7 +684,7 @@ def test_poly_nd(gold, parallel_kw: dict, fast: bool, use_dask: bool) -> None:
         angle_range=(-15, 15),
         eV_range=(-0.2, 0.2),
         temp=100.0,
-        fast=fast,
+        use_step_edge=use_step_edge,
         vary_temp=False,
         degree=2,
         parallel_kw=parallel_kw,
@@ -673,7 +718,7 @@ def test_spline(gold) -> None:
         eV_range=(-0.2, 0.2),
         temp=100.0,
         vary_temp=False,
-        fast=True,
+        use_step_edge=True,
         lam=None,
         plot=True,
         parallel_kw={"backend": "threading"},
@@ -693,7 +738,7 @@ def test_poly_crop_correct_uses_range_slice(gold) -> None:
         angle_range=(10.0, -10.0),
         eV_range=(0.2, -0.2),
         temp=100.0,
-        fast=True,
+        use_step_edge=True,
         vary_temp=False,
         degree=2,
         plot=False,
@@ -714,7 +759,7 @@ def test_spline_crop_correct_uses_range_slice(gold) -> None:
         angle_range=(10.0, -10.0),
         eV_range=(0.2, -0.2),
         temp=100.0,
-        fast=True,
+        use_step_edge=True,
         vary_temp=False,
         plot=False,
         correct=True,
@@ -853,7 +898,7 @@ def test_edge_is_invariant_to_energy_offset(gold: xr.DataArray, adaptive: bool) 
         "adaptive": adaptive,
         "temp": 100.0,
         "resolution": 0.02,
-        "fast": True,
+        "use_step_edge": True,
         "normalize": True,
         "progress": False,
         "parallel_kw": {
@@ -914,7 +959,7 @@ def test_poly_plot_supports_open_bounds(gold) -> None:
         temp=100.0,
         vary_temp=False,
         degree=2,
-        fast=True,
+        use_step_edge=True,
         plot=True,
         fig=fig,
         parallel_kw={"backend": "threading", "n_jobs": 1, "return_as": "list"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -448,7 +448,7 @@ def gold_fit_res(gold) -> xr.Dataset:
         gold,
         angle_range=(-13.5, 13.5),
         eV_range=(-0.204, 0.276),
-        fast=True,
+        use_step_edge=True,
         parallel_kw={"backend": "threading"},
     )
 
@@ -459,7 +459,7 @@ def gold_fit_res_fd(gold) -> xr.Dataset:
         gold,
         angle_range=(-13.5, 13.5),
         eV_range=(-0.204, 0.276),
-        fast=False,
+        use_step_edge=False,
         parallel_kw={"backend": "threading"},
     )
 

--- a/tests/interactive/imagetool/manager/helpers.py
+++ b/tests/interactive/imagetool/manager/helpers.py
@@ -306,7 +306,7 @@ def configure_goldtool_child(
                 "Bin x": 2,
                 "Bin y": 3,
                 "Resolution": 0.015,
-                "Fast": False,
+                "Step edge": False,
                 "Linear": False,
                 "Method": "cg",
                 "Scale cov": False,
@@ -337,7 +337,7 @@ def configure_goldtool_child(
 
     tool.params_roi.modify_roi(x0=-8.0, x1=8.0, y0=-0.2, y1=0.1)
     tool.refit_on_source_update_check.setChecked(True)
-    tool._toggle_fast()
+    tool._toggle_step_edge()
     tool._sync_spline_lambda_enabled()
 
     if fitted:

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -74,7 +74,7 @@ def _configure_goldtool_state(
                 "Bin x": 2,
                 "Bin y": 3,
                 "Resolution": 0.015,
-                "Fast": False,
+                "Step edge": False,
                 "Linear": False,
                 "Method": "cg",
                 "Scale cov": False,
@@ -105,7 +105,7 @@ def _configure_goldtool_state(
 
     win.params_roi.modify_roi(x0=-8.0, x1=8.0, y0=-0.2, y1=0.1)
     win.refit_on_source_update_check.setChecked(True)
-    win._toggle_fast()
+    win._toggle_step_edge()
     win._sync_spline_lambda_enabled()
 
     if fitted:
@@ -154,15 +154,23 @@ def test_goldtool_adaptive_toggle_is_persisted_and_forwarded(
     adaptive_check = typing.cast(
         "QtWidgets.QCheckBox", win.params_edge.widgets["Adaptive"]
     )
+    step_edge_check = typing.cast(
+        "QtWidgets.QCheckBox", win.params_edge.widgets["Step edge"]
+    )
     assert not adaptive_check.isChecked()
+    assert not step_edge_check.isChecked()
 
     adaptive_check.setChecked(True)
+    step_edge_check.setChecked(True)
     status = win.tool_status
     assert status.edge_values.adaptive is True
+    assert status.edge_values.use_step_edge is True
 
     adaptive_check.setChecked(False)
+    step_edge_check.setChecked(False)
     win.tool_status = status
     assert adaptive_check.isChecked()
+    assert step_edge_check.isChecked()
 
     win._argnames["data"] = "gold"
     provenance = win.current_provenance_spec()
@@ -179,6 +187,7 @@ def test_goldtool_adaptive_toggle_is_persisted_and_forwarded(
         provenance.display_code(), {"__builtins__": {}}, namespace
     )
     assert replay_kwargs["adaptive"] is True
+    assert replay_kwargs["use_step_edge"] is True
 
     edge_kwargs: dict[str, typing.Any] = {}
     edge_center = gold.mean("eV")
@@ -199,6 +208,7 @@ def test_goldtool_adaptive_toggle_is_persisted_and_forwarded(
     task.run()
 
     assert edge_kwargs["adaptive"] is True
+    assert edge_kwargs["use_step_edge"] is True
 
 
 def _seed_goldtool_poly_result(win: GoldTool, result: xr.Dataset) -> None:
@@ -210,16 +220,16 @@ def _seed_goldtool_poly_result(win: GoldTool, result: xr.Dataset) -> None:
     win.params_tab.setDisabled(False)
 
 
-@pytest.mark.parametrize("fast", [True, False], ids=["StepB", "FD"])
+@pytest.mark.parametrize("use_step_edge", [True, False], ids=["StepB", "FD"])
 def test_goldtool(
-    qtbot, gold, fast, gold_fit_res, gold_fit_res_fd, accept_dialog
+    qtbot, gold, use_step_edge, gold_fit_res, gold_fit_res_fd, accept_dialog
 ) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
-    win.params_edge.widgets["Fast"].setChecked(fast)
+    win.params_edge.widgets["Step edge"].setChecked(use_step_edge)
     win.params_edge.widgets["# CPU"].setValue(1)
 
-    expected = gold_fit_res if fast else gold_fit_res_fd
+    expected = gold_fit_res if use_step_edge else gold_fit_res_fd
     _seed_goldtool_poly_result(win, expected)
 
     def check_generated_code(w: GoldTool) -> None:
@@ -371,8 +381,10 @@ def test_goldtool_roundtrip_fitted(qtbot, gold) -> None:
 
         with xr.load_dataset(filename, engine="h5netcdf") as saved:
             saved_state = json.loads(saved.attrs["tool_state"])
-            assert saved_state["schema_version"] == 2
+            assert saved_state["schema_version"] == 3
             assert "fit_snapshot" not in saved_state
+            assert saved_state["edge_values"]["Step edge"] is False
+            assert "Fast" not in saved_state["edge_values"]
             assert "go" not in saved_state["edge_values"]
             assert "copy" not in saved_state["poly_values"]
             assert "itool" not in saved_state["poly_values"]
@@ -392,9 +404,7 @@ def test_goldtool_roundtrip_fitted(qtbot, gold) -> None:
         assert str(win_restored.info_text) == str(win.info_text)
 
 
-def test_goldtool_loads_legacy_state_with_raw_dicts_and_fit_snapshot(
-    qtbot, gold
-) -> None:
+def test_goldtool_loads_legacy_state_with_fast_and_fit_snapshot(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
     qtbot.addWidget(win)
     _configure_goldtool_state(win, fitted=True, spline=True)
@@ -403,14 +413,17 @@ def test_goldtool_loads_legacy_state_with_raw_dicts_and_fit_snapshot(
 
     saved = _drop_goldtool_fit_payload(win.to_dataset())
     legacy_state = json.loads(saved.attrs["tool_state"])
-    legacy_state.pop("schema_version", None)
-    legacy_state["edge_values"] = {
+    legacy_state["schema_version"] = 2
+    legacy_edge_values = {
         **dict(win.params_edge.values),
         "go": True,
         "unknown": "ignored",
         "Method": "unsupported-method",
         "# CPU": 0,
     }
+    legacy_edge_values["Fast"] = True
+    legacy_edge_values.pop("Step edge")
+    legacy_state["edge_values"] = legacy_edge_values
     legacy_state["poly_values"] = {
         **dict(win.params_poly.values),
         "itool": True,
@@ -433,9 +446,13 @@ def test_goldtool_loads_legacy_state_with_raw_dicts_and_fit_snapshot(
     assert isinstance(restored, GoldTool)
 
     assert restored.params_tab.currentIndex() == 0
+    assert restored.params_edge.values["Step edge"] is True
     assert restored.params_edge.values["Method"] == "least_squares"
     assert restored.params_edge.values["# CPU"] == 1
-    assert "go" not in restored.tool_status.edge_values.model_dump(by_alias=True)
+    restored_edge_values = restored.tool_status.edge_values.model_dump(by_alias=True)
+    assert restored_edge_values["Step edge"] is True
+    assert "Fast" not in restored_edge_values
+    assert "go" not in restored_edge_values
     assert "copy" not in restored.tool_status.poly_values.model_dump(by_alias=True)
     xr.testing.assert_equal(restored.edge_center, win.edge_center)
     xr.testing.assert_equal(restored.edge_stderr, win.edge_stderr)
@@ -850,7 +867,7 @@ def test_edge_fit_task_aborted_before_run_skips_fit(gold, monkeypatch) -> None:
             "Fix T": False,
             "Linear": True,
             "Resolution": 0.01,
-            "Fast": True,
+            "Step edge": True,
             "Adaptive": False,
             "Method": "leastsq",
             "Scale cov": True,
@@ -888,7 +905,7 @@ def test_edge_fit_task_aborted_after_progress_skips_fit(gold, monkeypatch) -> No
             "Fix T": False,
             "Linear": True,
             "Resolution": 0.01,
-            "Fast": True,
+            "Step edge": True,
             "Adaptive": False,
             "Method": "leastsq",
             "Scale cov": True,
@@ -932,7 +949,7 @@ def test_edge_fit_task_aborted_during_parallel_setup_skips_fit(
             "Fix T": False,
             "Linear": True,
             "Resolution": 0.01,
-            "Fast": True,
+            "Step edge": True,
             "Adaptive": False,
             "Method": "leastsq",
             "Scale cov": True,
@@ -981,7 +998,7 @@ def test_edge_fit_task_aborted_after_fit_skips_finished_signal(
             "Fix T": False,
             "Linear": True,
             "Resolution": 0.01,
-            "Fast": True,
+            "Step edge": True,
             "Adaptive": False,
             "Method": "leastsq",
             "Scale cov": True,


### PR DESCRIPTION
## Summary

- Add `use_step_edge` to the public gold fitting APIs.
- Accept the old `fast` keyword through `**kwargs` and emit `FutureWarning`.
- Rename the GoldTool option to `Step edge`.
- Load existing GoldTool schema version 2 states that contain `Fast`.
- Update generated code and ARPES skill examples.

## Rationale

The `fast` name describes expected performance, but the option changes the fit model.
The new name states that the broadened step-edge model is selected.

## User impact

New code uses `use_step_edge=True`. Existing calls with `fast=` continue to work
during the deprecation period. Existing serialized GoldTool states migrate when loaded.

## Validation

- `uv run pytest -q tests/analysis/test_gold.py` (202 passed)
- `uv run pytest -q tests/interactive/test_fermiedge.py` (77 passed)
- `uv run ruff check src/erlab/analysis/gold.py src/erlab/interactive/fermiedge.py tests/analysis/test_gold.py tests/conftest.py tests/interactive/test_fermiedge.py`
- `uv run ruff format --check src/erlab/analysis/gold.py src/erlab/interactive/fermiedge.py tests/analysis/test_gold.py tests/conftest.py tests/interactive/test_fermiedge.py`
- `uv run mypy src`
- `git diff --check`
