### PR TITLE
feat(figurecomposer): add source-free figures

### DIFF
--- a/docs/source/user-guide/interactive/figure-composer.md
+++ b/docs/source/user-guide/interactive/figure-composer.md
@@ -14,8 +14,11 @@ steps that each correspond to a plotting operation.
 
 ## Opening Figure Composer
 
-Open data in ImageTool Manager, then use one of these entry points:
+Use one of these entry points:
 
+- From ImageTool Manager, choose {menuselection}`File --> New Empty Figure` to create
+  a figure without data sources. Add sources later with {guilabel}`Add…` or by dragging
+  ImageTool rows into the figure.
 - From ImageTool, right-click an image or line plot and choose {guilabel}`New Figure`.
   - If multiple cursors exist, a figure with multiple axes is created. This is useful
     for quickly generating comparison figures with several slices of the same data.
@@ -87,8 +90,9 @@ arguments of the plotting or styling calls it generates.
 
 The step table shows each operation, its target, and its current status. For steps that
 act on axes, the {guilabel}`Target` column highlights the affected axes in a miniature
-of the current subplot or GridSpec layout. The {guilabel}`Status` reports missing sources, invalid targets or inputs, and rendering errors
-when they occur. Hover over a reported problem for details.
+of the current subplot or GridSpec layout. The {guilabel}`Status` reports missing
+sources, invalid targets or inputs, and rendering errors when they occur. Hover over a
+reported problem for details.
 
 There are several step types:
 

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -258,6 +258,10 @@ and right-click context menus:
   Combine selected data with {func}`xarray.concat` and open the result in a new
   ImageTool window.
 
+- {guilabel}`New Empty Figure`
+
+  Create a Figure Composer window without data sources or recipe steps.
+
 - {guilabel}`Add to Figure…`
 
   Create a new {ref}`Figure Composer <figure-composer>` figure from the selected rows.
@@ -339,6 +343,10 @@ file metadata. Use {guilabel}`Revert Assignment` to restore its earlier value.
 (imagetool-manager-figure-composer)=
 
 ## Creating Matplotlib figures
+
+Choose {menuselection}`File --> New Empty Figure` to create a Figure Composer window
+without data sources or recipe steps. Use {guilabel}`Add…` in the new window or drag
+ImageTool rows into it when you are ready to add data.
 
 Use {guilabel}`Add to Figure…` from the right-click context menu of one or more
 ImageTool rows to send their data to {ref}`Figure Composer <figure-composer>`. When no

--- a/src/erlab/interactive/_figurecomposer/_model/_document.py
+++ b/src/erlab/interactive/_figurecomposer/_model/_document.py
@@ -1493,8 +1493,11 @@ class FigureDocument:
         )
         if not result:
             return result
+        recipe_updates: dict[str, typing.Any] = {"sources": tuple(existing.values())}
+        if not self.recipe.sources:
+            recipe_updates["primary_source"] = next(iter(existing))
         self.replace_recipe_and_source_payloads(
-            self.recipe.model_copy(update={"sources": tuple(existing.values())}),
+            self.recipe.model_copy(update=recipe_updates),
             candidate_data,
             candidate_bases,
         )

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -43,6 +43,7 @@ from matplotlib.figure import Figure
 
 import numpy as np
 import pydantic
+import xarray as xr
 
 import erlab
 import erlab.interactive._figurecomposer._codegen
@@ -189,7 +190,6 @@ if typing.TYPE_CHECKING:
         Sequence,
     )
 
-    import xarray as xr
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 
     from erlab.interactive._options import OptionDialog
@@ -210,6 +210,7 @@ _PERSISTED_PREVIEW_CACHE_MAX_BYTES = 384_000
 _RESTORE_OPERATION_EDITOR_KEY = "figure_composer_operation_editor"
 _RESTORE_REDRAW_KEY = "figure_composer_restored_redraw"
 _INITIAL_SIZE_HINT_EXTRA_HEIGHT = 80
+_SOURCE_FREE_DATA_DIM = "_figure_composer_source_free"
 _STEPS_CLIPBOARD_MIME = "application/x-erlab-figure-composer-steps+json"
 _STEPS_CLIPBOARD_PAYLOAD_TYPE = "erlab.figure_composer.steps"
 _STEPS_CLIPBOARD_PAYLOAD_VERSION = 1
@@ -222,6 +223,14 @@ _OPERATION_STATUS_LABELS = {
     "invalid_input": "Invalid input",
     "render_error": "Render error",
 }
+
+
+def _source_free_tool_data() -> xr.DataArray:
+    """Return the private data carrier required by ``ToolWindow`` persistence."""
+    return xr.DataArray(
+        np.empty((0,), dtype=np.uint8),
+        dims=(_SOURCE_FREE_DATA_DIM,),
+    )
 
 
 class _FigureComposerStepMimeData(QtCore.QMimeData):
@@ -425,7 +434,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             if recipe is not None
             else self._default_recipe(data)
         )
-        initial_source_data = dict(source_data or {})
+        initial_source_data = {} if source_data is None else dict(source_data)
         if source_data is None:
             if initial_recipe.primary_source in {
                 source.name for source in initial_recipe.sources
@@ -434,8 +443,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             else:
                 source_name = _source_name(data)
             initial_source_data[source_name] = data
-        if initial_recipe.primary_source not in initial_source_data:
+        if initial_recipe.primary_source not in initial_source_data and (
+            source_data is None or initial_recipe.sources
+        ):
             initial_source_data[initial_recipe.primary_source] = data
+        self._source_free_data = _source_free_tool_data()
         self._document = FigureDocument(
             initial_recipe,
             source_data=initial_source_data,
@@ -567,6 +579,15 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             primary_source=primary,
         )
         return cls(source_data[primary], recipe=recipe, source_data=source_data)
+
+    @classmethod
+    def empty(cls) -> FigureComposerTool:
+        """Create a source-free figure with the default layout."""
+        return cls(
+            _source_free_tool_data(),
+            recipe=FigureRecipeState(),
+            source_data={},
+        )
 
     @property
     def figure_window(self) -> _FigureComposerDisplayWindow:
@@ -4343,10 +4364,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     @property
     def tool_data(self) -> xr.DataArray:
-        """Return the live primary source; call ``touch_source_data`` after edits."""
+        """Return the primary source or the private source-free data carrier."""
         if self._document.recipe.primary_source in self._document.source_data:
             return self._document.source_data[self._document.recipe.primary_source]
-        return next(iter(self._document.source_data.values()))
+        return next(iter(self._document.source_data.values()), self._source_free_data)
 
     @property
     def tool_status(self) -> FigureRecipeState:
@@ -4366,7 +4387,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             self._document.replace_recipe(
                 status.model_copy(update={"sources": sources, "operations": operations})
             )
-            self._ensure_primary_source_data()
+            if sources:
+                self._ensure_primary_source_data()
+            else:
+                self._document.replace_source_payloads({}, {})
             self._normalize_operation_source_selections()
             self._apply_recipe_to_controls()
         source_data_changed = self._document.source_revision != previous_source_revision
@@ -5317,7 +5341,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         script_inputs, skip_source_selection_names, source_name_map = (
             self._display_code_source_plan()
         )
-        if not script_inputs:
+        if not script_inputs and self._document.recipe.sources:
             return None
         return script(
             erlab.interactive._figurecomposer._provenance._figure_build_operation(

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -138,6 +138,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     concat_action: QtGui.QAction
     compact_workspace_action: QtGui.QAction
     create_figure_action: QtGui.QAction
+    new_figure_action: QtGui.QAction
     duplicate_action: QtGui.QAction
     edit_note_action: QtGui.QAction
     copy_note_action: QtGui.QAction

--- a/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
@@ -729,6 +729,17 @@ class _FigureComposerWorkflowController(QtCore.QObject):
         self._collection.select_uid(uid)
         return uid
 
+    def create_empty_figure(self, *, show: bool = True) -> str:
+        """Create a manager-owned figure without data sources or recipe steps."""
+        from erlab.interactive._figurecomposer import FigureComposerTool
+        from erlab.interactive._figurecomposer._defaults import figure_options_context
+
+        with figure_options_context(self._host.effective_interactive_options):
+            tool = FigureComposerTool.empty()
+        uid = self._host.add_figuretool(tool, show=show)
+        self._collection.select_uid(uid)
+        return uid
+
     @QtCore.Slot()
     def create_figure_from_selection(self) -> None:
         from erlab.interactive.imagetool.manager._figurecomposer import _dialogs

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -573,6 +573,14 @@ class ImageToolManager(_ImageToolManagerBase):
         )
         self.create_figure_action.setIcon(QtGui.QIcon.fromTheme("insert-image"))
 
+        self.new_figure_action = QtWidgets.QAction("New Empty Figure", self)
+        self.new_figure_action.setObjectName("manager_new_figure_action")
+        self.new_figure_action.triggered.connect(self._create_empty_figure_from_action)
+        self.new_figure_action.setToolTip(
+            "Create an editable Matplotlib figure without data sources"
+        )
+        self.new_figure_action.setIcon(QtGui.QIcon.fromTheme("document-new"))
+
         self.reload_action = QtWidgets.QAction("Reload Data", self)
         self.reload_action.setObjectName("manager_reload_data_action")
         self.reload_action.triggered.connect(self.reload_selected)
@@ -660,6 +668,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self.file_menu.addAction(self.explorer_action)
         self.file_menu.addAction(self.acquisition_context_action)
         self.file_menu.addSeparator()
+        self.file_menu.addAction(self.new_figure_action)
         self.file_menu.addAction(self.new_manager_action)
         self.file_menu.addSeparator()
         self.file_menu.addAction(self.store_action)
@@ -1388,6 +1397,13 @@ class ImageToolManager(_ImageToolManagerBase):
             title=title,
             show=show,
         )
+
+    def create_empty_figure(self, *, show: bool = True) -> str:
+        return self._figure_workflows.create_empty_figure(show=show)
+
+    @QtCore.Slot()
+    def _create_empty_figure_from_action(self) -> None:
+        self.create_empty_figure()
 
     def _choose_figure_append_target(
         self, operation: FigureOperationState | None

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import xarray as xr
+from matplotlib.figure import Figure
 from qtpy import QtCore, QtWidgets
 
 import erlab.interactive._figurecomposer._rendering as figurecomposer_rendering
@@ -28,12 +29,96 @@ from erlab.interactive.imagetool._figurecomposer_adapter import (
     build_figure_composer_operation,
 )
 from erlab.interactive.imagetool.manager._figurecomposer import _dialogs
-from tests.interactive.imagetool.manager.helpers import select_tools
+from tests.interactive.imagetool.manager.helpers import (
+    _exec_generated_code,
+    select_tools,
+)
 
 from ._common import (
+    _assert_figure_composer_provenance_replayable,
     _set_unsupported_plot_slices_cursor_state,
     _unsupported_plot_slices_data,
 )
+
+
+def test_manager_new_empty_figure_action_creates_source_free_figure(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        assert manager.new_figure_action.isEnabled()
+        assert manager.new_figure_action.objectName() == "manager_new_figure_action"
+        assert manager.new_figure_action in manager.file_menu.actions()
+        assert manager.new_figure_action not in manager.edit_menu.actions()
+        assert manager.new_figure_action not in manager.tree_view._menu.actions()
+
+        manager.new_figure_action.trigger()
+
+        [figure_uid] = manager._tool_graph.figure_uids
+        figure_tool = manager._child_node(figure_uid).tool_window
+        assert isinstance(figure_tool, FigureComposerTool)
+        assert figure_tool.tool_status.sources == ()
+        assert figure_tool.tool_status.operations == ()
+        assert figure_tool.source_data() == {}
+        assert figure_tool._persistence_reference_node_uids() == frozenset()
+        assert figure_tool.source_panel.source_list.topLevelItemCount() == 0
+
+        namespace = _exec_generated_code(figure_tool.generated_code(), {})
+        assert isinstance(namespace["fig"], Figure)
+        assert len(namespace["fig"].axes) == 1
+        replay_code = _assert_figure_composer_provenance_replayable(
+            figure_tool,
+            case_label="source-free figure",
+        )
+        replay_namespace = _exec_generated_code(replay_code, {})
+        assert isinstance(replay_namespace["fig"], Figure)
+
+
+def test_manager_empty_figure_workspace_roundtrip(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    workspace_path = tmp_path / "source-free-figure.itws"
+    with manager_context() as manager:
+        figure_uid = manager.create_empty_figure(show=False)
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=False,
+            mark_dirty=False,
+            select=False,
+        )
+        loaded_node = manager._child_node(figure_uid)
+        assert loaded_node.tool_window is None
+        assert loaded_node.pending_workspace_tool_payload is not None
+        assert loaded_node.materialize_pending_workspace_payload()
+        loaded_tool = loaded_node.tool_window
+        assert isinstance(loaded_tool, FigureComposerTool)
+        assert loaded_tool.tool_status.sources == ()
+        assert loaded_tool.tool_status.operations == ()
+        assert loaded_tool.source_data() == {}
+        assert loaded_tool._persistence_reference_node_uids() == frozenset()
+
+        manager._figure_collection.select_uid(figure_uid)
+        manager.duplicate_selected()
+        qtbot.wait_until(
+            lambda: len(manager._tool_graph.figure_uids) == 2,
+            timeout=5000,
+        )
+        duplicate_uid = next(
+            uid for uid in manager._tool_graph.figure_uids if uid != figure_uid
+        )
+        duplicate_tool = manager._child_node(duplicate_uid).tool_window
+        assert isinstance(duplicate_tool, FigureComposerTool)
+        assert duplicate_tool.tool_status.sources == ()
+        assert duplicate_tool.tool_status.operations == ()
+        assert duplicate_tool.source_data() == {}
 
 
 def test_imagetool_plot_with_matplotlib_warns_for_uneditable_selection(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -82,6 +82,28 @@ from ._common import (
 )
 
 
+def test_figure_composer_empty_figure_promotes_first_added_source(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(3.0),
+        dims=("x",),
+        coords={"x": np.arange(3.0)},
+        name="line",
+    )
+    tool = FigureComposerTool.empty()
+    qtbot.addWidget(tool)
+
+    result = tool.add_sources(
+        (FigureSourceState(name="line", node_uid="node-line"),),
+        {"line": data},
+    )
+
+    assert result.added == (("line", "line"),)
+    assert tool.tool_status.primary_source == "line"
+    assert tuple(source.name for source in tool.tool_status.sources) == ("line",)
+    xr.testing.assert_identical(tool.source_data()["line"], data)
+    xr.testing.assert_identical(tool.tool_data, data)
+
+
 def _source_context_action(
     tool: FigureComposerTool, object_name: str
 ) -> tuple[QtWidgets.QMenu, QtGui.QAction]:


### PR DESCRIPTION
## Summary

- Add **File > New Empty Figure** to ImageTool Manager.
- Create Figure Composer windows without source metadata or recipe steps.
- Keep source-free figures valid through generated code, provenance replay, workspace restore, and duplication.
- Promote the first source added later to the primary source.
- Document the source-free workflow.

## Why

Users can prepare a figure layout before they select or load data. The figure remains independent of ImageTool sources until the user adds one.

## Validation

- `uv run pytest tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py tests/interactive/imagetool/manager/figurecomposer/test_sources.py -q` (`142 passed`)
- Ruff format and lint checks for all changed Python files
- `uv run mypy src` (`262 source files`)
