### PR TITLE
fix(interactive): infer KTool guideline delta sign

### DIFF
--- a/src/erlab/interactive/imagetool/_kspace_conversion.py
+++ b/src/erlab/interactive/imagetool/_kspace_conversion.py
@@ -180,9 +180,11 @@ def assign_kspace_configuration(
 
 def initial_normal_emission_from_slicer_area(
     slicer_area: ImageSlicerArea,
+    *,
+    configuration: AxesConfiguration | int | None = None,
 ) -> tuple[tuple[float, float] | None, float | None]:
     """Return ktool-compatible normal-emission seed values from an ImageTool."""
-    data = slicer_area.data
+    data = erlab.utils.array._restore_nonuniform_dims(slicer_area.data)
     dim_values = {
         str(dim): float(value)
         for dim, value in zip(data.dims, slicer_area.current_values, strict=True)
@@ -212,11 +214,18 @@ def initial_normal_emission_from_slicer_area(
         ):
             dim = str(data.dims[axis])
             if axis in slicer_area.array_slicer._nonuniform_axes_set:
+                uniform_value = float(value)
+                uniform_coord = np.asarray(
+                    slicer_area.array_slicer.coords_uniform[axis], dtype=float
+                )
+                physical_coord = np.asarray(
+                    slicer_area.array_slicer.coords[axis], dtype=float
+                )
                 value = float(
                     np.interp(
-                        value,
-                        slicer_area.array_slicer.coords_uniform[axis],
-                        slicer_area.array_slicer.coords[axis],
+                        uniform_value,
+                        uniform_coord,
+                        physical_coord,
                     )
                 )
             guideline_values[dim] = float(value)
@@ -224,7 +233,16 @@ def initial_normal_emission_from_slicer_area(
             guideline_values["alpha"],
             guideline_values["beta"],
         )
-        initial_delta = -slicer_area.main_image._guideline_angle
+        if configuration is None:
+            configuration = kspace_configuration(data)
+        elif not isinstance(configuration, AxesConfiguration):
+            configuration = AxesConfiguration(int(configuration))
+        delta_sign = -1.0
+        if configuration == AxesConfiguration.Type2:
+            delta_sign *= -1
+        if guideline_dims == ("beta", "alpha"):
+            delta_sign *= -1
+        initial_delta = delta_sign * slicer_area.main_image._guideline_angle
 
     return initial_normal_emission, initial_delta
 

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -1706,7 +1706,8 @@ class KspaceConversionDialog(DataTransformDialog):
     def _seed_from_current_view(self) -> None:
         initial_normal_emission, initial_delta = (
             _kspace_conversion.initial_normal_emission_from_slicer_area(
-                self.slicer_area
+                self.slicer_area,
+                configuration=self._control_data.kspace.configuration,
             )
         )
         if initial_normal_emission is not None:

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -3892,6 +3892,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             data_name=self.watched_data_name,
             initial_normal_emission=initial_normal_emission,
             initial_delta=initial_delta,
+            _initial_delta_from_guideline=initial_delta is not None,
             options_model=self._options_model,
             execute=False,
         )

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -2265,6 +2265,7 @@ def ktool(
     initial_delta: float | None = None,
     options_model: AppOptions | None = None,
     execute: bool | None = None,
+    _initial_delta_from_guideline: bool = False,
 ) -> KspaceTool | None:
     """Interactive momentum conversion tool.
 
@@ -2316,6 +2317,13 @@ def ktool(
         if resolved_input_coordinates is None:
             return None
         configuration, input_coordinates, edited_names = resolved_input_coordinates
+        if (
+            _initial_delta_from_guideline
+            and initial_delta is not None
+            and _kspace_conversion.kspace_configuration(data) is None
+            and configuration == AxesConfiguration.Type2
+        ):
+            initial_delta *= -1
         win = KspaceTool(
             data,
             avec=avec,

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -8431,6 +8431,7 @@ def test_itool_open_in_ktool_uses_guideline_seed_on_alpha_beta_plane(
 
     assert captured["kwargs"]["initial_normal_emission"] == (1.0, 4.0)
     assert captured["kwargs"]["initial_delta"] == pytest.approx(30.0)
+    assert captured["kwargs"]["_initial_delta_from_guideline"] is True
 
     win.close()
 
@@ -8463,6 +8464,7 @@ def test_itool_open_in_ktool_ignores_non_alpha_beta_guidelines(
 
     assert captured["kwargs"]["initial_normal_emission"] == (4.0, 1.0)
     assert captured["kwargs"]["initial_delta"] is None
+    assert captured["kwargs"]["_initial_delta_from_guideline"] is False
 
     win.close()
 

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -411,6 +411,72 @@ def test_ktool_assigns_missing_configuration(
         KspaceTool(data)
 
 
+@pytest.mark.parametrize(
+    ("configuration", "guideline_derived", "expected_delta"),
+    [
+        (AxesConfiguration.Type1, True, -12.0),
+        (AxesConfiguration.Type2, True, 12.0),
+        (AxesConfiguration.Type2, False, -12.0),
+    ],
+)
+def test_ktool_resolves_guideline_delta_after_missing_configuration(
+    qtbot,
+    anglemap,
+    accept_dialog,
+    configuration: AxesConfiguration,
+    guideline_derived: bool,
+    expected_delta: float,
+) -> None:
+    data = anglemap.qsel(eV=-0.1).copy(deep=True)
+    del data.attrs["configuration"]
+    holder: dict[str, KspaceTool | None] = {}
+    normal_emission = (float(data.alpha[4]), float(data.beta[4]))
+
+    accept_dialog(
+        lambda: holder.update(
+            win=ktool(
+                data,
+                initial_normal_emission=normal_emission,
+                initial_delta=-12.0,
+                execute=False,
+                _initial_delta_from_guideline=guideline_derived,
+            )
+        ),
+        pre_call=lambda dialog: _select_input_configuration(dialog, configuration),
+    )
+    win = holder["win"]
+    assert isinstance(win, KspaceTool)
+    _add_hidden_tool(qtbot, win)
+
+    assert win._offset_spins["delta"].value() == pytest.approx(expected_delta)
+    assert "configuration" not in data.attrs
+
+
+def test_ktool_guideline_delta_missing_configuration_cancel(
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = anglemap.qsel(eV=-0.1).copy(deep=True)
+    del data.attrs["configuration"]
+    holder: dict[str, KspaceTool | None] = {}
+
+    accept_dialog(
+        lambda: holder.update(
+            win=ktool(
+                data,
+                initial_normal_emission=(float(data.alpha[4]), float(data.beta[4])),
+                initial_delta=-12.0,
+                execute=False,
+                _initial_delta_from_guideline=True,
+            )
+        ),
+        accept_call=lambda dialog: dialog.reject(),
+    )
+
+    assert holder["win"] is None
+    assert "configuration" not in data.attrs
+
+
 def test_ktool_missing_coordinate_persistence_preserves_copy_operations(
     qtbot,
     anglemap,
@@ -590,6 +656,34 @@ def test_kspace_conversion_dialog_assigns_missing_configuration(
     restored.restore_transform_operations(operations)
     assert restored.current_configuration == AxesConfiguration.Type1
     assert restored._input_coordinates_widget.is_complete
+
+
+def test_kspace_conversion_dialog_resolves_guideline_delta_after_configuration(
+    qtbot,
+    anglemap,
+    accept_dialog,
+) -> None:
+    data = anglemap.qsel(eV=-0.1).copy(deep=True)
+    del data.attrs["configuration"]
+    win = erlab.interactive.itool(data, execute=False)
+    _add_hidden_tool(qtbot, win)
+    plot_item = win.slicer_area.main_image
+    plot_item.set_guidelines(3)
+    plot_item._guidelines_items[0].setAngle(60.0)
+    holder: dict[str, KspaceConversionDialog] = {}
+
+    accept_dialog(
+        lambda: holder.update(
+            dialog=_add_kspace_conversion_dialog(qtbot, win.slicer_area)
+        ),
+        pre_call=lambda coordinate_dialog: _select_input_configuration(
+            coordinate_dialog,
+            AxesConfiguration.Type2,
+        ),
+    )
+
+    assert holder["dialog"]._normal_delta == pytest.approx(-30.0)
+    assert "configuration" not in data.attrs
 
 
 def test_kspace_conversion_dialog_missing_hv_preflight_accept_and_cancel(
@@ -778,8 +872,13 @@ def test_kspace_conversion_dialog_missing_configuration_cancel(
 def test_kspace_conversion_seed_helpers_cover_nonuniform_guidelines() -> None:
     data = xr.DataArray(
         np.zeros((3, 3)),
-        dims=("alpha", "beta"),
-        coords={"alpha": [-1.0, 0.0, 1.0], "beta": [10.0, 20.0, 40.0]},
+        dims=("alpha", "beta_idx"),
+        coords={
+            "alpha": [-1.0, 0.0, 1.0],
+            "beta_idx": [0.0, 1.0, 2.0],
+            "beta": ("beta_idx", [10.0, 20.0, 40.0]),
+        },
+        attrs={"configuration": int(AxesConfiguration.Type1)},
     )
     slicer_area = SimpleNamespace(
         data=data,
@@ -803,6 +902,119 @@ def test_kspace_conversion_seed_helpers_cover_nonuniform_guidelines() -> None:
 
     assert normal_emission == pytest.approx((0.5, 30.0))
     assert delta == pytest.approx(-12.0)
+
+
+@pytest.mark.parametrize(
+    ("configuration", "standard_sign"),
+    [
+        (AxesConfiguration.Type1, -1.0),
+        (AxesConfiguration.Type2, 1.0),
+        (AxesConfiguration.Type1DA, -1.0),
+        (AxesConfiguration.Type2DA, -1.0),
+    ],
+)
+@pytest.mark.parametrize(
+    ("dims", "order_sign"),
+    [
+        (("alpha", "beta"), 1.0),
+        (("beta", "alpha"), -1.0),
+    ],
+)
+def test_kspace_conversion_seed_infers_delta_from_configuration_and_axis_order(
+    configuration: AxesConfiguration,
+    standard_sign: float,
+    dims: tuple[str, str],
+    order_sign: float,
+) -> None:
+    data = xr.DataArray(
+        np.zeros((3, 3)),
+        dims=dims,
+        coords={dim: [-1.0, 0.0, 1.0] for dim in dims},
+        attrs={"configuration": int(configuration)},
+    )
+    slicer_area = SimpleNamespace(
+        data=data,
+        current_values=(0.0, 0.0),
+        main_image=SimpleNamespace(
+            display_axis=(0, 1),
+            is_guidelines_visible=True,
+            _guideline_offset=(0.0, 0.0),
+            _guideline_angle=12.0,
+        ),
+        array_slicer=SimpleNamespace(_nonuniform_axes_set=set()),
+    )
+
+    normal_emission, delta = (
+        _kspace_conversion.initial_normal_emission_from_slicer_area(slicer_area)
+    )
+
+    assert normal_emission == pytest.approx((0.0, 0.0))
+    assert delta == pytest.approx(12.0 * standard_sign * order_sign)
+
+
+def test_kspace_conversion_seed_uses_base_sign_without_configuration() -> None:
+    data = xr.DataArray(
+        np.zeros((3, 3)),
+        dims=("alpha", "beta"),
+        coords={"alpha": [-1.0, 0.0, 1.0], "beta": [-1.0, 0.0, 1.0]},
+    )
+    slicer_area = SimpleNamespace(
+        data=data,
+        current_values=(0.0, 0.0),
+        main_image=SimpleNamespace(
+            display_axis=(0, 1),
+            is_guidelines_visible=True,
+            _guideline_offset=(0.0, 0.0),
+            _guideline_angle=12.0,
+        ),
+        array_slicer=SimpleNamespace(_nonuniform_axes_set=set()),
+    )
+
+    normal_emission, delta = (
+        _kspace_conversion.initial_normal_emission_from_slicer_area(slicer_area)
+    )
+
+    assert normal_emission == pytest.approx((0.0, 0.0))
+    assert delta == pytest.approx(-12.0)
+
+    _, delta = _kspace_conversion.initial_normal_emission_from_slicer_area(
+        slicer_area,
+        configuration=AxesConfiguration.Type2,
+    )
+    assert delta == pytest.approx(12.0)
+
+
+def test_kspace_conversion_seed_ignores_guidelines_outside_first_two_angle_axes() -> (
+    None
+):
+    data = xr.DataArray(
+        np.zeros((3, 3, 3)),
+        dims=("eV", "alpha", "beta"),
+        coords={
+            "eV": [-1.0, 0.0, 1.0],
+            "alpha": [-1.0, 0.0, 1.0],
+            "beta": [-1.0, 0.0, 1.0],
+        },
+        attrs={"configuration": int(AxesConfiguration.Type1)},
+    )
+    slicer_area = SimpleNamespace(
+        data=data,
+        current_values=(0.0, 0.0, 0.0),
+        main_image=SimpleNamespace(
+            display_axis=(0, 1),
+            is_guidelines_visible=True,
+            _guideline_offset=(0.0, 0.0),
+            _guideline_angle=12.0,
+        ),
+        array_slicer=SimpleNamespace(_nonuniform_axes_set=set()),
+    )
+
+    normal_emission, delta = (
+        _kspace_conversion.initial_normal_emission_from_slicer_area(slicer_area)
+    )
+
+    assert normal_emission == pytest.approx((0.0, 0.0))
+    assert delta is None
 
 
 def test_kspace_normal_emission_reports_missing_required_coords() -> None:


### PR DESCRIPTION
## Summary

- Infer a guideline-derived delta sign from the axes configuration and displayed axis order.
- Use rotation guidelines only when the first two displayed axes are `alpha` and `beta`, in either order.
- Apply a configuration selected in the KTool prompt without changing explicit `initial_delta` values.
- Keep the source data unchanged when configuration is selected or the prompt is canceled.

## Root cause

ImageTool guideline angles follow display-axis direction. KTool delta follows an axes-configuration convention. The previous handoff always negated the guideline angle before a missing configuration was resolved. Type 2 configurations and reversed alpha-beta display order could therefore produce the wrong sign.

## Validation

- `uv run pytest tests/interactive/test_kspace.py` - 137 passed with PyQt6.
- `uv run pytest tests/interactive/imagetool/test_imagetool.py -k 'open_in_ktool'` - 7 passed with PyQt6.
- Focused guideline tests - 16 KTool tests and 2 ImageTool tests passed with PySide6.
- `uv run mypy src`
- `uv run ruff check`
- `uv run ruff format --check`
- `git diff --check`
