### PR TITLE
feat(figurecomposer): add text input completions

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_completion_values.py
+++ b/src/erlab/interactive/_figurecomposer/_completion_values.py
@@ -1,0 +1,61 @@
+"""Curated completion values and their text conversion helpers."""
+
+from __future__ import annotations
+
+import typing
+
+from erlab.interactive._figurecomposer._text import _code_args, _literal_from_text
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+LABEL_COMPLETIONS: tuple[str, ...] = (
+    r"$E-E_F$ (eV)",
+    r"$E$ (eV)",
+    r"$E_{\mathrm{kin}}$ (eV)",
+    r"$k_x$ (Å${}^{-1}$)",
+    r"$k_y$ (Å${}^{-1}$)",
+    r"$k_z$ (Å${}^{-1}$)",
+    r"$k_{||}$ (Å${}^{-1}$)",
+    r"$h\nu$ (eV)",
+    r"$\alpha$ (deg)",
+    r"$\beta$ (deg)",
+    r"$\theta$ (deg)",
+    r"$\phi$ (deg)",
+    r"$T$ (K)",
+    "Temperature (K)",
+    "Intensity (arb. units)",
+)
+
+FONT_SIZE_COMPLETIONS: tuple[str, ...] = (
+    "xx-small",
+    "x-small",
+    "small",
+    "medium",
+    "large",
+    "x-large",
+    "xx-large",
+    "smaller",
+    "larger",
+)
+
+
+def _format_completion_literal(value: typing.Any, *, completions: Sequence[str]) -> str:
+    """Format a literal while showing curated string values without quotes."""
+    if value is None:
+        return ""
+    if isinstance(value, str) and value in completions:
+        return value
+    return _code_args((value,))
+
+
+def _completion_literal_from_text(
+    text: str, *, completions: Sequence[str]
+) -> typing.Any:
+    """Parse curated strings directly and other text as a Python literal."""
+    stripped = text.strip()
+    if not stripped:
+        return None
+    if stripped in completions:
+        return stripped
+    return _literal_from_text(stripped)

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
@@ -66,6 +66,10 @@ import typing
 import matplotlib
 import matplotlib.scale
 
+from erlab.interactive._figurecomposer._completion_values import (
+    FONT_SIZE_COMPLETIONS,
+    LABEL_COMPLETIONS,
+)
 from erlab.interactive._figurecomposer._line_style import (
     LINE_MARKER_OPTIONS,
     LINE_STYLE_DEFAULT_LABEL,
@@ -187,6 +191,7 @@ class MethodControlSpec:
     none_label: str | None = None
     exclusive_group: str | None = None
     none_is_unset: bool = False
+    completions: tuple[str, ...] = ()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -203,6 +208,7 @@ class MethodSpec:
     controls: tuple[MethodControlSpec, ...] = ()
     allow_extra_kwargs: bool = True
     text_values_policy: MethodTextValuesPolicy = MethodTextValuesPolicy.NONE
+    text_values_completions: tuple[str, ...] = ()
     text_values_kwarg: str = "values"
     preserves_empty_text: bool = False
     callable_name: str | None = None
@@ -291,6 +297,8 @@ def _text_arg(
     index: int,
     object_name: str,
     tooltip: str,
+    *,
+    completions: Sequence[str] = (),
 ) -> MethodControlSpec:
     return MethodControlSpec(
         kind=MethodControlKind.TEXT_ARG,
@@ -298,6 +306,22 @@ def _text_arg(
         arg_index=index,
         object_name=object_name,
         tooltip=tooltip,
+        completions=tuple(completions),
+    )
+
+
+def _label_arg(
+    label: str,
+    index: int,
+    object_name: str,
+    tooltip: str,
+) -> MethodControlSpec:
+    return _text_arg(
+        label,
+        index,
+        object_name,
+        tooltip,
+        completions=LABEL_COMPLETIONS,
     )
 
 
@@ -596,6 +620,7 @@ def _literal_kwarg(
     tooltip: str,
     *,
     default: typing.Any = None,
+    completions: Sequence[str] = (),
 ) -> MethodControlSpec:
     return MethodControlSpec(
         kind=MethodControlKind.LITERAL_KWARG,
@@ -604,6 +629,22 @@ def _literal_kwarg(
         object_name=object_name,
         tooltip=tooltip,
         default=default,
+        completions=tuple(completions),
+    )
+
+
+def _font_size_kwarg(
+    label: str,
+    key: str,
+    object_name: str,
+    tooltip: str,
+) -> MethodControlSpec:
+    return _literal_kwarg(
+        label,
+        key,
+        object_name,
+        tooltip,
+        completions=FONT_SIZE_COMPLETIONS,
     )
 
 
@@ -824,13 +865,13 @@ def _text_artist_controls(
         horizontalalignment_tooltip += "\nSelecting this value clears Location."
     return (
         _text_color_control(f"{object_name_prefix}ColorEdit", description),
-        _literal_kwarg(
+        _font_size_kwarg(
             "Font size",
             "fontsize",
             f"{object_name_prefix}FontSizeEdit",
             (
                 f"Font size for {description}.\n"
-                "Use a number or a quoted named size such as 'large'."
+                "Use a number or a named size such as large."
             ),
         ),
         _kwarg_combo(
@@ -972,11 +1013,11 @@ def _label_subplots_text_controls(
                 f"{object_name_prefix}FontWeightCombo",
                 "Font weight for subplot labels.",
             ),
-            _literal_kwarg(
+            _font_size_kwarg(
                 "Font size",
                 "fontsize",
                 f"{object_name_prefix}FontSizeEdit",
-                "Matplotlib font size. Use 8 or quoted names such as 'large'.",
+                "Matplotlib font size. Use 8 or a named size such as large.",
             ),
         )
     )
@@ -1015,17 +1056,17 @@ def _legend_controls(prefix: str) -> tuple[MethodControlSpec, ...]:
             "Show or hide the legend frame.",
             default=True,
         ),
-        _text_kwarg(
+        _font_size_kwarg(
             "Font size",
             "fontsize",
             f"figureComposer{prefix}MethodLegendFontSizeEdit",
-            "Legend text size.\nUse a named size or a numeric value.",
+            "Legend text size.\nUse a number or a named size.",
         ),
-        _text_kwarg(
+        _font_size_kwarg(
             "Title size",
             "title_fontsize",
             f"figureComposer{prefix}MethodLegendTitleFontSizeEdit",
-            "Legend title text size.\nUse a named size or a numeric value.",
+            "Legend title text size.\nUse a number or a named size.",
         ),
         _float_kwarg(
             "Marker scale",
@@ -1526,7 +1567,7 @@ AXES_METHODS: dict[str, MethodSpec] = {
         call_policy=MethodCallPolicy.BOUND_EACH_AXIS,
         default_args=("x",),
         controls=(
-            _text_arg(
+            _label_arg(
                 "Label",
                 0,
                 "figureComposerAxesMethodXLabelEdit",
@@ -1554,7 +1595,7 @@ AXES_METHODS: dict[str, MethodSpec] = {
         call_policy=MethodCallPolicy.BOUND_EACH_AXIS,
         default_args=("y",),
         controls=(
-            _text_arg(
+            _label_arg(
                 "Label",
                 0,
                 "figureComposerAxesMethodYLabelEdit",
@@ -1792,7 +1833,7 @@ FIGURE_METHODS: dict[str, MethodSpec] = {
         call_policy=MethodCallPolicy.BOUND_FIGURE,
         default_args=("x label",),
         controls=(
-            _text_arg(
+            _label_arg(
                 "Text",
                 0,
                 "figureComposerFigureMethodTextEdit",
@@ -1812,7 +1853,7 @@ FIGURE_METHODS: dict[str, MethodSpec] = {
         call_policy=MethodCallPolicy.BOUND_FIGURE,
         default_args=("y label",),
         controls=(
-            _text_arg(
+            _label_arg(
                 "Text",
                 0,
                 "figureComposerFigureMethodTextEdit",
@@ -2316,6 +2357,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
         target_domain=MethodTargetDomain.AXES,
         call_policy=MethodCallPolicy.AXES_POSITIONAL,
         text_values_policy=MethodTextValuesPolicy.POSITIONAL,
+        text_values_completions=LABEL_COMPLETIONS,
         preserves_empty_text=True,
         controls=(
             _kwarg_combo(
@@ -2338,6 +2380,7 @@ ERLAB_METHODS: dict[str, MethodSpec] = {
         target_domain=MethodTargetDomain.AXES,
         call_policy=MethodCallPolicy.AXES_POSITIONAL,
         text_values_policy=MethodTextValuesPolicy.POSITIONAL,
+        text_values_completions=LABEL_COMPLETIONS,
         preserves_empty_text=True,
         controls=(
             _kwarg_combo(

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
@@ -8,6 +8,10 @@ import typing
 
 from qtpy import QtCore, QtGui, QtWidgets
 
+from erlab.interactive._figurecomposer._completion_values import (
+    _completion_literal_from_text,
+    _format_completion_literal,
+)
 from erlab.interactive._figurecomposer._line_style import (
     color_kw_value_from_text,
     normalize_style_value,
@@ -94,6 +98,7 @@ from erlab.interactive._figurecomposer._text import (
     _text_tuple_from_text,
 )
 from erlab.interactive._figurecomposer._ui._color_widgets import _ColorLineEditWidget
+from erlab.interactive._figurecomposer._ui._completion import CompletingPlainTextEdit
 from erlab.interactive._figurecomposer._ui._operation_editor import StepSection
 from erlab.interactive._figurecomposer._ui._tick_params import TickParamsEditorWidget
 
@@ -141,9 +146,14 @@ def _method_plain_text_edit(
     mixed: bool,
     object_name: str,
     parent: QtWidgets.QWidget | None,
+    completions: Sequence[str] = (),
 ) -> QtWidgets.QPlainTextEdit:
-    edit = QtWidgets.QPlainTextEdit(parent)
-    edit.setPlainText(text)
+    edit: QtWidgets.QPlainTextEdit
+    if completions:
+        edit = CompletingPlainTextEdit(text, parent, completions=completions)
+    else:
+        edit = QtWidgets.QPlainTextEdit(parent)
+        edit.setPlainText(text)
     editor.apply_mixed_plain_text_edit(edit, mixed)
     edit.setMaximumHeight(70)
     edit.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
@@ -256,17 +266,14 @@ def _build_method_editor(
             lambda target: target.text_values,
             lambda value: "\n".join(typing.cast("Sequence[str]", value)),
         )
-        text_edit = QtWidgets.QPlainTextEdit(page)
-        text_edit.setPlainText(text_values_text)
-        editor.apply_mixed_plain_text_edit(text_edit, text_values_mixed)
-        text_edit.setMaximumHeight(70)
-        text_edit.setVerticalScrollBarPolicy(
-            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        text_edit = _method_plain_text_edit(
+            editor,
+            text_values_text,
+            mixed=text_values_mixed,
+            object_name="figureComposerMethodTextValuesEdit",
+            parent=page,
+            completions=spec.text_values_completions,
         )
-        text_edit.setHorizontalScrollBarPolicy(
-            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
-        )
-        text_edit.setObjectName("figureComposerMethodTextValuesEdit")
         editor.connect_plain_text_changed(
             text_edit,
             lambda text: _update_current_method_text_values(editor, text),
@@ -514,6 +521,7 @@ def _add_method_control_row(
                 mixed=mixed,
                 object_name=control.object_name,
                 parent=layout.parentWidget(),
+                completions=control.completions,
             )
             editor.connect_plain_text_changed(
                 edit,
@@ -527,7 +535,11 @@ def _add_method_control_row(
                 lambda target: _method_arg_value(target, spec, index, control.default),
                 _format_literal_value,
             )
-            edit = editor.line_edit(text, parent=layout.parentWidget())
+            edit = editor.line_edit(
+                text,
+                parent=layout.parentWidget(),
+                completions=control.completions,
+            )
             editor.apply_mixed_line_edit(edit, mixed)
             edit.setObjectName(control.object_name)
             editor.connect_line_edit_finished(
@@ -550,7 +562,11 @@ def _add_method_control_row(
                     else repr(value)
                 ),
             )
-            edit = editor.line_edit(text, parent=layout.parentWidget())
+            edit = editor.line_edit(
+                text,
+                parent=layout.parentWidget(),
+                completions=control.completions,
+            )
             editor.apply_mixed_line_edit(edit, mixed)
             edit.setObjectName(control.object_name)
             editor.connect_line_edit_finished(
@@ -577,7 +593,11 @@ def _add_method_control_row(
                     else ""
                 ),
             )
-            edit = editor.line_edit(text, parent=layout.parentWidget())
+            edit = editor.line_edit(
+                text,
+                parent=layout.parentWidget(),
+                completions=control.completions,
+            )
             editor.apply_mixed_line_edit(edit, mixed)
             edit.setObjectName(control.object_name)
             editor.connect_line_edit_finished(
@@ -591,7 +611,11 @@ def _add_method_control_row(
                 lambda target: _method_float_pair_args(editor, target, spec),
                 _format_limit_pair,
             )
-            edit = editor.line_edit(text, parent=layout.parentWidget())
+            edit = editor.line_edit(
+                text,
+                parent=layout.parentWidget(),
+                completions=control.completions,
+            )
             editor.apply_mixed_line_edit(edit, mixed)
             edit.setObjectName(control.object_name)
             editor.connect_line_edit_finished(
@@ -606,7 +630,11 @@ def _add_method_control_row(
                 lambda target: _method_arg_value(target, spec, index, control.default),
                 _format_aspect_value,
             )
-            edit = editor.line_edit(text, parent=layout.parentWidget())
+            edit = editor.line_edit(
+                text,
+                parent=layout.parentWidget(),
+                completions=control.completions,
+            )
             editor.apply_mixed_line_edit(edit, mixed)
             edit.setObjectName(control.object_name)
             editor.connect_line_edit_finished(
@@ -783,7 +811,11 @@ def _add_method_control_row(
                     lambda target: _method_kwarg_value(target, key, control.default),
                     _format_int_value,
                 )
-                edit = editor.line_edit(text, parent=layout.parentWidget())
+                edit = editor.line_edit(
+                    text,
+                    parent=layout.parentWidget(),
+                    completions=control.completions,
+                )
                 editor.apply_mixed_line_edit(edit, mixed)
                 edit.setObjectName(control.object_name)
                 editor.connect_line_edit_finished(
@@ -830,7 +862,11 @@ def _add_method_control_row(
                     lambda target: _method_kwarg_value(target, key, control.default),
                     _format_float_value,
                 )
-                edit = editor.line_edit(text, parent=layout.parentWidget())
+                edit = editor.line_edit(
+                    text,
+                    parent=layout.parentWidget(),
+                    completions=control.completions,
+                )
                 editor.apply_mixed_line_edit(edit, mixed)
                 edit.setObjectName(control.object_name)
                 editor.connect_line_edit_finished(
@@ -876,7 +912,11 @@ def _add_method_control_row(
                 lambda target: _method_kwarg_value(target, key, control.default),
                 lambda value: str(value or ""),
             )
-            edit = editor.line_edit(text, parent=layout.parentWidget())
+            edit = editor.line_edit(
+                text,
+                parent=layout.parentWidget(),
+                completions=control.completions,
+            )
             editor.apply_mixed_line_edit(edit, mixed)
             edit.setObjectName(control.object_name)
             editor.connect_line_edit_finished(
@@ -915,12 +955,32 @@ def _add_method_control_row(
             editor.add_form_row(layout, control.label, color_edit, control.tooltip)
         case MethodControlKind.LITERAL_KWARG:
             key = _control_key(control)
+            formatter = (
+                functools.partial(
+                    _format_completion_literal,
+                    completions=control.completions,
+                )
+                if control.completions
+                else _format_literal_value
+            )
+            parser = (
+                functools.partial(
+                    _completion_literal_from_text,
+                    completions=control.completions,
+                )
+                if control.completions
+                else _optional_literal_from_text
+            )
             text, mixed = editor.batch_text(
                 operation,
                 lambda target: _method_kwarg_value(target, key, control.default),
-                _format_literal_value,
+                formatter,
             )
-            edit = editor.line_edit(text, parent=layout.parentWidget())
+            edit = editor.line_edit(
+                text,
+                parent=layout.parentWidget(),
+                completions=control.completions,
+            )
             editor.apply_mixed_line_edit(edit, mixed)
             edit.setObjectName(control.object_name)
             editor.connect_line_edit_finished(
@@ -928,7 +988,7 @@ def _add_method_control_row(
                 _parsed_method_kwarg_update_callback(
                     editor,
                     key,
-                    _optional_literal_from_text,
+                    parser,
                 ),
             )
             editor.add_form_row(layout, control.label, edit, control.tooltip)
@@ -943,7 +1003,11 @@ def _add_method_control_row(
                     else ""
                 ),
             )
-            edit = editor.line_edit(text, parent=layout.parentWidget())
+            edit = editor.line_edit(
+                text,
+                parent=layout.parentWidget(),
+                completions=control.completions,
+            )
             editor.apply_mixed_line_edit(edit, mixed)
             edit.setObjectName(control.object_name)
             editor.connect_line_edit_finished(
@@ -962,7 +1026,11 @@ def _add_method_control_row(
                 lambda target: _method_kwarg_value(target, key, control.default),
                 _format_pair,
             )
-            edit = editor.line_edit(text, parent=layout.parentWidget())
+            edit = editor.line_edit(
+                text,
+                parent=layout.parentWidget(),
+                completions=control.completions,
+            )
             editor.apply_mixed_line_edit(edit, mixed)
             edit.setObjectName(control.object_name)
             editor.connect_line_edit_finished(

--- a/src/erlab/interactive/_figurecomposer/_ui/_completion.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_completion.py
@@ -1,0 +1,184 @@
+"""Qt text inputs with reusable completion support."""
+
+from __future__ import annotations
+
+import typing
+
+from qtpy import QtCore, QtGui, QtWidgets
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+
+def _create_completer(
+    widget: QtWidgets.QWidget,
+    completions: Sequence[str],
+) -> tuple[QtCore.QStringListModel, QtWidgets.QCompleter, QtWidgets.QAbstractItemView]:
+    model = QtCore.QStringListModel(list(completions), widget)
+    completer = QtWidgets.QCompleter(model, widget)
+    completer.setWidget(widget)
+    completer.setCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
+    completer.setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
+    completer.setFilterMode(QtCore.Qt.MatchFlag.MatchStartsWith)
+    completer.setWrapAround(False)
+    popup = typing.cast("QtWidgets.QAbstractItemView", completer.popup())
+    return model, completer, popup
+
+
+def _create_completion_shortcut(
+    widget: QtWidgets.QWidget,
+    callback: Callable[[], None],
+) -> QtGui.QShortcut:
+    shortcut = QtGui.QShortcut(QtGui.QKeySequence("Ctrl+Space"), widget)
+    shortcut.setContext(QtCore.Qt.ShortcutContext.WidgetShortcut)
+    shortcut.activated.connect(callback)
+    return shortcut
+
+
+def _prepare_completions(
+    completer: QtWidgets.QCompleter,
+    popup: QtWidgets.QAbstractItemView,
+    prefix: str,
+) -> bool:
+    completer.setCompletionPrefix(prefix)
+    if completer.completionCount() == 0:
+        popup.hide()
+        return False
+    completion_model = typing.cast(
+        "QtCore.QAbstractItemModel", completer.completionModel()
+    )
+    popup.setCurrentIndex(completion_model.index(0, 0))
+    return True
+
+
+class CompletingLineEdit(QtWidgets.QLineEdit):
+    """Single-line text editor with curated, optional completions."""
+
+    COMPLETIONS: tuple[str, ...] = ()
+
+    def __init__(
+        self,
+        text: str = "",
+        parent: QtWidgets.QWidget | None = None,
+        *,
+        completions: Sequence[str] | None = None,
+    ) -> None:
+        super().__init__(text, parent)
+        completion_values = self.COMPLETIONS if completions is None else completions
+        (
+            self.completion_model,
+            self.completion_completer,
+            self.completer_popup,
+        ) = _create_completer(self, completion_values)
+        self.setCompleter(self.completion_completer)
+        self.completion_completer.activated[str].connect(self._insert_completion)
+        self.completion_shortcut = _create_completion_shortcut(
+            self, self.show_all_completions
+        )
+
+    @QtCore.Slot()
+    def show_all_completions(self) -> None:
+        """Show all configured completions."""
+        if _prepare_completions(self.completion_completer, self.completer_popup, ""):
+            self.completion_completer.complete()
+
+    @QtCore.Slot(str)
+    def _insert_completion(self, completion: str) -> None:
+        if self.text() != completion:
+            self.selectAll()
+            self.insert(completion)
+        self.setModified(True)
+        self.completer_popup.hide()
+
+
+class CompletingPlainTextEdit(QtWidgets.QPlainTextEdit):
+    """Multiline text editor that completes the current line."""
+
+    COMPLETIONS: tuple[str, ...] = ()
+
+    def __init__(
+        self,
+        text: str = "",
+        parent: QtWidgets.QWidget | None = None,
+        *,
+        completions: Sequence[str] | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setPlainText(text)
+        completion_values = self.COMPLETIONS if completions is None else completions
+        (
+            self.completion_model,
+            self.completion_completer,
+            self.completer_popup,
+        ) = _create_completer(self, completion_values)
+        self.completion_completer.activated[str].connect(self._insert_completion)
+        self.completion_shortcut = _create_completion_shortcut(
+            self, self.show_all_completions
+        )
+        self._inserting_completion = False
+        self.textChanged.connect(self._update_completions)
+
+    def keyPressEvent(self, event: QtGui.QKeyEvent | None) -> None:
+        if event is None:  # pragma: no cover - Qt always supplies a key event.
+            return
+        if self.completer_popup.isVisible() and event.key() in {
+            QtCore.Qt.Key.Key_Enter,
+            QtCore.Qt.Key.Key_Return,
+            QtCore.Qt.Key.Key_Escape,
+            QtCore.Qt.Key.Key_Tab,
+            QtCore.Qt.Key.Key_Backtab,
+        }:
+            event.ignore()
+            return
+        super().keyPressEvent(event)
+
+    @QtCore.Slot()
+    def show_all_completions(self) -> None:
+        """Show all configured completions for the current line."""
+        self._show_completions("")
+
+    @QtCore.Slot()
+    def _update_completions(self) -> None:
+        if self._inserting_completion:
+            return
+        prefix = self._current_line_prefix()
+        if not prefix or prefix in self.completion_model.stringList():
+            self.completer_popup.hide()
+            return
+        self._show_completions(prefix)
+
+    def _current_line_prefix(self) -> str:
+        cursor = self.textCursor()
+        cursor.movePosition(
+            QtGui.QTextCursor.MoveOperation.StartOfLine,
+            QtGui.QTextCursor.MoveMode.KeepAnchor,
+        )
+        return cursor.selectedText()
+
+    def _show_completions(self, prefix: str) -> None:
+        if not _prepare_completions(
+            self.completion_completer, self.completer_popup, prefix
+        ):
+            return
+        scrollbar = typing.cast(
+            "QtWidgets.QScrollBar", self.completer_popup.verticalScrollBar()
+        )
+        popup_rect = self.cursorRect()
+        popup_rect.setWidth(
+            self.completer_popup.sizeHintForColumn(0) + scrollbar.sizeHint().width()
+        )
+        self.completion_completer.complete(popup_rect)
+
+    @QtCore.Slot(str)
+    def _insert_completion(self, completion: str) -> None:
+        self._inserting_completion = True
+        try:
+            cursor = self.textCursor()
+            cursor.beginEditBlock()
+            cursor.select(QtGui.QTextCursor.SelectionType.LineUnderCursor)
+            cursor.insertText(completion)
+            cursor.endEditBlock()
+            self.setTextCursor(cursor)
+        finally:
+            self._inserting_completion = False
+        self.completer_popup.hide()

--- a/src/erlab/interactive/_figurecomposer/_ui/_operation_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_operation_editor.py
@@ -11,6 +11,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 from erlab.interactive._figurecomposer._exceptions import FigureComposerInputError
+from erlab.interactive._figurecomposer._ui._completion import CompletingLineEdit
 from erlab.interactive._figurecomposer._ui._editor_controls import (
     MIXED_VALUE,
     MIXED_VALUES_TEXT,
@@ -902,10 +903,19 @@ class FigureOperationEditor(QtWidgets.QWidget):
         text: str = "",
         *,
         parent: QtWidgets.QWidget | None = None,
+        completions: Sequence[str] = (),
     ) -> QtWidgets.QLineEdit:
-        edit = QtWidgets.QLineEdit(parent or self._current_page() or self)
+        edit_parent = parent or self._current_page() or self
+        edit: QtWidgets.QLineEdit
+        if completions:
+            edit = CompletingLineEdit(
+                text,
+                edit_parent,
+                completions=completions,
+            )
+        else:
+            edit = QtWidgets.QLineEdit(text, edit_parent)
         self.mark_control(edit)
-        edit.setText(text)
         return edit
 
     def mixed_value_widget(

--- a/src/erlab/interactive/_figurecomposer/_ui/_tick_params.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_tick_params.py
@@ -6,6 +6,11 @@ import typing
 
 from qtpy import QtCore, QtWidgets
 
+from erlab.interactive._figurecomposer._completion_values import (
+    FONT_SIZE_COMPLETIONS,
+    _completion_literal_from_text,
+    _format_completion_literal,
+)
 from erlab.interactive._figurecomposer._line_style import (
     LINE_STYLE_OPTIONS,
     color_kw_value_from_text,
@@ -14,8 +19,8 @@ from erlab.interactive._figurecomposer._operations._method._catalog import (
     TICK_PARAMS_CONTROLLED_KWARGS,
     TICK_PARAMS_DEFAULT_KWARGS,
 )
-from erlab.interactive._figurecomposer._text import _code_args, _literal_from_text
 from erlab.interactive._figurecomposer._ui._color_widgets import _ColorLineEditWidget
+from erlab.interactive._figurecomposer._ui._completion import CompletingLineEdit
 from erlab.interactive._figurecomposer._ui._line_style import (
     configure_style_combo,
     style_combo_value,
@@ -82,7 +87,11 @@ class TickParamsEditorWidget(QtWidgets.QWidget):
         self.width_edit = _line_edit(f"{object_prefix}WidthEdit", self)
         self.pad_edit = _line_edit(f"{object_prefix}PadEdit", self)
         self.label_rotation_edit = _line_edit(f"{object_prefix}LabelRotationEdit", self)
-        self.label_size_edit = _line_edit(f"{object_prefix}LabelSizeEdit", self)
+        self.label_size_edit = _line_edit(
+            f"{object_prefix}LabelSizeEdit",
+            self,
+            completions=FONT_SIZE_COMPLETIONS,
+        )
         self.label_font_edit = _line_edit(f"{object_prefix}LabelFontEdit", self)
         self.zorder_edit = _line_edit(f"{object_prefix}ZOrderEdit", self)
         self.grid_alpha_edit = _line_edit(f"{object_prefix}GridAlphaEdit", self)
@@ -157,7 +166,11 @@ class TickParamsEditorWidget(QtWidgets.QWidget):
                 _format_float(self._kwargs.get("labelrotation")),
             )
             self._set_line_edit(
-                self.label_size_edit, _format_literal(self._kwargs.get("labelsize"))
+                self.label_size_edit,
+                _format_completion_literal(
+                    self._kwargs.get("labelsize"),
+                    completions=FONT_SIZE_COMPLETIONS,
+                ),
             )
             self._set_line_edit(
                 self.label_font_edit, str(self._kwargs.get("labelfontfamily") or "")
@@ -372,7 +385,7 @@ class TickParamsEditorWidget(QtWidgets.QWidget):
             lambda: self._commit_float(self.label_rotation_edit, "labelrotation")
         )
         self.label_size_edit.editingFinished.connect(
-            lambda: self._commit_literal(self.label_size_edit, "labelsize")
+            lambda: self._commit_font_size(self.label_size_edit)
         )
         self.label_font_edit.editingFinished.connect(
             lambda: self._commit_text(self.label_font_edit, "labelfontfamily")
@@ -440,16 +453,16 @@ class TickParamsEditorWidget(QtWidgets.QWidget):
         self._set_line_edit(edit, _format_float(value))
         self._set_kwarg(key, value)
 
-    def _commit_literal(self, edit: QtWidgets.QLineEdit, key: str) -> None:
+    def _commit_font_size(self, edit: QtWidgets.QLineEdit) -> None:
         text = edit.text().strip()
-        if not text:
-            self._set_kwarg(key, None)
-            return
         try:
-            value = _literal_from_text(text)
+            value = _completion_literal_from_text(
+                text,
+                completions=FONT_SIZE_COMPLETIONS,
+            )
         except ValueError:
             return
-        self._set_kwarg(key, value)
+        self._set_kwarg("labelsize", value)
 
     def _commit_text(self, edit: QtWidgets.QLineEdit, key: str) -> None:
         self._set_kwarg(key, edit.text().strip() or None)
@@ -601,8 +614,17 @@ class _DisclosureWidget(QtWidgets.QWidget):
         self._button.setToolTip(text)
 
 
-def _line_edit(object_name: str, parent: QtWidgets.QWidget) -> QtWidgets.QLineEdit:
-    edit = QtWidgets.QLineEdit(parent)
+def _line_edit(
+    object_name: str,
+    parent: QtWidgets.QWidget,
+    *,
+    completions: Sequence[str] = (),
+) -> QtWidgets.QLineEdit:
+    edit: QtWidgets.QLineEdit
+    if completions:
+        edit = CompletingLineEdit(parent=parent, completions=completions)
+    else:
+        edit = QtWidgets.QLineEdit(parent)
     edit.setObjectName(object_name)
     edit.setPlaceholderText("Auto")
     edit.setMaximumWidth(80)
@@ -633,12 +655,6 @@ def _add_labeled_widget(
 
 def _format_float(value: typing.Any) -> str:
     return "" if value is None else f"{float(value):g}"
-
-
-def _format_literal(value: typing.Any) -> str:
-    if value is None:
-        return ""
-    return _code_args((value,))
 
 
 def _tri_state_text(value: bool | None) -> str:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -12,8 +12,10 @@ import xarray as xr
 from matplotlib.text import Text
 from qtpy import QtCore, QtGui, QtWidgets
 
+import erlab.interactive._figurecomposer._completion_values as completion_values
 import erlab.interactive._figurecomposer._rendering as figurecomposer_rendering
 import erlab.interactive._figurecomposer._tool as figurecomposer_tool_module
+import erlab.interactive._figurecomposer._ui._completion as completion_widgets
 import erlab.interactive._figurecomposer._ui._tick_params as figurecomposer_tick_params
 import erlab.interactive._stylesheets
 import erlab.plotting as eplt
@@ -1499,11 +1501,13 @@ def test_figure_composer_batch_same_method_edits_selected_steps(qtbot) -> None:
                     family=FigureMethodFamily.AXES,
                     name="set_title",
                     args=("left",),
+                    kwargs={"fontsize": 8},
                 ),
                 FigureOperationState.method(
                     family=FigureMethodFamily.AXES,
                     name="set_title",
                     args=("right",),
+                    kwargs={"fontsize": 10},
                 ),
                 FigureOperationState.method(
                     family=FigureMethodFamily.AXES,
@@ -1525,10 +1529,24 @@ def test_figure_composer_batch_same_method_edits_selected_steps(qtbot) -> None:
     assert title_edit is not None
     assert title_edit.toPlainText() == ""
     assert title_edit.placeholderText() == "(multiple values)"
+    font_size_edit = method_page.findChild(
+        completion_widgets.CompletingLineEdit,
+        "figureComposerAxesMethodTitleFontSizeEdit",
+    )
+    assert font_size_edit is not None
+    assert font_size_edit.text() == ""
+    assert font_size_edit.placeholderText() == "(multiple values)"
 
     title_edit.textChanged.emit()
     assert tool.tool_status.operations[0].method_args == ("left",)
     assert tool.tool_status.operations[1].method_args == ("right",)
+
+    font_size_edit.completion_completer.activated[str].emit("large")
+    assert font_size_edit.isModified()
+    font_size_edit.editingFinished.emit()
+    assert tool.tool_status.operations[0].method_kwargs == {"fontsize": "large"}
+    assert tool.tool_status.operations[1].method_kwargs == {"fontsize": "large"}
+    assert tool.tool_status.operations[2].method_kwargs == {}
 
     title_edit.setPlainText("shared")
     assert tool.tool_status.operations[0].method_args == ("shared",)
@@ -1564,14 +1582,25 @@ def test_figure_composer_method_text_args_accept_real_newlines(qtbot) -> None:
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("method")
-    label_edit = tool.operation_editor.stack.currentWidget().findChild(
-        QtWidgets.QPlainTextEdit, "figureComposerAxesMethodXLabelEdit"
+    label_input = tool.operation_editor.stack.currentWidget().findChild(
+        completion_widgets.CompletingPlainTextEdit,
+        "figureComposerAxesMethodXLabelEdit",
     )
-    assert label_edit is not None
-    assert label_edit.toPlainText() == r"h\nu"
+    assert label_input is not None
+    assert label_input.toPlainText() == r"h\nu"
 
-    label_edit.setPlainText("Energy\n(eV)")
+    label_input.selectAll()
+    qtbot.keyClicks(label_input, "Energy")
+    qtbot.keyClick(label_input, QtCore.Qt.Key.Key_Return)
+    qtbot.keyClicks(label_input, "(eV)")
     assert tool.tool_status.operations[0].method_args == ("Energy\n(eV)",)
+    assert label_input.toPlainText() == "Energy\n(eV)"
+    figurecomposer_rendering._render_into_figure(
+        tool,
+        tool.figure,
+        sync_visible=False,
+    )
+    assert tool.figure.axes[0].get_xlabel() == "Energy\n(eV)"
     restored_status = FigureRecipeState.model_validate_json(
         tool.tool_status.model_dump_json()
     )
@@ -1581,8 +1610,215 @@ def test_figure_composer_method_text_args_accept_real_newlines(qtbot) -> None:
     exec(tool.generated_code(), namespace)  # noqa: S102
     assert namespace["fig"].axes[0].get_xlabel() == "Energy\n(eV)"
 
-    label_edit.setPlainText(r"h\nu")
+    label_input.selectAll()
+    qtbot.keyClicks(label_input, r"h\nu")
     assert tool.tool_status.operations[0].method_args == (r"h\nu",)
+
+
+def test_figure_composer_label_completion_accepts_current_line(qtbot) -> None:
+    label_input = completion_widgets.CompletingPlainTextEdit(
+        "first\n",
+        completions=completion_values.LABEL_COMPLETIONS,
+    )
+    qtbot.addWidget(label_input)
+    label_input.show()
+    label_input.setFocus()
+    cursor = label_input.textCursor()
+    cursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
+    label_input.setTextCursor(cursor)
+
+    qtbot.keyClicks(label_input, "$E-E")
+    qtbot.waitUntil(label_input.completer_popup.isVisible)
+    qtbot.keyClick(label_input.completer_popup, QtCore.Qt.Key.Key_Return)
+
+    assert (
+        label_input.toPlainText() == f"first\n{completion_values.LABEL_COMPLETIONS[0]}"
+    )
+    assert not label_input.completer_popup.isVisible()
+
+    label_input.undo()
+    assert label_input.toPlainText() == "first\n$E-E"
+    label_input.completion_shortcut.activated.emit()
+    assert label_input.completion_completer.completionPrefix() == ""
+    assert label_input.completion_completer.completionCount() == len(
+        completion_values.LABEL_COMPLETIONS
+    )
+
+
+def test_figure_composer_line_edit_completion_accepts_font_size_name(
+    qtbot,
+) -> None:
+    class FontSizeLineEdit(completion_widgets.CompletingLineEdit):
+        COMPLETIONS = completion_values.FONT_SIZE_COMPLETIONS
+
+    edit = FontSizeLineEdit()
+    qtbot.addWidget(edit)
+    edit.show()
+    edit.setFocus()
+
+    qtbot.keyClicks(edit, "l")
+    qtbot.waitUntil(edit.completer_popup.isVisible)
+    edit.completion_completer.activated[str].emit("large")
+
+    assert edit.text() == "large"
+    assert edit.isModified()
+    assert edit.isUndoAvailable()
+    assert not edit.completer_popup.isVisible()
+
+    edit.undo()
+    assert edit.text() == "l"
+    edit.redo()
+    assert edit.text() == "large"
+
+    edit.setModified(False)
+    edit.completion_completer.activated[str].emit("large")
+    assert edit.text() == "large"
+    assert edit.isModified()
+
+    edit.clear()
+    edit.completion_shortcut.activated.emit()
+    assert edit.completion_completer.completionPrefix() == ""
+    assert edit.completion_completer.completionCount() == len(
+        completion_values.FONT_SIZE_COMPLETIONS
+    )
+
+    empty_edit = completion_widgets.CompletingLineEdit()
+    qtbot.addWidget(empty_edit)
+    empty_edit.show_all_completions()
+    assert not empty_edit.completer_popup.isVisible()
+
+
+def test_figure_composer_completion_literal_values() -> None:
+    completions = completion_values.FONT_SIZE_COMPLETIONS
+
+    assert (
+        completion_values._format_completion_literal(None, completions=completions)
+        == ""
+    )
+    assert (
+        completion_values._format_completion_literal("large", completions=completions)
+        == "large"
+    )
+    assert (
+        completion_values._format_completion_literal("custom", completions=completions)
+        == '"custom"'
+    )
+    assert (
+        completion_values._completion_literal_from_text("", completions=completions)
+        is None
+    )
+    assert (
+        completion_values._completion_literal_from_text(
+            "large", completions=completions
+        )
+        == "large"
+    )
+    assert completion_values._completion_literal_from_text(
+        "9.5", completions=completions
+    ) == pytest.approx(9.5)
+
+
+@pytest.mark.parametrize(
+    ("family", "name"),
+    [
+        (FigureMethodFamily.AXES, "set_xlabel"),
+        (FigureMethodFamily.AXES, "set_ylabel"),
+        (FigureMethodFamily.FIGURE, "supxlabel"),
+        (FigureMethodFamily.FIGURE, "supylabel"),
+    ],
+)
+def test_figure_composer_label_methods_offer_curated_manual_input(
+    qtbot, family, name
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    initial_label = completion_values.LABEL_COMPLETIONS[-1]
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=family,
+                    name=name,
+                    args=(initial_label,),
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tool.operation_editor.select_section("method")
+    label_input = tool.operation_editor.stack.currentWidget().findChild(
+        completion_widgets.CompletingPlainTextEdit
+    )
+    assert label_input is not None
+    assert not label_input.isReadOnly()
+    assert label_input.toPlainText() == initial_label
+    assert label_input.completion_completer.widget() is label_input
+    assert (
+        label_input.completion_completer.completionMode()
+        == QtWidgets.QCompleter.CompletionMode.PopupCompletion
+    )
+
+    selected_label = completion_values.LABEL_COMPLETIONS[0]
+    label_input.selectAll()
+    qtbot.keyClicks(label_input, "$E-E")
+    assert label_input.completion_completer.completionPrefix() == "$E-E"
+    label_input.completion_completer.activated[str].emit(selected_label)
+
+    operation = tool.tool_status.operations[0]
+    assert operation.method_args == (selected_label,)
+
+    label_input.show_all_completions()
+    assert label_input.completion_completer.completionPrefix() == ""
+    assert label_input.completion_completer.completionCount() == len(
+        completion_values.LABEL_COMPLETIONS
+    )
+
+    label_input.selectAll()
+    qtbot.keyClicks(label_input, "Manual label")
+    operation = tool.tool_status.operations[0]
+    assert operation.method_args == ("Manual label",)
+
+
+@pytest.mark.parametrize("name", ["set_xlabels", "set_ylabels"])
+def test_figure_composer_plural_label_methods_offer_completion(qtbot, name) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="data", label="data"),),
+            operations=(
+                FigureOperationState.method(
+                    family=FigureMethodFamily.ERLAB,
+                    name=name,
+                ),
+            ),
+            primary_source="data",
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    tool.operation_editor.select_section("method")
+    page = tool.operation_editor.stack.currentWidget()
+    label_input = page.findChild(
+        completion_widgets.CompletingPlainTextEdit,
+        "figureComposerMethodTextValuesEdit",
+    )
+    assert label_input is not None
+    label_input.setPlainText("first\n")
+    cursor = label_input.textCursor()
+    cursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
+    label_input.setTextCursor(cursor)
+    qtbot.keyClicks(label_input, "$E-E")
+
+    selected_label = completion_values.LABEL_COMPLETIONS[0]
+    assert label_input.completion_completer.completionPrefix() == "$E-E"
+    label_input.completion_completer.activated[str].emit(selected_label)
+
+    assert label_input.toPlainText() == f"first\n{selected_label}"
+    assert tool.tool_status.operations[0].text_values == ("first", selected_label)
 
 
 @pytest.mark.parametrize(
@@ -1723,10 +1959,8 @@ def test_figure_composer_loaded_method_preserves_semantic_none() -> None:
 )
 def test_figure_composer_text_methods_share_artist_controls(family, name) -> None:
     operation = FigureOperationState.method(family=family, name=name)
-    controls = {
-        control.key: control
-        for control in method_catalog._method_spec(operation).controls
-    }
+    spec = method_catalog._method_spec(operation)
+    controls = {control.key: control for control in spec.controls}
 
     assert {
         "color",
@@ -1737,6 +1971,7 @@ def test_figure_composer_text_methods_share_artist_controls(family, name) -> Non
         "rotation_mode",
     } <= controls.keys()
     assert controls["fontsize"].kind == method_catalog.MethodControlKind.LITERAL_KWARG
+    assert controls["fontsize"].completions == completion_values.FONT_SIZE_COMPLETIONS
     assert controls["color"].aliases == ("c",)
     assert controls["horizontalalignment"].aliases == ("ha",)
     assert controls["verticalalignment"].aliases == ("va",)
@@ -1748,6 +1983,11 @@ def test_figure_composer_text_methods_share_artist_controls(family, name) -> Non
         )
     else:
         assert controls["horizontalalignment"].exclusive_group is None
+    assert spec.text_values_completions == (
+        completion_values.LABEL_COMPLETIONS
+        if name in {"set_xlabels", "set_ylabels"}
+        else ()
+    )
 
 
 def test_figure_composer_set_titles_default_location_uses_stylesheet(qtbot) -> None:
@@ -1841,6 +2081,7 @@ def test_figure_composer_text_controls_handle_constructor_aliases(qtbot) -> None
     assert rotation_edit is not None
     assert rotation_mode_combo is not None
     assert font_size_edit is not None
+    assert isinstance(font_size_edit, completion_widgets.CompletingLineEdit)
     assert extra_edit is not None
     assert color_edit.text() == "navy"
     assert horizontal_combo.currentData() == "left"
@@ -1849,6 +2090,16 @@ def test_figure_composer_text_controls_handle_constructor_aliases(qtbot) -> None
     assert rotation_mode_combo.currentData() == "anchor"
     assert font_size_edit.text() == "8"
     assert extra_edit.text() == ""
+
+    font_size_edit.setText("large")
+    font_size_edit.editingFinished.emit()
+    assert tool.tool_status.operations[0].method_kwargs["fontsize"] == "large"
+
+    font_size_edit.setText("9.5")
+    font_size_edit.editingFinished.emit()
+    assert tool.tool_status.operations[0].method_kwargs["fontsize"] == pytest.approx(
+        9.5
+    )
 
     font_size_edit.setText("9")
     font_size_edit.editingFinished.emit()
@@ -3146,6 +3397,14 @@ def test_figure_composer_tick_params_editor_edge_commits(qtbot) -> None:
     qtbot.addWidget(editor)
     emitted: list[dict[str, typing.Any]] = []
     editor.sigTickParamsChanged.connect(emitted.append)
+    label_size_edit = editor.findChild(
+        completion_widgets.CompletingLineEdit,
+        "figureComposerAxesMethodTickParamsLabelSizeEdit",
+    )
+    assert label_size_edit is not None
+    assert label_size_edit.completion_model.stringList() == list(
+        completion_values.FONT_SIZE_COMPLETIONS
+    )
 
     editor.setToolTip("ignored")
     assert editor.toolTip() == ""
@@ -3184,7 +3443,7 @@ def test_figure_composer_tick_params_editor_edge_commits(qtbot) -> None:
     )
     assert emitted == []
     _finish_tick_params_edit(
-        editor, "figureComposerAxesMethodTickParamsLabelSizeEdit", "'small'"
+        editor, "figureComposerAxesMethodTickParamsLabelSizeEdit", "small"
     )
     assert emitted[-1]["labelsize"] == "small"
     _finish_tick_params_edit(


### PR DESCRIPTION
## Summary

- Add reusable Qt completion widgets for single-line and multiline inputs.
- Offer curated scientific labels for axis-label methods, including `set_xlabels` and `set_ylabels`.
- Offer named Matplotlib font sizes while keeping manual numeric input.
- Preserve multiline editing, batch updates, and undo behavior.

## Validation

- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q tests/interactive/imagetool/manager/figurecomposer/test_method.py` (68 passed)
- Focused PySide6 Figure Composer tests (23 passed)
- New completion modules have 100% branch coverage.

The full test suite will run in CI.
