### PR TITLE
fix(analysis.transform): correctly shift coordinates for inputs containing NaNs

### DIFF
--- a/src/erlab/analysis/transform.py
+++ b/src/erlab/analysis/transform.py
@@ -647,13 +647,14 @@ def shift(
         raise ValueError(f"Dimension {along} must have at least 2 points.")
     along_step: float = float(coord[1] - coord[0])
 
-    # Normalize shift values to "index units" and fill NaNs
-    shift = (shift.copy() / along_step).fillna(0.0)
+    # Normalize shift values to "index units"
+    shift = shift.copy() / along_step
 
     if shift_coords:
         # We first apply the integer part of the average shift to the coords
-        rigid_shift: float = float(np.round(shift.values.mean()))
-        shift = shift - rigid_shift
+        rigid_shift: float = round(float(shift.mean()))
+
+        shift = (shift - rigid_shift).fillna(0.0)
 
         # Apply rigid shift to coordinates
         out = out.assign_coords({along: out[along].values + rigid_shift * along_step})
@@ -678,6 +679,8 @@ def shift(
         if bool(out.chunks):
             out = out.chunk({along: -1})
         out = out.assign_coords({along: new_along})
+    else:
+        shift = shift.fillna(0.0)
 
     # Broadcast shift array to match non-along dims of output array
     shift_broadcast = shift.broadcast_like(out.isel({along: 0}, drop=True))

--- a/tests/analysis/test_transform.py
+++ b/tests/analysis/test_transform.py
@@ -150,6 +150,19 @@ def test_shift(use_dask) -> None:
     assert np.allclose(shifted, expected, equal_nan=True)
 
 
+def test_shift_coords_ignores_nan_shifts_for_rigid_coordinate_shift() -> None:
+    data = xr.DataArray(
+        np.arange(6, dtype=float).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"y": [10.0, 11.0, 12.0]},
+    )
+    shifts = xr.DataArray([2.0, np.nan], dims="x")
+
+    shifted = shift(data, shifts, along="y", shift_coords=True)
+
+    np.testing.assert_allclose(shifted.y, [12.0, 13.0, 14.0])
+
+
 def test_shift_order1_optimized() -> None:
     arr = xr.DataArray(
         np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),


### PR DESCRIPTION
Fixes an issue where the `shift` function would return an incorrect coordinate grid for shifts including NaNs `shift_coords=True`. Now, NaN values in the shift array are ignored for rigid coordinate shifts, ensuring that only valid shifts affect the output coordinates.