### PR TITLE
fix(manager): preserve deferred tools after source removal

### DIFF
--- a/src/erlab/analysis/gold.py
+++ b/src/erlab/analysis/gold.py
@@ -669,9 +669,6 @@ def guess_edge_fit_range(
         If the input is not one-dimensional, lacks required temperature metadata, has
         insufficient data, or has no qualifying falling edge.
 
-    .. versionchanged:: 3.27.0
-
-        Added `use_step_edge`. The old ``fast`` argument is deprecated.
     """
     use_step_edge = _parse_deprecated_fast(use_step_edge, kwargs)
     _raise_unexpected_kwargs("guess_edge_fit_range", kwargs)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -464,17 +464,39 @@ class _WorkspaceLoader:
     ) -> xr.DataArray | None:
         if not node.is_imagetool:
             return None
+        return self._saved_workspace_reference_source_data_for_uid(
+            node.uid,
+            snapshot_token=snapshot_token,
+            data_role=data_role,
+            owner_node=owner_node,
+            reference_datasets=reference_datasets,
+            source_node=node,
+        )
+
+    def _saved_workspace_reference_source_data_for_uid(
+        self,
+        node_uid: str,
+        *,
+        snapshot_token: str | None,
+        data_role: ScriptInputDataRole,
+        owner_node: _ImageToolWrapper | _ManagedWindowNode | None,
+        reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] | None,
+        source_node: _ImageToolWrapper | _ManagedWindowNode | None = None,
+        workspace_path: str | os.PathLike[str] | None = None,
+    ) -> xr.DataArray | None:
+        """Read a referenced ImageTool snapshot after its node was removed."""
         pending_owner = (
             None if owner_node is None else owner_node.pending_workspace_tool_payload
         )
-        workspace_path = (
-            pending_owner[0]
-            if pending_owner is not None
-            else self._manager._workspace_state.path
-        )
+        if workspace_path is None:
+            workspace_path = (
+                pending_owner[0]
+                if pending_owner is not None
+                else self._manager._workspace_state.path
+            )
         if workspace_path is None:
             return None
-        payload_path = self._workspace_payload_path_for_uid(workspace_path, node.uid)
+        payload_path = self._workspace_payload_path_for_uid(workspace_path, node_uid)
         opened = self._workspace_imagetool_reference_dataset_at(
             workspace_path,
             payload_path,
@@ -482,18 +504,39 @@ class _WorkspaceLoader:
             reference_datasets=reference_datasets,
         )
         ds = workspace_format._restore_workspace_dataset_attrs(opened.copy(deep=False))
+        saved_uid = workspace_format._decode_workspace_attr_text(
+            ds.attrs.get("manager_node_uid")
+        )
+        saved_kind = workspace_format._decode_workspace_attr_text(
+            ds.attrs.get("manager_node_kind")
+        )
+        if saved_uid != node_uid or saved_kind != "imagetool":
+            return None
         saved_token = workspace_format._decode_workspace_attr_text(
             ds.attrs.get("manager_node_snapshot_token")
             if data_role == "displayed"
             else ds.attrs.get("manager_node_source_snapshot_token")
         )
-        if saved_token != snapshot_token:
+        if snapshot_token is not None and saved_token != snapshot_token:
             return None
-        return self.pending._workspace_imagetool_source_data(
-            node,
+        if source_node is not None:
+            return self.pending._workspace_imagetool_source_data(
+                source_node,
+                opened,
+                attrs=None,
+                data_role=data_role,
+            )
+        saved_name = workspace_format._decode_workspace_attr_text(
+            ds.attrs.get("itool_name")
+        )
+        return self.pending._workspace_imagetool_source_data_from_payload(
             opened,
-            attrs=None,
+            attrs=ds.attrs,
             data_role=data_role,
+            name=saved_name or None,
+            source_input_ndim=typing.cast(
+                "int | None", ds.attrs.get("manager_node_source_input_ndim")
+            ),
         )
 
     @staticmethod
@@ -568,17 +611,35 @@ class _WorkspaceLoader:
             if not isinstance(node_uid, str) or not node_uid:
                 return None
             target: int | str = node_uid
-            if loaded_targets_by_uid is None:
-                if node_uid not in self._manager._tool_graph.nodes:
-                    return None
-            else:
+            if loaded_targets_by_uid is not None:
                 target = loaded_targets_by_uid.get(node_uid, node_uid)
             data_role = payload.get("data_role", "displayed")
             if data_role not in {"source", "displayed"}:
                 return None
             try:
-                source_node = self._manager._node_for_target(target)
                 snapshot_token = payload.get("node_snapshot_token")
+                try:
+                    source_node = self._manager._node_for_target(target)
+                except resolver_error_types:
+                    pending_owner = (
+                        None
+                        if owner_node is None
+                        else owner_node.pending_workspace_tool_payload
+                    )
+                    if pending_owner is None:
+                        return None
+                    return self._saved_workspace_reference_source_data_for_uid(
+                        node_uid,
+                        snapshot_token=(
+                            snapshot_token
+                            if isinstance(snapshot_token, str) and snapshot_token
+                            else None
+                        ),
+                        data_role=typing.cast("ScriptInputDataRole", data_role),
+                        owner_node=owner_node,
+                        reference_datasets=reference_datasets,
+                        workspace_path=pending_owner[0],
+                    )
                 if (
                     isinstance(snapshot_token, str)
                     and snapshot_token

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -27,6 +27,7 @@ from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME, ImageTool
 from erlab.interactive.imagetool._provenance._model import (
     ScriptInputDataRole,
     ToolProvenanceSpec,
+    mark_promoted_1d_source,
     parse_tool_provenance_operation,
     parse_tool_provenance_spec,
     require_live_source_spec,
@@ -267,9 +268,26 @@ class _PendingWorkspacePayloads:
         attrs: Mapping[typing.Any, typing.Any] | None,
         data_role: ScriptInputDataRole,
     ) -> xr.DataArray:
+        data = self._workspace_imagetool_source_data_from_payload(
+            opened,
+            attrs=attrs,
+            data_role=data_role,
+            name=None if node.name == "" else node.name,
+        )
+        return node._finalize_script_input_data(data)
+
+    def _workspace_imagetool_source_data_from_payload(
+        self,
+        opened: xr.Dataset,
+        *,
+        attrs: Mapping[typing.Any, typing.Any] | None,
+        data_role: ScriptInputDataRole,
+        name: str | None,
+        source_input_ndim: int | None = None,
+    ) -> xr.DataArray:
+        """Restore script-input data without requiring a live manager node."""
         ds = workspace_format._restore_workspace_dataset_attrs(opened.copy(deep=False))
         ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
-        name = None if node.name == "" else node.name
         data = self._loader._workspace_imagetool_payload_data(ds).rename(name)
         if attrs is None:
             attrs = ds.attrs
@@ -292,7 +310,9 @@ class _PendingWorkspacePayloads:
                         data = self._apply_pending_workspace_filter(
                             data, state.get("filter_operation")
                         )
-        return node._finalize_script_input_data(data)
+        if source_input_ndim == 1:
+            data = mark_promoted_1d_source(data)
+        return data.copy(deep=False)
 
     @staticmethod
     def _pending_workspace_data_with_loaded_coords(data: xr.DataArray) -> xr.DataArray:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -387,7 +387,18 @@ class _WorkspaceSaver:
                 node.pending_workspace_payload is not None
                 and not node.materialize_pending_workspace_payload()
             ):
-                raise ValueError("Could not read this saved tool from the workspace.")
+                message = "Could not read this saved tool from the workspace"
+                if node.display_text:
+                    message += f": {node.display_text!r}"
+                message += f" ({node.uid})"
+                unavailable_uids = (
+                    self._pending_workspace_tool_unavailable_reference_uids(node)
+                )
+                if unavailable_uids:
+                    message += ". Unavailable manager-node references: " + ", ".join(
+                        unavailable_uids
+                    )
+                raise ValueError(f"{message}.")
             tool = typing.cast("erlab.interactive.utils.ToolWindow", node.tool_window)
             if not tool.can_save_and_load():
                 return
@@ -933,6 +944,50 @@ class _WorkspaceSaver:
             ):
                 return False
         return True
+
+    def _pending_workspace_tool_unavailable_reference_uids(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> tuple[str, ...]:
+        attrs = node.pending_workspace_payload_attrs
+        if attrs is None:
+            return ()
+        payload = attrs.get(erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR)
+        if isinstance(payload, bytes):
+            with contextlib.suppress(UnicodeDecodeError):
+                payload = payload.decode()
+        if not isinstance(payload, str):
+            return ()
+        try:
+            references = json.loads(payload)
+        except Exception:
+            return ()
+        if not isinstance(references, dict):
+            return ()
+        unavailable_uids: set[str] = set()
+        for reference in references.values():
+            if not isinstance(reference, dict):
+                continue
+            kind = reference.get("kind")
+            if kind == "parent_source":
+                parent_uid = node.parent_uid
+                if (
+                    isinstance(parent_uid, str)
+                    and parent_uid not in self._manager._tool_graph.nodes
+                ):
+                    unavailable_uids.add(parent_uid)
+                continue
+            if kind != "manager_node":
+                continue
+            node_uid = reference.get("node_uid")
+            if (
+                isinstance(node_uid, str)
+                and node_uid
+                and not self._controller._tool_data_reference_matches_current_snapshot(
+                    reference
+                )
+            ):
+                unavailable_uids.add(node_uid)
+        return tuple(sorted(unavailable_uids))
 
     def _workspace_save_snapshot(
         self, fname: str | os.PathLike[str]

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -733,6 +733,44 @@ def test_pending_tool_reference_reads_owner_workspace(
         assert workspace_paths == [imported_path]
 
 
+def test_saved_workspace_reference_rejects_mismatched_payload(
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        loader = manager._workspace_controller.loading
+        monkeypatch.setattr(
+            loader,
+            "_workspace_payload_path_for_uid",
+            lambda *_args, **_kwargs: "payload",
+        )
+        monkeypatch.setattr(
+            loader,
+            "_workspace_imagetool_reference_dataset_at",
+            lambda *_args, **_kwargs: xr.Dataset(
+                attrs={
+                    "manager_node_uid": "different-source",
+                    "manager_node_kind": "imagetool",
+                }
+            ),
+        )
+
+        assert (
+            loader._saved_workspace_reference_source_data_for_uid(
+                "expected-source",
+                snapshot_token=None,
+                data_role="displayed",
+                owner_node=None,
+                reference_datasets=None,
+                workspace_path=tmp_path / "workspace.itws",
+            )
+            is None
+        )
+
+
 def test_manager_workspace_roundtrip_restores_loader_and_standalone_apps(
     qtbot,
     tmp_path: pathlib.Path,

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import logging
 import pathlib
+import types
 import typing
 import weakref
 from collections.abc import Callable, Mapping
@@ -648,6 +649,88 @@ def test_manager_workspace_import_does_not_restore_manager_layout(
             manager._workspace_controller.saving._workspace_layout_snapshot()
             == current_layout
         )
+
+
+def test_eager_tool_reference_does_not_read_associated_workspace(
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        loader = manager._workspace_controller.loading
+        manager._workspace_state.path = tmp_path / "associated.itws"
+        reference = {"kind": "manager_node", "node_uid": "missing-source"}
+        ds = xr.Dataset(
+            attrs={
+                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                    {"data": reference}
+                )
+            }
+        )
+        monkeypatch.setattr(
+            loader,
+            "_saved_workspace_reference_source_data_for_uid",
+            lambda *_args, **_kwargs: pytest.fail(
+                "an eager import must not read the associated workspace"
+            ),
+        )
+
+        _parent_data, resolver = loader._workspace_tool_restore_references(
+            ds,
+            parent_target=None,
+            loaded_targets_by_uid={},
+        )
+
+        assert resolver(reference) is None
+
+
+def test_pending_tool_reference_reads_owner_workspace(
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        loader = manager._workspace_controller.loading
+        manager._workspace_state.path = tmp_path / "associated.itws"
+        imported_path = tmp_path / "imported.itws"
+        reference = {"kind": "manager_node", "node_uid": "removed-source"}
+        ds = xr.Dataset(
+            attrs={
+                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                    {"data": reference}
+                )
+            }
+        )
+        resolved = xr.DataArray([1.0], dims=("x",))
+        workspace_paths: list[pathlib.Path] = []
+
+        def _saved_source(*_args, workspace_path, **_kwargs):
+            workspace_paths.append(pathlib.Path(workspace_path))
+            return resolved
+
+        monkeypatch.setattr(
+            loader, "_saved_workspace_reference_source_data_for_uid", _saved_source
+        )
+        owner_node = typing.cast(
+            "typing.Any",
+            types.SimpleNamespace(
+                pending_workspace_tool_payload=(imported_path, "figures/tool")
+            ),
+        )
+
+        _parent_data, resolver = loader._workspace_tool_restore_references(
+            ds,
+            parent_target=None,
+            loaded_targets_by_uid={},
+            owner_node=owner_node,
+        )
+
+        assert resolver(reference) is resolved
+        assert workspace_paths == [imported_path]
 
 
 def test_manager_workspace_roundtrip_restores_loader_and_standalone_apps(

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -2173,10 +2173,32 @@ def test_pending_workspace_1d_roles_match_materialized_provenance_input(
             assert ".squeeze()" not in code
             namespace = _exec_generated_code(code, {"watched_1d": data.copy(deep=True)})
             xr.testing.assert_identical(namespace["derived"], data)
-
         manager.get_imagetool(0)
         for role in ("source", "displayed"):
             xr.testing.assert_identical(wrapper.data_for_role(role), pending[role])
+
+
+def test_detached_pending_workspace_source_preserves_promoted_1d_marker(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="source")
+    opened = xr.Dataset({_ITOOL_DATA_NAME: data})
+
+    with manager_context() as manager:
+        pending = manager._workspace_controller.loading.pending
+        for data_role in ("source", "displayed"):
+            restored = pending._workspace_imagetool_source_data_from_payload(
+                opened,
+                attrs={},
+                data_role=data_role,
+                name="restored",
+                source_input_ndim=1,
+            )
+
+            assert restored.name == "restored"
+            assert restored.attrs["_erlab_promoted_from_1d_source"] is True
 
 
 def test_pending_workspace_filter_validation(monkeypatch) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -1234,6 +1234,105 @@ def test_generation_save_copies_pending_tools_without_construction(
             )
 
 
+def test_generation_save_embeds_pending_tool_data_after_source_removal(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25, dtype=np.float64).reshape((5, 5)),
+            dims=("x", "y"),
+            coords={"x": np.arange(5), "y": np.arange(5)},
+            name="source",
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        root_uid = manager._tool_graph.root_wrappers[0].uid
+
+        figure_uid = manager.add_figuretool(
+            _WorkspaceManagerReferenceFigureTool(
+                data.rename("figure"), reference_uid=root_uid
+            ),
+            show=False,
+        )
+        fname = tmp_path / "removed-pending-reference.itws"
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        figure_node = manager._child_node(figure_uid)
+        assert figure_node.pending_workspace_tool_payload is not None
+        manager.remove_imagetool(0)
+
+        assert _request_workspace_save_and_wait(qtbot, manager)
+        assert figure_node.pending_workspace_tool_payload is None
+        figure = manager.get_childtool(figure_uid)
+        xr.testing.assert_identical(figure.tool_data, data.rename("figure"))
+
+        with h5py.File(fname, "r") as h5_file:
+            payload = h5_file[
+                _current_workspace_payload_path(fname, f"figures/{figure_uid}")
+            ]
+            assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in payload
+            assert (
+                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR not in payload.attrs
+            )
+
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+        restored = manager.get_childtool(figure_uid)
+        xr.testing.assert_identical(restored.tool_data, data.rename("figure"))
+
+
+def test_generation_save_detaches_pending_figure_composer_from_removed_source(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(25, dtype=np.float64).reshape((5, 5)),
+            dims=("x", "y"),
+            coords={"x": np.arange(5), "y": np.arange(5)},
+            name="source",
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        figure_uid = manager.create_figure_from_targets((0,), show=False)
+
+        fname = tmp_path / "removed-figure-composer-source.itws"
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+
+        figure_node = manager._child_node(figure_uid)
+        assert figure_node.pending_workspace_tool_payload is not None
+        manager.remove_imagetool(0)
+
+        assert _request_workspace_save_and_wait(qtbot, manager)
+        figure = manager.get_childtool(figure_uid)
+        xr.testing.assert_identical(figure.tool_data, data)
+
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname, replace=True, associate=True, mark_dirty=False, select=False
+        )
+        restored = manager.get_childtool(figure_uid)
+        xr.testing.assert_identical(restored.tool_data, data)
+        assert all(source.node_uid is None for source in restored.tool_status.sources)
+
+
 def test_hidden_toolwindow_with_missing_saved_class_is_skipped(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -1463,9 +1463,26 @@ def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
     pending = types.SimpleNamespace(
         is_imagetool=False,
         pending_workspace_payload=("workspace.itws", "/tool"),
+        pending_workspace_payload_attrs={
+            erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                {
+                    "data": {
+                        "kind": "manager_node",
+                        "node_uid": "missing-source",
+                    }
+                }
+            )
+        },
+        display_text="Saved figure",
+        parent_uid=None,
+        uid="figure-uid",
         materialize_pending_workspace_payload=lambda: False,
     )
-    with pytest.raises(ValueError, match="Could not read this saved tool"):
+    saver._manager = types.SimpleNamespace(_tool_graph=types.SimpleNamespace(nodes={}))
+    saver._controller = types.SimpleNamespace(
+        _tool_data_reference_matches_current_snapshot=lambda _reference: False
+    )
+    with pytest.raises(ValueError, match=r"Saved figure.*missing-source"):
         saver._serialize_workspace_node({}, pending, "0", include_children=False)
 
     unsavable = types.SimpleNamespace(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -1495,6 +1495,99 @@ def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
     assert constructor == {}
 
 
+@pytest.mark.parametrize(
+    ("attrs", "parent_uid", "nodes", "expected"),
+    [
+        (None, None, {}, ()),
+        (
+            {erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: b"\xff"},
+            None,
+            {},
+            (),
+        ),
+        (
+            {erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: "not-json"},
+            None,
+            {},
+            (),
+        ),
+        (
+            {erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: "[]"},
+            None,
+            {},
+            (),
+        ),
+        (
+            {
+                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                    {
+                        "invalid": None,
+                        "parent": {"kind": "parent_source"},
+                        "external": {"kind": "external"},
+                        "empty": {"kind": "manager_node", "node_uid": ""},
+                        "available": {
+                            "kind": "manager_node",
+                            "node_uid": "available-source",
+                        },
+                    }
+                ).encode()
+            },
+            "missing-parent",
+            {"available-source": object()},
+            ("missing-parent",),
+        ),
+        (
+            {
+                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                    {"parent": {"kind": "parent_source"}}
+                )
+            },
+            "available-parent",
+            {"available-parent": object()},
+            (),
+        ),
+    ],
+)
+def test_pending_workspace_unavailable_reference_uids(
+    attrs,
+    parent_uid,
+    nodes,
+    expected,
+) -> None:
+    saver = workspace_saving._WorkspaceSaver.__new__(workspace_saving._WorkspaceSaver)
+    saver._manager = types.SimpleNamespace(
+        _tool_graph=types.SimpleNamespace(nodes=nodes)
+    )
+    saver._controller = types.SimpleNamespace(
+        _tool_data_reference_matches_current_snapshot=lambda reference: (
+            reference.get("node_uid") in nodes
+        )
+    )
+    node = types.SimpleNamespace(
+        pending_workspace_payload_attrs=attrs,
+        parent_uid=parent_uid,
+    )
+
+    assert saver._pending_workspace_tool_unavailable_reference_uids(node) == expected
+
+
+def test_serialize_workspace_node_error_without_optional_metadata() -> None:
+    saver = workspace_saving._WorkspaceSaver.__new__(workspace_saving._WorkspaceSaver)
+    saver._manager = types.SimpleNamespace(_tool_graph=types.SimpleNamespace(nodes={}))
+    pending = types.SimpleNamespace(
+        is_imagetool=False,
+        pending_workspace_payload=("workspace.itws", "/tool"),
+        pending_workspace_payload_attrs=None,
+        display_text="",
+        parent_uid=None,
+        uid="figure-uid",
+        materialize_pending_workspace_payload=lambda: False,
+    )
+
+    with pytest.raises(ValueError, match="Could not read this saved tool"):
+        saver._serialize_workspace_node({}, pending, "0", include_children=False)
+
+
 def test_workspace_gc_controller_lifecycle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,


### PR DESCRIPTION
## Summary

- Restore removed ImageTool source data from the previous workspace generation when a deferred saved tool still uses it.
- Embed the restored data in the surviving tool and remove stale manager-node references.
- Keep eager imports isolated from the currently associated workspace.
- Include the failing tool and unavailable source UIDs in save errors.

## Root cause

Deferred saved tools can store references to ImageTool payloads instead of duplicate arrays. Removing a referenced ImageTool made the reference stale. Save then tried to construct the deferred tool after its source node was gone, so the tool data could not be restored.

## User impact

Users can remove source ImageTools and save the workspace without losing a surviving Figure Composer or another saved tool that used those sources.

## Validation

- `uv run pytest -q tests/interactive/imagetool/manager/workspace/test_pending_persistence.py tests/interactive/imagetool/manager/workspace/test_saving.py tests/interactive/imagetool/manager/workspace/test_loading.py` (`201 passed`)
- Focused PySide6 workspace tests (`4 passed`)
- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `uv run mypy src` (`262 source files`)
- `git diff --check origin/main...HEAD`
