### PR TITLE
test(imagetool): clean up dialogs before parent

### DIFF
--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -295,71 +295,92 @@ def test_operation_backed_dialog_empty_operation_edges(qtbot, monkeypatch) -> No
     )
     win = itool(data, execute=False)
     qtbot.addWidget(win)
+    dialogs: list[QtWidgets.QDialog] = []
 
-    filter_dialog = imagetool_dialogs.DataFilterDialog(win.slicer_area)
-    qtbot.addWidget(filter_dialog)
-    assert filter_dialog.filter_operation() is None
-    assert filter_dialog.filter_operations() == []
+    try:
+        filter_dialog = imagetool_dialogs.DataFilterDialog(win.slicer_area)
+        dialogs.append(filter_dialog)
+        qtbot.addWidget(filter_dialog)
+        assert filter_dialog.filter_operation() is None
+        assert filter_dialog.filter_operations() == []
 
-    def _raise_expression_code(*_args, **_kwargs) -> str:
-        raise RuntimeError("cannot emit")
+        def _raise_expression_code(*_args, **_kwargs) -> str:
+            raise RuntimeError("cannot emit")
 
-    monkeypatch.setattr(
-        imagetool_dialogs,
-        "operations_expression_code",
-        _raise_expression_code,
-    )
-    assert filter_dialog.make_code() == ""
+        monkeypatch.setattr(
+            imagetool_dialogs,
+            "operations_expression_code",
+            _raise_expression_code,
+        )
+        assert filter_dialog.make_code() == ""
 
-    aggregate_dialog = AggregateDialog(win.slicer_area)
-    qtbot.addWidget(aggregate_dialog)
-    for check in aggregate_dialog.dim_checks.values():
-        check.setChecked(False)
-    with pytest.raises(ValueError, match="No dimensions selected"):
-        aggregate_dialog.source_transform_operation()
+        aggregate_dialog = AggregateDialog(win.slicer_area)
+        dialogs.append(aggregate_dialog)
+        qtbot.addWidget(aggregate_dialog)
+        for check in aggregate_dialog.dim_checks.values():
+            check.setChecked(False)
+        with pytest.raises(ValueError, match="No dimensions selected"):
+            aggregate_dialog.source_transform_operation()
 
-    coarsen_dialog = CoarsenDialog(win.slicer_area)
-    qtbot.addWidget(coarsen_dialog)
-    with pytest.raises(ValueError, match="No dimensions selected"):
-        coarsen_dialog.source_transform_operation()
+        coarsen_dialog = CoarsenDialog(win.slicer_area)
+        dialogs.append(coarsen_dialog)
+        qtbot.addWidget(coarsen_dialog)
+        with pytest.raises(ValueError, match="No dimensions selected"):
+            coarsen_dialog.source_transform_operation()
 
-    thin_dialog = ThinDialog(win.slicer_area)
-    qtbot.addWidget(thin_dialog)
-    thin_dialog.global_radio.setChecked(True)
-    thin_dialog.global_spin.setValue(1)
-    with pytest.raises(ValueError, match="No thinning requested"):
-        thin_dialog.source_transform_operation()
-    thin_dialog.per_dim_radio.setChecked(True)
-    for spin in thin_dialog.factor_spins.values():
-        spin.setValue(1)
-    with pytest.raises(ValueError, match="No thinning requested"):
-        thin_dialog.source_transform_operation()
+        thin_dialog = ThinDialog(win.slicer_area)
+        dialogs.append(thin_dialog)
+        qtbot.addWidget(thin_dialog)
+        thin_dialog.global_radio.setChecked(True)
+        thin_dialog.global_spin.setValue(1)
+        with pytest.raises(ValueError, match="No thinning requested"):
+            thin_dialog.source_transform_operation()
+        thin_dialog.per_dim_radio.setChecked(True)
+        for spin in thin_dialog.factor_spins.values():
+            spin.setValue(1)
+        with pytest.raises(ValueError, match="No thinning requested"):
+            thin_dialog.source_transform_operation()
 
-    normalize_dialog = NormalizeDialog(win.slicer_area)
-    qtbot.addWidget(normalize_dialog)
-    assert normalize_dialog.filter_operation() is None
-    xr.testing.assert_identical(normalize_dialog.process_data(data), data)
+        normalize_dialog = NormalizeDialog(win.slicer_area)
+        dialogs.append(normalize_dialog)
+        qtbot.addWidget(normalize_dialog)
+        assert normalize_dialog.filter_operation() is None
+        xr.testing.assert_identical(normalize_dialog.process_data(data), data)
 
-    gaussian_dialog = GaussianFilterDialog(win.slicer_area)
-    qtbot.addWidget(gaussian_dialog)
-    assert gaussian_dialog.filter_operation() is None
+        gaussian_dialog = GaussianFilterDialog(win.slicer_area)
+        dialogs.append(gaussian_dialog)
+        qtbot.addWidget(gaussian_dialog)
+        assert gaussian_dialog.filter_operation() is None
 
-    swap_dialog = SwapDimsDialog(win.slicer_area)
-    qtbot.addWidget(swap_dialog)
-    with pytest.raises(ValueError, match="No dimensions changed"):
-        swap_dialog.source_transform_operation()
+        swap_dialog = SwapDimsDialog(win.slicer_area)
+        dialogs.append(swap_dialog)
+        qtbot.addWidget(swap_dialog)
+        with pytest.raises(ValueError, match="No dimensions changed"):
+            swap_dialog.source_transform_operation()
 
-    squeeze_dialog = SqueezeDialog(win.slicer_area)
-    qtbot.addWidget(squeeze_dialog)
-    with pytest.raises(ValueError, match="No dimensions selected"):
-        squeeze_dialog.source_transform_operation()
+        squeeze_dialog = SqueezeDialog(win.slicer_area)
+        dialogs.append(squeeze_dialog)
+        qtbot.addWidget(squeeze_dialog)
+        with pytest.raises(ValueError, match="No dimensions selected"):
+            squeeze_dialog.source_transform_operation()
 
-    rename_dialog = RenameDimsCoordsDialog(win.slicer_area)
-    qtbot.addWidget(rename_dialog)
-    with pytest.raises(ValueError, match="No names changed"):
-        rename_dialog.source_transform_operation()
-
-    win.close()
+        rename_dialog = RenameDimsCoordsDialog(win.slicer_area)
+        dialogs.append(rename_dialog)
+        qtbot.addWidget(rename_dialog)
+        with pytest.raises(ValueError, match="No names changed"):
+            rename_dialog.source_transform_operation()
+    finally:
+        for dialog in reversed(dialogs):
+            if erlab.interactive.utils.qt_is_valid(dialog):
+                dialog.close()
+                dialog.deleteLater()
+        if erlab.interactive.utils.qt_is_valid(win):
+            win.close()
+            win.deleteLater()
+        QtWidgets.QApplication.sendPostedEvents(
+            None, int(QtCore.QEvent.Type.DeferredDelete.value)
+        )
+        QtWidgets.QApplication.processEvents()
 
 
 def test_tool_output_operation_editors_restore_parameters(qtbot) -> None:


### PR DESCRIPTION
## Summary

- Keep strong references to operation dialogs until cleanup completes.
- Close and delete child dialogs before the parent ImageTool.
- Drain deferred Qt deletion events before pytest-qt processes pending events.
- Run cleanup after assertion failures through a finally block.

## Validation

- PyQt6 exact test with coverage and xdist: 1 passed.
- PySide6 exact test: 1 passed.
- Adjacent PyQt6 coverage and xdist tests: 3 passed.
- Full PyQt6 test_imagetool.py coverage and xdist group: 473 passed.
- Ruff check and format check passed.