### PR TITLE
feat(figure-composer): support shared GridSpec axes

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -70,7 +70,8 @@ and DPI of the figure, and the number of axes and their arrangement.
   several cells or nested regions created with {class}`matplotlib.gridspec.GridSpec`.
   Drag in the GridSpec editor to create rectangular axes or nested grids. Open a nested
   grid to edit it in place, then use the breadcrumb controls to return to the parent
-  grid.
+  grid. Select an axes region, then use the x or y control under {guilabel}`Share axes`
+  to select the axes that share that coordinate axis.
 
 (figure-composer-recipe)=
 

--- a/src/erlab/interactive/_figurecomposer/_code.py
+++ b/src/erlab/interactive/_figurecomposer/_code.py
@@ -15,6 +15,7 @@ from erlab.interactive._figurecomposer._model._gridspec import (
     _gridspec_axis_code_tuple,
     _gridspec_has_invalid_regions,
     _gridspec_invalid_axes_ids,
+    _gridspec_shared_axes_targets,
     _gridspec_span_code,
     _gridspec_valid_axes_ids,
 )
@@ -26,7 +27,11 @@ from erlab.interactive._figurecomposer._rendering import (
     _setup_kwargs,
     _setup_layout_value,
 )
-from erlab.interactive._figurecomposer._text import _code_kwargs, _format_axes_tuple
+from erlab.interactive._figurecomposer._text import (
+    _code_kwargs,
+    _format_axes_tuple,
+    _RawCode,
+)
 
 if typing.TYPE_CHECKING:
     import xarray as xr
@@ -176,6 +181,8 @@ def _gridspec_setup_code_lines(context: FigureRecipeContext) -> list[str]:
     code_names = _gridspec_axis_code_names(
         setup, reserved_names=_reserved_code_names(context)
     )
+    sharex_targets = _gridspec_shared_axes_targets(setup, "x")
+    sharey_targets = _gridspec_shared_axes_targets(setup, "y")
 
     def grid_kwargs(grid: FigureGridSpecGridState) -> dict[str, typing.Any]:
         grid_kwargs: dict[str, typing.Any] = {
@@ -199,11 +206,19 @@ def _gridspec_setup_code_lines(context: FigureRecipeContext) -> list[str]:
             lines.append(
                 f"{grid_var} = fig.add_gridspec({_code_kwargs(grid_kwargs(grid))})"
             )
-        lines.extend(
-            f"{code_names[axis.axes_id]} = fig.add_subplot("
-            f"{grid_var}{_gridspec_span_code(axis.span, grid)})"
-            for axis in grid.axes
-        )
+        for axis in grid.axes:
+            subplot_kwargs: dict[str, typing.Any] = {}
+            if target := sharex_targets.get(axis.axes_id):
+                subplot_kwargs["sharex"] = _RawCode(code_names[target])
+            if target := sharey_targets.get(axis.axes_id):
+                subplot_kwargs["sharey"] = _RawCode(code_names[target])
+            kwargs_code = _code_kwargs(subplot_kwargs)
+            if kwargs_code:
+                kwargs_code = f", {kwargs_code}"
+            lines.append(
+                f"{code_names[axis.axes_id]} = fig.add_subplot("
+                f"{grid_var}{_gridspec_span_code(axis.span, grid)}{kwargs_code})"
+            )
         for child_index, child in enumerate(grid.child_grids):
             child_var = f"{grid_var}_{child_index}"
             if child.span is None:

--- a/src/erlab/interactive/_figurecomposer/_model/_gridspec.py
+++ b/src/erlab/interactive/_figurecomposer/_model/_gridspec.py
@@ -27,6 +27,110 @@ def _gridspec_all_axes_ids(setup: FigureSubplotsState) -> tuple[str, ...]:
     return tuple(axis.axes_id for axis in _gridspec_all_axes(setup))
 
 
+def _gridspec_shared_axes_group(
+    setup: FigureSubplotsState,
+    axes_id: str,
+    dimension: typing.Literal["x", "y"],
+) -> tuple[str, ...]:
+    """Return the ordered shared-axis group that contains *axes_id*."""
+    if axes_id not in _gridspec_axes_by_id(setup):
+        return ()
+    groups = _gridspec_shared_axes_groups(setup, dimension)
+    group = next((group for group in groups if axes_id in group), (axes_id,))
+    group_ids = set(group)
+    return tuple(item for item in _gridspec_all_axes_ids(setup) if item in group_ids)
+
+
+def _gridspec_shared_axes_targets(
+    setup: FigureSubplotsState,
+    dimension: typing.Literal["x", "y"],
+) -> dict[str, str]:
+    """Map each valid non-anchor axes to its stable shared-axis anchor."""
+    valid_axes_ids = _gridspec_valid_axes_ids(setup, _gridspec_all_axes_ids(setup))
+    targets: dict[str, str] = {}
+    for group in _gridspec_shared_axes_groups(setup, dimension):
+        members = tuple(axes_id for axes_id in valid_axes_ids if axes_id in group)
+        if len(members) < 2:
+            continue
+        anchor = members[0]
+        targets.update(dict.fromkeys(members[1:], anchor))
+    return targets
+
+
+def _gridspec_set_shared_axes_group(
+    setup: FigureSubplotsState,
+    axes_id: str,
+    dimension: typing.Literal["x", "y"],
+    shared_axes_ids: Iterable[str],
+) -> FigureSubplotsState:
+    """Replace the shared-axis group that contains *axes_id*."""
+    all_axes_ids = _gridspec_all_axes_ids(setup)
+    if axes_id not in all_axes_ids:
+        return setup
+    requested = {axes_id, *shared_axes_ids}
+    selected = tuple(item for item in all_axes_ids if item in requested)
+    selected_set = set(selected)
+    updated_groups: list[tuple[str, ...]] = []
+    for group in _gridspec_shared_axes_groups(setup, dimension):
+        remaining = tuple(item for item in group if item not in selected_set)
+        if len(remaining) >= 2:
+            updated_groups.append(remaining)
+    if len(selected) >= 2:
+        updated_groups.append(selected)
+    return _gridspec_replace_shared_axes_groups(
+        setup,
+        dimension,
+        _gridspec_order_shared_axes_groups(setup, updated_groups),
+    )
+
+
+def _gridspec_shared_axes_groups(
+    setup: FigureSubplotsState, dimension: typing.Literal["x", "y"]
+) -> tuple[tuple[str, ...], ...]:
+    if dimension == "x":
+        return setup.gridspec.shared_x_axes
+    if dimension == "y":
+        return setup.gridspec.shared_y_axes
+    raise ValueError(f"unknown shared-axis dimension {dimension!r}")
+
+
+def _gridspec_replace_shared_axes_groups(
+    setup: FigureSubplotsState,
+    dimension: typing.Literal["x", "y"],
+    groups: tuple[tuple[str, ...], ...],
+) -> FigureSubplotsState:
+    field = "shared_x_axes" if dimension == "x" else "shared_y_axes"
+    if groups == _gridspec_shared_axes_groups(setup, dimension):
+        return setup
+    return setup.model_copy(
+        update={
+            "gridspec": setup.gridspec.model_copy(update={field: groups}),
+        }
+    )
+
+
+def _gridspec_order_shared_axes_groups(
+    setup: FigureSubplotsState, groups: Iterable[tuple[str, ...]]
+) -> tuple[tuple[str, ...], ...]:
+    axis_order = {
+        axes_id: index for index, axes_id in enumerate(_gridspec_all_axes_ids(setup))
+    }
+    fallback = len(axis_order)
+    ordered_groups = [
+        tuple(sorted(group, key=lambda item: axis_order.get(item, fallback)))
+        for group in groups
+    ]
+    return tuple(
+        sorted(
+            ordered_groups,
+            key=lambda group: min(
+                (axis_order.get(item, fallback) for item in group),
+                default=fallback,
+            ),
+        )
+    )
+
+
 def _gridspec_valid_axes_ids(
     setup: FigureSubplotsState, axes_ids: Iterable[str]
 ) -> tuple[str, ...]:
@@ -184,12 +288,43 @@ def _gridspec_root_from_subplots(setup: FigureSubplotsState) -> FigureGridSpecGr
     )
 
 
+def _subplots_shared_axes_groups(
+    setup: FigureSubplotsState,
+    axes_ids: tuple[str, ...],
+    share: bool | typing.Literal["none", "all", "row", "col"],
+) -> tuple[tuple[str, ...], ...]:
+    if share is False or share == "none":
+        return ()
+    if share is True or share == "all":
+        return (axes_ids,) if len(axes_ids) >= 2 else ()
+    if share == "row":
+        groups = tuple(
+            axes_ids[row * setup.ncols : (row + 1) * setup.ncols]
+            for row in range(setup.nrows)
+        )
+    else:
+        groups = tuple(
+            tuple(axes_ids[row * setup.ncols + col] for row in range(setup.nrows))
+            for col in range(setup.ncols)
+        )
+    return tuple(group for group in groups if len(group) >= 2)
+
+
 def _gridspec_setup_from_subplots(setup: FigureSubplotsState) -> FigureSubplotsState:
     root = _gridspec_root_from_subplots(setup)
+    axes_ids = tuple(axis.axes_id for axis in root.axes)
     return setup.model_copy(
         update={
             "layout_mode": "gridspec",
-            "gridspec": FigureGridSpecLayoutState(root=root),
+            "gridspec": FigureGridSpecLayoutState(
+                root=root,
+                shared_x_axes=_subplots_shared_axes_groups(
+                    setup, axes_ids, setup.sharex
+                ),
+                shared_y_axes=_subplots_shared_axes_groups(
+                    setup, axes_ids, setup.sharey
+                ),
+            ),
         }
     )
 
@@ -443,6 +578,18 @@ def _gridspec_axes_root_targets(
 def _gridspec_remove_region(
     setup: FigureSubplotsState, grid_id: str, region_id: str
 ) -> FigureSubplotsState:
+    grid = _gridspec_grid_by_id(setup, grid_id)
+    if grid is None:
+        return setup
+    removed_axes_ids = {axis.axes_id for axis in grid.axes if axis.axes_id == region_id}
+    for child in grid.child_grids:
+        if child.grid_id == region_id:
+            removed_axes_ids.update(axis.axes_id for axis in _iter_axes(child))
+    if not removed_axes_ids and not any(
+        child.grid_id == region_id for child in grid.child_grids
+    ):
+        return setup
+
     def updater(grid: FigureGridSpecGridState) -> FigureGridSpecGridState:
         return grid.model_copy(
             update={
@@ -453,7 +600,21 @@ def _gridspec_remove_region(
             }
         )
 
-    return _gridspec_replace_grid(setup, grid_id, updater)
+    updated = _gridspec_replace_grid(setup, grid_id, updater)
+    for dimension in ("x", "y"):
+        remaining_groups: list[tuple[str, ...]] = []
+        for group in _gridspec_shared_axes_groups(updated, dimension):
+            remaining = tuple(
+                axes_id for axes_id in group if axes_id not in removed_axes_ids
+            )
+            if len(remaining) >= 2:
+                remaining_groups.append(remaining)
+        updated = _gridspec_replace_shared_axes_groups(
+            updated,
+            dimension,
+            tuple(remaining_groups),
+        )
+    return updated
 
 
 def _gridspec_nearest_axes_after_region_delete(

--- a/src/erlab/interactive/_figurecomposer/_model/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_model/_state.py
@@ -95,8 +95,26 @@ class FigureGridSpecLayoutState(pydantic.BaseModel):
     root: FigureGridSpecGridState = pydantic.Field(
         default_factory=lambda: FigureGridSpecGridState(grid_id="root", label="Root")
     )
+    shared_x_axes: tuple[tuple[str, ...], ...] = ()
+    shared_y_axes: tuple[tuple[str, ...], ...] = ()
 
     model_config = pydantic.ConfigDict(extra="forbid")
+
+    @pydantic.field_validator("shared_x_axes", "shared_y_axes")
+    @classmethod
+    def _validate_shared_axes(
+        cls, value: tuple[tuple[str, ...], ...]
+    ) -> tuple[tuple[str, ...], ...]:
+        used: set[str] = set()
+        for group in value:
+            if len(group) < 2:
+                raise ValueError("shared-axis groups must contain at least two axes")
+            if len(set(group)) != len(group):
+                raise ValueError("shared-axis groups cannot contain duplicate axes")
+            if used.intersection(group):
+                raise ValueError("an axis cannot belong to multiple shared-axis groups")
+            used.update(group)
+        return value
 
 
 _SLICE_MARKER_KEY = "__erlab_figure_composer_slice__"

--- a/src/erlab/interactive/_figurecomposer/_rendering.py
+++ b/src/erlab/interactive/_figurecomposer/_rendering.py
@@ -26,6 +26,7 @@ from erlab.interactive._figurecomposer._model._axes import (
 from erlab.interactive._figurecomposer._model._gridspec import (
     _gridspec_all_axes_ids,
     _gridspec_region_valid,
+    _gridspec_shared_axes_targets,
     _gridspec_valid_axes_ids,
 )
 from erlab.interactive._figurecomposer._model._sources import (
@@ -186,6 +187,8 @@ def _make_gridspec_axes(
 ) -> dict[str, matplotlib.axes.Axes]:
     setup = tool._document.recipe.setup
     axes_by_id: dict[str, matplotlib.axes.Axes] = {}
+    sharex_targets = _gridspec_shared_axes_targets(setup, "x")
+    sharey_targets = _gridspec_shared_axes_targets(setup, "y")
 
     def gridspec_kwargs(grid: FigureGridSpecGridState) -> dict[str, typing.Any]:
         kwargs: dict[str, typing.Any] = {
@@ -205,11 +208,17 @@ def _make_gridspec_axes(
     def build_grid(grid: FigureGridSpecGridState, spec: typing.Any) -> None:
         for axis_state in grid.axes:
             if _gridspec_region_valid(grid, axis_state.span):
+                subplot_kwargs: dict[str, typing.Any] = {}
+                if target := sharex_targets.get(axis_state.axes_id):
+                    subplot_kwargs["sharex"] = axes_by_id[target]
+                if target := sharey_targets.get(axis_state.axes_id):
+                    subplot_kwargs["sharey"] = axes_by_id[target]
                 axes_by_id[axis_state.axes_id] = figure.add_subplot(
                     spec[
                         axis_state.span.row_start : axis_state.span.row_stop,
                         axis_state.span.col_start : axis_state.span.col_stop,
-                    ]
+                    ],
+                    **subplot_kwargs,
                 )
         for child in grid.child_grids:
             if child.span is None or not _gridspec_region_valid(grid, child.span):

--- a/src/erlab/interactive/_figurecomposer/_ui/_layout_panel.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_layout_panel.py
@@ -23,9 +23,12 @@ from erlab.interactive._figurecomposer._model._gridspec import (
     _gridspec_region_label,
     _gridspec_region_valid,
     _gridspec_remove_region,
+    _gridspec_set_shared_axes_group,
+    _gridspec_shared_axes_group,
     _gridspec_update_axis_variable_name,
     _gridspec_update_grid_settings,
     _gridspec_update_region_span,
+    _gridspec_valid_axes_ids,
 )
 from erlab.interactive._figurecomposer._model._state import (
     FigureGridSpecGridState,
@@ -45,6 +48,61 @@ from erlab.interactive._widgets import _Separator
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
+
+
+class _GridSpecShareAxesDialog(QtWidgets.QDialog):
+    """Select one complete shared-axis group from a visual GridSpec layout."""
+
+    def __init__(
+        self,
+        setup: FigureSubplotsState,
+        axes_id: str,
+        dimension: typing.Literal["x", "y"],
+        *,
+        reserved_names: Iterable[str] = (),
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._axes_id = axes_id
+        self.setObjectName(f"figureComposerGridSpecShare{dimension.upper()}Dialog")
+        self.setWindowTitle(f"Share {dimension} axis")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        names = _gridspec_axis_code_names(setup, reserved_names=reserved_names)
+        axis_name = names.get(axes_id, axes_id)
+        label = QtWidgets.QLabel(
+            f"Select all axes that share the {dimension} axis with {axis_name}.",
+            self,
+        )
+        label.setWordWrap(True)
+        layout.addWidget(label)
+
+        self.axes_selector = _GridSpecViewWidget(self, mode="select")
+        self.axes_selector.set_layout(setup.gridspec.root, names)
+        self.axes_selector.set_selected_axes_ids(
+            _gridspec_shared_axes_group(setup, axes_id, dimension)
+        )
+        self.axes_selector.sigSelectionChanged.connect(self._selection_changed)
+        layout.addWidget(self.axes_selector)
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+    def selected_axes_ids(self) -> tuple[str, ...]:
+        """Return the selected group, including the fixed current axes."""
+        return self.axes_selector.selected_axes_ids()
+
+    @QtCore.Slot(object)
+    def _selection_changed(self, axes_ids_object: object) -> None:
+        axes_ids = typing.cast("tuple[str, ...]", axes_ids_object)
+        if self._axes_id not in axes_ids:
+            self.axes_selector.set_selected_axes_ids((*axes_ids, self._axes_id))
 
 
 class FigureLayoutPanel(QtWidgets.QWidget):
@@ -193,8 +251,34 @@ class FigureLayoutPanel(QtWidgets.QWidget):
         )
         self.sharex_combo = QtWidgets.QComboBox(self)
         self.sharex_combo.addItems(["False", "True", "row", "col", "all"])
+        self.sharex_combo.setToolTip(
+            "Matplotlib sharex setting passed to plt.subplots."
+        )
         self.sharey_combo = QtWidgets.QComboBox(self)
         self.sharey_combo.addItems(["False", "True", "row", "col", "all"])
+        self.sharey_combo.setToolTip(
+            "Matplotlib sharey setting passed to plt.subplots."
+        )
+        self.gridspec_sharex_button = _step_toolbar_button(
+            self,
+            "figureComposerGridSpecShareXButton",
+            "Independent…",
+            "Select axes that share the x axis.",
+        )
+        self.gridspec_sharey_button = _step_toolbar_button(
+            self,
+            "figureComposerGridSpecShareYButton",
+            "Independent…",
+            "Select axes that share the y axis.",
+        )
+        self.sharex_control = QtWidgets.QStackedWidget(self)
+        self.sharex_control.setObjectName("figureComposerShareXControl")
+        self.sharex_control.addWidget(self.sharex_combo)
+        self.sharex_control.addWidget(self.gridspec_sharex_button)
+        self.sharey_control = QtWidgets.QStackedWidget(self)
+        self.sharey_control.setObjectName("figureComposerShareYControl")
+        self.sharey_control.addWidget(self.sharey_combo)
+        self.sharey_control.addWidget(self.gridspec_sharey_button)
         self.width_ratios_edit = QtWidgets.QLineEdit(self)
         self.width_ratios_edit.setObjectName("figureComposerWidthRatiosEdit")
         self.height_ratios_edit = QtWidgets.QLineEdit(self)
@@ -287,13 +371,13 @@ class FigureLayoutPanel(QtWidgets.QWidget):
             7,
             "Share axes",
             "figureComposerShareControls",
-            "Matplotlib shared-axis settings passed to plt.subplots.",
+            "Configure shared x and y axes.",
             "x",
-            self.sharex_combo,
-            "Matplotlib sharex setting passed to plt.subplots.",
+            self.sharex_control,
+            "Shared x-axis settings for the current layout.",
             "y",
-            self.sharey_combo,
-            "Matplotlib sharey setting passed to plt.subplots.",
+            self.sharey_control,
+            "Shared y-axis settings for the current layout.",
         )
         self._add_grid_pair_row(
             layout,
@@ -490,6 +574,12 @@ class FigureLayoutPanel(QtWidgets.QWidget):
         self.layout_combo.currentTextChanged.connect(self._controls_changed)
         self.sharex_combo.currentTextChanged.connect(self._controls_changed)
         self.sharey_combo.currentTextChanged.connect(self._controls_changed)
+        self.gridspec_sharex_button.clicked.connect(
+            lambda: self._edit_gridspec_shared_axes("x")
+        )
+        self.gridspec_sharey_button.clicked.connect(
+            lambda: self._edit_gridspec_shared_axes("y")
+        )
 
     @QtCore.Slot()
     @QtCore.Slot(int)
@@ -683,8 +773,8 @@ class FigureLayoutPanel(QtWidgets.QWidget):
         gridspec_mode = setup.layout_mode == "gridspec"
         self.gridspec_editor_container.setVisible(gridspec_mode)
         self.gridspec_editor_widget.setVisible(gridspec_mode)
-        self.sharex_combo.setEnabled(not gridspec_mode)
-        self.sharey_combo.setEnabled(not gridspec_mode)
+        self.sharex_control.setCurrentIndex(int(gridspec_mode))
+        self.sharey_control.setCurrentIndex(int(gridspec_mode))
 
     def _sync_size_mm_controls(self) -> None:
         self.width_mm_spin.setValue(self._setup.figsize[0] * _MM_PER_INCH)
@@ -843,6 +933,79 @@ class FigureLayoutPanel(QtWidgets.QWidget):
             if has_region
             else "Select an axes or nested grid region to delete it."
         )
+        self._refresh_gridspec_share_controls()
+
+    def _refresh_gridspec_share_controls(self) -> None:
+        setup = self._setup
+        region_id = self.gridspec_layout_widget.selected_region_id()
+        valid_region = bool(region_id and _gridspec_valid_axes_ids(setup, (region_id,)))
+        can_share = (
+            valid_region
+            and len(_gridspec_valid_axes_ids(setup, _gridspec_all_axes_ids(setup))) >= 2
+        )
+        share_buttons: tuple[
+            tuple[typing.Literal["x", "y"], QtWidgets.QToolButton], ...
+        ] = (
+            ("x", self.gridspec_sharex_button),
+            ("y", self.gridspec_sharey_button),
+        )
+        for dimension, button in share_buttons:
+            button.setEnabled(can_share)
+            if not valid_region:
+                button.setText("Select axes…")
+                button.setToolTip("Select an axes region before configuring sharing.")
+                continue
+            group = _gridspec_shared_axes_group(
+                setup,
+                region_id,
+                dimension,
+            )
+            if len(group) < 2:
+                button.setText("Independent…")
+                button.setToolTip(
+                    f"The selected axes has an independent {dimension} axis. "
+                    "Click to change it."
+                )
+                continue
+            names = tuple(
+                _gridspec_axis_display_name(
+                    setup, axes_id, reserved_names=self._reserved_names
+                )
+                for axes_id in group
+                if axes_id != region_id
+            )
+            button.setText(f"Shared ({len(group)} axes)…")
+            button.setToolTip(
+                f"The selected axes shares its {dimension} axis with "
+                + ", ".join(names)
+                + ". Click to change the group."
+            )
+
+    def _edit_gridspec_shared_axes(self, dimension: typing.Literal["x", "y"]) -> None:
+        if self._syncing or self._released or self._setup.layout_mode != "gridspec":
+            return
+        axes_id = self.gridspec_layout_widget.selected_region_id()
+        if not _gridspec_valid_axes_ids(self._setup, (axes_id,)):
+            return
+        dialog = _GridSpecShareAxesDialog(
+            self._setup,
+            axes_id,
+            dimension,
+            reserved_names=self._reserved_names,
+            parent=self,
+        )
+        result = dialog.exec()
+        selected_axes_ids = dialog.selected_axes_ids()
+        dialog.deleteLater()
+        if result != QtWidgets.QDialog.DialogCode.Accepted:
+            return
+        setup = _gridspec_set_shared_axes_group(
+            self._setup,
+            axes_id,
+            dimension,
+            selected_axes_ids,
+        )
+        self._request_setup(setup, selected_region_id=axes_id)
 
     @staticmethod
     def _set_combo_value(combo: QtWidgets.QComboBox, value: str) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -274,6 +274,14 @@ def test_figure_document_converts_layout_and_operation_targets_atomically() -> N
     axes_ids = figurecomposer_gridspec._gridspec_all_axes_ids(gridspec_setup)
     converted = document.recipe.operations
     assert gridspec_setup.layout_mode == "gridspec"
+    assert gridspec_setup.gridspec.shared_x_axes == (
+        (axes_ids[0], axes_ids[2]),
+        (axes_ids[1], axes_ids[3]),
+    )
+    assert gridspec_setup.gridspec.shared_y_axes == (
+        (axes_ids[0], axes_ids[1]),
+        (axes_ids[2], axes_ids[3]),
+    )
     assert converted[0].axes.axes_ids == (axes_ids[1], axes_ids[2])
     assert converted[0].axes.expression == ""
     assert converted[1] == figure_operation

--- a/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
@@ -711,6 +711,79 @@ def test_figure_composer_codegen_axes_helpers_cover_invalid_targets(qtbot) -> No
         )
 
 
+def test_figure_composer_gridspec_shared_axes_render_and_generate_code(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    top = FigureGridSpecAxesState(
+        axes_id="top-id",
+        label="top",
+        span=FigureGridSpecSpanState(row_start=0, row_stop=1, col_start=0, col_stop=1),
+    )
+    lower_left = FigureGridSpecAxesState(
+        axes_id="lower-left-id",
+        label="lower_left",
+        span=FigureGridSpecSpanState(row_start=0, row_stop=1, col_start=0, col_stop=1),
+    )
+    lower_right = FigureGridSpecAxesState(
+        axes_id="lower-right-id",
+        label="lower_right",
+        span=FigureGridSpecSpanState(row_start=0, row_stop=1, col_start=1, col_stop=2),
+    )
+    child = FigureGridSpecGridState(
+        grid_id="child",
+        nrows=1,
+        ncols=2,
+        span=FigureGridSpecSpanState(row_start=1, row_stop=2, col_start=0, col_stop=1),
+        axes=(lower_left, lower_right),
+    )
+    setup = FigureSubplotsState(
+        layout_mode="gridspec",
+        gridspec=FigureGridSpecLayoutState(
+            root=FigureGridSpecGridState(
+                grid_id="root",
+                nrows=2,
+                ncols=1,
+                axes=(top,),
+                child_grids=(child,),
+            ),
+            shared_x_axes=(("top-id", "lower-left-id", "lower-right-id"),),
+            shared_y_axes=(("top-id", "lower-right-id"),),
+        ),
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            setup=setup,
+            sources=(FigureSourceState(name="data", label="data"),),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    figure = plt.figure()
+    rendered = figurecomposer_rendering._make_axes(tool, figure, sync_visible=False)
+    assert isinstance(rendered, dict)
+    shared_x = rendered["top-id"].get_shared_x_axes()
+    shared_y = rendered["top-id"].get_shared_y_axes()
+    assert shared_x.joined(rendered["top-id"], rendered["lower-left-id"])
+    assert shared_x.joined(rendered["top-id"], rendered["lower-right-id"])
+    assert not shared_y.joined(rendered["top-id"], rendered["lower-left-id"])
+    assert shared_y.joined(rendered["top-id"], rendered["lower-right-id"])
+    plt.close(figure)
+
+    namespace = {"data": data}
+    exec(tool.generated_code(), namespace)  # noqa: S102
+    generated_top = namespace["top"]
+    generated_left = namespace["lower_left"]
+    generated_right = namespace["lower_right"]
+    generated_shared_x = generated_top.get_shared_x_axes()
+    generated_shared_y = generated_top.get_shared_y_axes()
+    assert generated_shared_x.joined(generated_top, generated_left)
+    assert generated_shared_x.joined(generated_top, generated_right)
+    assert not generated_shared_y.joined(generated_top, generated_left)
+    assert generated_shared_y.joined(generated_top, generated_right)
+    plt.close(namespace["fig"])
+
+
 def test_figure_composer_gridspec_helpers_cover_naming_and_region_edges() -> None:
     invalid_child = FigureGridSpecGridState(
         grid_id="child",
@@ -900,6 +973,14 @@ def test_figure_composer_state_validators_cover_invalid_values() -> None:
         FigureGridSpecGridState(nrows=0, ncols=1)
     with pytest.raises(ValueError, match="ratios must be positive"):
         FigureGridSpecGridState(nrows=1, ncols=1, width_ratios=(0.0,))
+    with pytest.raises(ValueError, match="at least two axes"):
+        FigureGridSpecLayoutState(shared_x_axes=(("axis-a",),))
+    with pytest.raises(ValueError, match="duplicate axes"):
+        FigureGridSpecLayoutState(shared_x_axes=(("axis-a", "axis-a"),))
+    with pytest.raises(ValueError, match="multiple shared-axis groups"):
+        FigureGridSpecLayoutState(
+            shared_x_axes=(("axis-a", "axis-b"), ("axis-b", "axis-c"))
+        )
     with pytest.raises(ValueError, match="at least one row"):
         FigureSubplotsState(nrows=0)
     with pytest.raises(ValueError, match="figsize values"):
@@ -1135,4 +1216,142 @@ def test_gridspec_transformations_validate_edits_and_ignore_stale_ids() -> None:
     assert (
         figurecomposer_gridspec._gridspec_remove_region(setup, "root", "missing")
         == setup
+    )
+
+
+def test_gridspec_shared_axes_groups_update_and_clean_up() -> None:
+    axes = tuple(
+        FigureGridSpecAxesState(
+            axes_id=f"axis-{index}",
+            span=FigureGridSpecSpanState(
+                row_start=0,
+                row_stop=1,
+                col_start=index,
+                col_stop=index + 1,
+            ),
+        )
+        for index in range(4)
+    )
+    setup = FigureSubplotsState(
+        layout_mode="gridspec",
+        gridspec=FigureGridSpecLayoutState(
+            root=FigureGridSpecGridState(grid_id="root", nrows=1, ncols=4, axes=axes),
+            shared_x_axes=(("axis-0", "axis-1", "axis-2"),),
+            shared_y_axes=(("axis-0", "axis-1"),),
+        ),
+    )
+
+    assert figurecomposer_gridspec._gridspec_shared_axes_group(
+        setup, "axis-1", "x"
+    ) == ("axis-0", "axis-1", "axis-2")
+    assert figurecomposer_gridspec._gridspec_shared_axes_group(
+        setup, "axis-3", "x"
+    ) == ("axis-3",)
+    assert (
+        figurecomposer_gridspec._gridspec_shared_axes_group(setup, "missing", "x") == ()
+    )
+    assert figurecomposer_gridspec._gridspec_shared_axes_targets(setup, "x") == {
+        "axis-1": "axis-0",
+        "axis-2": "axis-0",
+    }
+
+    updated = figurecomposer_gridspec._gridspec_set_shared_axes_group(
+        setup, "axis-0", "x", ("axis-0", "axis-3")
+    )
+    assert updated.gridspec.shared_x_axes == (
+        ("axis-0", "axis-3"),
+        ("axis-1", "axis-2"),
+    )
+    assert (
+        figurecomposer_gridspec._gridspec_set_shared_axes_group(
+            updated, "missing", "x", ("axis-0",)
+        )
+        == updated
+    )
+    assert (
+        figurecomposer_gridspec._gridspec_set_shared_axes_group(
+            updated, "axis-0", "x", ("axis-0", "axis-3")
+        )
+        == updated
+    )
+    independent = figurecomposer_gridspec._gridspec_set_shared_axes_group(
+        updated, "axis-0", "x", ("axis-0",)
+    )
+    assert independent.gridspec.shared_x_axes == (("axis-1", "axis-2"),)
+    with pytest.raises(ValueError, match="unknown shared-axis dimension"):
+        figurecomposer_gridspec._gridspec_shared_axes_group(
+            setup, "axis-0", typing.cast("typing.Any", "z")
+        )
+
+    invalid_root = updated.gridspec.root.model_copy(update={"ncols": 3})
+    invalid_setup = updated.model_copy(
+        update={"gridspec": updated.gridspec.model_copy(update={"root": invalid_root})}
+    )
+    assert figurecomposer_gridspec._gridspec_shared_axes_targets(
+        invalid_setup, "x"
+    ) == {"axis-2": "axis-1"}
+
+    restored = FigureSubplotsState.model_validate_json(updated.model_dump_json())
+    assert restored == updated
+    assert (
+        figurecomposer_gridspec._gridspec_remove_region(updated, "missing", "axis-1")
+        == updated
+    )
+    removed = figurecomposer_gridspec._gridspec_remove_region(updated, "root", "axis-1")
+    assert removed.gridspec.shared_x_axes == (("axis-0", "axis-3"),)
+    assert removed.gridspec.shared_y_axes == ()
+
+    nested_axes = tuple(
+        axis.model_copy(
+            update={
+                "axes_id": f"nested-{index}",
+                "span": FigureGridSpecSpanState(
+                    row_start=0,
+                    row_stop=1,
+                    col_start=index,
+                    col_stop=index + 1,
+                ),
+            }
+        )
+        for index, axis in enumerate(axes[:2])
+    )
+    child = FigureGridSpecGridState(
+        grid_id="child",
+        nrows=1,
+        ncols=2,
+        span=FigureGridSpecSpanState(row_start=0, row_stop=1, col_start=0, col_stop=1),
+        axes=nested_axes,
+    )
+    nested_setup = FigureSubplotsState(
+        layout_mode="gridspec",
+        gridspec=FigureGridSpecLayoutState(
+            root=FigureGridSpecGridState(
+                grid_id="root", nrows=1, ncols=1, child_grids=(child,)
+            ),
+            shared_x_axes=(("nested-0", "nested-1"),),
+        ),
+    )
+    removed_child = figurecomposer_gridspec._gridspec_remove_region(
+        nested_setup, "root", "child"
+    )
+    assert removed_child.gridspec.root.child_grids == ()
+    assert removed_child.gridspec.shared_x_axes == ()
+
+
+def test_subplots_shared_axes_groups_cover_boolean_modes() -> None:
+    setup = FigureSubplotsState(nrows=1, ncols=2)
+    axes_ids = ("axis-0", "axis-1")
+
+    assert (
+        figurecomposer_gridspec._subplots_shared_axes_groups(setup, axes_ids, False)
+        == ()
+    )
+    assert figurecomposer_gridspec._subplots_shared_axes_groups(
+        setup, axes_ids, True
+    ) == (axes_ids,)
+    assert (
+        figurecomposer_gridspec._subplots_shared_axes_groups(
+            FigureSubplotsState(), ("axis-0",), True
+        )
+        == ()
     )

--- a/tests/interactive/imagetool/manager/figurecomposer/test_layout_panel.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_layout_panel.py
@@ -1,4 +1,5 @@
 import pytest
+from qtpy import QtWidgets
 
 from erlab.interactive._figurecomposer import (
     FigureGridSpecAxesState,
@@ -7,7 +8,10 @@ from erlab.interactive._figurecomposer import (
     FigureGridSpecSpanState,
     FigureSubplotsState,
 )
-from erlab.interactive._figurecomposer._ui._layout_panel import FigureLayoutPanel
+from erlab.interactive._figurecomposer._ui._layout_panel import (
+    FigureLayoutPanel,
+    _GridSpecShareAxesDialog,
+)
 
 
 def _grid_setup(*, child: FigureGridSpecGridState | None = None) -> FigureSubplotsState:
@@ -32,6 +36,41 @@ def _grid_setup(*, child: FigureGridSpecGridState | None = None) -> FigureSubplo
                     ),
                 ),
                 child_grids=() if child is None else (child,),
+            )
+        ),
+    )
+
+
+def _two_axis_grid_setup() -> FigureSubplotsState:
+    return FigureSubplotsState(
+        layout_mode="gridspec",
+        gridspec=FigureGridSpecLayoutState(
+            root=FigureGridSpecGridState(
+                grid_id="root",
+                nrows=1,
+                ncols=2,
+                axes=(
+                    FigureGridSpecAxesState(
+                        axes_id="left",
+                        label="left_axis",
+                        span=FigureGridSpecSpanState(
+                            row_start=0,
+                            row_stop=1,
+                            col_start=0,
+                            col_stop=1,
+                        ),
+                    ),
+                    FigureGridSpecAxesState(
+                        axes_id="right",
+                        label="right_axis",
+                        span=FigureGridSpecSpanState(
+                            row_start=0,
+                            row_stop=1,
+                            col_start=1,
+                            col_stop=2,
+                        ),
+                    ),
+                ),
             )
         ),
     )
@@ -88,6 +127,8 @@ def test_layout_panel_emits_validated_setup_and_mode_requests(qtbot) -> None:
     panel.setup_requested.connect(requests.append)
     panel.layout_mode_requested.connect(modes.append)
     panel.set_setup(FigureSubplotsState())
+    panel._edit_gridspec_shared_axes("x")
+    assert requests == []
 
     panel.nrows_spin.setValue(3)
     assert requests[-1].nrows == 3
@@ -108,6 +149,53 @@ def test_layout_panel_emits_validated_setup_and_mode_requests(qtbot) -> None:
     panel.layout_mode_combo.setCurrentText("gridspec")
     assert modes == ["gridspec"]
     assert requests[-1].layout_mode == "subplots"
+
+
+def test_layout_panel_edits_gridspec_shared_axes_with_accept_and_cancel(
+    qtbot, accept_dialog
+) -> None:
+    panel = FigureLayoutPanel()
+    qtbot.addWidget(panel)
+    requests: list[FigureSubplotsState] = []
+    panel.setup_requested.connect(requests.append)
+    panel.set_setup(_two_axis_grid_setup())
+    panel._edit_gridspec_shared_axes("x")
+    assert requests == []
+    panel.gridspec_layout_widget.set_selected_region("left")
+    panel.gridspec_layout_widget.sigRegionSelected.emit("left", "axes")
+
+    assert panel.sharex_control.currentWidget() is panel.gridspec_sharex_button
+    assert panel.sharey_control.currentWidget() is panel.gridspec_sharey_button
+    assert panel.gridspec_sharex_button.isEnabled()
+    assert panel.gridspec_sharey_button.isEnabled()
+
+    def select_shared_axes(dialog: QtWidgets.QDialog) -> None:
+        assert isinstance(dialog, _GridSpecShareAxesDialog)
+        dialog.axes_selector.set_selected_axes_ids(("left", "right"), emit=True)
+
+    accept_dialog(
+        panel.gridspec_sharex_button.click,
+        pre_call=select_shared_axes,
+    )
+    assert requests[-1].gridspec.shared_x_axes == (("left", "right"),)
+    panel.set_setup(requests.pop())
+
+    accept_dialog(
+        panel.gridspec_sharey_button.click,
+        accept_call=lambda dialog: dialog.reject(),
+    )
+    assert requests == []
+
+
+def test_gridspec_share_dialog_keeps_current_axes_selected(qtbot) -> None:
+    dialog = _GridSpecShareAxesDialog(
+        _two_axis_grid_setup(), "left", "x", reserved_names=("data",)
+    )
+    qtbot.addWidget(dialog)
+
+    dialog.axes_selector.set_selected_axes_ids(("right",), emit=True)
+
+    assert dialog.selected_axes_ids() == ("left", "right")
 
 
 def test_layout_panel_validates_gridspec_gestures_and_preserves_selection(


### PR DESCRIPTION
## Summary

- Add persistent x-axis and y-axis sharing groups for GridSpec layouts.
- Add visual selectors for sharing axes across regular and nested grids.
- Apply the saved groups to live rendering and generated Matplotlib code.
- Preserve subplot sharing when a regular subplot layout is converted to GridSpec.
- Remove deleted axes from sharing groups and document the new controls.

## User impact

Users can select any compatible axes in a GridSpec layout and share their x or y coordinate axis. Figure Composer saves the selection and generated code reproduces the same sharing.

## Validation

- Focused PyQt6 Figure Composer tests: 50 passed.
- Focused PySide6 sharing and layout tests: 11 passed.
- All Figure Composer test modules passed under PyQt6 in split runs.
- `uv run mypy src`
- Targeted Ruff check and format verification
- Sphinx HTML build with warnings treated as errors
- `git diff --check`
