### PR TITLE
fix(figurecomposer): show controls for selected BZ mode

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
@@ -394,7 +394,7 @@ def _add_spinbox_row(
     spinbox_factory: Callable[..., QtWidgets.QDoubleSpinBox] | None = None,
     suffix: str = "",
     update: Callable[[float], None] | None = None,
-) -> None:
+) -> QtWidgets.QWidget:
     mixed = editor.batch_is_mixed(operation, lambda target: getattr(target, field))
     if spinbox_factory is None:
         spinbox = _spinbox(float(getattr(operation, field)), parent=parent)
@@ -411,12 +411,14 @@ def _add_spinbox_row(
         if update is not None
         else lambda value: editor.request_update(**{field: value}),
     )
+    field_widget = editor.mixed_value_widget(spinbox, mixed=mixed, parent=parent)
     editor.add_form_row(
         layout,
         label,
-        editor.mixed_value_widget(spinbox, mixed=mixed, parent=parent),
+        field_widget,
         tooltip,
     )
+    return field_widget
 
 
 def _build_kz_row(
@@ -424,7 +426,7 @@ def _build_kz_row(
     operation: FigureOperationState,
     page: QtWidgets.QWidget,
     layout: QtWidgets.QFormLayout,
-) -> None:
+) -> QtWidgets.QWidget:
     kz_pi_mixed = editor.batch_is_mixed(
         operation, lambda target: target.bz_kz_pi_over_c
     )
@@ -462,6 +464,7 @@ def _build_kz_row(
     )
 
     row = QtWidgets.QWidget(page)
+    row.setObjectName("figureComposerBZKzRow")
     row_layout = QtWidgets.QHBoxLayout(row)
     row_layout.setContentsMargins(0, 0, 0, 0)
     row_layout.setSpacing(6)
@@ -481,6 +484,17 @@ def _build_kz_row(
         row,
         "Fixed out-of-plane momentum for in-plane slices.",
     )
+    return row
+
+
+def _set_slice_momentum_row_visibility(
+    layout: QtWidgets.QFormLayout,
+    kz_row: QtWidgets.QWidget,
+    k_parallel_row: QtWidgets.QWidget,
+    mode: typing.Literal["in_plane", "out_of_plane"] | None,
+) -> None:
+    layout.setRowVisible(kz_row, mode != "out_of_plane")
+    layout.setRowVisible(k_parallel_row, mode != "in_plane")
 
 
 def _build_slice_editor(
@@ -490,10 +504,21 @@ def _build_slice_editor(
     layout: QtWidgets.QFormLayout,
 ) -> None:
     mode_mixed = editor.batch_is_mixed(operation, lambda target: target.bz_mode)
+
+    def update_mode(text: str) -> None:
+        mode = _mode_from_text(text)
+        _set_slice_momentum_row_visibility(
+            layout,
+            kz_row,
+            k_parallel_row,
+            mode,
+        )
+        editor.request_update(bz_mode=mode)
+
     mode_combo = editor.combo(
         tuple(_MODE_LABELS.values()),
         None if mode_mixed else _mode_text(operation.bz_mode),
-        lambda text: editor.request_update(bz_mode=_mode_from_text(text)),
+        update_mode,
         parent=page,
         mixed=mode_mixed,
     )
@@ -516,8 +541,8 @@ def _build_slice_editor(
         parent=page,
         suffix="°",
     )
-    _build_kz_row(editor, operation, page, layout)
-    _add_spinbox_row(
+    kz_row = _build_kz_row(editor, operation, page, layout)
+    k_parallel_row = _add_spinbox_row(
         editor,
         operation,
         layout,
@@ -527,6 +552,12 @@ def _build_slice_editor(
         tooltip="Fixed in-plane momentum component for out-of-plane slices.",
         parent=page,
         suffix=" Å⁻¹",
+    )
+    _set_slice_momentum_row_visibility(
+        layout,
+        kz_row,
+        k_parallel_row,
+        None if mode_mixed else operation.bz_mode,
     )
 
     bounds_text, bounds_mixed = editor.batch_text(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
@@ -81,8 +81,16 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     assert kz_spin.suffix() == " π/c"
     assert kz_absolute_spin.suffix() == " Å⁻¹"
     assert k_parallel_spin.suffix() == " Å⁻¹"
+    slice_layout = page.layout()
+    assert isinstance(slice_layout, QtWidgets.QFormLayout)
+    kz_row = page.findChild(QtWidgets.QWidget, "figureComposerBZKzRow")
+    assert kz_row is not None
+    assert slice_layout.isRowVisible(kz_row)
+    assert not slice_layout.isRowVisible(k_parallel_spin)
 
     _activate_combo_text(mode_combo, "Out-of-plane")
+    assert not slice_layout.isRowVisible(kz_row)
+    assert slice_layout.isRowVisible(k_parallel_spin)
     angle_spin.setValue(30.0)
     kz_spin.setValue(0.5)
     assert np.isclose(kz_absolute_spin.value(), np.pi / 2.0)
@@ -167,6 +175,41 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
         "linestyle": "-.",
         "linewidth": 1.5,
     }
+
+
+@pytest.mark.parametrize(
+    ("mode", "kz_visible", "k_parallel_visible"),
+    [("in_plane", True, False), ("out_of_plane", False, True)],
+)
+def test_figure_composer_bz_overlay_restores_mode_control_visibility(
+    qtbot, mode: str, kz_visible: bool, k_parallel_visible: bool
+) -> None:
+    operation = FigureOperationState.bz_overlay(
+        axes=FigureAxesSelectionState(axes=((0, 0),)),
+        mode=mode,
+    )
+    tool = _bz_tool(operation)
+    qtbot.addWidget(tool)
+    tool.operation_panel.operation_list.setCurrentItem(
+        tool.operation_panel.operation_list.topLevelItem(0)
+    )
+
+    tool.operation_editor.select_section("slice")
+    page = tool.operation_editor.stack.currentWidget()
+    assert page is not None
+    layout = page.layout()
+    assert isinstance(layout, QtWidgets.QFormLayout)
+    kz_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZKzSpin")
+    k_parallel_spin = page.findChild(
+        QtWidgets.QDoubleSpinBox, "figureComposerBZKParallelSpin"
+    )
+    assert kz_spin is not None
+    assert k_parallel_spin is not None
+    kz_row = page.findChild(QtWidgets.QWidget, "figureComposerBZKzRow")
+    assert kz_row is not None
+
+    assert layout.isRowVisible(kz_row) is kz_visible
+    assert layout.isRowVisible(k_parallel_spin) is k_parallel_visible
 
 
 def test_figure_composer_bz_overlay_state_round_trip() -> None:


### PR DESCRIPTION
## Summary

- Show the fixed `kz` controls only for in-plane Brillouin-zone slices.
- Show the fixed in-plane momentum control only for out-of-plane slices.
- Update the visible row immediately when the mode changes.
- Preserve both momentum values when the user switches modes.
- Restore the correct control visibility from saved operation state.

## Root cause

The Brillouin-zone editor added both momentum rows without connecting their
visibility to the selected slice mode.

## Validation

- `QT_QPA_PLATFORM=offscreen QT_API=pyqt6 uv run pytest -q tests/interactive/imagetool/manager/figurecomposer/test_overlays.py` (26 passed)
- `QT_QPA_PLATFORM=offscreen QT_API=pyside6 uv run pytest -q tests/interactive/imagetool/manager/figurecomposer/test_overlays.py` (26 passed)
- `uv run ruff check src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py tests/interactive/imagetool/manager/figurecomposer/test_overlays.py`
- `uv run ruff format --check src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py tests/interactive/imagetool/manager/figurecomposer/test_overlays.py`
- `uv run mypy src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py`
- `git diff --check`
