### PR TITLE
fix(interactive): materialize restored ToolWindow data

### DIFF
--- a/src/erlab/accessors/kspace.py
+++ b/src/erlab/accessors/kspace.py
@@ -1556,19 +1556,11 @@ class MomentumAccessor(ERLabDataArrayAccessor):
             [typing.cast("tuple[str, ...]", target_dict[d].dims) for d in input_dims]
         )
 
-        ufunc_args = (
+        out = xr.apply_ufunc(
+            _wrap_interpn,
             self._data_ensure_binding(),
             *tuple(self._coord_for_conversion(dim) for dim in input_dims),
             *tuple(target_dict[dim] for dim in input_dims),
-        )
-        ufunc_args = tuple(
-            arg.chunk(dict.fromkeys(core_dims, -1)) if arg.chunks is not None else arg
-            for arg, core_dims in zip(ufunc_args, input_core_dims, strict=True)
-        )
-
-        out = xr.apply_ufunc(
-            _wrap_interpn,
-            *ufunc_args,
             vectorize=True,
             dask="parallelized",
             input_core_dims=input_core_dims,

--- a/src/erlab/analysis/gold.py
+++ b/src/erlab/analysis/gold.py
@@ -960,8 +960,6 @@ def edge(
             "eV": _range_slice_for_coord(gold["eV"], eV_range),
         }
     )
-    if gold_sel.chunks is not None:
-        gold_sel = gold_sel.chunk({"eV": -1})
 
     if temp is None:
         temp = gold.qinfo.get_value("sample_temp")

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -1091,6 +1091,7 @@ class _WorkspaceLoader:
                         ds,
                         _source_parent_data=source_parent_data,
                         _tool_data_reference_resolver=tool_data_reference_resolver,
+                        _materialize_tool_data_references=True,
                         _defer_restore_work=True,
                     )
                 )

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -1091,6 +1091,7 @@ class _PendingWorkspacePayloads:
                         ds,
                         _source_parent_data=source_parent_data,
                         _tool_data_reference_resolver=tool_data_reference_resolver,
+                        _materialize_tool_data_references=True,
                         _defer_restore_work=True,
                     )
                 )

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -5586,6 +5586,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         reference_resolver: Callable[[Mapping[str, typing.Any]], xr.DataArray | None]
         | None,
         variable_names: Collection[str] | None = None,
+        materialize_references: bool = False,
     ) -> dict[str, xr.DataArray]:
         requested = None if variable_names is None else frozenset(variable_names)
         references = cls._saved_tool_data_references(ds)
@@ -5594,12 +5595,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             if requested is not None and variable_name not in requested:
                 continue
             try:
-                data_items[variable_name] = cls._resolve_saved_tool_data_reference(
+                resolved = cls._resolve_saved_tool_data_reference(
                     reference,
                     ds,
                     source_parent_data=source_parent_data,
                     reference_resolver=reference_resolver,
                 )
+                if materialize_references:
+                    resolved = resolved.copy(deep=False).load()
+                data_items[variable_name] = resolved
             except _MissingSavedToolDataReferenceError:
                 if cls._missing_saved_tool_data_reference_optional(
                     variable_name, reference, ds
@@ -5671,6 +5675,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             "Callable[[Mapping[str, typing.Any]], xr.DataArray | None] | None",
             kwargs.pop("_tool_data_reference_resolver", None),
         )
+        materialize_data_references = bool(
+            kwargs.pop("_materialize_tool_data_references", False)
+        )
         defer_restore_work = bool(kwargs.pop("_defer_restore_work", False))
         ds = _serialization.restore_private_coords(ds, _SAVED_TOOL_DATA_NAME)
 
@@ -5689,6 +5696,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             ds,
             source_parent_data=source_parent_data,
             reference_resolver=reference_resolver,
+            materialize_references=materialize_data_references,
         )
 
         # Instantiate the class and set the status

--- a/tests/accessors/test_kspace.py
+++ b/tests/accessors/test_kspace.py
@@ -1034,17 +1034,6 @@ def test_kconv_hvdep_kinetic_rejects(
     )
 
 
-def test_kconv_rechunks_core_dimensions(anglemap) -> None:
-    data = anglemap.copy(deep=True)
-    data.attrs["configuration"] = AxesConfiguration.Type1.value
-
-    expected = data.kspace.convert(silent=True)
-    chunked = data.chunk({"alpha": 4, "beta": 4, "eV": 4})
-    actual = chunked.kspace.convert(silent=True).compute()
-
-    xarray.testing.assert_allclose(actual, expected)
-
-
 @pytest.mark.parametrize("missing_coord", ["alpha", "beta", "chi", "xi", "eV", "hv"])
 def test_kconv_missing_coord(missing_coord, anglemap):
     data = anglemap.copy().assign_coords(chi=0.0)

--- a/tests/analysis/test_gold.py
+++ b/tests/analysis/test_gold.py
@@ -492,7 +492,7 @@ def test_edge_adaptive_uses_per_edc_ranges(
     gold: xr.DataArray, use_dask: bool, normalize: bool
 ) -> None:
     if use_dask:
-        gold = gold.chunk(alpha=1, eV=25)
+        gold = gold.chunk(alpha=1)
 
     result = edge(
         gold,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -2072,7 +2072,8 @@ def test_manager_pending_figure_source_reference_uses_saved_imagetool_dim_order(
         assert isinstance(loaded_figure, FigureComposerTool)
         source = loaded_figure.source_data()[loaded_figure.tool_status.primary_source]
         assert source.dims == data.dims
-        assert source.chunks is not None
+        assert source.chunks is None
+        assert workspace_arrays.dataarray_is_numpy_backed(source)
         np.testing.assert_array_equal(source.values, data.values)
         assert source_node.pending_workspace_memory_payload is not None
 

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -1860,6 +1860,39 @@ def test_manager_load_workspace_tool_dataset_rejects_root_tool(
         )
 
 
+def test_manager_load_workspace_tool_dataset_materializes_reference(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(16.0).reshape((4, 4)), dims=("x", "y"), name="parent"
+    ).chunk({"x": 2, "y": 2})
+
+    with manager_context() as manager:
+        parent = itool(data, manager=False, execute=False, auto_compute=False)
+        assert isinstance(parent, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(parent, show=False)
+
+        child = _WorkspaceSweepChildTool(data.rename("child"))
+        child.set_source_binding(full_data())
+        manager.add_childtool(child, 0, show=False)
+        with child._save_tool_data_reference_context(manager._tool_graph.nodes):
+            ds = child.to_dataset()
+
+        target = manager._workspace_controller.loading._load_workspace_tool_dataset(
+            ds, parent_target=0
+        )
+        loaded_child = manager.get_childtool(target)
+
+        assert data.chunks is not None
+        assert loaded_child.tool_data.chunks is None
+        assert workspace_arrays.dataarray_is_numpy_backed(loaded_child.tool_data)
+        xr.testing.assert_identical(
+            loaded_child.tool_data, data.rename("child").compute()
+        )
+
+
 def test_manager_workspace_partially_loads_corrupted_child_with_warning(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -2725,7 +2725,7 @@ def test_manager_workspace_show_materializes_hidden_memory_payload(
         assert loaded.array_slicer.get_value(0, 1) == 3.0
 
 
-def test_manager_workspace_child_tool_reference_keeps_pending_parent_unmaterialized(
+def test_manager_workspace_child_tool_reference_materializes_only_child_data(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -2800,11 +2800,12 @@ def test_manager_workspace_child_tool_reference_keeps_pending_parent_unmateriali
         assert isinstance(loaded_child, _WorkspaceSweepChildTool)
         assert loaded_child.tool_data.name == child_data.name
         assert loaded_child.tool_data.dims == child_data.dims
-        assert loaded_child.tool_data.chunks is not None
+        assert loaded_child.tool_data.chunks is None
+        assert workspace_arrays.dataarray_is_numpy_backed(loaded_child.tool_data)
         np.testing.assert_array_equal(loaded_child.tool_data.values, child_data.values)
 
 
-def test_manager_workspace_tool_manager_node_reference_keeps_pending_source(
+def test_manager_workspace_tool_reference_materializes_without_opening_source(
     qtbot,
     monkeypatch,
     tmp_path,
@@ -2858,7 +2859,7 @@ def test_manager_workspace_tool_manager_node_reference_keeps_pending_source(
         def _fail_materialize_pending_payload(_node) -> bool:
             if _node.is_imagetool:
                 pytest.fail(
-                    "tool manager-node restore should not materialize source data"
+                    "tool reference restore should not open the source ImageTool"
                 )
             return original_materialize(_node)
 
@@ -2866,7 +2867,7 @@ def test_manager_workspace_tool_manager_node_reference_keeps_pending_source(
             del cls
             if load_data:
                 pytest.fail(
-                    "tool manager-node restore should not eagerly load source data"
+                    "tool reference restore should not eagerly open the source payload"
                 )
             return original_read(workspace_path, payload_path, load_data=load_data)
 
@@ -2894,7 +2895,8 @@ def test_manager_workspace_tool_manager_node_reference_keeps_pending_source(
         assert isinstance(loaded_figure, _WorkspaceManagerReferenceFigureTool)
         assert loaded_figure.tool_data.name == data.name
         assert loaded_figure.tool_data.dims == data.dims
-        assert loaded_figure.tool_data.chunks is not None
+        assert loaded_figure.tool_data.chunks is None
+        assert workspace_arrays.dataarray_is_numpy_backed(loaded_figure.tool_data)
         np.testing.assert_array_equal(loaded_figure.tool_data.values, data.values)
 
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -4508,6 +4508,29 @@ def test_tool_window_resolves_references_with_missing_placeholder_variables() ->
         )
 
 
+def test_tool_window_materializes_referenced_data_without_mutating_source() -> None:
+    source = xr.DataArray(np.arange(4.0), dims=("x",)).chunk({"x": 2})
+    variable_name = erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+    ds = xr.Dataset(
+        attrs={
+            erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                {variable_name: {"kind": "manager_node", "node_uid": "source"}}
+            )
+        }
+    )
+
+    data_items = erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(
+        ds,
+        source_parent_data=None,
+        reference_resolver=lambda _reference: source,
+        materialize_references=True,
+    )
+
+    assert source.chunks is not None
+    assert data_items[variable_name].chunks is None
+    xr.testing.assert_identical(data_items[variable_name], source.compute())
+
+
 def test_tool_window_source_binding_empty_and_type_error_branches(qtbot) -> None:
     tool = _PersistentTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))
     qtbot.addWidget(tool)


### PR DESCRIPTION
## Summary

- Materialize referenced ToolWindow data before the tool is constructed.
- Keep the referenced ImageTool pending and unopened.
- Copy resolved references before loading so a Dask-backed parent is not mutated.
- Remove automatic core-dimension rechunking from gold fitting and momentum conversion.

## Root cause

Workspace restore opened memory-backed ImageTool payloads with Dask so it could resolve child references without opening the parent window. The temporary Dask representation then became the permanent ToolWindow data backing. This made restored GoldTool and KTool windows slow and exposed HDF5 chunk layout to analysis routines.

## User impact

Restored child tools now use an eager snapshot while their parent ImageTool can remain pending. The child remains usable when its original source can no longer reload. Analysis routines no longer apply an implicit and potentially expensive rechunk.

## Validation

- `uv run --group pyqt6 pytest -q tests/analysis/test_gold.py tests/accessors/test_kspace.py` — 387 passed
- `uv run --group pyqt6 pytest -q tests/interactive/test_utils.py tests/interactive/imagetool/manager/workspace/test_pending.py` — 268 passed
- `uv run --group pyqt6 pytest -q tests/interactive/imagetool/manager/workspace/test_loading.py` — 56 passed
- `uv run mypy src`
- Ruff checks for all changed files
- `git diff --check`
