### PR TITLE
fix(analysis): support restored multi-chunk Dask data

### DIFF
--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -1556,11 +1556,19 @@ class MomentumAccessor(ERLabDataArrayAccessor):
             [typing.cast("tuple[str, ...]", target_dict[d].dims) for d in input_dims]
         )
 
-        out = xr.apply_ufunc(
-            _wrap_interpn,
+        ufunc_args = (
             self._data_ensure_binding(),
             *tuple(self._coord_for_conversion(dim) for dim in input_dims),
             *tuple(target_dict[dim] for dim in input_dims),
+        )
+        ufunc_args = tuple(
+            arg.chunk(dict.fromkeys(core_dims, -1)) if arg.chunks is not None else arg
+            for arg, core_dims in zip(ufunc_args, input_core_dims, strict=True)
+        )
+
+        out = xr.apply_ufunc(
+            _wrap_interpn,
+            *ufunc_args,
             vectorize=True,
             dask="parallelized",
             input_core_dims=input_core_dims,

--- a/src/erlab/analysis/gold.py
+++ b/src/erlab/analysis/gold.py
@@ -960,6 +960,8 @@ def edge(
             "eV": _range_slice_for_coord(gold["eV"], eV_range),
         }
     )
+    if gold_sel.chunks is not None:
+        gold_sel = gold_sel.chunk({"eV": -1})
 
     if temp is None:
         temp = gold.qinfo.get_value("sample_temp")

--- a/tests/accessors/test_kspace.py
+++ b/tests/accessors/test_kspace.py
@@ -1034,6 +1034,17 @@ def test_kconv_hvdep_kinetic_rejects(
     )
 
 
+def test_kconv_rechunks_core_dimensions(anglemap) -> None:
+    data = anglemap.copy(deep=True)
+    data.attrs["configuration"] = AxesConfiguration.Type1.value
+
+    expected = data.kspace.convert(silent=True)
+    chunked = data.chunk({"alpha": 4, "beta": 4, "eV": 4})
+    actual = chunked.kspace.convert(silent=True).compute()
+
+    xarray.testing.assert_allclose(actual, expected)
+
+
 @pytest.mark.parametrize("missing_coord", ["alpha", "beta", "chi", "xi", "eV", "hv"])
 def test_kconv_missing_coord(missing_coord, anglemap):
     data = anglemap.copy().assign_coords(chi=0.0)

--- a/tests/analysis/test_gold.py
+++ b/tests/analysis/test_gold.py
@@ -492,7 +492,7 @@ def test_edge_adaptive_uses_per_edc_ranges(
     gold: xr.DataArray, use_dask: bool, normalize: bool
 ) -> None:
     if use_dask:
-        gold = gold.chunk(alpha=1)
+        gold = gold.chunk(alpha=1, eV=25)
 
     result = edge(
         gold,


### PR DESCRIPTION
## Summary

- Rechunk the energy axis before Dask-backed Fermi-edge fitting.
- Rechunk each k-space interpolation core dimension before conversion.
- Add regression tests with multiple chunks along the affected core dimensions.

## Root cause

ImageTool workspace restore opens referenced parent data lazily with the saved HDF5 chunk layout. The restored data can contain multiple Dask chunks along `eV`, `alpha`, or another interpolation dimension. Xarray generalized ufuncs require each core dimension to use one chunk, so GoldTool reruns and KTool preview conversion could fail after workspace restore.

The fix preserves lazy execution. It combines only the dimensions that each generalized ufunc consumes as core dimensions. Outer-dimension chunking remains unchanged.

## Validation

- `uv run --group pyqt6 pytest tests/analysis/test_gold.py tests/accessors/test_kspace.py -q` (`388 passed`)
- `uv run ruff check src/erlab/accessors/kspace.py src/erlab/analysis/gold.py tests/accessors/test_kspace.py tests/analysis/test_gold.py`
- `uv run mypy src/erlab/analysis/gold.py src/erlab/accessors/kspace.py`
- `git diff --check`

The full `uv run mypy src` command could not complete because optional packages are not installed in this worktree. The missing packages include `numbagg`, `nexusformat`, `csaps`, `hvplot`, `panel`, `astropy`, and `iminuit`.
