### PR TITLE
Add editable Line2D kwargs to Figure Composer line styles

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_line_style.py
+++ b/src/erlab/interactive/_figurecomposer/_line_style.py
@@ -9,7 +9,7 @@ import matplotlib.lines
 import matplotlib.markers
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Collection, Iterable
 
     from erlab.interactive._figurecomposer._model._state import FigureOperationState
 
@@ -33,7 +33,7 @@ def _style_options(values: Iterable[typing.Any]) -> tuple[str, ...]:
 LINE_STYLE_OPTIONS = _style_options(matplotlib.lines.lineStyles)
 LINE_MARKER_OPTIONS = _style_options(matplotlib.markers.MarkerStyle.markers)
 LINE_STYLE_DEFAULT_LABEL = "None"
-CONTROLLED_LINE_KW_KEYS = frozenset(
+STROKE_LINE_KW_KEYS = frozenset(
     (
         "c",
         "color",
@@ -41,6 +41,10 @@ CONTROLLED_LINE_KW_KEYS = frozenset(
         "linestyle",
         "lw",
         "linewidth",
+    )
+)
+MARKER_LINE_KW_KEYS = frozenset(
+    (
         "marker",
         "ms",
         "markersize",
@@ -50,6 +54,7 @@ CONTROLLED_LINE_KW_KEYS = frozenset(
         "markeredgecolor",
     )
 )
+CONTROLLED_LINE_KW_KEYS = STROKE_LINE_KW_KEYS | MARKER_LINE_KW_KEYS
 
 
 def color_kw_value_from_text(text: str) -> typing.Any:
@@ -107,9 +112,14 @@ def line_kw_float(
         return None
 
 
-def extra_line_kw(operation: FigureOperationState) -> dict[str, typing.Any]:
+def extra_line_kw(
+    operation: FigureOperationState,
+    *,
+    controlled_keys: Collection[str] = CONTROLLED_LINE_KW_KEYS,
+    reserved_keys: Collection[str] = (),
+) -> dict[str, typing.Any]:
     return {
         key: value
         for key, value in operation.line_kw.items()
-        if key not in CONTROLLED_LINE_KW_KEYS
+        if key not in controlled_keys and key not in reserved_keys
     }

--- a/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_bz_overlay.py
@@ -13,6 +13,7 @@ from erlab.interactive._figurecomposer._code import _axes_code, _axes_sequence_c
 from erlab.interactive._figurecomposer._line_style import (
     LINE_STYLE_DEFAULT_LABEL,
     LINE_STYLE_OPTIONS,
+    STROKE_LINE_KW_KEYS,
     color_kw_value_from_text,
     line_kw_float,
     line_kw_style_value,
@@ -43,6 +44,7 @@ from erlab.interactive._figurecomposer._text import (
 )
 from erlab.interactive._figurecomposer._ui._color_widgets import _ColorLineEditWidget
 from erlab.interactive._figurecomposer._ui._line_style import (
+    add_extra_line_kw_control,
     optional_positive_spinbox,
     optional_positive_spinbox_value,
     update_current_line_kw,
@@ -60,6 +62,19 @@ if typing.TYPE_CHECKING:
 
 
 _CENTERING_TYPES = ("P", "A", "B", "C", "F", "I", "R")
+_RESERVED_LINE_KW_KEYS = frozenset(
+    (
+        "angle",
+        "ax",
+        "bounds",
+        "k_parallel",
+        "kz",
+        "midpoint_kwargs",
+        "midpoints",
+        "vertex_kwargs",
+        "vertices",
+    )
+)
 _MODE_LABELS = {
     "in_plane": "In-plane",
     "out_of_plane": "Out-of-plane",
@@ -703,6 +718,19 @@ def _build_style_editor(
             ),
         ),
         "Line style controls for BZ boundaries.",
+    )
+    add_extra_line_kw_control(
+        editor,
+        operation,
+        page,
+        layout,
+        object_name="figureComposerBZLineKwEdit",
+        tooltip=(
+            "Additional Matplotlib Line2D kwargs for BZ boundaries not covered by "
+            "the controls above."
+        ),
+        controlled_keys=STROKE_LINE_KW_KEYS,
+        reserved_keys=_RESERVED_LINE_KW_KEYS,
     )
 
     vertices_mixed = editor.batch_is_mixed(operation, lambda target: target.bz_vertices)

--- a/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_line_profile.py
@@ -96,6 +96,7 @@ from erlab.interactive._figurecomposer._ui._color_widgets import (
 )
 from erlab.interactive._figurecomposer._ui._label_help import legend_label_input_widget
 from erlab.interactive._figurecomposer._ui._line_style import (
+    add_extra_line_kw_control,
     optional_positive_spinbox,
     optional_positive_spinbox_value,
     update_current_line_kw,
@@ -1156,6 +1157,18 @@ def _add_line_style_controls(
             ),
         ),
         "Marker face and edge colors for the extracted profiles.",
+    )
+    add_extra_line_kw_control(
+        editor,
+        operation,
+        page,
+        layout,
+        object_name="figureComposerLineKwEdit",
+        tooltip=(
+            "Additional Matplotlib Line2D kwargs for the extracted profiles not "
+            "covered by the controls above."
+        ),
+        reserved_keys=("label",),
     )
 
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_photon_energy.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_photon_energy.py
@@ -9,6 +9,7 @@ from erlab.interactive._figurecomposer._code import _axes_code, _axes_sequence_c
 from erlab.interactive._figurecomposer._line_style import (
     LINE_STYLE_DEFAULT_LABEL,
     LINE_STYLE_OPTIONS,
+    STROKE_LINE_KW_KEYS,
     color_kw_value_from_text,
     line_kw_float,
     line_kw_style_value,
@@ -42,6 +43,7 @@ from erlab.interactive._figurecomposer._text import (
 )
 from erlab.interactive._figurecomposer._ui._color_widgets import _ColorLineEditWidget
 from erlab.interactive._figurecomposer._ui._line_style import (
+    add_extra_line_kw_control,
     optional_positive_spinbox,
     optional_positive_spinbox_value,
     update_current_line_kw,
@@ -60,6 +62,7 @@ if typing.TYPE_CHECKING:
 
 
 _DEFAULT_LABEL_TEMPLATE = r"$h\nu = {hv:g}$ eV"
+_RESERVED_LINE_KW_KEYS = frozenset(("label",))
 _SECTION_TOOLTIPS = {
     "photon": "Choose photon energies and the electron binding-energy slice.",
     "style": "Set curve styling and legend labels.",
@@ -381,6 +384,19 @@ def _build_style_editor(
             ),
         ),
         "Line style controls for photon-energy annotation curves.",
+    )
+    add_extra_line_kw_control(
+        editor,
+        operation,
+        page,
+        layout,
+        object_name="figureComposerPhotonEnergyLineKwEdit",
+        tooltip=(
+            "Additional Matplotlib Line2D kwargs for photon-energy annotation "
+            "curves not covered by the controls above."
+        ),
+        controlled_keys=STROKE_LINE_KW_KEYS,
+        reserved_keys=_RESERVED_LINE_KW_KEYS,
     )
 
     legend_mixed = editor.batch_is_mixed(operation, lambda target: target.show_legend)

--- a/src/erlab/interactive/_figurecomposer/_operations/_plot_slices/_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_plot_slices/_editor.py
@@ -25,7 +25,6 @@ from erlab.interactive._figurecomposer._line_style import (
     LINE_STYLE_DEFAULT_LABEL,
     LINE_STYLE_OPTIONS,
     color_kw_value_from_text,
-    extra_line_kw,
     line_kw_float,
     line_kw_style_value,
     line_kw_text,
@@ -89,9 +88,9 @@ from erlab.interactive._figurecomposer._text import (
 from erlab.interactive._figurecomposer._ui._color_widgets import _ColorLineEditWidget
 from erlab.interactive._figurecomposer._ui._label_help import legend_label_input_widget
 from erlab.interactive._figurecomposer._ui._line_style import (
+    add_extra_line_kw_control,
     optional_positive_spinbox,
     optional_positive_spinbox_value,
-    update_current_extra_line_kw,
     update_current_line_kw,
 )
 from erlab.interactive._figurecomposer._ui._line_transform import (
@@ -974,21 +973,15 @@ def _build_plot_slices_editor(
             "Marker face and edge colors for 1D plot_slices panels.",
         )
 
-        line_kwargs_text, line_kwargs_mixed = editor.batch_text(
-            operation, extra_line_kw, _format_dict
-        )
-        line_kwargs_edit = editor.line_edit(line_kwargs_text, parent=colors_page)
-        editor.apply_mixed_line_edit(line_kwargs_edit, line_kwargs_mixed)
-        line_kwargs_edit.setObjectName("figureComposerPlotSlicesLineKwEdit")
-        editor.connect_line_edit_finished(
-            line_kwargs_edit,
-            lambda text: update_current_extra_line_kw(editor, _dict_from_text(text)),
-        )
-        editor.add_form_row(
+        add_extra_line_kw_control(
+            editor,
+            operation,
+            colors_page,
             colors_layout,
-            "Kwargs",
-            line_kwargs_edit,
-            "Additional Matplotlib Line2D kwargs not covered by the controls above.",
+            object_name="figureComposerPlotSlicesLineKwEdit",
+            tooltip=(
+                "Additional Matplotlib Line2D kwargs not covered by the controls above."
+            ),
         )
 
         add_line_transform_controls(

--- a/src/erlab/interactive/_figurecomposer/_ui/_line_style.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_line_style.py
@@ -6,13 +6,18 @@ import typing
 
 from qtpy import QtWidgets
 
+from erlab.interactive._figurecomposer._exceptions import FigureComposerInputError
 from erlab.interactive._figurecomposer._line_style import (
     CONTROLLED_LINE_KW_KEYS,
     LINE_STYLE_DEFAULT_LABEL,
+    extra_line_kw,
     normalize_style_value,
 )
+from erlab.interactive._figurecomposer._text import _dict_from_text, _format_dict
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Collection
+
     from erlab.interactive._figurecomposer._model._state import FigureOperationState
     from erlab.interactive._figurecomposer._ui._operation_editor import (
         FigureOperationEditor,
@@ -101,17 +106,65 @@ def update_current_line_kw(
 
 
 def update_current_extra_line_kw(
-    editor: FigureOperationEditor, extra_line_kw: dict[str, typing.Any]
+    editor: FigureOperationEditor,
+    extra_line_kw: dict[str, typing.Any],
+    *,
+    controlled_keys: Collection[str] = CONTROLLED_LINE_KW_KEYS,
+    reserved_keys: Collection[str] = (),
 ) -> None:
+    invalid_keys = sorted(
+        extra_line_kw.keys() & (set(controlled_keys) | set(reserved_keys))
+    )
+    if invalid_keys:
+        names = ", ".join(invalid_keys)
+        raise FigureComposerInputError(
+            f"These line kwargs have dedicated controls or operation fields: {names}."
+        )
+
     def update_operation(
         _operation_index: int, operation: FigureOperationState
     ) -> FigureOperationState:
         line_kw = {
             key: value
             for key, value in operation.line_kw.items()
-            if key in CONTROLLED_LINE_KW_KEYS
+            if key in controlled_keys
         }
         line_kw.update(extra_line_kw)
         return operation.model_copy(update={"line_kw": line_kw})
 
     editor.request_transform(update_operation)
+
+
+def add_extra_line_kw_control(
+    editor: FigureOperationEditor,
+    operation: FigureOperationState,
+    page: QtWidgets.QWidget,
+    layout: QtWidgets.QFormLayout,
+    *,
+    object_name: str,
+    tooltip: str,
+    controlled_keys: Collection[str] = CONTROLLED_LINE_KW_KEYS,
+    reserved_keys: Collection[str] = (),
+) -> None:
+    kwargs_text, kwargs_mixed = editor.batch_text(
+        operation,
+        lambda target: extra_line_kw(
+            target,
+            controlled_keys=controlled_keys,
+            reserved_keys=reserved_keys,
+        ),
+        _format_dict,
+    )
+    kwargs_edit = editor.line_edit(kwargs_text, parent=page)
+    editor.apply_mixed_line_edit(kwargs_edit, kwargs_mixed)
+    kwargs_edit.setObjectName(object_name)
+    editor.connect_line_edit_finished(
+        kwargs_edit,
+        lambda text: update_current_extra_line_kw(
+            editor,
+            _dict_from_text(text),
+            controlled_keys=controlled_keys,
+            reserved_keys=reserved_keys,
+        ),
+    )
+    editor.add_form_row(layout, "Line kwargs", kwargs_edit, tooltip)

--- a/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
@@ -99,10 +99,20 @@ def test_figure_composer_line_style_helpers_update_recipe(qtbot) -> None:
     operation = FigureOperationState.plot_slices(
         label="line-slices",
         sources=("data",),
-    ).model_copy(update={"line_kw": {"lw": "2", "custom": 1}, "cmap": "magma"})
+    ).model_copy(
+        update={
+            "line_kw": {"lw": "2", "marker": "o", "custom": 1},
+            "cmap": "magma",
+        }
+    )
     assert figurecomposer_line_style.line_kw_text(operation, "linewidth", "lw") == "2"
     assert figurecomposer_line_style.line_kw_float(operation, "linewidth", "lw") == 2.0
     assert figurecomposer_line_style.extra_line_kw(operation) == {"custom": 1}
+    assert figurecomposer_line_style.extra_line_kw(
+        operation,
+        controlled_keys=figurecomposer_line_style.STROKE_LINE_KW_KEYS,
+        reserved_keys=("custom",),
+    ) == {"marker": "o"}
     bad_operation = operation.model_copy(update={"line_kw": {"linewidth": "bad"}})
     assert figurecomposer_line_style.line_kw_float(bad_operation, "linewidth") is None
 
@@ -152,8 +162,21 @@ def test_figure_composer_line_style_helpers_update_recipe(qtbot) -> None:
     assert tool.tool_status.operations[0].line_kw == {
         "lw": "2",
         "color": "red",
+        "marker": "o",
         "zorder": 5,
     }
+    with pytest.raises(ValueError, match=r"dedicated controls.*angle"):
+        figurecomposer_line_style_ui.update_current_extra_line_kw(
+            tool.operation_editor,
+            {"angle": 30.0},
+            controlled_keys=figurecomposer_line_style.STROKE_LINE_KW_KEYS,
+            reserved_keys=("angle",),
+        )
+    with pytest.raises(ValueError, match=r"dedicated controls.*linewidth"):
+        figurecomposer_line_style_ui.update_current_extra_line_kw(
+            tool.operation_editor,
+            {"linewidth": 3.0},
+        )
 
 
 def test_figure_composer_step_editor_section_headers_are_native_subgroups(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -400,6 +400,7 @@ def test_figure_composer_line_profile_operation_uses_semantic_sections(
                 "figureComposerLineMarkerSizeSpin",
                 "figureComposerLineMarkerFaceColorEdit",
                 "figureComposerLineMarkerEdgeColorEdit",
+                "figureComposerLineKwEdit",
                 "figureComposerLineGradientCheck",
             ),
         ),
@@ -790,6 +791,7 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     marker_edge_edit = style_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineMarkerEdgeColorEdit"
     )
+    line_kw_edit = style_page.findChild(QtWidgets.QLineEdit, "figureComposerLineKwEdit")
     gradient_check = style_page.findChild(
         QtWidgets.QCheckBox, "figureComposerLineGradientCheck"
     )
@@ -808,6 +810,11 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     assert marker_face_button is not None
     assert marker_edge_edit is not None
     assert marker_edge_edit.text() == "black"
+    assert line_kw_edit is not None
+    assert line_kw_edit.text() == ""
+    line_kw_edit.setText("dashes=[4, 2], alpha=0.75")
+    line_kw_edit.setModified(True)
+    line_kw_edit.editingFinished.emit()
     assert gradient_check is not None
     assert gradient_check.isChecked()
 
@@ -944,6 +951,8 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
         assert line.get_markersize() == 6.0
         assert line.get_markerfacecolor() == "yellow"
         assert line.get_markeredgecolor() == "black"
+        assert line._unscaled_dash_pattern == (0, [4, 2])
+        assert line.get_alpha() == 0.75
         np.testing.assert_allclose(
             fig.axes[0].images[index].cmap(1.0),
             mcolors.to_rgba(line.get_color()),
@@ -982,6 +991,8 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
         assert line.get_markersize() == 6.0
         assert line.get_markerfacecolor() == "yellow"
         assert line.get_markeredgecolor() == "black"
+        assert line._unscaled_dash_pattern == (0, [4, 2])
+        assert line.get_alpha() == 0.75
         np.testing.assert_allclose(
             namespace["fig"].axes[0].images[index].cmap(1.0),
             mcolors.to_rgba(line.get_color()),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
@@ -138,6 +138,7 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     line_width_spin = page.findChild(
         QtWidgets.QDoubleSpinBox, "figureComposerBZLineWidthSpin"
     )
+    line_kw_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerBZLineKwEdit")
     vertices_check = page.findChild(
         QtWidgets.QCheckBox, "figureComposerBZVerticesCheck"
     )
@@ -145,6 +146,7 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     assert color_edit is not None
     assert line_style_combo is not None
     assert line_width_spin is not None
+    assert line_kw_edit is not None
     assert vertices_check is not None
     assert vertex_kw_edit is not None
 
@@ -152,6 +154,8 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     color_edit.editingFinished.emit()
     _activate_combo_text(line_style_combo, "-.")
     line_width_spin.setValue(1.5)
+    line_kw_edit.setText("dashes=[4, 2], alpha=0.75, marker='o'")
+    line_kw_edit.editingFinished.emit()
     vertices_check.setChecked(True)
     vertex_kw_edit.setText("s=12, color='tab:green'")
     vertex_kw_edit.editingFinished.emit()
@@ -174,6 +178,9 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
         "color": "tab:red",
         "linestyle": "-.",
         "linewidth": 1.5,
+        "dashes": [4, 2],
+        "alpha": 0.75,
+        "marker": "o",
     }
 
 
@@ -212,6 +219,55 @@ def test_figure_composer_bz_overlay_restores_mode_control_visibility(
     assert layout.isRowVisible(k_parallel_spin) is k_parallel_visible
 
 
+def test_figure_composer_batch_bz_overlay_line_kwargs_preserve_controls(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(4.0).reshape(2, 2),
+        dims=("kx", "ky"),
+        coords={"kx": [-1.0, 1.0], "ky": [-1.0, 1.0]},
+        name="data",
+    )
+    operations = tuple(
+        FigureOperationState.bz_overlay(
+            label=label,
+            axes=FigureAxesSelectionState(axes=((0, 0),)),
+        ).model_copy(
+            update={
+                "line_kw": {"color": color, "dashes": dashes},
+            }
+        )
+        for label, color, dashes in (
+            ("first", "tab:red", [2, 1]),
+            ("second", "tab:blue", [4, 2]),
+        )
+    )
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=operations,
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    _select_operation_rows(tool, (0, 1))
+    tool.operation_editor.select_section("style")
+    page = tool.operation_editor.stack.currentWidget()
+    line_kw_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerBZLineKwEdit")
+    assert line_kw_edit is not None
+    assert line_kw_edit.text() == ""
+    assert line_kw_edit.placeholderText() == "(multiple values)"
+
+    line_kw_edit.setText("alpha=0.5")
+    line_kw_edit.setModified(True)
+    line_kw_edit.editingFinished.emit()
+
+    assert [operation.line_kw for operation in tool.tool_status.operations] == [
+        {"color": "tab:red", "alpha": 0.5},
+        {"color": "tab:blue", "alpha": 0.5},
+    ]
+
+
 def test_figure_composer_bz_overlay_state_round_trip() -> None:
     operation = FigureOperationState.bz_overlay(
         axes=FigureAxesSelectionState(axes=((0, 0),)),
@@ -227,7 +283,7 @@ def test_figure_composer_bz_overlay_state_round_trip() -> None:
             "bz_bounds": (-1.0, 1.0, -2.0, 2.0),
             "bz_vertices": True,
             "bz_midpoint_kw": {"color": "tab:blue"},
-            "line_kw": {"color": "tab:red"},
+            "line_kw": {"color": "tab:red", "dashes": [4, 2]},
         }
     )
     recipe = FigureRecipeState(
@@ -242,7 +298,10 @@ def test_figure_composer_bz_overlay_state_round_trip() -> None:
     assert restored.operations[0].bz_centering_type == "I"
     assert restored.operations[0].bz_bounds == (-1.0, 1.0, -2.0, 2.0)
     assert restored.operations[0].bz_midpoint_kw == {"color": "tab:blue"}
-    assert restored.operations[0].line_kw == {"color": "tab:red"}
+    assert restored.operations[0].line_kw == {
+        "color": "tab:red",
+        "dashes": [4, 2],
+    }
 
 
 def test_figure_composer_bz_overlay_render_matches_plotting_helper(qtbot) -> None:
@@ -292,7 +351,11 @@ def test_figure_composer_bz_overlay_out_of_plane_render_and_code(qtbot) -> None:
             "bz_midpoints": True,
             "bz_vertex_kw": {"s": 11},
             "bz_midpoint_kw": {"s": 13},
-            "line_kw": {"color": "tab:orange"},
+            "line_kw": {
+                "color": "tab:orange",
+                "dashes": [4, 2],
+                "alpha": 0.75,
+            },
         }
     )
     data = xr.DataArray(
@@ -327,6 +390,8 @@ def test_figure_composer_bz_overlay_out_of_plane_render_and_code(qtbot) -> None:
     for axis in figure.axes:
         _assert_bz_lines_match_segments(axis.lines, segments)
         assert all(line.get_color() == "tab:orange" for line in axis.lines)
+        assert all(line._unscaled_dash_pattern == (0, [4, 2]) for line in axis.lines)
+        assert all(line.get_alpha() == 0.75 for line in axis.lines)
         assert len(axis.collections) == 1
         np.testing.assert_allclose(axis.collections[0].get_offsets(), midpoints)
         assert axis.collections[0].get_sizes()[0] == 13
@@ -336,6 +401,9 @@ def test_figure_composer_bz_overlay_out_of_plane_render_and_code(qtbot) -> None:
     namespace = _exec_generated_code(code, {"data": tool.source_data()["data"]})
     assert len(namespace["fig"].axes) == 2
     assert all(axis.lines for axis in namespace["fig"].axes)
+    for axis in namespace["fig"].axes:
+        assert all(line._unscaled_dash_pattern == (0, [4, 2]) for line in axis.lines)
+        assert all(line.get_alpha() == 0.75 for line in axis.lines)
 
 
 def test_figure_composer_bz_overlay_text_parsers() -> None:
@@ -735,6 +803,9 @@ def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> No
     line_width_spin = page.findChild(
         QtWidgets.QDoubleSpinBox, "figureComposerPhotonEnergyLineWidthSpin"
     )
+    line_kw_edit = page.findChild(
+        QtWidgets.QLineEdit, "figureComposerPhotonEnergyLineKwEdit"
+    )
     legend_check = page.findChild(
         QtWidgets.QCheckBox, "figureComposerPhotonEnergyLegendCheck"
     )
@@ -747,6 +818,7 @@ def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> No
     assert color_edit is not None
     assert line_style_combo is not None
     assert line_width_spin is not None
+    assert line_kw_edit is not None
     assert legend_check is not None
     assert legend_kw_edit is not None
     assert label_edit is not None
@@ -755,6 +827,8 @@ def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> No
     color_edit.editingFinished.emit()
     _activate_combo_text(line_style_combo, "--")
     line_width_spin.setValue(1.5)
+    line_kw_edit.setText("dashes=[4, 2], alpha=0.75, marker='o'")
+    line_kw_edit.editingFinished.emit()
     legend_check.setChecked(False)
     legend_kw_edit.setText("title='Photon energy', frameon=False")
     legend_kw_edit.editingFinished.emit()
@@ -772,6 +846,9 @@ def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> No
         "color": "tab:red",
         "linestyle": "--",
         "linewidth": 1.5,
+        "dashes": [4, 2],
+        "alpha": 0.75,
+        "marker": "o",
     }
 
 
@@ -786,7 +863,11 @@ def test_figure_composer_photon_energy_overlay_state_round_trip() -> None:
             "show_legend": False,
             "legend_kw": {"title": "Photon energy", "frameon": False},
             "label_template": "hv={hv:g}",
-            "line_kw": {"color": "tab:green", "linewidth": 1.25},
+            "line_kw": {
+                "color": "tab:green",
+                "linewidth": 1.25,
+                "dashes": [4, 2],
+            },
         }
     )
     recipe = FigureRecipeState(
@@ -810,6 +891,7 @@ def test_figure_composer_photon_energy_overlay_state_round_trip() -> None:
     assert restored.operations[0].line_kw == {
         "color": "tab:green",
         "linewidth": 1.25,
+        "dashes": [4, 2],
     }
 
 
@@ -827,7 +909,12 @@ def test_figure_composer_photon_energy_overlay_render_and_code(
     ).model_copy(
         update={
             "photon_energies": hv_values,
-            "line_kw": {"color": "tab:blue", "linewidth": 1.5},
+            "line_kw": {
+                "color": "tab:blue",
+                "linewidth": 1.5,
+                "dashes": [4, 2],
+                "alpha": 0.75,
+            },
             "legend_kw": {"title": "Photon energy", "frameon": False},
         }
     )
@@ -846,6 +933,8 @@ def test_figure_composer_photon_energy_overlay_render_and_code(
     assert axis.get_legend().get_frame_on() is False
     assert all(line.get_color() == "tab:blue" for line in axis.lines)
     assert all(line.get_linewidth() == 1.5 for line in axis.lines)
+    assert all(line._unscaled_dash_pattern == (0, [4, 2]) for line in axis.lines)
+    assert all(line.get_alpha() == 0.75 for line in axis.lines)
 
     code = tool.generated_code()
     assert "import erlab" in code
@@ -861,6 +950,10 @@ def test_figure_composer_photon_energy_overlay_render_and_code(
     assert generated_axis.get_legend() is not None
     assert generated_axis.get_legend().get_title().get_text() == "Photon energy"
     assert generated_axis.get_legend().get_frame_on() is False
+    assert all(
+        line._unscaled_dash_pattern == (0, [4, 2]) for line in generated_axis.lines
+    )
+    assert all(line.get_alpha() == 0.75 for line in generated_axis.lines)
 
 
 def test_figure_composer_photon_energy_overlay_multiple_axes_code(qtbot) -> None:


### PR DESCRIPTION
## Summary

- Add editable extra Matplotlib `Line2D` kwargs to plot profiles, plot slices, BZ overlays, and photon-energy overlays.
- Preserve dedicated controls and operation fields by rejecting conflicting kwargs.
- Reuse shared UI and filtering logic across line-style editors.
- Extend rendering, generated-code, batch-edit, and state round-trip coverage.

## Testing

- Updated pytest and Qt UI tests for custom line kwargs, rendering, generated code, batch edits, and persistence.
- Not run (not requested).