### PR TITLE
Preserve tool names while restoring pending workspace windows

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -694,9 +694,7 @@ class _WorkspaceLoader:
         source_state = workspace_format._decode_workspace_attr_text(
             attrs.get(erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR)
         )
-        if source_state in {"fresh", "stale", "unavailable"}:
-            return typing.cast("_ManagedWindowNode._source_state_type", source_state)
-        return "fresh"
+        return erlab.interactive.utils._normalize_tool_source_state(source_state)
 
     def _root_workspace_imagetool_kwargs(
         self, ds: xr.Dataset, kwargs: dict[str, typing.Any]

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -1165,6 +1165,12 @@ class _ManagedWindowNode(QtCore.QObject):
             return self.tool_window.tool_name
         if self.pending_workspace_tool_payload is not None:
             attrs = self.pending_workspace_payload_attrs or {}
+            tool_name = attrs.get("tool_name")
+            if isinstance(tool_name, bytes):
+                with contextlib.suppress(UnicodeDecodeError):
+                    tool_name = tool_name.decode()
+            if isinstance(tool_name, str) and tool_name:
+                return tool_name
             qualname = attrs.get("tool_cls_qualname")
             if isinstance(qualname, bytes):
                 with contextlib.suppress(UnicodeDecodeError):

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -1177,12 +1177,6 @@ class _ManagedWindowNode(QtCore.QObject):
                     qualname = qualname.decode()
             if isinstance(qualname, str) and qualname:
                 return qualname.rsplit(":", maxsplit=1)[-1].rsplit(".", maxsplit=1)[-1]
-            display_name = attrs.get("tool_display_name")
-            if isinstance(display_name, bytes):
-                with contextlib.suppress(UnicodeDecodeError):
-                    display_name = display_name.decode()
-            if isinstance(display_name, str) and display_name:
-                return display_name
         return None
 
     @property

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -1100,6 +1100,21 @@ _TOOL_INPUT_PROVENANCE_SPEC_ATTR = "tool_input_provenance_spec"
 _TOOL_DATA_REFERENCES_ATTR = "tool_data_references"
 _TOOL_DATA_BLOB_NAME_ATTR = "tool_data_blob_name"
 _SAVED_TOOL_DATA_NAME = "<saved-tool-data>"
+
+
+def _normalize_tool_source_state(
+    value: typing.Any,
+) -> typing.Literal["fresh", "stale", "unavailable"]:
+    if isinstance(value, bytes):
+        try:
+            value = value.decode()
+        except UnicodeDecodeError:
+            return "fresh"
+    if isinstance(value, str) and value in {"fresh", "stale", "unavailable"}:
+        return typing.cast("typing.Literal['fresh', 'stale', 'unavailable']", value)
+    return "fresh"
+
+
 _SAVED_TOOL_DATA_REFERENCE_DIM = "<saved-tool-data-reference>"
 _SAVED_TOOL_DATA_BLOB_DIM_PREFIX = "<saved-tool-data-blob-"
 _NONE_TOOL_DATA_NAME = "<none-value>"
@@ -5769,9 +5784,8 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     auto_update=bool(
                         ds.attrs.get(_TOOL_SOURCE_AUTO_UPDATE_ATTR, False)
                     ),
-                    state=typing.cast(
-                        "typing.Literal['fresh', 'stale', 'unavailable']",
-                        ds.attrs.get(_TOOL_SOURCE_STATE_ATTR, "fresh"),
+                    state=_normalize_tool_source_state(
+                        ds.attrs.get(_TOOL_SOURCE_STATE_ATTR)
                     ),
                 )
             if _TOOL_INPUT_PROVENANCE_SPEC_ATTR in ds.attrs:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -5283,6 +5283,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             "tool_data_name": str(data_name),
             "tool_title": self.windowTitle(),
             "tool_cls_qualname": self._qual_name(),
+            "tool_name": self.tool_name,
             "tool_display_name": self._tool_display_name,
             "tool_window_state": _qt_state.qt_window_state_json(self),
             "erlab_version": erlab.__version__,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -983,11 +983,12 @@ def test_manager_workspace_restores_figure_preview_and_live_details(
         pending_fields = tuple(loaded_node.metadata_fields)
         assert manager._details_panel._metadata_fields_cache == pending_fields
         pending_type_badge = loaded_node.type_badge_text
+        assert pending_type_badge == FigureComposerTool.tool_name
 
         assert loaded_node.materialize_pending_workspace_payload()
         loaded_tool = loaded_node.tool_window
         assert isinstance(loaded_tool, FigureComposerTool)
-        assert loaded_node.type_badge_text != pending_type_badge
+        assert loaded_node.type_badge_text == pending_type_badge
         manager._flush_idle_work(force=True)
         live_fields = tuple(loaded_node.metadata_fields)
         assert live_fields != pending_fields

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -2357,6 +2357,7 @@ def test_hidden_workspace_toolwindows_restore_pending_until_shown(
         assert root_node.pending_workspace_memory_payload is not None
         assert child_node.pending_workspace_tool_payload is not None
         assert child_node.tool_window is None
+        assert child_node.type_badge_text == _AddedTimeChildTool.tool_name
         assert figure_node.pending_workspace_tool_payload is not None
         assert figure_node.tool_window is None
         assert figure_uid in manager._figure_uids()
@@ -2366,6 +2367,7 @@ def test_hidden_workspace_toolwindows_restore_pending_until_shown(
         assert constructed == ["Hidden child"]
         assert child_node.pending_workspace_tool_payload is None
         assert child_node.tool_window is not None
+        assert child_node.type_badge_text == _AddedTimeChildTool.tool_name
         assert root_node.pending_workspace_memory_payload is not None
 
 

--- a/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
@@ -1060,7 +1060,7 @@ def test_pending_toolwindow_metadata_and_preview_helpers(
                 "figure_composer_preview_cache_png": "not valid base64",
             }
         )
-        assert node.type_badge_text == "Display Tool"
+        assert node.type_badge_text is None
         text_without_data = loader.pending._pending_workspace_tool_info_text(node)
         assert text_without_data is not None
         assert "Data:" not in text_without_data

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -4184,6 +4184,21 @@ def test_tool_window_dataset_roundtrips_source_and_input_provenance(qtbot) -> No
     assert restored.input_provenance_spec == input_spec.to_replay_spec()
 
 
+def test_tool_window_dataset_normalizes_invalid_source_state(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4)})
+    tool = _PersistentTool(data)
+    qtbot.addWidget(tool)
+    tool.set_source_binding(full_data(), auto_update=True, state="stale")
+    saved = tool.to_dataset()
+    saved.attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = "unknown"
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, _PersistentTool)
+    assert restored.source_state == "fresh"
+
+
 def test_tool_window_dataset_prefers_source_spec_over_legacy_binding(qtbot) -> None:
     data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4)})
     tool = _PersistentTool(data.isel(x=slice(1, 3)))


### PR DESCRIPTION
## Summary

- Store each tool's stable `tool_name` in workspace payloads.
- Use the persisted name for pending windows before their tool instance is created.
- Keep pending workspace type badges consistent before and after restoration.

## Testing

- Added unit coverage for pending hidden workspace tool windows and their type badges.