### PR TITLE
feat(interactive.ftool): support weighted parameter fits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ Pytest enforces strict markers and `xfail_strict`; name files `test_<feature>.py
 
 User-facing generated/copied/replay code must be as clean and direct as possible. Treat readability of generated code as product behavior, not a cosmetic afterthought. Copied code is also teaching material for users moving between scripts and the GUI, so prefer public APIs, semantic variable names, complete expressions, and best-practice examples. Avoid meaningless relay assignments, repeated scratch variables, reused generic names such as `derived` across unrelated subexpressions, leaked internal manager helpers, and temporaries that do not carry semantic value. Prefer semantic names from watched variables, console assignments, provenance inputs, or visible actions, and inline one-use aliases when it is safe to do so.
 
+Copied code is notebook-facing representative code, not an exact serialized replay program. Use direct public expressions. Omit routine framework imports for one provenance step, and import each required module at most once in a composed workflow. Do not add defensive `.copy()` calls, private restoration helpers, or other internal machinery only to preserve replay isolation. If a normal public operation updates input metadata, copied code should show that update directly. Keep exact source isolation and non-mutating behavior in the separate structured replay and execution paths.
+
 When changing provenance or code-generation paths, scan the emitted code for redundant reassignments and internal implementation details. Add property-style tests for cleanliness when it is the behavior under test, while still executing the generated code and asserting the resulting object/value exactly.
 
 ## Interactive Qt Notes

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -258,6 +258,16 @@ and right-click context menus:
   Combine selected data with {func}`xarray.concat` and open the result in a new
   ImageTool window.
 
+- {guilabel}`Open in ftool…`
+
+  Select two ImageTool rows. The dialog assigns one row to {guilabel}`Data` and one row
+  to {guilabel}`Standard uncertainty`. Use {guilabel}`Swap` to exchange the assignments.
+  The manager opens a weighted `ftool`. The data ImageTool remains the parent row. The
+  standard uncertainty ImageTool remains a named dependency of `ftool`.
+
+  The standard uncertainty must align with, and broadcast to, the data. If it is missing
+  or incompatible, the manager does not open an unweighted `ftool`.
+
 - {guilabel}`New Empty Figure`
 
   Create a Figure Composer window without data sources or recipe steps.

--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -482,7 +482,13 @@ For 2D data, the tool fits a *stack* of 1D curves.
 6. Start the 2D sequence with {guilabel}`Fit ⤒` or {guilabel}`Fit ⤓`. The tool will step through the selected range while populating the parameters according to the chosen
    mode.
 
-7. Inspect the parameter plot to verify trends. If a slice fails, move to it with {guilabel}`Index`, fix the parameters, then continue the sequence.
+7. Inspect the parameter plot. If a slice fails, move to it with {guilabel}`Index`, fix
+   the parameters, then continue the sequence.
+
+   :::{tip} When working in ImageTool Manager, right-click the plot and choose
+   {guilabel}`Open parameter values in ftool` to fit the selected values using their
+   standard errors. The weighted fit omits points that do not have a finite, positive
+   standard error. If no valid points remain, ftool does not open. :::
 
 8. When all indices in the range are fitted, click {guilabel}`Save fit` to export the
    combined results or {guilabel}`Copy code` to generate reproducible code for the full

--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -226,6 +226,17 @@ There are three ways to start `ftool`.
    eri.ftool(data, model=my_model)
    ```
 
+   To perform a weighted fit, supply the absolute standard uncertainty of each data
+   point:
+
+   ```python
+   eri.ftool(values, uncertainty=standard_uncertainty)
+   ```
+
+   `ftool` shows these values as one-standard-deviation error bars and passes their
+   reciprocal to lmfit as weights. The uncertainty can omit dimensions that xarray can
+   broadcast from the data. Its coordinates must align with the data coordinates.
+
 2. From the ImageTool context menu
 
    Right-click an image plot or line plot and choose {guilabel}`ftool`.

--- a/docs/source/user-guide/interactive/tool-authoring.md
+++ b/docs/source/user-guide/interactive/tool-authoring.md
@@ -32,12 +32,12 @@ In practice, `ToolWindow` enables several things:
 - standard undo/redo actions for the lightweight UI state stored in `tool_status`;
 - integration with the ImageTool manager, including tool naming, preview images, rich
   info text, and manager refresh notifications through `sigInfoChanged`;
-- remembering which ImageTool data and selection opened the tool, including saved
-  metadata, stale or unavailable status tracking, and the built-in update dialog;
+- remembering which ImageTool inputs opened the tool, including saved metadata, stale
+  or unavailable status tracking, and the built-in update dialog;
 - ImageTool windows declared in `IMAGE_TOOL_OUTPUTS` that appear as child rows of the
   tool in the ImageTool manager and can be reopened, refreshed, and persisted; and
-- the update hooks used by tools that can react when ImageTool data changes, such as
-  `validate_update_data()`, `update_data()`, and `_cancel_background_work()`.
+- the update hooks used by tools that can react when ImageTool inputs change:
+  `validate_update_inputs()`, `update_inputs()`, and `_cancel_background_work()`.
 
 Use `ToolWindow` when your tool should do any of the following:
 
@@ -48,8 +48,11 @@ Use `ToolWindow` when your tool should do any of the following:
 
 `ToolWindow` assumes a few things about your implementation:
 
-- The constructor accepts `data` as its single positional input. Additional options can
-  be keyword arguments.
+- The constructor accepts `data` as its primary positional input. Additional initial
+  inputs and options can be keyword arguments. The Manager records durable input
+  bindings separately when it registers the tool. A saveable multi-input tool must
+  let restore omit its non-primary constructor inputs. Restore supplies their saved
+  values through one complete `update_inputs()` call.
 - The nested `StateModel` contains the lightweight UI state that participates in
   undo/redo history.
 - `tool_data` returns the main `DataArray`.
@@ -62,15 +65,17 @@ As a practical authoring checklist:
 - Required for the core `ToolWindow` interface:
   constructor with `data`, `StateModel`, `tool_data`, and `tool_status`.
 - Required if the tool can be refreshed from ImageTool data:
-  `update_data()`. In practice, this is the normal baseline for repository tools, so
-  the examples below implement it even in the minimal case. Return `False` when the
-  new data is accepted but the tool cannot publish a fresh result yet.
+  `update_inputs()`. It always receives the complete named input mapping, including for
+  a tool with one input. Return `False` when the tool does not apply the input. Call
+  `_defer_source_refresh()` first if accepted asynchronous work will apply it later.
+  Override `validate_update_inputs()` when the tool
+  must normalize an input or validate relationships between inputs.
 - Optional, but strongly recommended for user-facing tools:
   `tool_name` (the base class default is just `"tool"`).
 - Optional for tools with expensive or bulky save-only state:
   `_append_persistence_payload()` and `_restore_persistence_payload()`.
 - Optional manager / provenance integration:
-  `validate_update_data()`, `_cancel_background_work()`, `preview_imageitem`,
+  `validate_update_inputs()`, `_cancel_background_work()`, `preview_imageitem`,
   `info_text`, `COPY_PROVENANCE`, `IMAGE_TOOL_OUTPUTS`, and
   `detached_output_imagetool_provenance()`.
 
@@ -91,9 +96,14 @@ up the corresponding `ToolWindow` surface:
   optional; implement `info_text`, `preview_imageitem`, and emit `sigInfoChanged` when
   either changes.
 - Refresh the tool when the ImageTool that opened it changes:
-  `update_data()` is part of the minimal tool surface; `validate_update_data()` and
-  `_cancel_background_work()` are optional additions when normalization or worker
-  shutdown matter.
+  implement `update_inputs()` and read the primary array by its stable name, usually
+  `inputs["data"]`. `validate_update_inputs()` and `_cancel_background_work()` are
+  optional additions when normalization or worker shutdown matter.
+- Refresh a tool from several ImageTool or ToolWindow results:
+  register named targets through
+  `ImageToolManager.add_childtool(..., script_inputs=...)`. The Manager reads the
+  primary input from the `ToolWindow` declaration. Use `parent` only to select where
+  the row appears. The update contract is unchanged from the one-input case.
 - Generate code that repeats the tool's main action:
   optional; usually set `COPY_PROVENANCE` to a `ToolScriptProvenanceDefinition`. Prefer
   `label + expression_method + assign` for the common single-step case, add
@@ -155,11 +165,13 @@ use Qt Designer) next to it. The rest of this page uses two real examples:
 
 If you only want to remember the minimum required pieces, this is it. The tool below is still
 fully functional: it displays a scaled 2D array, saves and restores its state, and can
-accept replacement data. It intentionally does **not** implement any of the optional
-manager integration or provenance hooks, but it still includes `update_data()` because
-that is the practical baseline for tools that may be launched from ImageTool.
+accept replacement data. It intentionally does **not** implement optional manager
+metadata or provenance hooks. It still implements `update_inputs()` because this is the
+one refresh contract for every `ToolWindow`.
 
 ```python
+from collections.abc import Mapping
+
 import pydantic
 import pyqtgraph as pg
 import xarray as xr
@@ -204,7 +216,7 @@ class MinimalScaleTool(erlab.interactive.utils.ToolWindow):
         self._reset_history_stack()
 
     def _coerce_data(self, data: xr.DataArray) -> xr.DataArray:
-        # Minimal tools can validate inline instead of overriding validate_update_data().
+        # Minimal tools can share constructor and refresh validation in one helper.
         parsed = erlab.interactive.utils.parse_data(data)
         if parsed.ndim != 2:
             raise ValueError("`data` must be 2D")
@@ -230,9 +242,9 @@ class MinimalScaleTool(erlab.interactive.utils.ToolWindow):
         self.scale_spin.setValue(status.scale)
         self._refresh()
 
-    def update_data(self, new_data: xr.DataArray) -> bool:
-        # This is the minimal refresh path: replace the data and repaint.
-        self._data = self._coerce_data(new_data)
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+        # Even a one-input tool receives the complete named input mapping.
+        self._data = self._coerce_data(inputs["data"])
         with self._history_suppressed():
             self._refresh()
         self._reset_history_stack()
@@ -252,7 +264,7 @@ That is the minimum `ToolWindow` surface to keep in your head:
 - nested `StateModel`;
 - `tool_data`;
 - `tool_status` getter and setter; and
-- `update_data`.
+- `update_inputs`.
 
 Everything below is optional integration that you add when the tool needs it.
 
@@ -286,6 +298,7 @@ tool row.
 ```python
 import enum
 import typing
+from collections.abc import Mapping
 
 import pydantic
 import pyqtgraph as pg
@@ -334,7 +347,7 @@ class MyTool(erlab.interactive.utils.ToolWindow):
         super().__init__()
 
         # Validate the input once up front and keep a stable variable name around.
-        self._data = self.validate_update_data(data)
+        self._data = self._validate_data(data)
         self._data_name = data_name or (self._data.name or "data")
         self._filtered_itool: QtWidgets.QWidget | None = None
 
@@ -414,19 +427,25 @@ class MyTool(erlab.interactive.utils.ToolWindow):
             self.reference_check.setChecked(status.show_reference)
         self._refresh(notify=False)
 
-    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
-        # Optional but recommended: normalize / reject data updates in one place.
-        data = erlab.interactive.utils.parse_data(new_data)
+    @staticmethod
+    def _validate_data(data: xr.DataArray) -> xr.DataArray:
+        data = erlab.interactive.utils.parse_data(data)
         if data.ndim != 2:
             raise ValueError("`data` must be 2D")
         return data
 
-    def update_data(self, new_data: xr.DataArray) -> bool:
-        # Preserve the existing UI state while swapping in replacement data.
+    def validate_update_inputs(
+        self, inputs: Mapping[str, xr.DataArray]
+    ) -> Mapping[str, xr.DataArray]:
+        validated = dict(super().validate_update_inputs(inputs))
+        validated["data"] = self._validate_data(validated["data"])
+        return validated
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+        # Inputs have already passed validate_update_inputs().
         status = self.tool_status
-        validated = self.validate_update_data(new_data)
         with self._history_suppressed():
-            self._data = validated
+            self._data = inputs["data"]
             self.tool_status = status
             self._notify_data_changed()
         self._reset_history_stack()
@@ -448,12 +467,12 @@ class MyTool(erlab.interactive.utils.ToolWindow):
     def _filter_expression(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
         # Optional provenance method: return the final expression only.
         del data
-        input_expr = input_name or "data"
+        input_expr = primary_input or "data"
         window = self._filter_window()
         rolling_kwargs = ", ".join(f"{dim}={window}" for dim in self.tool_data.dims)
         return (
@@ -494,6 +513,10 @@ Some implementation details matter:
   and is stored separately in workspace files. If you need to persist expensive
   calculated arrays, use the explicit persistence hooks instead of `tool_status` so
   ordinary history snapshots stay cheap.
+- For a tool with several canonical inputs, override `_persistence_data_items()` and
+  store each non-primary input under its exact input name. The base class stores the
+  primary input as `<saved-tool-data>`. Restore validates and applies the complete
+  mapping once. Keep auxiliary arrays in `_restore_persistence_data_items()`.
 - Keep workspace restore cheap. If a saved tool has optional cached results, preview
   images, deserialized fit objects, or rendered figures, validate the saved state
   eagerly but defer that derived work through `ToolWindow` restore hooks. Hidden tools
@@ -513,7 +536,7 @@ Some implementation details matter:
   it to `self.copy_code`. Declaring `COPY_PROVENANCE` only tells `ToolWindow` how to
   generate the code when that slot is called.
 - Keep provenance methods on the shared `ToolWindow` calling convention:
-  `(*, input_name: str | None = None, data: xr.DataArray | None = None)`. Most
+  `(*, primary_input: str | None = None, data: xr.DataArray | None = None)`. Most
   single-step methods should return only the unassigned final expression. Let
   `ToolScriptProvenanceDefinition(assign=...)` or `assign_method=...` define the final
   variable name, and use `prelude_method` only when the generated code needs setup
@@ -544,8 +567,8 @@ Some implementation details matter:
   create any user-facing action.
 
 `DerivativeTool` in `erlab.interactive.derivative` is a good synchronous example:
-`tool_status` captures the preprocessing controls, and `update_data()` swaps in the new
-array while preserving the current settings.
+`tool_status` captures the preprocessing controls, and `update_inputs()` swaps in the
+new named input while preserving the current settings.
 
 ## Defer expensive restored work
 
@@ -650,37 +673,37 @@ should usually be able to react when the ImageTool that opened it changes.
 
 `ToolWindow` gives you three hooks for this:
 
-- `validate_update_data(new_data)`: normalize or reject replacement data before it
-  reaches the live UI.
-- `update_data(new_data)`: apply the new data without creating a brand-new window.
-  Return `False` when the input was accepted but the tool must stay stale until a
-  deferred recomputation or result publication finishes.
+- `validate_update_inputs(inputs)`: normalize or reject the complete named mapping
+  before it reaches the live UI.
+- `update_inputs(inputs)`: apply the already-validated mapping without creating a new
+  window. Return `False` when the tool does not apply the input. If accepted
+  asynchronous work will apply it later, call `_defer_source_refresh()` before you
+  return `False`.
 - `_cancel_background_work(timeout_ms=...)`: stop worker threads or queued tasks before
-  mutating the UI, if your tool fits in the background.
+  mutating the UI, if your tool runs work in the background.
 
 There are three common update strategies in the current codebase:
 
 1. In-place updates for simple tools.
 
-   `DerivativeTool` and `KspaceToolGUI` validate the new array, preserve `tool_status`,
-   replace their cached data, and recompute the plots.
+   `DerivativeTool` and `KspaceToolGUI` validate the `"data"` input, preserve
+   `tool_status`, replace their cached data, and recompute the plots.
 
 2. Rebuild-and-restore updates for tools whose UI depends heavily on the input data.
 
    `Fit1DTool` and `Fit2DTool` snapshot `tool_status`, tear down the central widget,
-   rebuild the UI, then restore the saved state. In that case, prefer
-   `self._perform_source_update(...)` so validation and background-task cancellation
-   stay in one place.
+   rebuild the UI, then restore the saved state. The base input transaction performs
+   validation and background-task cancellation before it calls `update_inputs()`.
 
 3. Deferred updates for tools that accept the new input before they can publish a fresh
    result.
 
-   `GoldTool.update_data()` returns `False` while a queued data update or refit is
-   still pending, and `Fit1DTool`, `Fit2DTool`, and `ResolutionTool` return `False`
-   when they have accepted new data but must finish an asynchronous refit before their
-   current outputs are fresh again. Returning `False` keeps the tool marked as
-   stale until that follow-up work finishes and the tool calls
-   `finalize_source_refresh()`.
+   `GoldTool`, `Fit1DTool`, `Fit2DTool`, and `ResolutionTool` call
+   `_defer_source_refresh()` after they start an asynchronous refit. They then return
+   `False` to keep the input transaction pending. These tools publish the replacement
+   input before the refit starts. They therefore call `finalize_source_refresh()` when
+   the refit succeeds, fails, is cancelled, or times out. Their fit-specific state
+   still reports that the calculated result is stale or failed.
 
 When your tool has worker threads, a typical pattern is:
 
@@ -689,27 +712,118 @@ def _cancel_background_work(self, *, timeout_ms: int) -> bool:
     return self._threadpool.waitForDone(timeout_ms)
 
 
-def update_data(self, new_data: xr.DataArray) -> bool:
+def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
     status = self.tool_status
     old_geom = self.saveGeometry()
-
-    def _apply_update(validated: xr.DataArray) -> bool:
-        with self._history_suppressed():
-            self._data = validated
-            self._rebuild_ui()
-            self.tool_status = status
-            self.restoreGeometry(old_geom)
-            self._notify_data_changed()
-        self._reset_history_stack()
-        return True
-
-    return self._perform_source_update(new_data, apply_update=_apply_update)
+    with self._history_suppressed():
+        self._data = inputs["data"]
+        self._rebuild_ui()
+        self.tool_status = status
+        self.restoreGeometry(old_geom)
+        self._notify_data_changed()
+    self._reset_history_stack()
+    return True
 ```
 
-If `_apply_update(...)` starts asynchronous follow-up work such as a refit, return
-`False` instead and call `finalize_source_refresh()` only after the new result has been
-published. This is what prevents rows created by the tool from updating against old
-calculated arrays.
+If `update_inputs(...)` starts asynchronous follow-up work such as a refit, call
+`_defer_source_refresh()` and return `False`. Call `finalize_source_refresh()` only
+after the new input or result is published. If the tool already published the new
+input, also finalize the input transaction when a follow-up calculation fails or is
+cancelled. Keep the calculation's own result state stale or failed. Call
+`abort_source_refresh()` only when the tool staged the input without publishing it. A
+bare `False` discards the pending binding update. With automatic updates enabled, the
+framework coalesces source changes that arrive during explicitly deferred work and
+applies the newest input after the current work settles. With automatic updates
+disabled, it commits the completed input and leaves the tool stale for the newer
+source. This prevents a new data array from keeping the old input binding.
+
+### Consume several Manager inputs
+
+A `ToolWindow` can depend on several ImageTool or ToolWindow results. The Manager keeps
+these named dependencies as a graph even though the tree shows the tool under only one
+row. Register all inputs together at the launch site:
+
+```python
+from erlab.interactive.imagetool.provenance import ScriptInput
+
+
+tool.set_script_inputs(
+    (ScriptInput(name="data"), ScriptInput(name="right")),
+    primary_input="data",
+)
+tool_uid = manager.add_childtool(
+    tool,
+    script_inputs={"data": data_target, "right": right_target},
+    parent=data_target,
+)
+```
+
+Each target is a Manager root index or node UID. The input names are durable identifiers
+that the tool update and provenance code use. Their insertion order is also preserved.
+The declaration fixes the names, roles, transforms, order, and primary input before the
+Manager binds them to live targets. The default `data_role="displayed"` uses the values
+currently displayed by an ImageTool, including an accepted filter. Use
+`data_role="source"` only when the tool intentionally consumes the durable unfiltered
+source array.
+The optional arguments have different purposes:
+
+- `parent` selects the one input whose row contains the tool in the tree. It does
+  not change the dependency graph.
+- The `ToolWindow.primary_input` declaration selects the input used as the primary
+  tool data. Structured provenance operations start from this input.
+
+If `parent` is omitted, it defaults to the primary input. Removing a non-tree input
+keeps the tool row and marks its source unavailable. Removing the tree parent removes
+the nested tool with that branch. Workspace save, load, import, and node-UID rebasing
+preserve all named bindings.
+
+Implement one update transaction for the complete input mapping:
+
+```python
+from collections.abc import Mapping
+
+import xarray as xr
+
+
+def validate_update_inputs(
+    self, inputs: Mapping[str, xr.DataArray]
+) -> Mapping[str, xr.DataArray]:
+    validated = dict(super().validate_update_inputs(inputs))
+    left, right = xr.align(validated["data"], validated["right"], join="exact")
+    validated["data"] = left
+    validated["right"] = right
+    return validated
+
+
+def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+    self._data = inputs["data"]
+    self._right = inputs["right"]
+    self._refresh()
+    return True
+```
+
+The framework checks that the names match the fixed bindings. It resolves all inputs,
+calls `validate_update_inputs()` once, and then calls `update_inputs()` once. The tool
+does not observe a partly refreshed input set. For asynchronous work, call
+`_defer_source_refresh()`, return `False`, and then call
+`finalize_source_refresh()` or `abort_source_refresh()` when the work stops.
+
+The Manager owns the complete input lifecycle. It resolves live nodes before it uses
+recorded provenance, requests trust only for a recorded fallback, and propagates stale
+or unavailable state through all active dependency edges. Workspace import remaps
+saved node UIDs while it preserves saved revision tokens. Subtree duplication preserves
+the initial revision tokens of the copied nodes and remaps binding UIDs. A `ToolWindow`
+does not fetch Manager nodes or select a replay policy. It only validates and applies
+the complete mapping that the Manager supplies.
+
+`script_inputs` and `primary_input` are the canonical input state on every refreshable
+Manager child `ToolWindow`. Input names, roles, transforms, order, and the primary
+input stay fixed after the first binding. The Manager can refresh node UIDs, snapshot
+tokens, labels, and fallback provenance. Use
+`add_childtool(..., script_inputs=...)` so target validation, dependency registration,
+persistence, and refresh callbacks stay consistent. Figure Composer is a separate
+Manager collection. It owns a dynamic `FigureSourceState` map instead of fixed child
+tool inputs.
 
 If the tool is launched from an ImageTool selection, the launch site should also record
 which ImageTool data and selection opened it:
@@ -718,6 +832,11 @@ which ImageTool data and selection opened it:
   active cursor or cropped selection.
 - Use ``erlab.interactive.imagetool.provenance.full_data()`` when the whole current
   array should be used again during an update.
+- Store that live transform on the matching `ScriptInput.source_spec`. Store the
+  already-transformed result's complete replay source on
+  `ScriptInput.provenance_spec`. Replay uses this fallback as-is and does not apply the
+  live transform again. The Manager updates the live node UID and snapshot token
+  without changing the fixed name, role, or transform.
 - To describe a tool's data transformations, import concrete operation models from
   ``erlab.interactive.imagetool._provenance._operations`` when a tool needs to write
   or modify the saved operation list explicitly. Pass those operation instances to
@@ -768,9 +887,9 @@ which ImageTool data and selection opened it:
   but should stay hidden from the steps list and generated code, such as an internal
   bookkeeping rename. If the step should remain visible but code generation should
   stop, return ``DerivationEntry(..., code=None)`` instead.
-- Ensure the caller sets `set_source_binding(...)`; the manager wrapper will provide
-  `set_source_parent_fetcher(...)` and `set_input_provenance_parent_fetcher(...)` when
-  the tool is attached to an ImageTool in the manager.
+- Ensure the launch path declares `script_inputs` and `primary_input`. A standalone
+  ImageTool installs one resolver for the complete mapping. The Manager registers the
+  same bindings as graph dependencies. The `ToolWindow` does not fetch parent data.
 
 If the tool offers "Copy Code" or otherwise generates code from its current input, also
 implement provenance for that code path:
@@ -885,8 +1004,11 @@ At minimum, add tests in `tests/interactive/test_<tool>.py` that cover:
 - `to_dataset()` / `from_dataset()` if the tool is savable, including any
   `_append_persistence_payload()` / `_restore_persistence_payload()` roundtrip when the
   tool uses them;
-- `validate_update_data()` and `update_data()` branches, including {guilabel}`Stale` or
-  {guilabel}`Unavailable` cases after the ImageTool that opened the tool changes;
+- `validate_update_inputs()` and `update_inputs()` as one atomic update, including the
+  one-input case and {guilabel}`Stale` or {guilabel}`Unavailable` states after a source
+  changes;
+- multi-input bindings when applicable, including a removed non-tree input and workspace
+  restore;
 - deferred restore behavior for any expensive restored cache, preview, render, or
   result recomputation;
 - dialog accept and cancel paths for any new dialogs, including {guilabel}`Save` and
@@ -896,7 +1018,7 @@ At minimum, add tests in `tests/interactive/test_<tool>.py` that cover:
 - generated code from `COPY_PROVENANCE` and every `IMAGE_TOOL_OUTPUTS` definition that
   provides provenance: execute it in an explicit namespace and assert that the
   resulting object exactly matches the expected `DataArray`; do not assert source
-  formatting unless that exact formatting is the behavior under test; and
+  formatting unless that exact formatting is the behavior under test;
 - grouped provenance behavior when applicable: serialization, full-group copy/paste
   preserving editability, partial copy/paste stripping group metadata while staying
   replayable, grouped edit replacement, grouped delete/revert behavior, and generated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "tqdm>=4.66.2",
   "varname>=0.13.0",
   "xarray>=2024.10.0",
-  "xarray-lmfit>=0.5.5",
+  "xarray-lmfit>=0.6.0",
   "xraydb>=4.5.8",
 ]
 

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -5117,9 +5117,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             raise ValueError("`data` must be a 1D DataArray")
         validated = {"data": data}
         if "uncertainty" in inputs:
-            uncertainty = _validate_uncertainty_input(data, inputs["uncertainty"])
-            if uncertainty is not None:
-                validated["uncertainty"] = uncertainty
+            uncertainty = inputs["uncertainty"]
+            _validate_uncertainty_input(data, uncertainty)
+            validated["uncertainty"] = uncertainty
         elif self._direct_weights is not None:
             _validate_weights_input(data, self._direct_weights)
         else:

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -37,6 +37,8 @@ if typing.TYPE_CHECKING:
 
     import lmfit
     import varname
+
+    from erlab.interactive.imagetool._provenance._model import ToolProvenanceSpec
 else:
     import lazy_loader as _lazy
 
@@ -49,6 +51,8 @@ _T = typing.TypeVar("_T")
 logger = logging.getLogger(__name__)
 _FIT_MULTI_LIVE_REFRESH_INTERVAL_S = 0.10
 _REGISTERED_MODEL_CLASSES: dict[str, type[lmfit.Model]] = {}
+_PERSISTED_UNCERTAINTY_VAR = "__ftool_uncertainty__"
+_PERSISTED_WEIGHTS_VAR = "__ftool_weights__"
 _LMFIT_CALLABLE_WARNING_RE = re.compile(
     r"^Could not unpack dill-encoded callable '([^']+)', saved with Python version .+$"
 )
@@ -84,6 +88,119 @@ def _library_lmfit_model_classes() -> tuple[type[lmfit.Model], ...]:
         ):
             classes.add(candidate)
     return tuple(classes)
+
+
+def _validate_uncertainty_input(
+    data: xr.DataArray, uncertainty: xr.DataArray | None
+) -> xr.DataArray | None:
+    """Validate an absolute standard-uncertainty input against fit data."""
+    if uncertainty is None:
+        return None
+    if not isinstance(uncertainty, xr.DataArray):
+        raise TypeError("`uncertainty` must be an xarray.DataArray")
+    if not np.issubdtype(uncertainty.dtype, np.number) or np.issubdtype(
+        uncertainty.dtype, np.complexfloating
+    ):
+        raise TypeError("`uncertainty` must contain real numeric values")
+    extra_dims = set(uncertainty.dims).difference(data.dims)
+    if extra_dims:
+        raise ValueError(
+            "`uncertainty` dimensions must be a subset of the data dimensions; "
+            f"unexpected dimensions: {sorted(map(str, extra_dims))}"
+        )
+    try:
+        aligned_data, aligned_uncertainty = xr.align(
+            data, uncertainty, join="exact", copy=False
+        )
+        broadcast_uncertainty = aligned_uncertainty.broadcast_like(
+            aligned_data
+        ).transpose(*aligned_data.dims)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            "`uncertainty` must align exactly and broadcast to the shape of `data`"
+        ) from exc
+    _validate_uncertainty_values(aligned_data, broadcast_uncertainty)
+    return uncertainty
+
+
+def _validate_uncertainty_values(
+    data: xr.DataArray, uncertainty: xr.DataArray
+) -> np.ndarray:
+    """Validate uncertainty values that correspond to finite fit data."""
+    data_values = np.asarray(data.values)
+    uncertainty_values = np.asarray(uncertainty.values)
+    invalid = ~np.isfinite(uncertainty_values) | (uncertainty_values <= 0)
+    if np.any(invalid & np.isfinite(data_values)):
+        raise ValueError(
+            "`uncertainty` must be finite and strictly positive wherever `data` "
+            "is finite"
+        )
+    return uncertainty_values
+
+
+def _broadcast_uncertainty(
+    data: xr.DataArray, uncertainty: xr.DataArray
+) -> xr.DataArray:
+    """Return uncertainty aligned and broadcast in data dimension order."""
+    _, aligned = xr.align(data, uncertainty, join="exact", copy=False)
+    return aligned.broadcast_like(data).transpose(*data.dims)
+
+
+def _validate_weights_input(
+    data: xr.DataArray, weights: xr.DataArray | None
+) -> xr.DataArray | None:
+    """Validate direct fit weights against fit data."""
+    if weights is None:
+        return None
+    if not isinstance(weights, xr.DataArray):
+        raise TypeError("`weights` must be an xarray.DataArray")
+    if not np.issubdtype(weights.dtype, np.number) or np.issubdtype(
+        weights.dtype, np.complexfloating
+    ):
+        raise TypeError("`weights` must contain real numeric values")
+    extra_dims = set(weights.dims).difference(data.dims)
+    if extra_dims:
+        raise ValueError(
+            "`weights` dimensions must be a subset of the data dimensions; "
+            f"unexpected dimensions: {sorted(map(str, extra_dims))}"
+        )
+    try:
+        aligned_data, aligned_weights = xr.align(
+            data, weights, join="exact", copy=False
+        )
+        broadcast_weights = aligned_weights.broadcast_like(aligned_data).transpose(
+            *aligned_data.dims
+        )
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            "`weights` must align exactly and broadcast to the shape of `data`"
+        ) from exc
+    _validate_weights_values(aligned_data, broadcast_weights)
+    return weights
+
+
+def _validate_weights_values(data: xr.DataArray, weights: xr.DataArray) -> np.ndarray:
+    """Validate weights that correspond to finite fit data."""
+    data_values = np.asarray(data.values)
+    weight_values = np.asarray(weights.values)
+    invalid = ~np.isfinite(weight_values) | (weight_values < 0)
+    if np.any(invalid & np.isfinite(data_values)):
+        raise ValueError(
+            "`weights` must be finite and nonnegative wherever `data` is finite"
+        )
+    return weight_values
+
+
+def _broadcast_weights(data: xr.DataArray, weights: xr.DataArray) -> xr.DataArray:
+    """Return weights aligned and broadcast in data dimension order."""
+    _, aligned = xr.align(data, weights, join="exact", copy=False)
+    return aligned.broadcast_like(data).transpose(*data.dims)
+
+
+def _uncertainty_from_weights(weights: xr.DataArray) -> xr.DataArray:
+    """Return display uncertainty derived from direct fit weights."""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return 1.0 / weights
 
 
 def _load_lmfit_for_ftool_restore(
@@ -684,6 +801,8 @@ class _FitWorker(QtCore.QThread):
         model: lmfit.Model,
         params: lmfit.Parameters,
         *,
+        weights: xr.DataArray | None = None,
+        scale_covar: bool = True,
         max_nfev: int,
         method: str,
         timeout: float,
@@ -693,6 +812,8 @@ class _FitWorker(QtCore.QThread):
         self._coord_name = coord_name
         self._model = model
         self._params = params.copy()
+        self._weights = weights
+        self._scale_covar = scale_covar
         self._max_nfev = max_nfev
         self._method = method
         self._timeout = timeout
@@ -734,6 +855,8 @@ class _FitWorker(QtCore.QThread):
                     self._coord_name,
                     model=self._model,
                     params=self._params,
+                    weights=self._weights,
+                    scale_covar=self._scale_covar,
                     max_nfev=self._max_nfev if self._max_nfev > 0 else None,
                     method=self._method,
                     iter_cb=_callback,
@@ -838,6 +961,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
     _PARAMETER_CODE_TRUST_FEATURE = "erlab.fit.parameter-expression"
     _FIT_RESULT_CODE_TRUST_FEATURE = "erlab.fit.serialized-result"
     _FIT_RESULT_CODE_TRUST_LOCATION = "fit-result"
+    _direct_weights: xr.DataArray | None
+    _direct_weights_name: str
 
     class StateModel(pydantic.BaseModel):
         data_name: str
@@ -848,6 +973,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         normalize_mean: bool = False
         show_components: bool
         refit_on_source_update: bool = False
+        scale_covar: bool = True
+        normalize_residuals: bool = True
+        uncertainty_name: str = "uncertainty"
+        weights_name: str = "weights"
         timeout: float
         max_nfev: int
         method: str
@@ -910,6 +1039,47 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
     def tool_data(self) -> xr.DataArray:
         return self._data
 
+    @property
+    def uncertainty(self) -> xr.DataArray | None:
+        """Absolute standard uncertainty used for weighted fitting."""
+        return self._uncertainty
+
+    def current_provenance_spec(
+        self, *, flush_deferred_restore: bool = True
+    ) -> ToolProvenanceSpec | None:
+        if self._uncertainty is not None:
+            return None
+        return super().current_provenance_spec(
+            flush_deferred_restore=flush_deferred_restore
+        )
+
+    def _set_uncertainty(self, uncertainty: xr.DataArray | None) -> None:
+        self._direct_weights = None
+        self._uncertainty = _validate_uncertainty_input(self._data, uncertainty)
+
+    def _set_direct_weights(
+        self, weights: xr.DataArray | None, *, weights_name: str | None = None
+    ) -> None:
+        self._direct_weights = _validate_weights_input(self._data, weights)
+        self._uncertainty = (
+            None
+            if self._direct_weights is None
+            else _uncertainty_from_weights(self._direct_weights)
+        )
+        if weights_name is not None:
+            self._direct_weights_name = weights_name
+            self._uncertainty_name = f"1 / ({weights_name})"
+        self._refresh_weighting_ui()
+
+    def _direct_weights_for_persistence(self) -> xr.DataArray | None:
+        return self._direct_weights
+
+    def _refresh_weighting_ui(self) -> None:
+        self.normalize_residuals_check.setEnabled(self._uncertainty is not None)
+        self._update_residual_axis_label()
+        self._populate_data_curve()
+        self._update_fit_curve()
+
     PLOT_RESAMPLE: int = 5
     FIT_COLOR: str = "c"
     BOUNDS_COLOR: str = "#adadad"
@@ -948,8 +1118,11 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         model: lmfit.Model | None = None,
         params: lmfit.Parameters | Mapping[str, typing.Any] = None,
         *,
+        uncertainty: xr.DataArray | None = None,
         data_name: str | None = None,
         model_name: str | None = None,
+        uncertainty_name: str | None = None,
+        scale_covar: bool | None = None,
     ) -> None:
         super().__init__()
         for model_class in (
@@ -961,11 +1134,18 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self._register_model_class(type(model))
         self._fit_execution_capability: object | None = None
         self._pending_fit_status: Fit1DTool.StateModel | None = None
+        self._uncertainty_name = uncertainty_name or "uncertainty"
+        self._direct_weights_name = "weights"
+        self._scale_covar_default = (
+            uncertainty is None if scale_covar is None else bool(scale_covar)
+        )
+        self._normalize_residuals_default = True
         self._fit_finished_connection_keys: set[tuple[object | None, object]] = set()
         self._reset_fit_state(
             data,
             model,
             params,
+            uncertainty=uncertainty,
             data_name=data_name,
             model_name=model_name,
         )
@@ -977,6 +1157,26 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     def _emit_info_changed(self, *_args: typing.Any) -> None:
         self.sigInfoChanged.emit()
+
+    def _scale_covar_toggled(self, checked: bool) -> None:
+        self._scale_covar_default = checked
+        self._mark_fit_stale()
+        self._write_state()
+
+    def _normalize_residuals_toggled(self, checked: bool) -> None:
+        self._normalize_residuals_default = checked
+        self._update_residual_axis_label()
+        self._update_fit_curve()
+        self._emit_info_changed()
+        self._write_state()
+
+    def _update_residual_axis_label(self) -> None:
+        normalized = (
+            self._uncertainty is not None and self.normalize_residuals_check.isChecked()
+        )
+        self.residual_plot.setLabel(
+            "left", "Normalized residual" if normalized else "Residual"
+        )
 
     @staticmethod
     def _bool_text(value: bool) -> str:
@@ -1025,12 +1225,24 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             ),
             ("Normalize by mean", self._bool_text(self.normalize_check.isChecked())),
             ("Plot components", self._bool_text(self.components_check.isChecked())),
+            (
+                "Standard uncertainty",
+                self._uncertainty_name if self._uncertainty is not None else "None",
+            ),
         ]
 
     def _summary_fit_rows(self) -> list[tuple[str, str]]:
         return [
             ("Status", self._fit_status_text()),
             ("Method", self.method_combo.currentText()),
+            (
+                "Scale covariance",
+                self._bool_text(self.scale_covar_check.isChecked()),
+            ),
+            (
+                "Normalize residuals",
+                self._bool_text(self.normalize_residuals_check.isChecked()),
+            ),
             ("Timeout", f"{self.timeout_spin.value():.2f} s"),
             (
                 "Max nfev",
@@ -1071,6 +1283,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         model: lmfit.Model | None,
         params: lmfit.Parameters | Mapping[str, typing.Any] | None,
         *,
+        uncertainty: xr.DataArray | None = None,
+        direct_weights: xr.DataArray | None = None,
         data_name: str | None,
         model_name: str | None,
     ) -> None:
@@ -1080,8 +1294,17 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
         running_thread = getattr(self, "_fit_thread", None)
         keep_running = running_thread is not None
+        running_scale_covar = getattr(self, "_fit_scale_covar", None)
 
         self._data: xr.DataArray = data
+        if uncertainty is not None and direct_weights is not None:
+            raise ValueError("Only one of `uncertainty` and direct weights can be set")
+        self._direct_weights = _validate_weights_input(data, direct_weights)
+        self._uncertainty = (
+            _validate_uncertainty_input(data, uncertainty)
+            if self._direct_weights is None
+            else _uncertainty_from_weights(self._direct_weights)
+        )
         self._coord_name: Hashable = data.dims[0]
         self._user_model: lmfit.Model | None = model
         if model is None:
@@ -1121,6 +1344,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_is_current: bool = False
         self._table_widths_initialized: bool = False
         self._fit_thread: _FitWorker | None = running_thread if keep_running else None
+        self._fit_scale_covar: bool | None = (
+            running_scale_covar if keep_running else None
+        )
         self._fit_start_time: float | None = None
         self._fit_running_multi: bool = False
         self._fit_cancel_requested: bool = keep_running
@@ -1129,6 +1355,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_multi_total: int | None = None
         self._fit_multi_step: int = 0
         self._fit_multi_fit_data: xr.DataArray | None = None
+        self._fit_multi_weights: xr.DataArray | None = None
         self._fit_multi_params: lmfit.Parameters | None = None
         self._fit_multi_last_live_refresh: float = 0.0
         self._fit_multi_live_refresh_pending: bool = False
@@ -1363,6 +1590,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             symbolPen=pg.mkPen(120, 120, 120),
             name="Data",
         )
+        self.data_errorbar = pg.ErrorBarItem(pen=pg.mkPen(120, 120, 120))
+        self.main_plot.addItem(self.data_errorbar)
         self.fit_curve = self.main_plot.plot(
             pen=pg.mkPen(self.FIT_COLOR, width=2), name="Fit"
         )
@@ -1631,6 +1860,25 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             "If checked, rerun the fit after this tool updates from ImageTool."
         )
         self.refit_on_source_update_check.toggled.connect(self._emit_info_changed)
+        self.scale_covar_check = QtWidgets.QCheckBox("Scale covariance")
+        self.scale_covar_check.setObjectName("ftoolScaleCovarCheck")
+        self.scale_covar_check.setChecked(self._scale_covar_default)
+        self.scale_covar_check.setToolTip(
+            "Scale the parameter covariance by reduced chi-square. Disable this "
+            "when supplied standard uncertainties are absolute."
+        )
+        self.scale_covar_check.toggled.connect(self._scale_covar_toggled)
+        self.normalize_residuals_check = QtWidgets.QCheckBox("Normalize residuals")
+        self.normalize_residuals_check.setObjectName("ftoolNormalizeResidualsCheck")
+        self.normalize_residuals_check.setChecked(self._normalize_residuals_default)
+        self.normalize_residuals_check.setEnabled(self._uncertainty is not None)
+        self._update_residual_axis_label()
+        self.normalize_residuals_check.setToolTip(
+            "Divide residuals by the supplied standard uncertainty."
+        )
+        self.normalize_residuals_check.toggled.connect(
+            self._normalize_residuals_toggled
+        )
         self.timeout_spin.valueChanged.connect(self._emit_info_changed)
         self.nfev_spin.valueChanged.connect(self._emit_info_changed)
         self.method_combo.currentTextChanged.connect(self._emit_info_changed)
@@ -1638,6 +1886,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         fit_layout.addRow("Timeout", self.timeout_spin)
         fit_layout.addRow("Max nfev", self.nfev_spin)
         fit_layout.addRow("Method", self.method_combo)
+        fit_layout.addRow(self.scale_covar_check)
+        fit_layout.addRow(self.normalize_residuals_check)
         fit_layout.addRow(self.refit_on_source_update_check)
         self._fit_tab_layout.addWidget(fit_group)
 
@@ -2394,6 +2644,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             normalize_mean=self.normalize_check.isChecked(),
             show_components=self.components_check.isChecked(),
             refit_on_source_update=self.refit_on_source_update_check.isChecked(),
+            scale_covar=self.scale_covar_check.isChecked(),
+            normalize_residuals=self.normalize_residuals_check.isChecked(),
+            uncertainty_name=self._uncertainty_name,
+            weights_name=self._direct_weights_name,
             timeout=self.timeout_spin.value(),
             max_nfev=self.nfev_spin.value(),
             method=self.method_combo.currentText(),
@@ -2530,6 +2784,24 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 self._sync_model_specific_controls()
 
             self._serialized_model_state = restored_model_state
+            self.components_check.setChecked(status.show_components)
+            self.refit_on_source_update_check.setChecked(status.refit_on_source_update)
+            self._scale_covar_default = status.scale_covar
+            self._normalize_residuals_default = status.normalize_residuals
+            self._uncertainty_name = status.uncertainty_name
+            self._direct_weights_name = status.weights_name
+            with QtCore.QSignalBlocker(self.scale_covar_check):
+                self.scale_covar_check.setChecked(status.scale_covar)
+            with QtCore.QSignalBlocker(self.normalize_residuals_check):
+                self.normalize_residuals_check.setChecked(status.normalize_residuals)
+            self._update_residual_axis_label()
+            self.timeout_spin.setValue(status.timeout)
+            self.nfev_spin.setValue(status.max_nfev)
+            self.method_combo.setCurrentText(status.method)
+            with QtCore.QSignalBlocker(self.normalize_check):
+                self.normalize_check.setChecked(status.normalize_mean)
+
+            self._slider_widths = dict(status.slider_widths)
 
             self._params_from_coord = self._sanitize_params_from_coord(
                 status.params_from_coord
@@ -2616,12 +2888,21 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     def _update_domain_brushes(self) -> None:
         xvals = self._x_values()
+        data_values = self._normalized_data_values()
         brushes = self._domain_brushes(xvals)
         if brushes is None:
             return
-        self.data_curve.setData(
-            xvals, self._normalized_data_values(), symbolBrush=brushes
-        )
+        self.data_curve.setData(xvals, data_values, symbolBrush=brushes)
+        uncertainty_values = self._normalized_uncertainty_values()
+        if uncertainty_values is None:
+            self.data_errorbar.setData(x=None, y=None, top=None, bottom=None)
+        else:
+            self.data_errorbar.setData(
+                x=xvals,
+                y=data_values,
+                top=uncertainty_values,
+                bottom=uncertainty_values,
+            )
         if self._last_residual is not None:
             self.residual_curve.setData(xvals, self._last_residual, symbolBrush=brushes)
 
@@ -2721,12 +3002,70 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             return data
         return data / norm
 
+    def _fit_uncertainty(self) -> xr.DataArray | None:
+        if self._uncertainty is None:
+            return None
+        uncertainty = _broadcast_uncertainty(self._data, self._uncertainty)
+        fit_data = self._fit_data_raw()
+        if self._fit_domain() is not None:
+            uncertainty = uncertainty.sel(
+                {self._coord_name: fit_data[self._coord_name]}
+            )
+        _validate_uncertainty_values(fit_data, uncertainty)
+        norm = self._fit_normalization_factor()
+        if norm is not None:
+            uncertainty = uncertainty / abs(norm)
+        return uncertainty
+
+    def _fit_weights(self) -> xr.DataArray | None:
+        if self._direct_weights is not None:
+            weights = self._direct_weights
+            fit_data = self._fit_data_raw()
+            if self._fit_domain() is not None and self._coord_name in weights.dims:
+                weights = weights.sel({self._coord_name: fit_data[self._coord_name]})
+            _validate_weights_values(fit_data, _broadcast_weights(fit_data, weights))
+            norm = self._fit_normalization_factor()
+            if norm is not None:
+                weights = weights * abs(norm)
+            return weights
+        uncertainty = self._fit_uncertainty()
+        return None if uncertainty is None else 1.0 / uncertainty
+
     def _normalized_data_values(self) -> np.ndarray:
         values = self._data.values
         norm = self._fit_normalization_factor()
         if norm is None:
             return values
         return values / norm
+
+    def _normalized_uncertainty_values(self) -> np.ndarray | None:
+        if self._uncertainty is None:
+            return None
+        if self._direct_weights is not None:
+            weights = typing.cast(
+                "np.ndarray", self._normalized_direct_weights_values()
+            )
+            with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+                values = 1.0 / weights
+            return np.where(np.isfinite(values), values, np.nan)
+        uncertainty = _broadcast_uncertainty(self._data, self._uncertainty)
+        values = np.asarray(
+            _validate_uncertainty_values(self._data, uncertainty), dtype=float
+        )
+        norm = self._fit_normalization_factor()
+        if norm is None:
+            return values
+        return values / abs(norm)
+
+    def _normalized_direct_weights_values(self) -> np.ndarray | None:
+        if self._direct_weights is None:
+            return None
+        weights = _broadcast_weights(self._data, self._direct_weights)
+        values = np.asarray(_validate_weights_values(self._data, weights), dtype=float)
+        norm = self._fit_normalization_factor()
+        if norm is None:
+            return values
+        return values * abs(norm)
 
     def _guess_params(self) -> None:
         if not self._current_fit_execution_allowed(focus_on_block=True):
@@ -3171,9 +3510,20 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 self._last_result_ds.modelfit_results.compute().item(), "best_fit", None
             )
             if best_fit is not None and np.shape(best_fit) == data_values.shape:
-                return data_values - best_fit
-        yvals = self._model_eval_values(xvals)
-        return data_values - yvals
+                residuals = data_values - best_fit
+            else:
+                residuals = data_values - self._model_eval_values(xvals)
+        else:
+            residuals = data_values - self._model_eval_values(xvals)
+        if self.normalize_residuals_check.isChecked():
+            direct_weights = self._normalized_direct_weights_values()
+            if direct_weights is not None:
+                residuals = residuals * direct_weights
+            else:
+                uncertainty = self._normalized_uncertainty_values()
+                if uncertainty is not None:
+                    residuals = residuals / uncertainty
+        return residuals
 
     @staticmethod
     def _params_match_result(ds: xr.Dataset, params: lmfit.Parameters) -> bool:
@@ -3427,8 +3777,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             restore.data,
             restore.model,
             restore.params,
-            data_name="data",
-            model_name="model",
+            uncertainty=self._uncertainty,
+            data_name=self._data_name,
+            model_name=self._model_name,
         )
         self._last_result_ds = fit_ds.copy()
         self._cache_fit_result_payload()
@@ -3500,6 +3851,25 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             else self._fit_is_current
         )
         return ds
+
+    def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
+        items = dict(super()._persistence_data_items())
+        direct_weights = self._direct_weights_for_persistence()
+        if direct_weights is not None:
+            items[_PERSISTED_WEIGHTS_VAR] = direct_weights
+        elif self.uncertainty is not None:
+            items[_PERSISTED_UNCERTAINTY_VAR] = self.uncertainty
+        return items
+
+    def _restore_persistence_data_items(
+        self, data_items: Mapping[str, xr.DataArray], ds: xr.Dataset
+    ) -> None:
+        del ds
+        if _PERSISTED_WEIGHTS_VAR in data_items:
+            self._set_direct_weights(data_items[_PERSISTED_WEIGHTS_VAR])
+        else:
+            self._set_uncertainty(data_items.get(_PERSISTED_UNCERTAINTY_VAR))
+            self._refresh_weighting_ui()
 
     def _apply_restored_fit_result(
         self, result_ds: xr.Dataset, *, fit_is_current: bool
@@ -3595,6 +3965,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         fit_data: xr.DataArray,
         params: lmfit.Parameters,
         *,
+        weights: xr.DataArray | None = None,
         multi: bool,
         step: int = 0,
         total: int = 0,
@@ -3609,11 +3980,17 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             return False
 
         try:
+            scale_covar = self._fit_scale_covar
+            if scale_covar is None:
+                scale_covar = self.scale_covar_check.isChecked()
+                self._fit_scale_covar = scale_covar
             thread = _FitWorker(
                 fit_data,
                 self._coord_name,
                 self._model,
                 params,
+                weights=weights,
+                scale_covar=scale_covar,
                 max_nfev=self.nfev_spin.value(),
                 method=self.method_combo.currentText(),
                 timeout=self.timeout_spin.value(),
@@ -3742,13 +4119,24 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
         try:
             fit_data = self._fit_data()
+            weights = self._fit_weights()
         except Exception:
             self._fit_start_errored(multi=False)
             return False
 
+        if weights is None:
+            return self._start_fit_worker(
+                fit_data,
+                self._params,
+                multi=False,
+                on_success=_on_success,
+                on_timeout=_on_timeout,
+                on_error=_on_error,
+            )
         return self._start_fit_worker(
             fit_data,
             self._params,
+            weights=weights,
             multi=False,
             on_success=_on_success,
             on_timeout=_on_timeout,
@@ -3762,6 +4150,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
         try:
             fit_data = self._fit_data()
+            weights = self._fit_weights()
         except Exception:
             self._fit_start_errored(multi=True)
             self._finish_multi_fit()
@@ -3770,6 +4159,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_multi_total = count
         self._fit_multi_step = 0
         self._fit_multi_fit_data = fit_data
+        self._fit_multi_weights = weights
         self._fit_multi_params = self._params
         self._fit_multi_last_live_refresh = time.monotonic()
         self._fit_multi_live_refresh_pending = False
@@ -3816,16 +4206,29 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self._fit_errored(message)
             self._finish_multi_fit()
 
-        started = self._start_fit_worker(
-            self._fit_multi_fit_data,
-            self._fit_multi_params,
-            multi=True,
-            step=self._fit_multi_step,
-            total=self._fit_multi_total,
-            on_success=_on_success,
-            on_timeout=_on_timeout,
-            on_error=_on_error,
-        )
+        if self._fit_multi_weights is None:
+            started = self._start_fit_worker(
+                self._fit_multi_fit_data,
+                self._fit_multi_params,
+                multi=True,
+                step=self._fit_multi_step,
+                total=self._fit_multi_total,
+                on_success=_on_success,
+                on_timeout=_on_timeout,
+                on_error=_on_error,
+            )
+        else:
+            started = self._start_fit_worker(
+                self._fit_multi_fit_data,
+                self._fit_multi_params,
+                weights=self._fit_multi_weights,
+                multi=True,
+                step=self._fit_multi_step,
+                total=self._fit_multi_total,
+                on_success=_on_success,
+                on_timeout=_on_timeout,
+                on_error=_on_error,
+            )
         if not started:
             self._finish_multi_fit()
 
@@ -3836,6 +4239,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_multi_total = None
         self._fit_multi_step = 0
         self._fit_multi_fit_data = None
+        self._fit_multi_weights = None
         self._fit_multi_params = None
         self._fit_multi_live_refresh_pending = False
         self._fit_multi_refresh_pending = False
@@ -3851,6 +4255,11 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         total: int = 0,
         emit_info: bool = True,
     ) -> None:
+        scale_covar_changed = (
+            not running
+            and self._fit_scale_covar is not None
+            and self.scale_covar_check.isChecked() != self._fit_scale_covar
+        )
         if running:
             self.fit_button.setEnabled(False)
             self.fit_multi_button.setEnabled(False)
@@ -3868,6 +4277,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self.fit_multi_button.setText("Fit ×20")
             self.cancel_fit_button.setEnabled(False)
             self.cancel_fit_button.setText("Cancel")
+            self._fit_scale_covar = None
+        self.scale_covar_check.setDisabled(running)
+        if scale_covar_changed:
+            self._mark_fit_stale(emit_info=False)
         if emit_info:
             self._emit_info_changed()
 
@@ -3914,9 +4327,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
         return data_name, model_name, lines
 
-    def _copy_fit_data_name(
+    def _copy_fit_source_name(
         self,
-        data_name: str,
+        source_name: str,
         *,
         lines: list[str] | None = None,
     ) -> str:
@@ -3926,8 +4339,18 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 {self._coord_name: slice(*fit_domain)}
             )
             if lines is not None:
-                lines.append(f"{data_name}_crop = {data_name}.sel({sel_kw})")
-            data_name = f"{data_name}_crop"
+                lines.append(f"{source_name}_crop = {source_name}.sel({sel_kw})")
+            source_name = f"{source_name}_crop"
+
+        return source_name
+
+    def _copy_fit_data_name(
+        self,
+        data_name: str,
+        *,
+        lines: list[str] | None = None,
+    ) -> str:
+        data_name = self._copy_fit_source_name(data_name, lines=lines)
 
         if self.normalize_check.isChecked():
             if lines is not None:
@@ -3935,6 +4358,113 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             data_name = f"{data_name}_norm"
 
         return data_name
+
+    def _copy_uncertainty_name(self, data_name: str, model_name: str) -> str:
+        """Return a generated uncertainty name that does not shadow an input."""
+        uncertainty_name = str(self._uncertainty_name)
+        reserved = set(
+            re.findall(
+                r"\b[A-Za-z_]\w*\b",
+                f"{data_name} {model_name} {uncertainty_name}",
+            )
+        )
+
+        generated_name = "fit_uncertainty"
+        suffix = 2
+        while any(
+            name == generated_name or name.startswith(f"{generated_name}_")
+            for name in reserved
+        ):
+            generated_name = f"fit_uncertainty_{suffix}"
+            suffix += 1
+        return generated_name
+
+    def _copy_weights_name(self, data_name: str, model_name: str) -> str:
+        """Return a generated weights name that does not shadow an input."""
+        weights_name = str(self._direct_weights_name)
+        reserved = set(
+            re.findall(
+                r"\b[A-Za-z_]\w*\b",
+                f"{data_name} {model_name} {weights_name}",
+            )
+        )
+
+        generated_name = "fit_weights"
+        suffix = 2
+        while any(
+            name == generated_name or name.startswith(f"{generated_name}_")
+            for name in reserved
+        ):
+            generated_name = f"fit_weights_{suffix}"
+            suffix += 1
+        return generated_name
+
+    def _copy_fit_uncertainty_name(
+        self,
+        data_name: str,
+        model_name: str,
+        *,
+        lines: list[str] | None = None,
+    ) -> str | None:
+        if self._uncertainty is None or self._direct_weights is not None:
+            return None
+        uncertainty_name = self._copy_uncertainty_name(data_name, model_name)
+        if lines is not None:
+            lines.append(
+                f"{uncertainty_name} = "
+                f"({self._uncertainty_name}).broadcast_like({data_name})"
+            )
+        uncertainty_name = self._copy_fit_source_name(uncertainty_name, lines=lines)
+        if self.normalize_check.isChecked():
+            raw_data_name = self._copy_fit_source_name(data_name)
+            if lines is not None:
+                lines.append(
+                    f"{uncertainty_name}_norm = {uncertainty_name} "
+                    f"/ abs({raw_data_name}.mean())"
+                )
+            uncertainty_name = f"{uncertainty_name}_norm"
+        return uncertainty_name
+
+    def _copy_fit_direct_weights_name(
+        self,
+        data_name: str,
+        model_name: str,
+        *,
+        lines: list[str] | None = None,
+    ) -> str | None:
+        if self._direct_weights is None:
+            return None
+        weights_name = self._copy_weights_name(data_name, model_name)
+        if lines is not None:
+            lines.append(f"{weights_name} = {self._direct_weights_name}")
+        if self._coord_name in self._direct_weights.dims:
+            weights_name = self._copy_fit_source_name(weights_name, lines=lines)
+        if self.normalize_check.isChecked():
+            raw_data_name = self._copy_fit_source_name(data_name)
+            if lines is not None:
+                lines.append(
+                    f"{weights_name}_norm = {weights_name} "
+                    f"* abs({raw_data_name}.mean())"
+                )
+            weights_name = f"{weights_name}_norm"
+        return weights_name
+
+    def _copy_fit_weights_name(
+        self,
+        data_name: str,
+        model_name: str,
+        *,
+        lines: list[str] | None = None,
+    ) -> str | None:
+        direct_weights_name = self._copy_fit_direct_weights_name(
+            data_name, model_name, lines=lines
+        )
+        if direct_weights_name is not None:
+            return direct_weights_name
+        uncertainty_name = self._copy_fit_uncertainty_name(
+            data_name, model_name, lines=lines
+        )
+        return None if uncertainty_name is None else f"1 / {uncertainty_name}"
 
     def _copy_prelude(
         self,
@@ -3947,6 +4477,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         )
 
         self._copy_fit_data_name(data_name, lines=lines)
+        self._copy_fit_weights_name(data_name, model_name, lines=lines)
 
         param_entries: list[str] = []
         param_kwargs: dict[str, typing.Any] = {}
@@ -3998,15 +4529,24 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         data: xr.DataArray | None = None,
     ) -> str:
         data_name, model_name, _ = self._make_model_code(input_name or self._data_name)
-        data_name = self._copy_fit_data_name(data_name)
+        input_data_name = data_name
+        data_name = self._copy_fit_data_name(input_data_name)
+        weights_name = self._copy_fit_weights_name(
+            input_data_name,
+            model_name,
+        )
+        fit_kwargs: dict[str, typing.Any] = {
+            "model": f"|{model_name}|",
+            "params": "|params|",
+            "method": self.method_combo.currentText(),
+            "scale_covar": self.scale_covar_check.isChecked(),
+        }
+        if weights_name is not None:
+            fit_kwargs["weights"] = f"|{weights_name}|"
         return erlab.interactive.utils.generate_code(
             self._data.xlm.modelfit,
             args=[self._coord_name],
-            kwargs={
-                "model": f"|{model_name}|",
-                "params": "|params|",
-                "method": self.method_combo.currentText(),
-            },
+            kwargs=fit_kwargs,
             name="modelfit",
             module=f"{data_name}.xlm",
         )
@@ -4555,6 +5095,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         data = erlab.interactive.utils.parse_data(new_data)
         if data.ndim != 1:
             raise ValueError("`data` must be a 1D DataArray")
+        if self._direct_weights is not None:
+            _validate_weights_input(data, self._direct_weights)
+        else:
+            _validate_uncertainty_input(data, self._uncertainty)
         return data
 
     def _cancel_background_work(self, *, timeout_ms: int) -> bool:
@@ -4576,6 +5120,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 validated,
                 self._model,
                 self._params.copy(),
+                uncertainty=(
+                    self._uncertainty if self._direct_weights is None else None
+                ),
+                direct_weights=self._direct_weights,
                 data_name=self._data_name,
                 model_name=self._model_name,
             )

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -3858,7 +3858,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         if direct_weights is not None:
             items[_PERSISTED_WEIGHTS_VAR] = direct_weights
         elif self.uncertainty is not None:
-            items[_PERSISTED_UNCERTAINTY_VAR] = self.uncertainty
+            uncertainty_key = _PERSISTED_UNCERTAINTY_VAR
+            if any(item.name == "uncertainty" for item in self.script_inputs):
+                uncertainty_key = "uncertainty"
+            items[uncertainty_key] = self.uncertainty
         return items
 
     def _restore_persistence_data_items(
@@ -3868,7 +3871,11 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         if _PERSISTED_WEIGHTS_VAR in data_items:
             self._set_direct_weights(data_items[_PERSISTED_WEIGHTS_VAR])
         else:
-            self._set_uncertainty(data_items.get(_PERSISTED_UNCERTAINTY_VAR))
+            self._set_uncertainty(
+                data_items.get(
+                    "uncertainty", data_items.get(_PERSISTED_UNCERTAINTY_VAR)
+                )
+            )
             self._refresh_weighting_ui()
 
     def _apply_restored_fit_result(
@@ -3941,6 +3948,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._set_fit_stats(None)
         self._set_elapsed_status(elapsed, timed_out=True)
         self._mark_fit_stale()
+        if self._source_refresh_deferred:
+            self.finalize_source_refresh()
 
     def _fit_errored(self, detailed_text: str | None = None) -> None:
         self._show_error(
@@ -3948,6 +3957,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         )
         self._set_fit_stats(None)
         self._mark_fit_stale()
+        if self._source_refresh_deferred:
+            self.finalize_source_refresh()
 
     def _fit_start_errored(self, *, multi: bool) -> None:
         self._fit_thread = None
@@ -4099,6 +4110,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self._finish_multi_fit()
         else:
             self._set_fit_running(False, multi=self._fit_running_multi)
+        if self._source_refresh_deferred:
+            self.finalize_source_refresh()
 
     def _run_fit(self) -> bool:
         def _on_success(result_ds: xr.Dataset) -> None:
@@ -4469,11 +4482,11 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
     def _copy_prelude(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
         data_name, model_name, lines = self._make_model_code(
-            input_name or self._data_name
+            primary_input or self._data_name
         )
 
         self._copy_fit_data_name(data_name, lines=lines)
@@ -4525,10 +4538,12 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
     def _fit_expression(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
-        data_name, model_name, _ = self._make_model_code(input_name or self._data_name)
+        data_name, model_name, _ = self._make_model_code(
+            primary_input or self._data_name
+        )
         input_data_name = data_name
         data_name = self._copy_fit_data_name(input_data_name)
         weights_name = self._copy_fit_weights_name(
@@ -5091,60 +5106,73 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         if emit_info:
             self._emit_info_changed()
 
-    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
-        data = erlab.interactive.utils.parse_data(new_data)
+    def validate_update_inputs(
+        self, inputs: Mapping[str, xr.DataArray]
+    ) -> Mapping[str, xr.DataArray]:
+        data = erlab.interactive.utils.parse_data(inputs["data"])
         if data.ndim != 1:
             raise ValueError("`data` must be a 1D DataArray")
-        if self._direct_weights is not None:
+        validated = {"data": data}
+        if "uncertainty" in inputs:
+            uncertainty = _validate_uncertainty_input(data, inputs["uncertainty"])
+            if uncertainty is not None:
+                validated["uncertainty"] = uncertainty
+        elif self._direct_weights is not None:
             _validate_weights_input(data, self._direct_weights)
         else:
             _validate_uncertainty_input(data, self._uncertainty)
-        return data
+        return validated
 
     def _cancel_background_work(self, *, timeout_ms: int) -> bool:
         return self._cancel_fit(wait=True, timeout_ms=timeout_ms)
 
-    def update_data(self, new_data: xr.DataArray) -> bool:
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
         had_fit = self._last_result_ds is not None
         status = self._saved_tool_status()
         old_geom = self.saveGeometry()
+        old_cw = self.centralWidget()
+        if old_cw is not None:
+            old_cw.setParent(None)
+            old_cw.deleteLater()
 
-        def _apply_update(validated: xr.DataArray) -> bool:
-            self._invalidate_fit_result_payload()
-            old_cw = self.centralWidget()
-            if old_cw is not None:
-                old_cw.setParent(None)
-                old_cw.deleteLater()
+        self._invalidate_fit_result_payload()
+        explicit_uncertainty = inputs.get("uncertainty")
+        direct_weights = (
+            None if explicit_uncertainty is not None else self._direct_weights
+        )
+        self._reset_fit_state(
+            inputs["data"],
+            self._model,
+            self._params.copy(),
+            uncertainty=(
+                explicit_uncertainty
+                if explicit_uncertainty is not None
+                else self._uncertainty
+                if direct_weights is None
+                else None
+            ),
+            direct_weights=direct_weights,
+            data_name=self._data_name,
+            model_name=self._model_name,
+        )
+        self._build_ui()
+        with self._history_suppressed():
+            self.tool_status = status
+        self._set_fit_stats(None)
+        self._update_fit_curve()
+        self._write_history = True
+        self._reset_history_stack()
+        self._mark_fit_stale()
+        self.restoreGeometry(old_geom)
+        self._notify_data_changed()
 
-            self._reset_fit_state(
-                validated,
-                self._model,
-                self._params.copy(),
-                uncertainty=(
-                    self._uncertainty if self._direct_weights is None else None
-                ),
-                direct_weights=self._direct_weights,
-                data_name=self._data_name,
-                model_name=self._model_name,
-            )
-            self._build_ui()
-            with self._history_suppressed():
-                self.tool_status = status
-            self._set_fit_stats(None)
-            self._update_fit_curve()
-            self._write_history = True
-            self._reset_history_stack()
-            self._mark_fit_stale()
-            self.restoreGeometry(old_geom)
-            self._notify_data_changed()
-
-            if had_fit and self.refit_on_source_update_check.isChecked():
-                self._source_refresh_deferred = self.has_source_binding
-                self._run_fit()
-                return False
-            return True
-
-        return self._perform_source_update(new_data, apply_update=_apply_update)
+        if had_fit and self.refit_on_source_update_check.isChecked():
+            if not self._run_fit():
+                return True
+            if self._source_refreshing:
+                self._defer_source_refresh()
+            return False
+        return True
 
     def _show_warning(self, title: str, text: str) -> None:
         QtWidgets.QMessageBox.warning(self, title, text)

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -1044,10 +1044,13 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         """Absolute standard uncertainty used for weighted fitting."""
         return self._uncertainty
 
+    def _uncertainty_is_script_input(self) -> bool:
+        return any(item.name == self._uncertainty_name for item in self.script_inputs)
+
     def current_provenance_spec(
         self, *, flush_deferred_restore: bool = True
     ) -> ToolProvenanceSpec | None:
-        if self._uncertainty is not None:
+        if self._uncertainty is not None and not self._uncertainty_is_script_input():
             return None
         return super().current_provenance_spec(
             flush_deferred_restore=flush_deferred_restore

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -26,8 +26,8 @@ from xarray_lmfit.modelfit import (
 import erlab.interactive.utils
 from erlab.interactive._fit1d import (
     Fit1DTool,
-    _FitCodeEditRejected,
     _broadcast_uncertainty,
+    _FitCodeEditRejected,
     _FitRestoreState,
     _load_lmfit_for_ftool_restore,
     _SnapCursorLine,
@@ -213,21 +213,35 @@ class _Fit2DParameterPlotItem(pg.PlotItem):
         )
         show_stderr_action.triggered.connect(self._show_parameter_stderr)
 
+        open_parameter_values_action = self.vb.menu.addAction(
+            "Open parameter values in ftool"
+        )
+        open_parameter_values_action.setObjectName("fit2dParamPlotOpenInFtoolAction")
+        open_parameter_values_action.triggered.connect(
+            self._open_parameter_values_in_ftool
+        )
+
         self.vb.menu.addSeparator()
 
         add_to_figure_action = self.vb.menu.addAction("Add parameter plot to Figure…")
         add_to_figure_action.setObjectName("fit2dParamPlotAddToFigureAction")
         add_to_figure_action.triggered.connect(self._add_parameter_plot_to_figure)
 
-    def _current_param_dataarray(
-        self, *, stderr: bool
-    ) -> tuple[str, xr.DataArray] | None:
+    def _current_param_name(self) -> str | None:
         param_name = self._tool.param_plot_combo.currentText().strip()
         if not param_name:
             self._tool._show_warning(
                 "No parameter selected",
                 "Select a parameter in the parameter plot first.",
             )
+            return None
+        return param_name
+
+    def _current_param_dataarray(
+        self, *, stderr: bool
+    ) -> tuple[str, xr.DataArray] | None:
+        param_name = self._current_param_name()
+        if param_name is None:
             return None
 
         da = self._tool._param_plot_dataarray(param_name, stderr=stderr)
@@ -240,6 +254,34 @@ class _Fit2DParameterPlotItem(pg.PlotItem):
             )
             return None
         return param_name, da
+
+    def _current_param_dataarrays(
+        self, *, for_weighted_fit: bool = False
+    ) -> tuple[str, xr.DataArray, xr.DataArray] | None:
+        param_name = self._current_param_name()
+        if param_name is None:
+            return None
+        if for_weighted_fit:
+            values, stderr = self._tool._param_plot_dataarrays_for_weighted_fit(
+                param_name
+            )
+        else:
+            values, stderr = self._tool._param_plot_dataarrays(param_name)
+        if values.size == 0 or stderr.size == 0:
+            self._tool._show_warning(
+                "No data available",
+                "No parameter values or standard errors are available for the "
+                "selected parameter in the current y-range.",
+            )
+            return None
+        if for_weighted_fit and not np.isfinite(values.values).any():
+            self._tool._show_warning(
+                "No valid parameter data",
+                "The selected parameter does not have any finite values with finite, "
+                "positive standard errors in the current y-range.",
+            )
+            return None
+        return param_name, values, stderr
 
     def _save_dataarray_as_hdf5(self, data: xr.DataArray) -> None:
         if isinstance(data.name, str):
@@ -321,6 +363,10 @@ class _Fit2DParameterPlotItem(pg.PlotItem):
             )
 
     @QtCore.Slot()
+    def _open_parameter_values_in_ftool(self) -> None:
+        self._tool._open_parameter_values_in_ftool()
+
+    @QtCore.Slot()
     def _add_parameter_plot_to_figure(self) -> None:
         self._tool._add_parameter_plot_to_figure()
 
@@ -359,11 +405,17 @@ class Fit2DTool(Fit1DTool):
 
     class Output(enum.StrEnum):
         PARAMETER_VALUES = "fit2d.param_plot.values"
+        PARAMETER_VALUES_FOR_WEIGHTED_FIT = "fit2d.param_plot.values_for_weighted_fit"
         PARAMETER_STDERR = "fit2d.param_plot.stderr"
 
     IMAGE_TOOL_OUTPUTS: typing.ClassVar = {
         Output.PARAMETER_VALUES: erlab.interactive.utils.ToolImageOutputDefinition(
             data_method="_parameter_values_output_data",
+        ),
+        Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT: (
+            erlab.interactive.utils.ToolImageOutputDefinition(
+                data_method="_parameter_values_for_weighted_fit_output_data",
+            )
         ),
         Output.PARAMETER_STDERR: erlab.interactive.utils.ToolImageOutputDefinition(
             data_method="_parameter_stderr_output_data",
@@ -375,7 +427,7 @@ class Fit2DTool(Fit1DTool):
 
     @classmethod
     def _parameter_output_id(cls, output: Output, param_name: str) -> str:
-        if output not in (cls.Output.PARAMETER_VALUES, cls.Output.PARAMETER_STDERR):
+        if output not in tuple(cls.Output):
             raise ValueError("output must be a Fit2DTool parameter output")
         return (
             f"{output.value}{cls._PARAMETER_OUTPUT_SEPARATOR}"
@@ -387,7 +439,7 @@ class Fit2DTool(Fit1DTool):
         cls, output_id: str | enum.Enum
     ) -> tuple[Output, str | None] | None:
         normalized = erlab.interactive.utils._normalize_tool_output_id(output_id)
-        for output in (cls.Output.PARAMETER_VALUES, cls.Output.PARAMETER_STDERR):
+        for output in cls.Output:
             if normalized == output.value:
                 return output, None
             prefix = f"{output.value}{cls._PARAMETER_OUTPUT_SEPARATOR}"
@@ -1681,7 +1733,12 @@ class Fit2DTool(Fit1DTool):
             param = params[param_name]
             plot_y.append(y)
             param_values.append(self._parameter_value(param))
-            param_errors.append(param.stderr if param.stderr is not None else 0.0)
+            stderr = param.stderr
+            param_errors.append(
+                stderr
+                if stderr is not None and np.isfinite(stderr) and stderr > 0
+                else np.nan
+            )
 
         return np.array(plot_y), np.array(param_values), np.array(param_errors)
 
@@ -1738,18 +1795,39 @@ class Fit2DTool(Fit1DTool):
                 names.append(name)
         return names
 
+    def _param_plot_dataarrays(
+        self, param_name: str
+    ) -> tuple[xr.DataArray, xr.DataArray]:
+        plot_y, param_values, param_errors = self._param_plot_data(param_name)
+        coords = {self._y_dim_name: plot_y}
+        dims = (self._y_dim_name,)
+        return (
+            xr.DataArray(
+                param_values,
+                coords=coords,
+                dims=dims,
+                name=f"{param_name}_values",
+            ),
+            xr.DataArray(
+                param_errors,
+                coords=coords,
+                dims=dims,
+                name=f"{param_name}_stderr",
+            ),
+        )
+
+    def _param_plot_dataarrays_for_weighted_fit(
+        self, param_name: str
+    ) -> tuple[xr.DataArray, xr.DataArray]:
+        values, stderr = self._param_plot_dataarrays(param_name)
+        valid = np.isfinite(values) & np.isfinite(stderr) & (stderr > 0)
+        return values.where(valid), stderr.where(valid)
+
     def _param_plot_dataarray(
         self, param_name: str, *, stderr: bool = False
     ) -> xr.DataArray:
-        plot_y, param_values, param_errors = self._param_plot_data(param_name)
-        values = param_errors if stderr else param_values
-        kind = "stderr" if stderr else "values"
-        return xr.DataArray(
-            values,
-            coords={self._y_dim_name: plot_y},
-            dims=(self._y_dim_name,),
-            name=f"{param_name}_{kind}",
-        )
+        values, errors = self._param_plot_dataarrays(param_name)
+        return errors if stderr else values
 
     def _show_dataarray_in_itool(
         self,
@@ -1767,7 +1845,7 @@ class Fit2DTool(Fit1DTool):
         if tool is not None:
             self._itool = tool
 
-    def _parameter_figure_output_target(
+    def _parameter_output_target(
         self,
         param_name: str,
         output: Output,
@@ -1784,6 +1862,35 @@ class Fit2DTool(Fit1DTool):
             return None
         target = self._output_imagetool_target(output_id)
         return target if isinstance(target, str) else None
+
+    def _parameter_output_targets(
+        self,
+        param_name: str,
+        values: xr.DataArray,
+        stderr: xr.DataArray,
+        *,
+        values_output: Output = Output.PARAMETER_VALUES,
+    ) -> tuple[str, str] | None:
+        values_output_id = self._parameter_output_id(values_output, param_name)
+        previous_values_target = self._output_imagetool_target(values_output_id)
+        values_target = self._parameter_output_target(param_name, values_output, values)
+        if values_target is not None:
+            stderr_target = self._parameter_output_target(
+                param_name, self.Output.PARAMETER_STDERR, stderr
+            )
+            if stderr_target is not None:
+                return values_target, stderr_target
+            if previous_values_target is None:
+                manager, _ = self._managed_output_imagetool_parent()
+                if manager is not None:
+                    manager._remove_childtool(values_target)
+                self._clear_output_imagetool_target(values_output_id)
+        self._show_warning(
+            "Could not open parameter data",
+            "Could not open the selected parameter values and standard errors "
+            "in ImageTool Manager.",
+        )
+        return None
 
     def _parameter_figure_operation(
         self,
@@ -1845,8 +1952,48 @@ class Fit2DTool(Fit1DTool):
             label=param_name,
         )
 
+    def _open_parameter_values_in_ftool(self) -> None:
+        manager, parent_uid = self._managed_output_imagetool_parent()
+        if manager is None or parent_uid is None:
+            self._show_warning(
+                "ImageTool Manager required",
+                "Open ftool in ImageTool Manager to fit parameter values.",
+            )
+            return
+
+        current = self.param_plot._current_param_dataarrays(for_weighted_fit=True)
+        if current is None:
+            return
+
+        param_name, values, stderr = current
+        values_output = self.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT
+        output_ids = (
+            self._parameter_output_id(values_output, param_name),
+            self._parameter_output_id(self.Output.PARAMETER_STDERR, param_name),
+        )
+        previous_targets = tuple(
+            self._output_imagetool_target(output_id) for output_id in output_ids
+        )
+        targets = self._parameter_output_targets(
+            param_name,
+            values,
+            stderr,
+            values_output=values_output,
+        )
+        if targets is None:
+            return
+
+        if manager.open_weighted_ftool(*targets) is not None:
+            return
+        for output_id, previous_target, target in zip(
+            output_ids, previous_targets, targets, strict=True
+        ):
+            if previous_target is None:
+                manager._remove_childtool(target)
+                self._clear_output_imagetool_target(output_id)
+
     def _add_parameter_plot_to_figure(self) -> None:
-        current = self.param_plot._current_param_dataarray(stderr=False)
+        current = self.param_plot._current_param_dataarrays()
         if current is None:
             return
 
@@ -1859,7 +2006,7 @@ class Fit2DTool(Fit1DTool):
             )
             return
 
-        param_name, values = current
+        param_name, values, stderr = current
         target_figure = None
         if manager._figure_uids():
             target_figure = manager._choose_figure_append_target(
@@ -1868,28 +2015,10 @@ class Fit2DTool(Fit1DTool):
             if target_figure is None:
                 return
 
-        stderr = self._param_plot_dataarray(param_name, stderr=True)
-        if values.size == 0 or stderr.size == 0:
-            self._show_warning(
-                "No data available",
-                "No parameter values or standard errors are available for the "
-                "selected parameter in the current y-range.",
-            )
+        targets = self._parameter_output_targets(param_name, values, stderr)
+        if targets is None:
             return
-
-        values_target = self._parameter_figure_output_target(
-            param_name, self.Output.PARAMETER_VALUES, values
-        )
-        stderr_target = self._parameter_figure_output_target(
-            param_name, self.Output.PARAMETER_STDERR, stderr
-        )
-        if values_target is None or stderr_target is None:
-            self._show_warning(
-                "Could not open parameter data",
-                "Could not open the selected parameter values and standard errors "
-                "in ImageTool Manager.",
-            )
-            return
+        values_target, stderr_target = targets
 
         operation = self._parameter_figure_operation(
             manager,
@@ -1897,7 +2026,6 @@ class Fit2DTool(Fit1DTool):
             values_target=values_target,
             stderr_target=stderr_target,
         )
-        targets = (values_target, stderr_target)
         if target_figure is None:
             manager.create_figure_from_targets(
                 targets,
@@ -3211,7 +3339,10 @@ class Fit2DTool(Fit1DTool):
     def current_provenance_spec(
         self, *, flush_deferred_restore: bool = True
     ) -> ToolProvenanceSpec | None:
-        if self._uncertainty_full is not None:
+        if (
+            self._uncertainty_full is not None
+            and not self._uncertainty_is_script_input()
+        ):
             return None
         # Manager metadata and other passive provenance consumers should not trigger
         # interactive warnings for incomplete fit ranges.
@@ -3249,19 +3380,25 @@ class Fit2DTool(Fit1DTool):
             source=source,
         )
 
-    def _current_param_output(self, *, stderr: bool) -> tuple[str, xr.DataArray] | None:
+    def _current_param_output(
+        self, *, stderr: bool, for_weighted_fit: bool = False
+    ) -> tuple[str, xr.DataArray] | None:
         param_name = self.param_plot_combo.currentText().strip()
         if not param_name or param_name not in self._param_plot_names():
             return None
+        if for_weighted_fit:
+            values, _ = self._param_plot_dataarrays_for_weighted_fit(param_name)
+            return param_name, values
         return param_name, self._param_plot_dataarray(param_name, stderr=stderr)
 
     def _resolve_parameter_output(
         self, output: Output, param_name: str
-    ) -> tuple[str, bool] | None:
+    ) -> tuple[str, bool, bool] | None:
         stderr = output == self.Output.PARAMETER_STDERR
+        for_weighted_fit = output == self.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT
         if not param_name or param_name not in self._param_plot_names():
             return None
-        return param_name, stderr
+        return param_name, stderr, for_weighted_fit
 
     def output_imagetool_data(self, output_id: str | enum.Enum) -> xr.DataArray | None:
         self._flush_restore_work()
@@ -3275,7 +3412,10 @@ class Fit2DTool(Fit1DTool):
         request = self._resolve_parameter_output(output, param_name)
         if request is None:
             return None
-        param_name, stderr = request
+        param_name, stderr, for_weighted_fit = request
+        if for_weighted_fit:
+            values, _ = self._param_plot_dataarrays_for_weighted_fit(param_name)
+            return values
         return self._param_plot_dataarray(param_name, stderr=stderr)
 
     def output_imagetool_provenance(
@@ -3290,7 +3430,10 @@ class Fit2DTool(Fit1DTool):
         output, param_name = parts
         if param_name is None:
             current = self._current_param_output(
-                stderr=output == self.Output.PARAMETER_STDERR
+                stderr=output == self.Output.PARAMETER_STDERR,
+                for_weighted_fit=(
+                    output == self.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT
+                ),
             )
             if current is None:
                 return None
@@ -3299,14 +3442,24 @@ class Fit2DTool(Fit1DTool):
         request = self._resolve_parameter_output(output, param_name)
         if request is None:
             return None
-        if self._uncertainty_full is not None:
+        if (
+            self._uncertainty_full is not None
+            and not self._uncertainty_is_script_input()
+        ):
             return None
-        param_name, stderr = request
-        return self._parameter_output_provenance(param_name, stderr=stderr, data=data)
+        param_name, stderr, for_weighted_fit = request
+        return self._parameter_output_provenance(
+            param_name,
+            stderr=stderr,
+            for_weighted_fit=for_weighted_fit,
+            data=data,
+        )
 
     def _parameter_model_fit_operation(
         self, param_name: str, *, stderr: bool
     ) -> ModelFitOperation | None:
+        if self._uncertainty_full is not None:
+            return None
         if not self.scale_covar_check.isChecked():
             return None
         model_choice = self._infer_model_choice(self._model)
@@ -3339,6 +3492,7 @@ class Fit2DTool(Fit1DTool):
         param_name: str,
         *,
         stderr: bool,
+        for_weighted_fit: bool,
         input_name: str | None,
     ) -> ScriptCodeOperation | None:
         """Build public replay code for models outside the structured catalog."""
@@ -3358,13 +3512,41 @@ class Fit2DTool(Fit1DTool):
         output_expression = (
             f"({fit_expression}).{result_variable}.sel(param={param_name!r}, drop=True)"
         )
-        if stderr:
-            output_expression += ".fillna(0.0)"
-        output_expression += f".rename({output_name!r})"
+        if for_weighted_fit:
+            code = (
+                f"{prelude}\nparameter_fit = {fit_expression}\n"
+                "fit_parameter_values = parameter_fit.modelfit_coefficients.sel(\n"
+                f"    param={param_name!r},\n"
+                "    drop=True,\n"
+                ")\n"
+                "fit_parameter_stderr = parameter_fit.modelfit_stderr.sel(\n"
+                f"    param={param_name!r},\n"
+                "    drop=True,\n"
+                ")\n"
+                "parameter_values = fit_parameter_values.where(\n"
+                "    fit_parameter_values.notnull()\n"
+                '    & (abs(fit_parameter_values) < float("inf"))\n'
+                "    & fit_parameter_stderr.notnull()\n"
+                "    & (fit_parameter_stderr > 0)\n"
+                '    & (fit_parameter_stderr < float("inf"))\n'
+                f").rename({output_name!r})"
+            )
+        elif stderr:
+            code = (
+                f"{prelude}\nfit_parameter_stderr = {output_expression}\n"
+                "parameter_stderr = fit_parameter_stderr.where(\n"
+                "    fit_parameter_stderr.notnull()\n"
+                "    & (fit_parameter_stderr > 0)\n"
+                '    & (fit_parameter_stderr < float("inf"))\n'
+                f").rename({output_name!r})"
+            )
+        else:
+            code = f"{prelude}\n{assign} = {output_expression}.rename({output_name!r})"
         output_label = "standard errors" if stderr else "values"
         return ScriptCodeOperation(
             label=f"Fit model and extract {param_name!r} parameter {output_label}",
-            code=f"{prelude}\n{assign} = {output_expression}",
+            code=code,
+            framework_owned=True,
         )
 
     def _parameter_output_provenance(
@@ -3372,12 +3554,17 @@ class Fit2DTool(Fit1DTool):
         param_name: str,
         *,
         stderr: bool,
+        for_weighted_fit: bool,
         data: xr.DataArray,
     ) -> ToolProvenanceSpec | None:
         del data
         input_name = self.primary_input or self._data_name_full
         seed_code = f"derived = {input_name}"
-        model_fit = self._parameter_model_fit_operation(param_name, stderr=stderr)
+        model_fit = (
+            None
+            if for_weighted_fit
+            else self._parameter_model_fit_operation(param_name, stderr=stderr)
+        )
         assign = "parameter_stderr" if stderr else "parameter_values"
         if model_fit is not None:
             operations: list[ToolProvenanceOperation] = []
@@ -3405,7 +3592,8 @@ class Fit2DTool(Fit1DTool):
         fallback = self._parameter_output_script_operation(
             param_name,
             stderr=stderr,
-            input_name="derived",
+            for_weighted_fit=for_weighted_fit,
+            input_name=input_name,
         )
         if fallback is None:
             return None
@@ -3419,6 +3607,12 @@ class Fit2DTool(Fit1DTool):
 
     def _parameter_values_output_data(self) -> xr.DataArray | None:
         current = self._current_param_output(stderr=False)
+        if current is None:
+            return None
+        return current[1]
+
+    def _parameter_values_for_weighted_fit_output_data(self) -> xr.DataArray | None:
+        current = self._current_param_output(stderr=False, for_weighted_fit=True)
         if current is None:
             return None
         return current[1]

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -1858,6 +1858,7 @@ class Fit2DTool(Fit1DTool):
 
     def _parameter_output_targets(
         self,
+        manager: ImageToolManager,
         param_name: str,
         values: xr.DataArray,
         stderr: xr.DataArray,
@@ -1874,9 +1875,7 @@ class Fit2DTool(Fit1DTool):
             if stderr_target is not None:
                 return values_target, stderr_target
             if previous_values_target is None:
-                manager, _ = self._managed_output_imagetool_parent()
-                if manager is not None:
-                    manager._remove_childtool(values_target)
+                manager._remove_childtool(values_target)
                 self._clear_output_imagetool_target(values_output_id)
         self._show_warning(
             "Could not open parameter data",
@@ -1968,6 +1967,7 @@ class Fit2DTool(Fit1DTool):
             self._output_imagetool_target(output_id) for output_id in output_ids
         )
         targets = self._parameter_output_targets(
+            manager,
             param_name,
             values,
             stderr,
@@ -2008,7 +2008,7 @@ class Fit2DTool(Fit1DTool):
             if target_figure is None:
                 return
 
-        targets = self._parameter_output_targets(param_name, values, stderr)
+        targets = self._parameter_output_targets(manager, param_name, values, stderr)
         if targets is None:
             return
         values_target, stderr_target = targets
@@ -2773,9 +2773,9 @@ class Fit2DTool(Fit1DTool):
             raise ValueError("`data` must be a 2D DataArray")
         validated = {"data": data}
         if "uncertainty" in inputs:
-            uncertainty = _validate_uncertainty_input(data, inputs["uncertainty"])
-            if uncertainty is not None:
-                validated["uncertainty"] = uncertainty
+            uncertainty = inputs["uncertainty"]
+            _validate_uncertainty_input(data, uncertainty)
+            validated["uncertainty"] = uncertainty
         elif self._direct_weights_full is not None:
             _validate_weights_input(data, self._direct_weights_full)
         else:

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -3546,7 +3546,6 @@ class Fit2DTool(Fit1DTool):
         return ScriptCodeOperation(
             label=f"Fit model and extract {param_name!r} parameter {output_label}",
             code=code,
-            framework_owned=True,
         )
 
     def _parameter_output_provenance(

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -39,11 +39,7 @@ from erlab.interactive._fit1d import (
 from erlab.interactive.imagetool._provenance._model import (
     ToolProvenanceOperation,
     ToolProvenanceSpec,
-    compose_full_provenance,
-    direct_replay_input_name,
-    replay_input_name,
     script,
-    to_replay_provenance_spec,
 )
 from erlab.interactive.imagetool._provenance._operations import (
     IselOperation,
@@ -635,7 +631,12 @@ class Fit2DTool(Fit1DTool):
         return data
 
     def _rebuild_ui_for_full_data(
-        self, data: xr.DataArray, params: lmfit.Parameters | None
+        self,
+        data: xr.DataArray,
+        params: lmfit.Parameters | None,
+        *,
+        uncertainty: xr.DataArray | None,
+        direct_weights: xr.DataArray | None,
     ) -> None:
         self._invalidate_fit_result_payload()
         old_cw = self.centralWidget()
@@ -643,8 +644,6 @@ class Fit2DTool(Fit1DTool):
             old_cw.setParent(None)
             old_cw.deleteLater()
 
-        uncertainty = self._uncertainty_full
-        direct_weights = self._direct_weights_full
         self._init_full_data_state(
             data,
             uncertainty=uncertainty if direct_weights is None else None,
@@ -1317,7 +1316,12 @@ class Fit2DTool(Fit1DTool):
         restored_data = self._data_with_saved_dims(self._data_full, state2d)
         if restored_data.dims != self._data_full.dims:
             with self._history_suppressed():
-                self._rebuild_ui_for_full_data(restored_data, self._params.copy())
+                self._rebuild_ui_for_full_data(
+                    restored_data,
+                    self._params.copy(),
+                    uncertainty=self._uncertainty_full,
+                    direct_weights=self._direct_weights_full,
+                )
 
         if state2d is not None:  # pragma: no branch
             y_size = int(self._data_full.sizes[self._y_dim_name])
@@ -2640,42 +2644,62 @@ class Fit2DTool(Fit1DTool):
         super()._mark_fit_fresh(emit_info=emit_info)
         self._update_full_fit_saveable()
 
-    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
-        data = erlab.interactive.utils.parse_data(new_data)
+    def validate_update_inputs(
+        self, inputs: Mapping[str, xr.DataArray]
+    ) -> Mapping[str, xr.DataArray]:
+        data = erlab.interactive.utils.parse_data(inputs["data"])
         if data.ndim != 2:
             raise ValueError("`data` must be a 2D DataArray")
-        if self._direct_weights_full is not None:
+        validated = {"data": data}
+        if "uncertainty" in inputs:
+            uncertainty = _validate_uncertainty_input(data, inputs["uncertainty"])
+            if uncertainty is not None:
+                validated["uncertainty"] = uncertainty
+        elif self._direct_weights_full is not None:
             _validate_weights_input(data, self._direct_weights_full)
         else:
             _validate_uncertainty_input(data, self._uncertainty_full)
-        return data
+        return validated
 
-    def update_data(self, new_data: xr.DataArray) -> bool:
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
         had_fit = self._last_result_ds is not None
         status = self._saved_tool_status()
         old_geom = self.saveGeometry()
+        data = self._data_with_saved_dims(inputs["data"], status.state2d)
+        explicit_uncertainty = inputs.get("uncertainty")
+        direct_weights = (
+            None if explicit_uncertainty is not None else self._direct_weights_full
+        )
+        self._rebuild_ui_for_full_data(
+            data,
+            self._params.copy(),
+            uncertainty=(
+                explicit_uncertainty
+                if explicit_uncertainty is not None
+                else self._uncertainty_full
+                if direct_weights is None
+                else None
+            ),
+            direct_weights=direct_weights,
+        )
+        with self._history_suppressed():
+            self.tool_status = status
+        self._refresh_main_image()
+        self._refresh_contents_from_index()
+        self._update_param_plot()
+        self._write_history = True
+        self._reset_history_stack()
+        self._mark_fit_stale()
+        self.restoreGeometry(old_geom)
+        self._notify_data_changed()
 
-        def _apply_update(validated: xr.DataArray) -> bool:
-            validated = self._data_with_saved_dims(validated, status.state2d)
-            self._rebuild_ui_for_full_data(validated, self._params.copy())
-            with self._history_suppressed():
-                self.tool_status = status
-            self._refresh_main_image()
-            self._refresh_contents_from_index()
-            self._update_param_plot()
-            self._write_history = True
-            self._reset_history_stack()
-            self._mark_fit_stale()
-            self.restoreGeometry(old_geom)
-            self._notify_data_changed()
-
-            if had_fit and self.refit_on_source_update_check.isChecked():
-                self._source_refresh_deferred = self.has_source_binding
-                self._run_fit()
-                return False
-            return True
-
-        return self._perform_source_update(new_data, apply_update=_apply_update)
+        if had_fit and self.refit_on_source_update_check.isChecked():
+            if not self._run_fit():
+                return True
+            if self._source_refreshing:
+                self._defer_source_refresh()
+            return False
+        return True
 
     def _update_full_fit_saveable(self) -> None:
         can_save: bool = self._fit_is_current and not any(
@@ -3138,11 +3162,11 @@ class Fit2DTool(Fit1DTool):
     def _full_fit_expression(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
         data_name, model_name, _ = self._make_model_code(
-            input_name or self._data_name_full
+            primary_input or self._data_name_full
         )
         input_data_name = data_name
         data_name = self._full_copy_fit_data_name(input_data_name)
@@ -3169,19 +3193,19 @@ class Fit2DTool(Fit1DTool):
     def _checked_full_copy_prelude(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str | None:
-        prelude = self._build_full_copy_prelude(input_name=input_name, warn=True)
+        prelude = self._build_full_copy_prelude(input_name=primary_input, warn=True)
         return prelude or None
 
     def _detached_full_copy_prelude(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str | None:
-        prelude = self._build_full_copy_prelude(input_name=input_name, warn=False)
+        prelude = self._build_full_copy_prelude(input_name=primary_input, warn=False)
         return prelude or None
 
     def current_provenance_spec(
@@ -3199,10 +3223,7 @@ class Fit2DTool(Fit1DTool):
     @QtCore.Slot()
     def copy_code(self) -> str:
         return self._copy_provenance_code(
-            self._resolve_script_provenance(
-                self.COPY_PROVENANCE,
-                include_parent_provenance=False,
-            )
+            self._resolve_script_provenance(self.COPY_PROVENANCE)
         )
 
     @QtCore.Slot()
@@ -3212,10 +3233,7 @@ class Fit2DTool(Fit1DTool):
     @QtCore.Slot()
     def copy_code_1d(self) -> str:
         return self._copy_provenance_code(
-            self._resolve_script_provenance(
-                Fit1DTool.COPY_PROVENANCE,
-                include_parent_provenance=False,
-            )
+            self._resolve_script_provenance(Fit1DTool.COPY_PROVENANCE)
         )
 
     def detached_output_imagetool_provenance(
@@ -3328,7 +3346,7 @@ class Fit2DTool(Fit1DTool):
             warn=False,
             input_name=input_name,
         )
-        fit_expression = self._full_fit_expression(input_name=input_name)
+        fit_expression = self._full_fit_expression(primary_input=input_name)
         if not prelude or not fit_expression:
             return None
         if "lmfit." in prelude:
@@ -3357,7 +3375,8 @@ class Fit2DTool(Fit1DTool):
         data: xr.DataArray,
     ) -> ToolProvenanceSpec | None:
         del data
-        input_provenance = self._effective_input_provenance_spec()
+        input_name = self.primary_input or self._data_name_full
+        seed_code = f"derived = {input_name}"
         model_fit = self._parameter_model_fit_operation(param_name, stderr=stderr)
         assign = "parameter_stderr" if stderr else "parameter_values"
         if model_fit is not None:
@@ -3375,42 +3394,28 @@ class Fit2DTool(Fit1DTool):
                     model_fit,
                 )
             )
-            local_spec = script(
+            return script(
                 *operations,
                 start_label="Start from current fit-tool input data",
-                seed_code=(
-                    "derived = data"
-                    if input_provenance is not None
-                    else f"derived = {self._data_name_full}"
-                ),
+                seed_code=seed_code,
                 active_name=assign,
+                script_inputs=self.script_inputs,
             )
-            return compose_full_provenance(input_provenance, local_spec)
 
-        input_name = replay_input_name(input_provenance) or self._data_name_full
         fallback = self._parameter_output_script_operation(
             param_name,
             stderr=stderr,
-            input_name=input_name,
+            input_name="derived",
         )
         if fallback is None:
             return None
-        local_spec = script(
+        return script(
             fallback,
             start_label="Start from current fit-tool input data",
+            seed_code=seed_code,
             active_name=assign,
+            script_inputs=self.script_inputs,
         )
-        if (
-            input_provenance is not None
-            and direct_replay_input_name(input_provenance) is not None
-        ):
-            replay_spec = to_replay_provenance_spec(local_spec)
-            if replay_spec is None:
-                raise RuntimeError("Could not convert local provenance to replay spec.")
-            return replay_spec.model_copy(
-                update={"start_label": typing.cast("str", input_provenance.start_label)}
-            )
-        return compose_full_provenance(input_provenance, local_spec)
 
     def _parameter_values_output_data(self) -> xr.DataArray | None:
         current = self._current_param_output(stderr=False)

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -292,15 +292,13 @@ class _Fit2DParameterPlotItem(pg.PlotItem):
         dialog.setNameFilters(["xarray HDF5 Files (*.h5)", "All files (*)"])
         dialog.setDefaultSuffix("h5")
 
-        if os.environ.get("PYTEST_VERSION") is not None:
-            dialog.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog)
-
         last_dir = pg.PlotItem.lastFileDir
         if not last_dir:
             last_dir = erlab.interactive.imagetool.manager._get_recent_directory()
         if not last_dir:
             last_dir = os.getcwd()
-        dialog.setDirectory(os.path.join(last_dir, f"{default_name}.h5"))
+        dialog.setDirectory(last_dir)
+        dialog.selectFile(f"{default_name}.h5")
 
         if dialog.exec():
             filename = dialog.selectedFiles()[0]

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -111,11 +111,6 @@ def _fit_dataset_settings(
     return scale_covar, weighted
 
 
-def _fit_dataset_scale_covar(fit_ds: xr.Dataset) -> bool | None:
-    """Return the common covariance-scaling setting in saved fit results."""
-    return _fit_dataset_settings(fit_ds)[0]
-
-
 def _rebuild_ui(
     *,
     mark_fresh: bool = True,

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -27,9 +27,14 @@ import erlab.interactive.utils
 from erlab.interactive._fit1d import (
     Fit1DTool,
     _FitCodeEditRejected,
+    _broadcast_uncertainty,
     _FitRestoreState,
+    _load_lmfit_for_ftool_restore,
     _SnapCursorLine,
     _State2D,
+    _uncertainty_from_weights,
+    _validate_uncertainty_input,
+    _validate_weights_input,
 )
 from erlab.interactive.imagetool._provenance._model import (
     ToolProvenanceOperation,
@@ -71,6 +76,50 @@ _FIT2D_SEQUENCE_LIVE_REFRESH_INTERVAL_S = 0.10
 _R = typing.TypeVar("_R")
 
 
+def _fit_dataset_settings(
+    fit_ds: xr.Dataset,
+) -> tuple[bool | None, bool | None]:
+    """Return common covariance-scaling and weighted-fit settings."""
+    if "modelfit_results" not in fit_ds:
+        return None, None
+    try:
+        result_ds = _load_lmfit_for_ftool_restore(
+            lambda: fit_ds[["modelfit_results"]].compute()
+        )
+        results = result_ds["modelfit_results"].values
+    except Exception:
+        return None, None
+    scale_covar_values: set[bool] = set()
+    weighted_values: set[bool] = set()
+    scale_covar_known = True
+    weighted_known = True
+    for result in results.flat:
+        value = getattr(result, "scale_covar", None)
+        if not isinstance(value, (bool, np.bool_)):
+            scale_covar_known = False
+        else:
+            scale_covar_values.add(bool(value))
+        if not hasattr(result, "weights"):
+            weighted_known = False
+        else:
+            weighted_values.add(result.weights is not None)
+
+    scale_covar = (
+        scale_covar_values.pop()
+        if scale_covar_known and len(scale_covar_values) == 1
+        else None
+    )
+    weighted = (
+        weighted_values.pop() if weighted_known and len(weighted_values) == 1 else None
+    )
+    return scale_covar, weighted
+
+
+def _fit_dataset_scale_covar(fit_ds: xr.Dataset) -> bool | None:
+    """Return the common covariance-scaling setting in saved fit results."""
+    return _fit_dataset_settings(fit_ds)[0]
+
+
 def _rebuild_ui(
     *,
     mark_fresh: bool = True,
@@ -110,6 +159,12 @@ def _rebuild_ui(
                     self._data_full.isel({self._y_dim_name: self._current_idx}),
                     self._model,
                     None,
+                    uncertainty=(
+                        self._current_uncertainty()
+                        if self._direct_weights_full is None
+                        else None
+                    ),
+                    direct_weights=self._current_direct_weights(),
                     data_name=self._data_name,
                     model_name=self._model_name,
                 )
@@ -304,6 +359,7 @@ class Fit2DTool(Fit1DTool):
     _FIT_RANGE_MIN_COORD: typing.ClassVar[str] = "__ftool_fit_range_min__"
     _FIT_RANGE_MAX_COORD: typing.ClassVar[str] = "__ftool_fit_range_max__"
     _PARAMETER_OUTPUT_SEPARATOR: typing.ClassVar[str] = ":"
+    _direct_weights_full: xr.DataArray | None
 
     class Output(enum.StrEnum):
         PARAMETER_VALUES = "fit2d.param_plot.values"
@@ -359,6 +415,52 @@ class Fit2DTool(Fit1DTool):
         return self._data_full
 
     @property
+    def uncertainty(self) -> xr.DataArray | None:
+        """Absolute standard uncertainty used for weighted fitting."""
+        return self._uncertainty_full
+
+    def _set_uncertainty(self, uncertainty: xr.DataArray | None) -> None:
+        self._direct_weights_full = None
+        self._uncertainty_full = _validate_uncertainty_input(
+            self._data_full, uncertainty
+        )
+        self._direct_weights = None
+        self._uncertainty = self._current_uncertainty()
+
+    def _set_direct_weights(
+        self, weights: xr.DataArray | None, *, weights_name: str | None = None
+    ) -> None:
+        self._direct_weights_full = _validate_weights_input(self._data_full, weights)
+        self._uncertainty_full = (
+            None
+            if self._direct_weights_full is None
+            else _uncertainty_from_weights(self._direct_weights_full)
+        )
+        self._direct_weights = self._current_direct_weights()
+        self._uncertainty = self._current_uncertainty()
+        if weights_name is not None:
+            self._direct_weights_name = weights_name
+            self._uncertainty_name = f"1 / ({weights_name})"
+        self._refresh_weighting_ui()
+
+    def _direct_weights_for_persistence(self) -> xr.DataArray | None:
+        return self._direct_weights_full
+
+    def _current_direct_weights(self) -> xr.DataArray | None:
+        if self._direct_weights_full is None:
+            return None
+        if self._y_dim_name not in self._direct_weights_full.dims:
+            return self._direct_weights_full
+        return self._direct_weights_full.isel({self._y_dim_name: self._current_idx})
+
+    def _current_uncertainty(self) -> xr.DataArray | None:
+        if self._uncertainty_full is None:
+            return None
+        return _broadcast_uncertainty(self._data_full, self._uncertainty_full).isel(
+            {self._y_dim_name: self._current_idx}
+        )
+
+    @property
     def preview_imageitem(self) -> pg.ImageItem:
         return self.image
 
@@ -368,15 +470,18 @@ class Fit2DTool(Fit1DTool):
         model: lmfit.Model | None = None,
         params: lmfit.Parameters | Mapping[str, typing.Any] | None = None,
         *,
+        uncertainty: xr.DataArray | None = None,
         data_name: str | None = None,
         model_name: str | None = None,
+        uncertainty_name: str | None = None,
+        scale_covar: bool | None = None,
     ) -> None:
         if data.ndim != 2:
             raise ValueError("`data` must be a 2D DataArray")
 
         if data_name is None:
             data_name = "data"
-        self._init_full_data_state(data, data_name=data_name)
+        self._init_full_data_state(data, uncertainty=uncertainty, data_name=data_name)
 
         if params is not None:
             parameter_inputs = _parse_params(params)
@@ -436,7 +541,10 @@ class Fit2DTool(Fit1DTool):
             self._data_full.isel({self._y_dim_name: self._current_idx}),
             model,
             params,
+            uncertainty=self._current_uncertainty(),
             model_name=model_name,
+            uncertainty_name=uncertainty_name,
+            scale_covar=scale_covar,
         )
 
         self.param_model.sigParamsChanged.connect(self._update_params_full)
@@ -475,8 +583,23 @@ class Fit2DTool(Fit1DTool):
         info += self._summary_section("Current Slice Stats", self._fit_stats_rows())
         return info
 
-    def _init_full_data_state(self, data: xr.DataArray, *, data_name: str) -> None:
+    def _init_full_data_state(
+        self,
+        data: xr.DataArray,
+        *,
+        uncertainty: xr.DataArray | None = None,
+        direct_weights: xr.DataArray | None = None,
+        data_name: str,
+    ) -> None:
         self._data_full: xr.DataArray = data
+        if uncertainty is not None and direct_weights is not None:
+            raise ValueError("Only one of `uncertainty` and direct weights can be set")
+        self._direct_weights_full = _validate_weights_input(data, direct_weights)
+        self._uncertainty_full = (
+            _validate_uncertainty_input(data, uncertainty)
+            if self._direct_weights_full is None
+            else _uncertainty_from_weights(self._direct_weights_full)
+        )
         self._y_dim_name: Hashable = data.dims[0]
         self._y_values_cache: np.ndarray | None = None
         y_size = int(self._data_full.sizes[self._y_dim_name])
@@ -520,11 +643,24 @@ class Fit2DTool(Fit1DTool):
             old_cw.setParent(None)
             old_cw.deleteLater()
 
-        self._init_full_data_state(data, data_name=self._data_name_full)
+        uncertainty = self._uncertainty_full
+        direct_weights = self._direct_weights_full
+        self._init_full_data_state(
+            data,
+            uncertainty=uncertainty if direct_weights is None else None,
+            direct_weights=direct_weights,
+            data_name=self._data_name_full,
+        )
         self._reset_fit_state(
             self._data_full.isel({self._y_dim_name: self._current_idx}),
             self._model,
             params,
+            uncertainty=(
+                self._current_uncertainty()
+                if self._direct_weights_full is None
+                else None
+            ),
+            direct_weights=self._current_direct_weights(),
             data_name=self._data_name,
             model_name=self._model_name,
         )
@@ -1276,7 +1412,19 @@ class Fit2DTool(Fit1DTool):
     def _do_transpose(self) -> None:
         """Transpose the full 2D data (swap axes)."""
         self._init_full_data_state(
-            self._data_full.transpose(), data_name=self._data_name_full
+            self._data_full.transpose(),
+            uncertainty=(
+                None
+                if self._uncertainty_full is None
+                or self._direct_weights_full is not None
+                else self._uncertainty_full.transpose()
+            ),
+            direct_weights=(
+                None
+                if self._direct_weights_full is None
+                else self._direct_weights_full.transpose()
+            ),
+            data_name=self._data_name_full,
         )
 
     @QtCore.Slot()
@@ -1842,6 +1990,8 @@ class Fit2DTool(Fit1DTool):
 
     def _load_contents_from_index(self) -> None:
         self._data = self._data_full.isel({self._y_dim_name: self._current_idx})
+        self._direct_weights = self._current_direct_weights()
+        self._uncertainty = self._current_uncertainty()
 
         params = self._params_full[self._current_idx]
         params_from_coord = self._params_from_coord_full[self._current_idx]
@@ -1959,7 +2109,11 @@ class Fit2DTool(Fit1DTool):
 
         self._model = base_model
         self._serialized_model_state = self._serialize_model_state(base_model)
-        self._init_full_data_state(fit_data, data_name=self._data_name_full)
+        self._init_full_data_state(
+            fit_data,
+            uncertainty=self._uncertainty_full,
+            data_name=self._data_name_full,
+        )
         self._current_idx = min(
             self._current_idx, self._data_full.sizes[self._y_dim_name] - 1
         )
@@ -2406,21 +2560,35 @@ class Fit2DTool(Fit1DTool):
 
         try:
             fit_data = self._fit_data()
+            weights = self._fit_weights()
         except Exception:
             self._fit_start_errored(multi=True)
             self._finish_fit_2d_sequence()
             return
 
-        started = self._start_fit_worker(
-            fit_data,
-            self._params,
-            multi=True,
-            step=step,
-            total=self._fit_2d_total,
-            on_success=_on_success,
-            on_timeout=_on_timeout,
-            on_error=_on_error,
-        )
+        if weights is None:
+            started = self._start_fit_worker(
+                fit_data,
+                self._params,
+                multi=True,
+                step=step,
+                total=self._fit_2d_total,
+                on_success=_on_success,
+                on_timeout=_on_timeout,
+                on_error=_on_error,
+            )
+        else:
+            started = self._start_fit_worker(
+                fit_data,
+                self._params,
+                weights=weights,
+                multi=True,
+                step=step,
+                total=self._fit_2d_total,
+                on_success=_on_success,
+                on_timeout=_on_timeout,
+                on_error=_on_error,
+            )
         if not started:
             self._finish_fit_2d_sequence()
 
@@ -2476,6 +2644,10 @@ class Fit2DTool(Fit1DTool):
         data = erlab.interactive.utils.parse_data(new_data)
         if data.ndim != 2:
             raise ValueError("`data` must be a 2D DataArray")
+        if self._direct_weights_full is not None:
+            _validate_weights_input(data, self._direct_weights_full)
+        else:
+            _validate_uncertainty_input(data, self._uncertainty_full)
         return data
 
     def update_data(self, new_data: xr.DataArray) -> bool:
@@ -2512,6 +2684,59 @@ class Fit2DTool(Fit1DTool):
         self.save_full_button.setEnabled(can_save)
         self.copy_full_button.setEnabled(can_save)
 
+    def _direct_weights_for_full_fit_results(
+        self, fit_ranges: list[tuple[float, float]]
+    ) -> xr.DataArray | None:
+        """Return direct weights in the form used by the selected full fit."""
+        if self._direct_weights_full is None:
+            return None
+
+        weights = self._direct_weights_full
+        y_slice = self._y_range_slice()
+        if self._y_dim_name in weights.dims:
+            weights = weights.isel({self._y_dim_name: y_slice})
+
+        common_fit_range = self._common_fit_range(fit_ranges)
+        if (
+            self._coord_name in weights.dims
+            and common_fit_range is not None
+            and not self._fit_range_is_full(common_fit_range)
+        ):
+            weights = weights.sel(
+                {self._coord_name: self._fit_range_slice(common_fit_range)}
+            )
+
+        if self.normalize_check.isChecked():
+            normalization_factors: list[float] = []
+            selected_indices = range(
+                *y_slice.indices(self._data_full.sizes[self._y_dim_name])
+            )
+            for index, fit_range in zip(selected_indices, fit_ranges, strict=True):
+                fit_data = self._data_full.isel({self._y_dim_name: index})
+                if not self._fit_range_is_full(fit_range):
+                    fit_data = fit_data.sel(
+                        {self._coord_name: self._fit_range_slice(fit_range)}
+                    )
+                mean_value = float(np.nanmean(fit_data.values))
+                normalization_factors.append(
+                    abs(mean_value)
+                    if np.isfinite(mean_value) and not np.isclose(mean_value, 0.0)
+                    else 1.0
+                )
+
+            factor_coords: dict[Hashable, typing.Any] = {}
+            if self._y_dim_name in self._data_full.coords:
+                factor_coords[self._y_dim_name] = self._data_full.coords[
+                    self._y_dim_name
+                ].isel({self._y_dim_name: y_slice})
+            weights = weights * xr.DataArray(
+                normalization_factors,
+                dims=(self._y_dim_name,),
+                coords=factor_coords,
+            )
+
+        return weights.rename("modelfit_weights")
+
     @QtCore.Slot()
     def _save_fit_full(self) -> None:
         self._flush_restore_work()
@@ -2526,6 +2751,7 @@ class Fit2DTool(Fit1DTool):
                 )
                 return
             results.append(self._fit_result_with_range(ds))
+        fit_ranges = [self._fit_result_range(result) for result in results]
         with erlab.interactive.utils.wait_dialog(self, "Combining fit results..."):
             full_ds = xr.concat(
                 results,
@@ -2537,6 +2763,9 @@ class Fit2DTool(Fit1DTool):
                 combine_attrs="override",
             )
             full_ds = self._restore_fit_coord_order(full_ds)
+            direct_weights = self._direct_weights_for_full_fit_results(fit_ranges)
+            if direct_weights is not None:
+                full_ds["modelfit_weights"] = direct_weights
         erlab.interactive.utils.save_fit_ui(full_ds, parent=self)
 
     def _full_fit_parameter_specs(
@@ -2660,7 +2889,7 @@ class Fit2DTool(Fit1DTool):
     def _build_full_copy_prelude(
         self, *, warn: bool = True, input_name: str | None = None
     ) -> str:
-        data_name, _model_name, lines = self._make_model_code(
+        data_name, model_name, lines = self._make_model_code(
             input_name or self._data_name_full
         )
         parameters = self._full_fit_parameter_specs(warn=warn)
@@ -2670,8 +2899,15 @@ class Fit2DTool(Fit1DTool):
         isel_kw = erlab.interactive.utils.format_kwargs(
             {self._y_dim_name: self._y_range_slice()}
         )
+        input_data_name = data_name
         data_name = self._full_copy_fit_data_name(
-            data_name,
+            input_data_name,
+            isel_kw=isel_kw,
+            lines=lines,
+        )
+        self._full_copy_fit_weights_name(
+            input_data_name,
+            model_name,
             isel_kw=isel_kw,
             lines=lines,
         )
@@ -2689,6 +2925,7 @@ class Fit2DTool(Fit1DTool):
         *,
         isel_kw: str | None = None,
         lines: list[str] | None = None,
+        normalize: bool | None = None,
     ) -> str:
         if isel_kw is None:
             isel_kw = erlab.interactive.utils.format_kwargs(
@@ -2758,7 +2995,9 @@ class Fit2DTool(Fit1DTool):
                     )
             data_name = f"{data_name}_crop"
 
-        if self.normalize_check.isChecked():
+        if normalize is None:
+            normalize = self.normalize_check.isChecked()
+        if normalize:
             if lines is not None:
                 lines.append(
                     f"{data_name}_norm = "
@@ -2767,6 +3006,128 @@ class Fit2DTool(Fit1DTool):
             data_name = f"{data_name}_norm"
 
         return data_name
+
+    def _full_copy_fit_uncertainty_name(
+        self,
+        data_name: str,
+        model_name: str,
+        *,
+        isel_kw: str | None = None,
+        lines: list[str] | None = None,
+    ) -> str | None:
+        if self._uncertainty_full is None or self._direct_weights_full is not None:
+            return None
+        uncertainty_name = self._copy_uncertainty_name(data_name, model_name)
+        if lines is not None:
+            lines.append(
+                f"{uncertainty_name} = "
+                f"({self._uncertainty_name}).broadcast_like({data_name})"
+            )
+        uncertainty_name = self._full_copy_fit_data_name(
+            uncertainty_name,
+            isel_kw=isel_kw,
+            lines=lines,
+            normalize=False,
+        )
+        if self.normalize_check.isChecked():
+            raw_data_name = self._full_copy_fit_data_name(
+                data_name,
+                isel_kw=isel_kw,
+                normalize=False,
+            )
+            if lines is not None:
+                lines.append(
+                    f"{uncertainty_name}_norm = {uncertainty_name} / "
+                    f'abs({raw_data_name}.mean("{self._coord_name}"))'
+                )
+            uncertainty_name = f"{uncertainty_name}_norm"
+        return uncertainty_name
+
+    def _full_copy_fit_direct_weights_name(
+        self,
+        data_name: str,
+        model_name: str,
+        *,
+        isel_kw: str | None = None,
+        lines: list[str] | None = None,
+    ) -> str | None:
+        if self._direct_weights_full is None:
+            return None
+        weights_name = self._copy_weights_name(data_name, model_name)
+        if lines is not None:
+            lines.append(f"{weights_name} = {self._direct_weights_name}")
+
+        fit_ranges = self._selected_fit_ranges()
+        common_fit_range = (
+            self._common_fit_range(fit_ranges) if fit_ranges is not None else None
+        )
+        if fit_ranges is None:
+            fit_domain = self._fit_domain()
+            common_fit_range = (
+                self._data_fit_range(self._data_full)
+                if fit_domain is None
+                else self._canonical_fit_range(fit_domain)
+            )
+
+        if (
+            self._coord_name in self._direct_weights_full.dims
+            and common_fit_range is not None
+            and not self._fit_range_is_full(common_fit_range)
+        ):
+            fit_slice = self._fit_range_slice(common_fit_range)
+            sel_kw = erlab.interactive.utils.format_kwargs(
+                {self._coord_name: fit_slice}
+            )
+            if lines is not None:
+                lines.append(f"{weights_name}_crop = {weights_name}.sel({sel_kw})")
+            weights_name = f"{weights_name}_crop"
+
+        if self._y_dim_name in self._direct_weights_full.dims:
+            if isel_kw is None:
+                isel_kw = erlab.interactive.utils.format_kwargs(
+                    {self._y_dim_name: self._y_range_slice()}
+                )
+            if lines is not None:
+                lines.append(f"{weights_name}_slices = {weights_name}.isel({isel_kw})")
+            weights_name = f"{weights_name}_slices"
+
+        if self.normalize_check.isChecked():
+            raw_data_name = self._full_copy_fit_data_name(
+                data_name,
+                isel_kw=isel_kw,
+                normalize=False,
+            )
+            if lines is not None:
+                lines.append(
+                    f"{weights_name}_norm = {weights_name} * "
+                    f'abs({raw_data_name}.mean("{self._coord_name}"))'
+                )
+            weights_name = f"{weights_name}_norm"
+        return weights_name
+
+    def _full_copy_fit_weights_name(
+        self,
+        data_name: str,
+        model_name: str,
+        *,
+        isel_kw: str | None = None,
+        lines: list[str] | None = None,
+    ) -> str | None:
+        direct_weights_name = self._full_copy_fit_direct_weights_name(
+            data_name,
+            model_name,
+            isel_kw=isel_kw,
+            lines=lines,
+        )
+        if direct_weights_name is not None:
+            return direct_weights_name
+        uncertainty_name = self._full_copy_fit_uncertainty_name(
+            data_name,
+            model_name,
+            isel_kw=isel_kw,
+            lines=lines,
+        )
+        return None if uncertainty_name is None else f"1 / {uncertainty_name}"
 
     def _recorded_common_fit_range(self) -> tuple[float, float] | None:
         fit_ranges = self._selected_fit_ranges()
@@ -2783,15 +3144,24 @@ class Fit2DTool(Fit1DTool):
         data_name, model_name, _ = self._make_model_code(
             input_name or self._data_name_full
         )
-        data_name = self._full_copy_fit_data_name(data_name)
+        input_data_name = data_name
+        data_name = self._full_copy_fit_data_name(input_data_name)
+        weights_name = self._full_copy_fit_weights_name(
+            input_data_name,
+            model_name,
+        )
+        fit_kwargs: dict[str, typing.Any] = {
+            "model": f"|{model_name}|",
+            "params": "|params|",
+            "method": self.method_combo.currentText(),
+            "scale_covar": self.scale_covar_check.isChecked(),
+        }
+        if weights_name is not None:
+            fit_kwargs["weights"] = f"|{weights_name}|"
         return erlab.interactive.utils.generate_code(
             self._data_full.xlm.modelfit,
             args=[self._coord_name],
-            kwargs={
-                "model": f"|{model_name}|",
-                "params": "|params|",
-                "method": self.method_combo.currentText(),
-            },
+            kwargs=fit_kwargs,
             name="modelfit",
             module=f"{data_name}.xlm",
         )
@@ -2817,6 +3187,8 @@ class Fit2DTool(Fit1DTool):
     def current_provenance_spec(
         self, *, flush_deferred_restore: bool = True
     ) -> ToolProvenanceSpec | None:
+        if self._uncertainty_full is not None:
+            return None
         # Manager metadata and other passive provenance consumers should not trigger
         # interactive warnings for incomplete fit ranges.
         return self._resolve_script_provenance(
@@ -2853,7 +3225,7 @@ class Fit2DTool(Fit1DTool):
         source: QtCore.QObject | None = None,
     ) -> ToolProvenanceSpec | None:
         if source is None:
-            return self._resolve_script_provenance(self._DETACHED_COPY_PROVENANCE)
+            return self.current_provenance_spec()
         return super().detached_output_imagetool_provenance(
             data,
             source=source,
@@ -2895,6 +3267,8 @@ class Fit2DTool(Fit1DTool):
         parts = self._parameter_output_parts(output_id)
         if parts is None:
             return super().output_imagetool_provenance(output_id, data)
+        if not self._fit_is_current:
+            return None
         output, param_name = parts
         if param_name is None:
             current = self._current_param_output(
@@ -2907,12 +3281,16 @@ class Fit2DTool(Fit1DTool):
         request = self._resolve_parameter_output(output, param_name)
         if request is None:
             return None
+        if self._uncertainty_full is not None:
+            return None
         param_name, stderr = request
         return self._parameter_output_provenance(param_name, stderr=stderr, data=data)
 
     def _parameter_model_fit_operation(
         self, param_name: str, *, stderr: bool
     ) -> ModelFitOperation | None:
+        if not self.scale_covar_check.isChecked():
+            return None
         model_choice = self._infer_model_choice(self._model)
         if model_choice not in ModelFitOperation.supported_models:
             return None
@@ -3052,8 +3430,11 @@ def ftool(
     model: lmfit.Model | None = None,
     params: lmfit.Parameters | dict[str, typing.Any] | None = None,
     *,
+    uncertainty: xr.DataArray | None = None,
     data_name: str | None = None,
     model_name: str | None = None,
+    uncertainty_name: str | None = None,
+    scale_covar: bool | None = None,
     execute: bool | None = None,
 ) -> Fit1DTool | Fit2DTool:
     """Launch an interactive fitting tool.
@@ -3075,19 +3456,58 @@ def ftool(
         Initial parameters for the fit. If `None`, parameters will be initialized from
         the model. If `data` is 2D, `params` can be a dictionary that is interpreted
         like the ``params`` argument of :meth:`xarray.DataArray.xlm.modelfit`.
+    uncertainty
+        Absolute standard uncertainty of `data`. It must align with and broadcast to
+        `data`. Values must be finite and strictly positive wherever `data` is finite.
+        The fit uses its reciprocal as the lmfit weights.
     data_name : str, optional
         The name of the data variable, used in code generation. If `None`, an attempt
         will be made to infer the name from the calling context.
     model_name : str, optional
         The name of the model variable, used in code generation. If `None`, an attempt
         will be made to infer the name from the calling context.
+    uncertainty_name : str, optional
+        The name of the uncertainty variable, used in code generation. If `None`, an
+        attempt will be made to infer the name from the calling context.
+    scale_covar
+        Whether lmfit scales the parameter covariance by reduced chi-square. If `None`,
+        the default is `True` without `uncertainty` and `False` with `uncertainty`.
+        A restored fit result keeps its saved setting when all results agree and the
+        saved weighting is available.
     """
     fit_ds: xr.Dataset | None = None
+    fit_ds_scale_covar: bool | None = None
+    fit_ds_weighted: bool | None = None
+    fit_ds_weights: xr.DataArray | None = None
+    fit_ds_weights_name: str | None = None
+    saved_weighting_reproducible = False
     if isinstance(data, xr.Dataset):
         fit_ds = data
+        fit_ds_scale_covar, fit_ds_weighted = _fit_dataset_settings(fit_ds)
         data = Fit1DTool._extract_fit_data(fit_ds)
         if data_name is None:
-            data_name = "data"
+            try:
+                fit_ds_name = str(varname.argname("data", func=ftool, vars_only=False))
+            except Exception:
+                fit_ds_name = "fit_result"
+        else:
+            fit_ds_name = data_name
+        data_name = f"({fit_ds_name})['modelfit_data']"
+        if (
+            uncertainty is None
+            and fit_ds_weighted is True
+            and "modelfit_weights" in fit_ds
+        ):
+            with contextlib.suppress(TypeError, ValueError):
+                fit_ds_weights = _validate_weights_input(
+                    data, fit_ds["modelfit_weights"]
+                )
+                fit_ds_weights_name = f"({fit_ds_name})['modelfit_weights']"
+        saved_weighting_reproducible = (
+            fit_ds_weighted is False and "modelfit_weights" not in fit_ds
+        ) or (fit_ds_weighted is True and fit_ds_weights is not None)
+        if scale_covar is None and uncertainty is None and saved_weighting_reproducible:
+            scale_covar = fit_ds_scale_covar
         params = None
     elif data_name is None:
         try:
@@ -3099,6 +3519,13 @@ def ftool(
             model_name = str(varname.argname("model", func=ftool, vars_only=False))
         except Exception:
             model_name = "model"
+    if uncertainty is not None and uncertainty_name is None:
+        try:
+            uncertainty_name = str(
+                varname.argname("uncertainty", func=ftool, vars_only=False)
+            )
+        except Exception:
+            uncertainty_name = "uncertainty"
     match data.ndim:
         case 1:
             tool_cls = Fit1DTool
@@ -3107,13 +3534,33 @@ def ftool(
         case _:
             raise ValueError("`data` must be a 1D or 2D DataArray")
     with _patch_encode4js(), erlab.interactive.utils.setup_qapp(execute):
-        win = tool_cls(data, model, params, data_name=data_name, model_name=model_name)
+        win = tool_cls(
+            data,
+            model,
+            params,
+            uncertainty=uncertainty,
+            data_name=data_name,
+            model_name=model_name,
+            uncertainty_name=uncertainty_name,
+            scale_covar=scale_covar,
+        )
         if fit_ds is not None:
             try:
                 win._restore_from_fit_dataset(fit_ds, model=model)
             except Exception:
                 win.close()
                 raise
+            if fit_ds_weights is not None:
+                win._set_direct_weights(
+                    fit_ds_weights, weights_name=fit_ds_weights_name
+                )
+            if (
+                uncertainty is not None
+                or not saved_weighting_reproducible
+                or fit_ds_scale_covar is None
+                or win.scale_covar_check.isChecked() != fit_ds_scale_covar
+            ):
+                win._mark_fit_stale()
         win.show()
         win.raise_()
         win.activateWindow()

--- a/src/erlab/interactive/_mesh.py
+++ b/src/erlab/interactive/_mesh.py
@@ -5,6 +5,7 @@ import enum
 import importlib.resources
 import os
 import typing
+from collections.abc import Mapping
 
 import numpy as np
 import numpy.typing as npt
@@ -533,9 +534,9 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
             self.corr_fft_image.setImage(log_magnitude_corr)
         self._notify_data_changed()
 
-    def update_data(self, new_data: xr.DataArray) -> None:
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
         status = self.tool_status
-        new_data = self.validate_update_data(new_data)
+        new_data = inputs["data"]
 
         self._data = new_data
         self._corrected = None
@@ -559,11 +560,13 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
             self._notify_data_changed()
         self._reset_history_stack()
 
-    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
-        data = erlab.interactive.utils.parse_data(new_data)
+    def validate_update_inputs(
+        self, inputs: Mapping[str, xr.DataArray]
+    ) -> Mapping[str, xr.DataArray]:
+        data = erlab.interactive.utils.parse_data(inputs["data"])
         if not all(dim in data.dims for dim in {"alpha", "eV"}):
             raise ValueError("Input DataArray must have 'alpha' and 'eV' dimensions.")
-        return data
+        return {"data": data}
 
     @QtCore.Slot()
     def _corr_itool(self) -> None:
@@ -598,28 +601,28 @@ class MeshTool(erlab.interactive.utils.ToolWindow):
     def _provenance_seed_code(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
         del data
-        return f"derived = {input_name or self.data_name}"
+        return f"derived = {primary_input or self.data_name}"
 
     def _corrected_provenance(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> RemoveMeshOperation:
-        del input_name, data
+        del primary_input, data
         return self._mesh_provenance_operation(output="corrected")
 
     def _mesh_provenance(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> RemoveMeshOperation:
-        del input_name, data
+        del primary_input, data
         return self._mesh_provenance_operation(output="mesh")
 
     def _corrected_output(self) -> xr.DataArray | None:

--- a/src/erlab/interactive/derivative.py
+++ b/src/erlab/interactive/derivative.py
@@ -29,7 +29,7 @@ import enum
 import functools
 import importlib.resources
 import typing
-from collections.abc import Callable, Hashable
+from collections.abc import Callable, Hashable, Mapping
 
 import numpy as np
 import pydantic
@@ -494,9 +494,9 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
         if tool is not None:
             self._itool = tool
 
-    def update_data(self, new_data: xr.DataArray) -> None:
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
         status = self.tool_status
-        data = self.validate_update_data(new_data)
+        data = inputs["data"]
 
         data_has_nan = bool(data.isnull().any())
         if data_has_nan:
@@ -512,11 +512,13 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
             self.update_preprocess()
         self._reset_history_stack()
 
-    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
-        data = erlab.interactive.utils.parse_data(new_data)
+    def validate_update_inputs(
+        self, inputs: Mapping[str, xr.DataArray]
+    ) -> Mapping[str, xr.DataArray]:
+        data = erlab.interactive.utils.parse_data(inputs["data"])
         if data.ndim != 2:
             raise ValueError("Input DataArray must be 2D")
-        return data
+        return {"data": data}
 
     def _result_provenance(
         self, *, transpose_output: bool = False
@@ -567,28 +569,28 @@ class DerivativeTool(erlab.interactive.utils.ToolWindow):
     def _provenance_seed_code(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
         del data
-        return f"derived = {input_name or self.data_name}"
+        return f"derived = {primary_input or self.data_name}"
 
     def _copy_provenance(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> tuple[ToolProvenanceOperation, ...]:
-        del input_name, data
+        del primary_input, data
         return self._result_provenance()
 
     def _output_provenance(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> tuple[ToolProvenanceOperation, ...]:
-        del input_name, data
+        del primary_input, data
         return self._result_provenance(transpose_output=True)
 
     def _result_output_data(self) -> xr.DataArray:

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -606,10 +606,6 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         self._fit_task: EdgeFitTask | None = None
         self._fit_closing = False
         self.sigAbortFitting.connect(self._abort_fit_task)
-        self._pending_update_request: _GoldUpdateRequest | None = None
-        self._pending_update_timer = QtCore.QTimer(self)
-        self._pending_update_timer.setSingleShot(True)
-        self._pending_update_timer.timeout.connect(self._flush_pending_update)
 
         # Resize roi to data bounds
         eV_span = self.data.eV.values[-1] - self.data.eV.values[0]
@@ -1094,42 +1090,26 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         self._reset_history_stack()
 
         if request.had_fit and request.refit:
-            self._source_refresh_deferred = self.has_source_binding
             self.perform_edge_fit()
+            if self._fit_task is None:
+                return True
+            if self._source_refreshing:
+                self._defer_source_refresh()
             return False
         return True
 
-    @QtCore.Slot()
-    def _flush_pending_update(self) -> None:
-        request = self._pending_update_request
-        if request is None:
-            return
-        if self._threadpool.activeThreadCount():
-            self._pending_update_timer.start(50)
-            return
-        self._pending_update_request = None
-        if self._apply_update_request(request):
-            self.finalize_source_refresh()
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+        return self._apply_update_request(self._make_update_request(inputs["data"]))
 
-    def update_data(self, new_data: xr.DataArray) -> bool:
-        self._source_refresh_deferred = False
-        data = self.validate_update_data(new_data)
-        request = self._make_update_request(data)
-        self._pending_update_request = request
-        self._abort_fit_task()
-        if self._threadpool.activeThreadCount():
-            self._pending_update_timer.start(50)
-            return False
-        self._pending_update_request = None
-        return self._apply_update_request(request)
-
-    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
-        data = erlab.interactive.utils.parse_data(new_data)
+    def validate_update_inputs(
+        self, inputs: Mapping[str, xr.DataArray]
+    ) -> Mapping[str, xr.DataArray]:
+        data = erlab.interactive.utils.parse_data(inputs["data"])
         if data.ndim != 2 or "eV" not in data.dims:
             raise ValueError("`data` must be a 2D DataArray with an `eV` dimension")
         if data.dims[0] != "eV":
             data = data.copy().T
-        return data
+        return {"data": data}
 
     def _toggle_step_edge(self) -> None:
         self.params_edge.widgets["Fix T"].setDisabled(
@@ -1164,11 +1144,7 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
     @QtCore.Slot()
     def perform_edge_fit(self) -> None:
-        if (
-            self._pending_update_request is not None
-            or self._fit_closing
-            or not erlab.interactive.utils.qt_is_valid(self)
-        ):
+        if self._fit_closing or not erlab.interactive.utils.qt_is_valid(self):
             return
         self.progress.setVisible(True)
         self.params_roi.draw_button.setChecked(False)
@@ -1206,7 +1182,11 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
         task.signals.sigFailed.connect(
             lambda message, task=task: self._handle_fit_failed(message, task=task)
         )
-        self._threadpool.start(task)
+        try:
+            self._threadpool.start(task)
+        except Exception:
+            self._handle_fit_failed(traceback.format_exc(), task=task)
+            return
         self._emit_info_changed()
 
     def _show_empty_fit_selection_warning(self) -> None:
@@ -1270,12 +1250,16 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     def _abort_fit_task(self) -> None:
         task = self._fit_task
         if task is None:
+            if self._source_refresh_deferred:
+                self.finalize_source_refresh()
             return
         self._fit_task = None
         self._disconnect_fit_task_signals(task)
         task.abort_fit()
         self.progress.reset()
         self._emit_info_changed()
+        if self._source_refresh_deferred:
+            self.finalize_source_refresh()
 
     def _handle_fit_failed(
         self, message: str, *, task: EdgeFitTask | None = None
@@ -1297,6 +1281,8 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
             "An error occurred during fitting. See details below.",
             detailed_text=erlab.interactive.utils._format_traceback(message),
         )
+        if self._source_refresh_deferred:
+            self.finalize_source_refresh()
 
     @property
     def edge_func(self) -> "Callable":
@@ -1498,9 +1484,10 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     def _current_mode_copy_label(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
+        del primary_input, data
         return self._copy_label(
             self._current_fit_mode(), include_corrected=self.data_corr is not None
         )
@@ -1508,68 +1495,74 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
     def _current_mode_copy_assign(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
+        del primary_input, data
         return "corrected" if self.data_corr is not None else "model_result"
 
     def _current_mode_corrected_label(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
+        del primary_input, data
         return self._copy_label(self._current_fit_mode(), include_corrected=True)
 
     def _current_mode_copy_expression(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
+        del data
         if self.data_corr is not None:
             return self._corrected_expression(
                 self._current_fit_mode(),
-                input_name=input_name,
+                input_name=primary_input,
             )
         return self._fit_expression(
             self._current_fit_mode(),
-            input_name=input_name,
+            input_name=primary_input,
         )
 
     def _current_mode_copy_prelude(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
+        del data
         if self.data_corr is None:
             return ""
         return "model_result = " + self._fit_expression(
             self._current_fit_mode(),
-            input_name=input_name,
+            input_name=primary_input,
         )
 
     def _current_mode_corrected_prelude(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
+        del data
         return "model_result = " + self._fit_expression(
             self._current_fit_mode(),
-            input_name=input_name,
+            input_name=primary_input,
         )
 
     def _current_mode_corrected_expression(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
+        del data
         return self._corrected_expression(
             self._current_fit_mode(),
-            input_name=input_name,
+            input_name=primary_input,
         )
 
     def _corrected_output(self) -> xr.DataArray:
@@ -1585,8 +1578,6 @@ class GoldTool(erlab.interactive.utils.AnalysisWindow):
 
     def _stop_server(self, *, timeout_ms: int | None = None) -> bool:
         """Stop the fitter thread properly."""
-        self._pending_update_request = None
-        self._pending_update_timer.stop()
         self._abort_fit_task()
         if timeout_ms is None:
             timeout_ms = self.BACKGROUND_TASK_TIMEOUT_MS
@@ -2071,7 +2062,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
     def _cancel_background_work(self, *, timeout_ms: int) -> bool:
         return self._cancel_fit(wait=True, timeout_ms=timeout_ms)
 
-    def update_data(self, new_data: xr.DataArray) -> bool:
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
         had_fit = self._result_ds is not None
         status = self.tool_status.model_copy(
             update={"results": ("No fit results", "—", "—", "—", "—")}
@@ -2087,20 +2078,24 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
             self._reset_history_stack()
 
             if had_fit and self.refit_on_source_update_check.isChecked():
-                self._source_refresh_deferred = self.has_source_binding
-                self.do_fit()
+                if not self.do_fit():
+                    return True
+                if self._source_refreshing:
+                    self._defer_source_refresh()
                 return False
             return True
 
-        return self._perform_source_update(new_data, apply_update=_apply_update)
+        return _apply_update(inputs["data"])
 
-    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
-        data = erlab.interactive.utils.parse_data(new_data)
+    def validate_update_inputs(
+        self, inputs: Mapping[str, xr.DataArray]
+    ) -> Mapping[str, xr.DataArray]:
+        data = erlab.interactive.utils.parse_data(inputs["data"])
         if (data.ndim != 2) or ("eV" not in data.dims):
             raise ValueError("Data must be 2D and have an 'eV' dimension.")
         if data.dims.index("eV") != 1:
             data = data.T
-        return data
+        return {"data": data}
 
     def _update_edc(self) -> None:
         """Calculate averaged EDC and update the plot."""
@@ -2211,14 +2206,21 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         was_cancelled = self._fit_cancel_requested
         self._fit_cancel_requested = False
         closing = self._fit_closing or not erlab.interactive.utils.qt_is_valid(self)
-        if action is not None and not closing:
-            action()
-        if self._fit_queued and not was_cancelled and not closing:
+        restart_started = False
+        try:
+            if action is not None and not closing:
+                action()
+            restart_requested = self._fit_queued and not was_cancelled and not closing
             self._fit_queued = False
-            self._start_fit_worker()
-        elif closing:
+            if restart_requested:
+                restart_started = self._start_fit_worker()
+        except Exception:
             self._fit_queued = False
-        thread.deleteLater()
+            self._handle_fit_error(traceback.format_exc(), self._fit_signature_current)
+        finally:
+            thread.deleteLater()
+            if self._source_refresh_deferred and not restart_started:
+                self.finalize_source_refresh()
 
     def _start_fit_worker(self) -> bool:
         if (
@@ -2265,7 +2267,15 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
 
         self._fit_thread = thread
         self._fit_cancel_requested = False
-        thread.start()
+        try:
+            thread.start()
+        except Exception:
+            self._fit_thread = None
+            with contextlib.suppress(Exception):
+                thread.deleteLater()
+            logger.exception("Failed to start resolution fit worker")
+            self._fit_failed("Fit failed to start")
+            return False
         return True
 
     def _handle_fit_cancelled(self) -> None:
@@ -2285,7 +2295,7 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self._replace_last_state()
 
     def _handle_fit_error(
-        self, message: str, fit_signature: tuple[typing.Any, ...]
+        self, message: str, fit_signature: tuple[typing.Any, ...] | None
     ) -> None:
         if fit_signature != self._fit_signature_current:
             return
@@ -2350,18 +2360,21 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         with self._history_suppressed():
             self._emit_info_changed()
         self._replace_last_state()
-        if self._source_refresh_deferred:
-            self.finalize_source_refresh()
 
     @QtCore.Slot()
-    def do_fit(self) -> None:
+    def do_fit(self) -> bool:
         """Perform a fit on the averaged EDC and update results."""
         self._invalidate_displayed_fit_if_stale()
         if self._fit_running():
             self._fit_queued = True
-            return
+            return False
         self._fit_queued = False
-        self._start_fit_worker()
+        try:
+            return self._start_fit_worker()
+        except Exception:
+            logger.exception("Failed to prepare resolution fit worker")
+            self._fit_failed("Fit failed to start")
+            return False
 
     def connect_signals(self) -> None:
         self.x0_spin.valueChanged.connect(self._update_region)
@@ -2414,14 +2427,14 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
     def _copy_expression(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
         data_name = erlab.interactive.utils.generate_code(
             xr.DataArray.sel,
             args=[],
             kwargs={self.y_dim: slice(*self.y_range)},
-            module=input_name or self.data_name,
+            module=primary_input or self.data_name,
         )
 
         # Check if any parameters are the same as the automatically guessed ones

--- a/src/erlab/interactive/imagetool/_provenance/_code.py
+++ b/src/erlab/interactive/imagetool/_provenance/_code.py
@@ -798,25 +798,10 @@ class _ScopeAwareTransformer(ast.NodeTransformer):
     visit_GeneratorExp = _visit_comprehension
 
 
-class _ModuleNameReplacer(_ScopeAwareTransformer):
-    def __init__(self, code: str, target: str, replacement: ast.expr) -> None:
+class _ModuleNameLoadCounter(_ScopeAwareTransformer):
+    def __init__(self, code: str, target: str) -> None:
         super().__init__(code)
         self._target = target
-        self._replacement = replacement
-
-    def visit_Name(self, node: ast.Name) -> ast.AST:
-        if (
-            node.id == self._target
-            and isinstance(node.ctx, ast.Load)
-            and self._resolves_to_module(node.id)
-        ):
-            return _clone_expr(self._replacement)
-        return node
-
-
-class _ModuleNameLoadCounter(_ModuleNameReplacer):
-    def __init__(self, code: str, target: str) -> None:
-        super().__init__(code, target, ast.Name(id=target, ctx=ast.Load()))
         self.count = 0
 
     def visit_Name(self, node: ast.Name) -> ast.AST:
@@ -826,26 +811,6 @@ class _ModuleNameLoadCounter(_ModuleNameReplacer):
             and self._resolves_to_module(node.id)
         ):
             self.count += 1
-        return node
-
-
-class _ModuleNameReplacementCollisionDetector(_ScopeAwareTransformer):
-    def __init__(self, code: str, target: str, replacement_names: set[str]) -> None:
-        super().__init__(code)
-        self._target = target
-        self._replacement_names = replacement_names
-        self.collision = False
-
-    def visit_Name(self, node: ast.Name) -> ast.AST:
-        if (
-            node.id == self._target
-            and isinstance(node.ctx, ast.Load)
-            and self._resolves_to_module(node.id)
-            and any(
-                not self._resolves_to_module(name) for name in self._replacement_names
-            )
-        ):
-            self.collision = True
         return node
 
 
@@ -1198,97 +1163,6 @@ def _code_uses_name_any_scope(code: str, name: str) -> bool:
         and isinstance(node.ctx, ast.Load)
         for node in ast.walk(module)
     )
-
-
-def _scope_identifiers(table: symtable.SymbolTable) -> set[str]:
-    identifiers = set(table.get_identifiers())
-    for child in table.get_children():
-        identifiers.update(_scope_identifiers(child))
-    return identifiers
-
-
-def _collision_free_source_name(code: str, input_expr: ast.expr) -> str:
-    unavailable = _scope_identifiers(symtable.symtable(code, "<provenance>", "exec"))
-    unavailable.update(
-        node.id for node in ast.walk(input_expr) if isinstance(node, ast.Name)
-    )
-    name = "source_data"
-    suffix = 2
-    while name in unavailable:
-        name = f"source_data_{suffix}"
-        suffix += 1
-    return name
-
-
-def rebase_default_replay_input(code: str, input_name: str) -> str:
-    """Replace the generic ``data`` replay input in generated code.
-
-    Manager clipboard actions use this when a concrete source is known, such as a
-    watched variable, a load snippet target, or a user-provided variable name.
-    """
-    if not _code_uses_name(code, "data"):
-        return code
-
-    try:
-        input_expr = ast.parse(input_name, mode="eval").body
-        module = ast.parse(code, mode="exec")
-    except SyntaxError:
-        return code
-
-    replacement_names = {
-        node.id
-        for node in ast.walk(input_expr)
-        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
-    }
-    collision_detector = _ModuleNameReplacementCollisionDetector(
-        code,
-        "data",
-        replacement_names,
-    )
-    collision_detector.visit(module)
-    source_assignment: ast.Assign | None = None
-    if collision_detector.collision:
-        source_name = _collision_free_source_name(code, input_expr)
-        source_assignment = ast.Assign(
-            targets=[ast.Name(id=source_name, ctx=ast.Store())],
-            value=input_expr,
-        )
-        input_expr = ast.Name(id=source_name, ctx=ast.Load())
-
-    replacer = _ModuleNameReplacer(code, "data", input_expr)
-    rebased = typing.cast("ast.Module", replacer.visit(module))
-    _remove_unused_generated_import_relays(
-        rebased,
-        replacer.generated_import_relay_ids,
-    )
-    if source_assignment is not None:
-        insert_at = 0
-        if (
-            rebased.body
-            and isinstance(rebased.body[0], ast.Expr)
-            and isinstance(rebased.body[0].value, ast.Constant)
-            and isinstance(rebased.body[0].value.value, str)
-        ):
-            insert_at = 1
-        while insert_at < len(rebased.body):
-            statement = rebased.body[insert_at]
-            if not (
-                isinstance(statement, ast.ImportFrom)
-                and statement.module == "__future__"
-            ):
-                break
-            insert_at += 1
-        rebased.body.insert(insert_at, source_assignment)
-    rebased = ast.fix_missing_locations(rebased)
-    return _simplify_display_code(
-        ast.unparse(rebased),
-        inline_targets={"derived"},
-    )
-
-
-def uses_default_replay_input(code: str) -> bool:
-    """Return whether generated replay code refers to the generic ``data`` input."""
-    return _code_uses_name(code, "data")
 
 
 def _receiver_path(node: ast.AST) -> tuple[str, tuple[str, ...]] | None:

--- a/src/erlab/interactive/imagetool/_provenance/_execution.py
+++ b/src/erlab/interactive/imagetool/_provenance/_execution.py
@@ -566,7 +566,7 @@ def file_load_source_status(
 @dataclass(frozen=True)
 class _ReplayCapability:
     replayable: bool = False
-    requires_trust: bool = False
+    replayable_with_code: bool = False
     reloadable: bool = False
 
 
@@ -618,10 +618,9 @@ def _analyze_replay_capability(
     check_reloadability: bool = True,
 ) -> _ReplayCapability:
     if spec.kind == "file":
-        loadable = file_load_source_status(spec) == "loadable"
         return _ReplayCapability(
-            replayable=True,
-            reloadable=check_reloadability and loadable,
+            reloadable=check_reloadability
+            and file_load_source_status(spec) == "loadable",
         )
     if spec.kind != "script":
         return _ReplayCapability()
@@ -629,8 +628,6 @@ def _analyze_replay_capability(
         raise ReplayGraphError(
             "Nested script provenance exceeded the maximum reload depth"
         )
-    child_capabilities: list[_ReplayCapability] = []
-    inputs_replayable = True
     inputs_reloadable = True
     for script_input in spec.script_inputs:
         if script_input.name in (external_input_names or ()) or (
@@ -641,9 +638,7 @@ def _analyze_replay_capability(
             continue
         input_spec = input_provenance_resolver(script_input)
         if input_spec is None:
-            inputs_replayable = False
             inputs_reloadable = False
-            child_capabilities.append(_ReplayCapability())
             continue
         capability = _analyze_replay_capability(
             input_spec,
@@ -653,19 +648,11 @@ def _analyze_replay_capability(
             depth + int(input_spec.kind == "script"),
             check_reloadability=check_reloadability,
         )
-        child_capabilities.append(capability)
-        inputs_replayable &= capability.replayable
         inputs_reloadable &= capability.reloadable
 
     local_strict = _script_validates(spec, external_input_names, True)
-    local_permissive = local_strict or _script_validates(
-        spec, external_input_names, False
-    )
-    replayable = local_permissive and inputs_replayable
-    requires_trust = replayable and (
-        not local_strict
-        or any(capability.requires_trust for capability in child_capabilities)
-    )
+    local_trusted = local_strict or _script_validates(spec, external_input_names, False)
+    replayable = local_strict
     file_source_reloadable = (
         not check_reloadability
         or spec.file_load_source is None
@@ -674,11 +661,10 @@ def _analyze_replay_capability(
     reloadable = (
         check_reloadability
         and replayable
-        and not requires_trust
         and inputs_reloadable
         and file_source_reloadable
     )
-    return _ReplayCapability(replayable, requires_trust, reloadable)
+    return _ReplayCapability(replayable, local_trusted, reloadable)
 
 
 def _compile_replay_preflight(
@@ -810,7 +796,7 @@ def script_provenance_replayable(
         external_input_names=external_input_names,
         live_input_resolver=live_input_resolver,
     )
-    return capability.replayable and (allow_code or not capability.requires_trust)
+    return capability.replayable_with_code if allow_code else capability.replayable
 
 
 def _script_provenance_validates(
@@ -831,19 +817,6 @@ def _script_provenance_validates(
     except (ReplayGraphError, TypeError, ValueError):
         return False
     return True
-
-
-def script_provenance_requires_trust(
-    spec: typing.Any,
-    *,
-    external_input_names: set[str] | None = None,
-    live_input_resolver: LiveInputResolver | None = None,
-) -> bool:
-    return _replay_capability(
-        spec,
-        external_input_names=external_input_names,
-        live_input_resolver=live_input_resolver,
-    ).requires_trust
 
 
 def replay_script_provenance(
@@ -960,9 +933,9 @@ def rebuild_script_inputs(
     """Resolve named inputs and refresh their durable source snapshots.
 
     Live manager nodes take priority. If ``allow_recorded`` is true and a live node is
-    unavailable, the recorded script or file provenance is replayed. The optional
-    The document host authorizes executable recorded provenance at its final replay
-    boundary. All inputs are resolved before the caller mutates a ToolWindow.
+    unavailable, the recorded script or file provenance is replayed. The document
+    host authorizes executable recorded provenance at its final replay boundary. All
+    inputs are resolved before the caller mutates a ToolWindow.
     """
     replay_cache = {} if cache is None else cache
     resolve_live = _memoized_live_input_resolver(live_input_resolver)

--- a/src/erlab/interactive/imagetool/_provenance/_execution.py
+++ b/src/erlab/interactive/imagetool/_provenance/_execution.py
@@ -564,10 +564,9 @@ def file_load_source_status(
 
 
 @dataclass(frozen=True)
-class _ReplayCapability:
-    replayable: bool = False
-    replayable_with_code: bool = False
-    reloadable: bool = False
+class _ScriptReplayValidation:
+    strict_replayable: bool = False
+    permissive_replayable: bool = False
 
 
 def _require_file_load_source(load_source: FileLoadSource) -> None:
@@ -592,79 +591,70 @@ def _validate_replay_graph_file_sources(graph: ReplayGraph) -> None:
             _require_file_load_source(node.payload["load_source"])
 
 
-def _script_validates(
-    spec: ToolProvenanceSpec,
-    external_input_names: set[str] | None,
-    strict: bool,
+def _script_provenance_validates(
+    spec: typing.Any,
+    *,
+    external_input_names: set[str] | None = None,
+    strict_replay_code: bool,
 ) -> bool:
+    parsed = parse_tool_provenance_spec(spec)
+    if parsed is None or parsed.kind != "script":
+        return False
     try:
         _validate_script_provenance(
-            spec,
+            parsed,
             external_input_names=external_input_names,
-            strict_replay_code=strict,
+            strict_replay_code=strict_replay_code,
         )
     except (ReplayGraphError, TypeError, ValueError):
         return False
     return True
 
 
-def _analyze_replay_capability(
+def _analyze_script_replay_validation(
     spec: ToolProvenanceSpec,
     external_input_names: set[str] | None,
     live_input_resolver: LiveInputResolver | None,
     input_provenance_resolver: InputProvenanceResolver,
     depth: int,
-    *,
-    check_reloadability: bool = True,
-) -> _ReplayCapability:
-    if spec.kind == "file":
-        return _ReplayCapability(
-            reloadable=check_reloadability
-            and file_load_source_status(spec) == "loadable",
-        )
+) -> _ScriptReplayValidation:
     if spec.kind != "script":
-        return _ReplayCapability()
+        return _ScriptReplayValidation()
     if depth > _MAX_SCRIPT_REPLAY_DEPTH:
         raise ReplayGraphError(
             "Nested script provenance exceeded the maximum reload depth"
         )
-    inputs_reloadable = True
     for script_input in spec.script_inputs:
         if script_input.name in (external_input_names or ()) or (
             live_input_resolver is not None
             and live_input_resolver(script_input) is not None
         ):
-            inputs_reloadable = False
             continue
         input_spec = input_provenance_resolver(script_input)
         if input_spec is None:
-            inputs_reloadable = False
             continue
-        capability = _analyze_replay_capability(
+        _analyze_script_replay_validation(
             input_spec,
             None,
             live_input_resolver,
             input_provenance_resolver,
             depth + int(input_spec.kind == "script"),
-            check_reloadability=check_reloadability,
         )
-        inputs_reloadable &= capability.reloadable
 
-    local_strict = _script_validates(spec, external_input_names, True)
-    local_trusted = local_strict or _script_validates(spec, external_input_names, False)
-    replayable = local_strict
-    file_source_reloadable = (
-        not check_reloadability
-        or spec.file_load_source is None
-        or file_load_source_status(spec) == "loadable"
+    strict_replayable = _script_provenance_validates(
+        spec,
+        external_input_names=external_input_names,
+        strict_replay_code=True,
     )
-    reloadable = (
-        check_reloadability
-        and replayable
-        and inputs_reloadable
-        and file_source_reloadable
+    permissive_replayable = strict_replayable or _script_provenance_validates(
+        spec,
+        external_input_names=external_input_names,
+        strict_replay_code=False,
     )
-    return _ReplayCapability(replayable, local_trusted, reloadable)
+    return _ScriptReplayValidation(
+        strict_replayable=strict_replayable,
+        permissive_replayable=permissive_replayable,
+    )
 
 
 def _compile_replay_preflight(
@@ -683,17 +673,17 @@ def _compile_replay_preflight(
     )
 
 
-def _replay_capability(
+def _script_replay_validation(
     value: typing.Any,
     *,
     external_input_names: set[str] | None = None,
     live_input_resolver: LiveInputResolver | None = None,
-) -> _ReplayCapability:
+) -> _ScriptReplayValidation:
     try:
         spec = parse_tool_provenance_spec(value)
         if spec is None:
-            return _ReplayCapability()
-        return _analyze_replay_capability(
+            return _ScriptReplayValidation()
+        return _analyze_script_replay_validation(
             spec,
             external_input_names,
             _memoized_live_input_resolver(live_input_resolver),
@@ -701,7 +691,7 @@ def _replay_capability(
             0,
         )
     except (ReplayGraphError, TypeError, ValueError):
-        return _ReplayCapability()
+        return _ScriptReplayValidation()
 
 
 def _can_reload_provenance(
@@ -791,32 +781,14 @@ def script_provenance_replayable(
     live_input_resolver: LiveInputResolver | None = None,
 ) -> bool:
     """Return whether a script can replay with the supplied input namespace."""
-    capability = _replay_capability(
+    validation = _script_replay_validation(
         spec,
         external_input_names=external_input_names,
         live_input_resolver=live_input_resolver,
     )
-    return capability.replayable_with_code if allow_code else capability.replayable
-
-
-def _script_provenance_validates(
-    spec: typing.Any,
-    *,
-    external_input_names: set[str] | None = None,
-    strict_replay_code: bool,
-) -> bool:
-    parsed = parse_tool_provenance_spec(spec)
-    if parsed is None or parsed.kind != "script":
-        return False
-    try:
-        _validate_script_provenance(
-            parsed,
-            external_input_names=external_input_names,
-            strict_replay_code=strict_replay_code,
-        )
-    except (ReplayGraphError, TypeError, ValueError):
-        return False
-    return True
+    return (
+        validation.permissive_replayable if allow_code else validation.strict_replayable
+    )
 
 
 def replay_script_provenance(

--- a/src/erlab/interactive/imagetool/_provenance/_execution.py
+++ b/src/erlab/interactive/imagetool/_provenance/_execution.py
@@ -7,6 +7,7 @@ import importlib
 import pathlib
 import typing
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 
 import numpy as np
 import xarray as xr
@@ -26,9 +27,12 @@ from erlab.interactive.imagetool._provenance._code import (
 )
 from erlab.interactive.imagetool._provenance._graph import (
     _REPLAY_ALIASES,
+    InputProvenanceResolver,
     LiveInputResolver,
     ReplayGraph,
     ReplayGraphError,
+    _memoized_by_identity,
+    _memoized_input_provenance_resolver,
     _validate_script_provenance,
     compile_replay_graph,
 )
@@ -36,6 +40,7 @@ from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     FileLoadSource,
     FileLoadSourceStatus,
+    ScriptInput,
     ToolProvenanceSpec,
     _script_input_reference_text,
     has_file_load_source,
@@ -62,6 +67,14 @@ if typing.TYPE_CHECKING:
 
 
 ExecutionAuthorizer = Callable[[tuple[typing.Any, ...]], object | None]
+_MAX_SCRIPT_REPLAY_DEPTH = 20
+
+
+def _memoized_live_input_resolver(
+    resolver: LiveInputResolver | None,
+) -> LiveInputResolver | None:
+    """Cache one live-input decision for each exact input object."""
+    return None if resolver is None else _memoized_by_identity(resolver)
 
 
 def _processed_replay_ndim(darr: xr.DataArray) -> int:
@@ -483,20 +496,13 @@ def replay_file_provenance(
         raise TypeError("Expected structured file provenance") from exc
 
 
-def file_load_source_status(
-    value: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
+def _file_load_source_status(
+    load_source: FileLoadSource | None,
     *,
     extension_status_resolver: _CapabilityStatusResolver | None = None,
 ) -> FileLoadSourceStatus:
-    """Return the current availability of the recorded file-load source.
-
-    A managed ImageTool can supply its own resolver so session-specific extension
-    validation failures do not affect other manager instances.
-    """
-    spec = parse_tool_provenance_spec(value)
-    if spec is None or spec.file_load_source is None:
+    if load_source is None:
         return "no-file-load-source"
-    load_source = spec.file_load_source
     if not pathlib.Path(load_source.path).exists():
         return "missing-file"
     replay_call = load_source.replay_call
@@ -538,6 +544,178 @@ def file_load_source_status(
         if capability_status == "validation-failed":
             return "extension-validation-failed"
     return "loadable"
+
+
+def file_load_source_status(
+    value: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
+    *,
+    extension_status_resolver: _CapabilityStatusResolver | None = None,
+) -> FileLoadSourceStatus:
+    """Return the current availability of the recorded file-load source.
+
+    A managed ImageTool can supply its own resolver so session-specific extension
+    validation failures do not affect other manager instances.
+    """
+    spec = parse_tool_provenance_spec(value)
+    return _file_load_source_status(
+        None if spec is None else spec.file_load_source,
+        extension_status_resolver=extension_status_resolver,
+    )
+
+
+@dataclass(frozen=True)
+class _ReplayCapability:
+    replayable: bool = False
+    requires_trust: bool = False
+    reloadable: bool = False
+
+
+def _require_file_load_source(load_source: FileLoadSource) -> None:
+    status = _file_load_source_status(load_source)
+    if status == "loadable":
+        return
+    if status == "missing-file":
+        message = "The recorded source file is not available"
+    elif status == "no-replay-call":
+        message = "The recorded source does not define replay loader metadata"
+    elif status == "missing-loader":
+        message = "The recorded source loader is not available"
+    else:
+        message = "The recorded provenance does not define a file source"
+    raise ReplayGraphError(message)
+
+
+def _validate_replay_graph_file_sources(graph: ReplayGraph) -> None:
+    """Require every reachable file node to have an available loader."""
+    for node in graph.nodes:
+        if node.kind == "file_load":
+            _require_file_load_source(node.payload["load_source"])
+
+
+def _script_validates(
+    spec: ToolProvenanceSpec,
+    external_input_names: set[str] | None,
+    strict: bool,
+) -> bool:
+    try:
+        _validate_script_provenance(
+            spec,
+            external_input_names=external_input_names,
+            strict_replay_code=strict,
+        )
+    except (ReplayGraphError, TypeError, ValueError):
+        return False
+    return True
+
+
+def _analyze_replay_capability(
+    spec: ToolProvenanceSpec,
+    external_input_names: set[str] | None,
+    live_input_resolver: LiveInputResolver | None,
+    input_provenance_resolver: InputProvenanceResolver,
+    depth: int,
+    *,
+    check_reloadability: bool = True,
+) -> _ReplayCapability:
+    if spec.kind == "file":
+        loadable = file_load_source_status(spec) == "loadable"
+        return _ReplayCapability(
+            replayable=True,
+            reloadable=check_reloadability and loadable,
+        )
+    if spec.kind != "script":
+        return _ReplayCapability()
+    if depth > _MAX_SCRIPT_REPLAY_DEPTH:
+        raise ReplayGraphError(
+            "Nested script provenance exceeded the maximum reload depth"
+        )
+    child_capabilities: list[_ReplayCapability] = []
+    inputs_replayable = True
+    inputs_reloadable = True
+    for script_input in spec.script_inputs:
+        if script_input.name in (external_input_names or ()) or (
+            live_input_resolver is not None
+            and live_input_resolver(script_input) is not None
+        ):
+            inputs_reloadable = False
+            continue
+        input_spec = input_provenance_resolver(script_input)
+        if input_spec is None:
+            inputs_replayable = False
+            inputs_reloadable = False
+            child_capabilities.append(_ReplayCapability())
+            continue
+        capability = _analyze_replay_capability(
+            input_spec,
+            None,
+            live_input_resolver,
+            input_provenance_resolver,
+            depth + int(input_spec.kind == "script"),
+            check_reloadability=check_reloadability,
+        )
+        child_capabilities.append(capability)
+        inputs_replayable &= capability.replayable
+        inputs_reloadable &= capability.reloadable
+
+    local_strict = _script_validates(spec, external_input_names, True)
+    local_permissive = local_strict or _script_validates(
+        spec, external_input_names, False
+    )
+    replayable = local_permissive and inputs_replayable
+    requires_trust = replayable and (
+        not local_strict
+        or any(capability.requires_trust for capability in child_capabilities)
+    )
+    file_source_reloadable = (
+        not check_reloadability
+        or spec.file_load_source is None
+        or file_load_source_status(spec) == "loadable"
+    )
+    reloadable = (
+        check_reloadability
+        and replayable
+        and not requires_trust
+        and inputs_reloadable
+        and file_source_reloadable
+    )
+    return _ReplayCapability(replayable, requires_trust, reloadable)
+
+
+def _compile_replay_preflight(
+    spec: ToolProvenanceSpec,
+    *,
+    live_input_resolver: LiveInputResolver | None,
+    input_provenance_resolver: InputProvenanceResolver,
+) -> ReplayGraph:
+    """Compile one reachable replay subtree without executing it."""
+    return compile_replay_graph(
+        spec,
+        live_input_resolver=live_input_resolver,
+        trusted_user_code=True,
+        structured_file_replay=True,
+        _input_provenance_resolver=input_provenance_resolver,
+    )
+
+
+def _replay_capability(
+    value: typing.Any,
+    *,
+    external_input_names: set[str] | None = None,
+    live_input_resolver: LiveInputResolver | None = None,
+) -> _ReplayCapability:
+    try:
+        spec = parse_tool_provenance_spec(value)
+        if spec is None:
+            return _ReplayCapability()
+        return _analyze_replay_capability(
+            spec,
+            external_input_names,
+            _memoized_live_input_resolver(live_input_resolver),
+            _memoized_input_provenance_resolver(),
+            0,
+        )
+    except (ReplayGraphError, TypeError, ValueError):
+        return _ReplayCapability()
 
 
 def _can_reload_provenance(
@@ -624,13 +802,15 @@ def script_provenance_replayable(
     *,
     external_input_names: set[str] | None = None,
     allow_code: bool = False,
+    live_input_resolver: LiveInputResolver | None = None,
 ) -> bool:
     """Return whether a script can replay with the supplied input namespace."""
-    return _script_provenance_validates(
+    capability = _replay_capability(
         spec,
         external_input_names=external_input_names,
-        strict_replay_code=not allow_code,
+        live_input_resolver=live_input_resolver,
     )
+    return capability.replayable and (allow_code or not capability.requires_trust)
 
 
 def _script_provenance_validates(
@@ -651,6 +831,19 @@ def _script_provenance_validates(
     except (ReplayGraphError, TypeError, ValueError):
         return False
     return True
+
+
+def script_provenance_requires_trust(
+    spec: typing.Any,
+    *,
+    external_input_names: set[str] | None = None,
+    live_input_resolver: LiveInputResolver | None = None,
+) -> bool:
+    return _replay_capability(
+        spec,
+        external_input_names=external_input_names,
+        live_input_resolver=live_input_resolver,
+    ).requires_trust
 
 
 def replay_script_provenance(
@@ -692,117 +885,186 @@ def rebuild_script_provenance(
     | None = None,
     extension_loader_executor: Callable[[FileLoadSource], typing.Any] | None = None,
     authorize: ExecutionAuthorizer | None = None,
+    _input_provenance_resolver: InputProvenanceResolver | None = None,
+    _preflighted: bool = False,
 ) -> tuple[xr.DataArray, typing.Any]:
     parsed = parse_tool_provenance_spec(spec)
     if parsed is None or parsed.kind != "script":
         raise ReplayGraphError("Selected provenance is not script-derived")
-    if depth > 20:
+    if depth > _MAX_SCRIPT_REPLAY_DEPTH:
         raise ReplayGraphError(
             "Nested script provenance exceeded the maximum reload depth"
         )
-    replayable = _script_provenance_validates(
-        parsed,
-        strict_replay_code=False,
+    resolve_live = _memoized_live_input_resolver(live_input_resolver)
+    resolve_input_provenance = (
+        _memoized_input_provenance_resolver()
+        if _input_provenance_resolver is None
+        else _input_provenance_resolver
     )
-    if not replayable:
-        raise ReplayGraphError(
-            "The recorded operation cannot be replayed automatically"
+    if not _preflighted:
+        preflight_graph = _compile_replay_preflight(
+            parsed,
+            live_input_resolver=resolve_live,
+            input_provenance_resolver=resolve_input_provenance,
         )
+        _validate_replay_graph_file_sources(preflight_graph)
 
-    live_results: dict[
-        tuple[str, str | None, str], tuple[xr.DataArray, typing.Any]
-    ] = {}
-    live_misses: set[tuple[str, str | None, str]] = set()
-
-    def resolve_live(
-        script_input: typing.Any,
-    ) -> tuple[xr.DataArray, typing.Any] | None:
-        if live_input_resolver is None:
-            return None
-        key = (script_input.name, script_input.node_uid, script_input.data_role)
-        if key in live_results:
-            return live_results[key]
-        if key in live_misses:
-            return None
-        resolved = live_input_resolver(script_input)
-        if resolved is None:
-            live_misses.add(key)
-            return None
-        live_results[key] = resolved
-        return resolved
-
-    def resolve_inputs(current: typing.Any, current_depth: int) -> typing.Any:
-        if current_depth > 20:
-            raise ReplayGraphError(
-                "Nested script provenance exceeded the maximum reload depth"
-            )
-        resolved_inputs = []
-        for script_input in current.script_inputs:
-            resolved = resolve_live(script_input)
-            if resolved is not None:
-                resolved_inputs.append(resolved[1])
-                continue
-
-            input_spec = script_input.parsed_provenance_spec()
-            if input_spec is None:
-                input_reference = _script_input_reference_text(script_input)
-                raise ReplayGraphError(
-                    f"{input_reference} "
-                    "is not open and "
-                    "does not contain recorded source provenance."
-                )
-            if input_spec.kind == "file":
-                resolved_inputs.append(
-                    script_input.model_copy(
-                        update={
-                            "node_uid": None,
-                            "node_snapshot_token": None,
-                            "provenance_spec": input_spec.model_dump(mode="json"),
-                        }
-                    )
-                )
-                continue
-            if input_spec.kind == "script":
-                input_replayable = _script_provenance_validates(
-                    input_spec,
-                    strict_replay_code=False,
-                )
-                if not input_replayable:
-                    raise ReplayGraphError(
-                        "The recorded operation cannot be replayed automatically"
-                    )
-                rebuilt_input = resolve_inputs(input_spec, current_depth + 1)
-                resolved_inputs.append(
-                    script_input.model_copy(
-                        update={
-                            "node_uid": None,
-                            "node_snapshot_token": None,
-                            "provenance_spec": rebuilt_input.model_dump(mode="json"),
-                        }
-                    )
-                )
-                continue
-            raise ReplayGraphError(
-                f"{_script_input_reference_text(script_input)} "
-                "is not open and "
-                "does not contain reloadable script or file provenance."
-            )
-        return current.model_copy(update={"script_inputs": tuple(resolved_inputs)})
-
-    rebuilt_spec = resolve_inputs(parsed, depth)
+    replay_cache = {} if cache is None else cache
+    resolved_inputs, rebuilt_inputs = rebuild_script_inputs(
+        parsed.script_inputs,
+        live_input_resolver=resolve_live,
+        cache=replay_cache,
+        authorize=authorize,
+        depth=depth,
+        extension_executor=extension_executor,
+        extension_loader_executor=extension_loader_executor,
+        _input_provenance_resolver=resolve_input_provenance,
+        _preflighted=True,
+    )
+    rebuilt_spec = parsed.model_copy(update={"script_inputs": rebuilt_inputs})
     graph = compile_replay_graph(
         rebuilt_spec,
-        live_input_resolver=resolve_live,
+        live_input_resolver=lambda script_input: (
+            resolved_inputs[script_input.name],
+            script_input,
+        ),
         trusted_user_code=True,
         structured_file_replay=True,
     )
     return (
         execute_replay_graph(
             graph,
-            cache=cache,
+            cache=replay_cache,
             extension_executor=extension_executor,
             extension_loader_executor=extension_loader_executor,
             authorize=authorize,
         ),
         rebuilt_spec,
     )
+
+
+def rebuild_script_inputs(
+    script_inputs: Sequence[ScriptInput],
+    *,
+    live_input_resolver: LiveInputResolver | None = None,
+    cache: dict[str, xr.DataArray] | None = None,
+    allow_recorded: bool = True,
+    depth: int = 0,
+    extension_executor: Callable[[typing.Any, xr.DataArray], xr.DataArray]
+    | None = None,
+    extension_loader_executor: Callable[[FileLoadSource], typing.Any] | None = None,
+    authorize: ExecutionAuthorizer | None = None,
+    _input_provenance_resolver: InputProvenanceResolver | None = None,
+    _preflighted: bool = False,
+) -> tuple[dict[str, xr.DataArray], tuple[ScriptInput, ...]]:
+    """Resolve named inputs and refresh their durable source snapshots.
+
+    Live manager nodes take priority. If ``allow_recorded`` is true and a live node is
+    unavailable, the recorded script or file provenance is replayed. The optional
+    The document host authorizes executable recorded provenance at its final replay
+    boundary. All inputs are resolved before the caller mutates a ToolWindow.
+    """
+    replay_cache = {} if cache is None else cache
+    resolve_live = _memoized_live_input_resolver(live_input_resolver)
+    resolve_input_provenance = (
+        _memoized_input_provenance_resolver()
+        if _input_provenance_resolver is None
+        else _input_provenance_resolver
+    )
+    input_names = tuple(script_input.name for script_input in script_inputs)
+    if len(set(input_names)) != len(input_names):
+        raise ReplayGraphError("Duplicate named provenance input")
+
+    planned_inputs: list[
+        tuple[
+            ScriptInput,
+            tuple[xr.DataArray, typing.Any] | ToolProvenanceSpec,
+        ]
+    ] = []
+    for script_input in script_inputs:
+        resolved = None if resolve_live is None else resolve_live(script_input)
+        if resolved is not None:
+            planned_inputs.append((script_input, resolved))
+            continue
+        if not allow_recorded:
+            raise ReplayGraphError(
+                f"{script_input.label} is not available in this Manager"
+            )
+
+        input_spec = resolve_input_provenance(script_input)
+        if input_spec is None:
+            raise ReplayGraphError(
+                f"{_script_input_reference_text(script_input)} is not open and "
+                "does not contain recorded source provenance."
+            )
+        if input_spec.kind not in {"file", "script"}:
+            raise ReplayGraphError(
+                f"{_script_input_reference_text(script_input)} is not open and "
+                "does not contain reloadable script or file provenance."
+            )
+        planned_inputs.append((script_input, input_spec))
+
+    preflight_graphs: dict[str, ReplayGraph] = {}
+    if not _preflighted:
+        for script_input, resolved_or_spec in planned_inputs:
+            if not isinstance(resolved_or_spec, ToolProvenanceSpec):
+                continue
+            preflight_graphs[script_input.name] = _compile_replay_preflight(
+                resolved_or_spec,
+                live_input_resolver=resolve_live,
+                input_provenance_resolver=resolve_input_provenance,
+            )
+        for graph in preflight_graphs.values():
+            _validate_replay_graph_file_sources(graph)
+
+    data_by_name: dict[str, xr.DataArray] = {}
+    refreshed_inputs: list[ScriptInput] = []
+    for script_input, resolved_or_spec in planned_inputs:
+        if not isinstance(resolved_or_spec, ToolProvenanceSpec):
+            data, refreshed_input = resolved_or_spec
+            data_by_name[script_input.name] = data
+            refreshed_inputs.append(refreshed_input)
+            continue
+
+        input_spec = resolved_or_spec
+        if input_spec.kind == "file":
+            graph = preflight_graphs.get(script_input.name)
+            if graph is None:
+                graph = compile_replay_graph(
+                    input_spec,
+                    trusted_user_code=True,
+                    structured_file_replay=True,
+                    _input_provenance_resolver=resolve_input_provenance,
+                )
+            data = execute_replay_graph(
+                graph,
+                cache=replay_cache,
+                extension_executor=extension_executor,
+                extension_loader_executor=extension_loader_executor,
+                authorize=authorize,
+            )
+            rebuilt_spec = input_spec
+        elif input_spec.kind == "script":
+            data, rebuilt_spec = rebuild_script_provenance(
+                input_spec,
+                live_input_resolver=resolve_live,
+                cache=replay_cache,
+                depth=depth + 1,
+                extension_executor=extension_executor,
+                extension_loader_executor=extension_loader_executor,
+                authorize=authorize,
+                _input_provenance_resolver=resolve_input_provenance,
+                _preflighted=True,
+            )
+        data_by_name[script_input.name] = data
+        refreshed_inputs.append(
+            script_input.model_copy(
+                update={
+                    "node_uid": None,
+                    "node_snapshot_token": None,
+                    "provenance_spec": rebuilt_spec.model_dump(mode="json"),
+                }
+            )
+        )
+
+    return data_by_name, tuple(refreshed_inputs)

--- a/src/erlab/interactive/imagetool/_provenance/_execution.py
+++ b/src/erlab/interactive/imagetool/_provenance/_execution.py
@@ -575,12 +575,10 @@ def _require_file_load_source(load_source: FileLoadSource) -> None:
         return
     if status == "missing-file":
         message = "The recorded source file is not available"
-    elif status == "no-replay-call":
-        message = "The recorded source does not define replay loader metadata"
     elif status == "missing-loader":
         message = "The recorded source loader is not available"
     else:
-        message = "The recorded provenance does not define a file source"
+        message = "The recorded extension loader is not available"
     raise ReplayGraphError(message)
 
 
@@ -592,17 +590,14 @@ def _validate_replay_graph_file_sources(graph: ReplayGraph) -> None:
 
 
 def _script_provenance_validates(
-    spec: typing.Any,
+    spec: ToolProvenanceSpec,
     *,
     external_input_names: set[str] | None = None,
     strict_replay_code: bool,
 ) -> bool:
-    parsed = parse_tool_provenance_spec(spec)
-    if parsed is None or parsed.kind != "script":
-        return False
     try:
         _validate_script_provenance(
-            parsed,
+            spec,
             external_input_names=external_input_names,
             strict_replay_code=strict_replay_code,
         )

--- a/src/erlab/interactive/imagetool/_provenance/_graph.py
+++ b/src/erlab/interactive/imagetool/_provenance/_graph.py
@@ -18,6 +18,7 @@ import re
 import symtable
 import tokenize
 import typing
+import uuid
 from collections import Counter
 from collections.abc import Callable, Collection, Mapping, Sequence
 
@@ -38,6 +39,9 @@ from erlab.interactive.imagetool._provenance._code import (
     _validate_script_replay_code,
 )
 from erlab.interactive.imagetool._provenance._model import (
+    ReplayStep,
+    ScriptInput,
+    ToolProvenanceSpec,
     _assignment_code,
     _script_input_reference_text,
     parse_tool_provenance_spec,
@@ -49,6 +53,31 @@ if typing.TYPE_CHECKING:
 
 class ReplayGraphError(Exception):
     """Raised when provenance cannot be compiled, emitted, or replayed."""
+
+
+InputProvenanceResolver = Callable[[ScriptInput], ToolProvenanceSpec | None]
+_T = typing.TypeVar("_T")
+_R = typing.TypeVar("_R")
+
+
+def _memoized_by_identity(resolver: Callable[[_T], _R]) -> Callable[[_T], _R]:
+    cache: dict[int, tuple[_T, _R]] = {}
+
+    def resolve(value: _T) -> _R:
+        key = id(value)
+        cached = cache.get(key)
+        if cached is not None and cached[0] is value:
+            return cached[1]
+        result = resolver(value)
+        cache[key] = (value, result)
+        return result
+
+    return resolve
+
+
+def _memoized_input_provenance_resolver() -> InputProvenanceResolver:
+    """Parse each exact input fallback once for one replay decision."""
+    return _memoized_by_identity(ScriptInput.parsed_provenance_spec)
 
 
 class ReplayNode:
@@ -161,6 +190,24 @@ _REPLAY_FRAMEWORK_IMPORTS = {
         for alias, target in _REPLAY_ALIASES.items()
     },
 }
+_REPLAY_PROTECTED_NAMES = {
+    "__builtins__",
+    "lmfit",
+    "load_script",
+    *_REPLAY_FRAMEWORK_IMPORTS,
+    *_SCRIPT_REPLAY_ALLOWED_BUILTINS,
+}
+_REPLAY_CANONICAL_IMPORT_TARGETS = {
+    "erlab": {"module:erlab"},
+    "era": {"module:erlab.analysis", "from:erlab:analysis"},
+    "eri": {"module:erlab.interactive", "from:erlab:interactive"},
+    "eplt": {"module:erlab.plotting", "from:erlab:plotting"},
+    "lmfit": {"module:lmfit"},
+    "np": {"module:numpy"},
+    "numpy": {"module:numpy"},
+    "xr": {"module:xarray"},
+    "xarray": {"module:xarray"},
+}
 _REPLAY_RESERVED_PUBLIC_NAMES = {"data", "derived", "tools"}
 _REPLAY_TEMP_PREFIX = "_itool_replay_"
 _FILE_LOAD_OUTPUT_SENTINEL = "_itool_file_load_output"
@@ -185,16 +232,33 @@ def _is_semantic_replay_name(name: str) -> bool:
     )
 
 
-def _reserved_names_from_spec(spec: typing.Any) -> set[str]:
+def _reserved_names_from_spec(
+    spec: typing.Any,
+    input_provenance_resolver: InputProvenanceResolver,
+    *,
+    external_input_names: Collection[str] = (),
+    live_input_resolver: LiveInputResolver | None = None,
+) -> set[str]:
     names: set[str] = set()
     active_name = getattr(spec, "active_name", None)
     if isinstance(active_name, str):
         names.add(active_name)
     for script_input in getattr(spec, "script_inputs", ()):
         names.add(script_input.name)
-        nested = script_input.parsed_provenance_spec()
+        if script_input.name in external_input_names or (
+            live_input_resolver is not None
+            and live_input_resolver(script_input) is not None
+        ):
+            continue
+        nested = input_provenance_resolver(script_input)
         if nested is not None:
-            names.update(_reserved_names_from_spec(nested))
+            names.update(
+                _reserved_names_from_spec(
+                    nested,
+                    input_provenance_resolver,
+                    live_input_resolver=live_input_resolver,
+                )
+            )
     for binding in getattr(spec, "script_context_bindings", ()):
         names.update(binding.names)
     return names
@@ -522,7 +586,6 @@ def _validate_script_provenance(
         raise ReplayGraphError(
             "Script provenance cannot be replayed without active_name"
         )
-
     builtin_names = set(_SCRIPT_REPLAY_ALLOWED_BUILTINS)
     if not strict_replay_code:
         builtin_names.update(vars(builtins))
@@ -542,6 +605,7 @@ def _validate_script_provenance(
         available_names.update(script_input.name for script_input in spec.script_inputs)
     elif external_input_names is not None:
         available_names.update(external_input_names)
+
     function_dependencies: dict[str, set[str]] = {}
     caller_names: set[str] = set()
     seed_caller_names: set[str] = set()
@@ -898,6 +962,43 @@ def _compile_replay_steps(
     return current_key
 
 
+def _add_external_input_node(
+    graph: ReplayGraph,
+    script_input: typing.Any,
+) -> str:
+    """Add and transform one display-only caller-provided input."""
+    if script_input.name in _REPLAY_PROTECTED_NAMES:
+        raise ReplayGraphError(
+            f"External provenance input {script_input.name!r} conflicts with a replay "
+            "global"
+        )
+    has_stable_identity = script_input.node_snapshot_token is not None
+    identity = (
+        (
+            script_input.node_uid,
+            script_input.data_role,
+            script_input.node_snapshot_token,
+        )
+        if has_stable_identity
+        else uuid.uuid4().hex
+    )
+    input_key = graph.add_node(
+        f"external_input:{identity!r}",
+        "external_input",
+        cacheable=has_stable_identity,
+        payload={"name": script_input.name},
+    )
+    source_spec = script_input.parsed_source_spec()
+    if source_spec is None:
+        return input_key
+    return _compile_replay_steps(
+        graph,
+        input_key,
+        ReplayStep.from_source_spec(source_spec),
+        display=True,
+    )
+
+
 def _script_seed_file_load_parts(
     seed_code: str,
     *,
@@ -961,7 +1062,7 @@ def _operation_replay_code(
             source_name=context_name,
             reserved_names=reserved_names,
         )
-    except (AttributeError, NotImplementedError) as exc:
+    except (AttributeError, NotImplementedError, TypeError, ValueError) as exc:
         raise ReplayGraphError("Operation does not provide replay code") from exc
     if code is None:
         raise ReplayGraphError("Operation does not provide replay code")
@@ -987,10 +1088,16 @@ def _compile_spec(
     external_inputs: Mapping[str, xr.DataArray] | None,
     live_input_resolver: LiveInputResolver | None,
     allow_unresolved_inputs: bool,
+    input_provenance_resolver: InputProvenanceResolver,
 ) -> str:
     parsed = parse_tool_provenance_spec(spec)
     if parsed is None:
         raise ReplayGraphError("Expected provenance spec")
+    try:
+        parsed._check_kind_fields()
+    except (TypeError, ValueError) as exc:
+        raise ReplayGraphError(str(exc)) from exc
+
     if parsed.kind == "file":
         load_source = parsed.file_load_source
         if load_source is None:
@@ -1034,30 +1141,41 @@ def _compile_spec(
         if parsed.script_inputs:
             for script_input in parsed.script_inputs:
                 live_data: xr.DataArray | None = None
+                live_key = f"live_input:{uuid.uuid4().hex}"
                 if external_inputs is not None and script_input.name in external_inputs:
                     live_data = external_inputs[script_input.name]
                 elif (
                     live_input_resolver is not None
                     and (resolved := live_input_resolver(script_input)) is not None
                 ):
-                    live_data = resolved[0]
+                    live_data, resolved_input = resolved
+                    if resolved_input.node_snapshot_token is not None:
+                        source_spec = resolved_input.parsed_source_spec()
+                        live_key = _canonical_key(
+                            "live_input",
+                            {
+                                "node_uid": resolved_input.node_uid,
+                                "data_role": resolved_input.data_role,
+                                "node_snapshot_token": (
+                                    resolved_input.node_snapshot_token
+                                ),
+                                "source_spec": (
+                                    None
+                                    if source_spec is None
+                                    else source_spec.model_dump(mode="json")
+                                ),
+                            },
+                        )
 
                 if live_data is not None:
                     input_key = graph.add_node(
-                        _canonical_key(
-                            "live_input",
-                            {
-                                "name": script_input.name,
-                                "node_snapshot_token": script_input.node_snapshot_token,
-                                "node_uid": script_input.node_uid,
-                            },
-                        ),
+                        live_key,
                         "live_input",
                         cacheable=False,
                         payload={"data": live_data},
                     )
                 else:
-                    input_spec = script_input.parsed_provenance_spec()
+                    input_spec = input_provenance_resolver(script_input)
                     if input_spec is None:
                         if allow_unresolved_inputs:
                             input_key = graph.add_node(
@@ -1071,6 +1189,10 @@ def _compile_spec(
                             )
                             bindings.append((script_input.name, input_key))
                             continue
+                        if display:
+                            input_key = _add_external_input_node(graph, script_input)
+                            bindings.append((script_input.name, input_key))
+                            continue
                         input_reference = _script_input_reference_text(script_input)
                         raise ReplayGraphError(
                             f"{input_reference} "
@@ -1082,9 +1204,10 @@ def _compile_spec(
                         display=display,
                         trusted_user_code=trusted_user_code,
                         structured_file_replay=structured_file_replay,
-                        external_inputs=external_inputs,
+                        external_inputs=None,
                         live_input_resolver=live_input_resolver,
                         allow_unresolved_inputs=allow_unresolved_inputs,
+                        input_provenance_resolver=input_provenance_resolver,
                     )
                     if display:
                         graph.add_alias(script_input.name, input_key)
@@ -1092,7 +1215,7 @@ def _compile_spec(
         elif external_inputs:
             for name, data in external_inputs.items():
                 input_key = graph.add_node(
-                    _canonical_key("external_input", {"name": name}),
+                    f"live_input:{uuid.uuid4().hex}",
                     "live_input",
                     cacheable=False,
                     payload={"data": data},
@@ -1490,6 +1613,7 @@ def compile_replay_graph(
     external_inputs: Mapping[str, xr.DataArray] | None = None,
     live_input_resolver: LiveInputResolver | None = None,
     allow_unresolved_inputs: bool = False,
+    _input_provenance_resolver: InputProvenanceResolver | None = None,
 ) -> ReplayGraph:
     """Compile provenance for code output or structured runtime execution.
 
@@ -1499,7 +1623,22 @@ def compile_replay_graph(
     parsed = parse_tool_provenance_spec(spec)
     if parsed is None:
         raise ReplayGraphError("Expected provenance spec")
-    reserved_names = _reserved_names_from_spec(parsed)
+    resolve_input_provenance = (
+        _memoized_input_provenance_resolver()
+        if _input_provenance_resolver is None
+        else _input_provenance_resolver
+    )
+    resolve_live = (
+        None
+        if live_input_resolver is None
+        else _memoized_by_identity(live_input_resolver)
+    )
+    reserved_names = _reserved_names_from_spec(
+        parsed,
+        resolve_input_provenance,
+        external_input_names=set(external_inputs or ()),
+        live_input_resolver=resolve_live,
+    )
     if external_inputs:
         reserved_names.update(external_inputs)
     graph = ReplayGraph(
@@ -1514,8 +1653,9 @@ def compile_replay_graph(
         trusted_user_code=trusted_user_code,
         structured_file_replay=structured_file_replay,
         external_inputs=external_inputs,
-        live_input_resolver=live_input_resolver,
+        live_input_resolver=resolve_live,
         allow_unresolved_inputs=allow_unresolved_inputs,
+        input_provenance_resolver=resolve_input_provenance,
     )
     return graph
 
@@ -1529,7 +1669,7 @@ def _node_may_contain_image_tool_dimensions(
 
     def visit(node_key: str) -> bool:
         node = node_by_key[node_key]
-        if node.kind in {"script", "live_input", "caller_input"}:
+        if node.kind in {"script", "live_input", "caller_input", "external_input"}:
             return True
         if node.kind in {"file_load", "setup"}:
             return False
@@ -1557,6 +1697,21 @@ def _source_view_emits_code(graph: ReplayGraph, node: ReplayNode) -> bool:
     if graph.display or node.payload["source_kind"] == "full_data":
         return False
     return _node_may_contain_image_tool_dimensions(graph, node.parents[0])
+
+
+def _emitted_node_key(
+    graph: ReplayGraph,
+    node_by_key: Mapping[str, ReplayNode],
+    key: str,
+) -> str:
+    """Return the node that owns the emitted value for ``key``."""
+    node = node_by_key[key]
+    while node.kind == "relay" or (
+        node.kind == "source_view" and not _source_view_emits_code(graph, node)
+    ):
+        key = node.parents[0]
+        node = node_by_key[key]
+    return key
 
 
 def _dotted_import_root_bindings(code: str) -> set[str]:
@@ -1600,13 +1755,7 @@ def _node_names(
     node_by_key = {node.key: node for node in graph.nodes}
 
     def emitted_key(key: str) -> str:
-        node = node_by_key[key]
-        while node.kind == "relay" or (
-            node.kind == "source_view" and not _source_view_emits_code(graph, node)
-        ):
-            key = node.parents[0]
-            node = node_by_key[key]
-        return key
+        return _emitted_node_key(graph, node_by_key, key)
 
     copied_script_bindings = _copied_script_bindings(graph)
     copied_names_by_key: dict[str, set[str]] = {}
@@ -1616,6 +1765,25 @@ def _node_names(
     for node in graph.nodes:
         if node.kind == "caller_input":
             preferred_names[node.key] = typing.cast("str", node.payload["name"])
+    external_names: set[str] = {
+        *_REPLAY_PROTECTED_NAMES,
+        *(
+            typing.cast("str", node.payload["name"])
+            for node in graph.nodes
+            if node.kind == "caller_input"
+        ),
+    }
+    for node in graph.nodes:
+        if node.kind != "external_input":
+            continue
+        base_name = typing.cast("str", node.payload["name"])
+        external_name = base_name
+        suffix = 2
+        while external_name in external_names:
+            external_name = f"{base_name}_{suffix}"
+            suffix += 1
+        preferred_names[node.key] = external_name
+        external_names.add(external_name)
     for public_name, key in graph.aliases:
         emitted_alias_key = emitted_key(key)
         if public_name not in copied_names_by_key.get(emitted_alias_key, set()):
@@ -1714,15 +1882,15 @@ def _node_names(
         ):
             names[node.key] = names[emitted_key(node.key)]
 
-    data_consumer_counts = Counter(
-        emitted_key(node.parents[0])
-        for node in graph.nodes
-        if node.parents
-        and node.kind not in {"setup", "relay"}
-        and not (
-            node.kind == "source_view" and not _source_view_emits_code(graph, node)
-        )
-    )
+    data_consumer_counts: Counter[str] = Counter()
+    for node in graph.nodes:
+        if (
+            not node.parents
+            or node.kind in {"setup", "relay"}
+            or (node.kind == "source_view" and not _source_view_emits_code(graph, node))
+        ):
+            continue
+        data_consumer_counts[emitted_key(node.parents[0])] += 1
     for node in graph.nodes:
         if node.kind != "operation" or not node.parents:
             continue
@@ -2822,6 +2990,44 @@ def _import_binding_targets(code: str) -> dict[str, str] | None:
     return targets
 
 
+def _emission_chunk_names(code: str) -> _CurrentScopeNames:
+    """Return module-scope names with mutation roots treated as stores."""
+    module = ast.parse(code, mode="exec")
+
+    class EmissionScopeNames(_CurrentScopeNames):
+        def _visit_mutation(self, node: ast.Attribute | ast.Subscript) -> None:
+            root = node.value
+            while isinstance(root, ast.Attribute | ast.Subscript):
+                root = root.value
+            if isinstance(node.ctx, ast.Store | ast.Del) and isinstance(root, ast.Name):
+                self.stores.add(root.id)
+            self.generic_visit(node)
+
+        visit_Attribute = _visit_mutation
+        visit_Subscript = _visit_mutation
+
+        def visit_Import(self, node: ast.Import) -> None:
+            self._visit_import(node)
+
+        def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+            self._visit_import(node)
+
+        def _visit_import(self, node: ast.Import | ast.ImportFrom) -> None:
+            bindings = _import_binding_targets(ast.unparse(node))
+            if bindings is None:
+                self.stores.add("*")
+                return
+            for name, target in bindings.items():
+                if target not in _REPLAY_CANONICAL_IMPORT_TARGETS.get(name, ()):
+                    self.stores.add(name)
+
+    names = EmissionScopeNames()
+    names.visit(module)
+    for dependencies in _script_function_dependencies(code).values():
+        names.loads.update(dependencies)
+    return names
+
+
 def _code_name_accesses(code: str) -> tuple[set[str], set[str]]:
     """Return conservatively accessed and rebound names in a code chunk."""
     try:
@@ -3128,7 +3334,45 @@ def emit_replay_code(
     names = _node_names(graph, output_name=output_name)
     node_by_key = {node.key: node for node in graph.nodes}
     extension_references = _extension_script_references(graph)
+    protected_graph = any(node.kind == "external_input" for node in graph.nodes)
     copied_script_bindings = _copied_script_bindings(graph)
+    aliases = list(graph.aliases) if include_all_aliases else []
+    if output_name is not None:
+        if graph.output_key is None:
+            raise ReplayGraphError("Replay graph has no output")
+        output_alias = (output_name, graph.output_key)
+        output_node = node_by_key[graph.output_key]
+        omit_mutating_display_alias = (
+            graph.display
+            and output_node.kind == "operation"
+            and bool(
+                getattr(
+                    output_node.payload["operation"],
+                    "statement_mutates_input",
+                    False,
+                )
+            )
+        )
+        if not omit_mutating_display_alias and output_alias not in aliases:
+            aliases = [*aliases, output_alias]
+    remaining_uses: Counter[str] = Counter()
+    for replay_node in graph.nodes:
+        if replay_node.kind in {"operation", "script"} or (
+            replay_node.kind == "source_view"
+            and _source_view_emits_code(graph, replay_node)
+        ):
+            remaining_uses.update(
+                _emitted_node_key(graph, node_by_key, key)
+                for key in replay_node.parents
+            )
+    remaining_uses.update(
+        _emitted_node_key(graph, node_by_key, key) for _name, key in aliases
+    )
+    owned_names = {
+        names[node.key]: node.key
+        for node in graph.nodes
+        if node.kind == "external_input"
+    }
     chunks: list[tuple[str, bool]] = []
     chunk_external_names: list[tuple[str, ...]] = []
     chunk_implicit_imports: list[bool] = []
@@ -3215,13 +3459,58 @@ def emit_replay_code(
     def append_code(
         code: str,
         *,
+        allowed_accesses: Collection[str] | None = None,
         group_imports: bool = False,
         external_names: tuple[str, ...] = (),
         uses_implicit_framework_imports: bool = True,
     ) -> None:
+        if protected_graph:
+            try:
+                scope_names = _emission_chunk_names(code)
+            except SyntaxError as exc:
+                raise ReplayGraphError(
+                    "Generated replay code is not valid Python"
+                ) from exc
+            stores = scope_names.stores
+            if "*" in stores:
+                raise ReplayGraphError(
+                    "Generated multi-input code contains an opaque namespace import"
+                )
+            if collision := sorted(stores & _REPLAY_PROTECTED_NAMES):
+                raise ReplayGraphError(
+                    "Generated multi-input code would overwrite replay global "
+                    f"{collision[0]!r}"
+                )
+            if allowed_accesses is not None:
+                live_names = {
+                    name
+                    for name, owner_key in owned_names.items()
+                    if remaining_uses[owner_key]
+                }
+                if collision := sorted(
+                    scope_names.loads & live_names - set(allowed_accesses)
+                ):
+                    raise ReplayGraphError(
+                        "Generated multi-input code would access unrelated "
+                        f"provenance name {collision[0]!r}"
+                    )
+            for store_name in stores:
+                owner_key = owned_names.get(store_name)
+                if owner_key is None:
+                    continue
+                if remaining_uses[owner_key]:
+                    raise ReplayGraphError(
+                        "Generated multi-input code would overwrite unrelated "
+                        f"provenance name {store_name!r}"
+                    )
+                owned_names.pop(store_name)
         chunks.append((code, graph.display and group_imports))
         chunk_external_names.append(external_names)
         chunk_implicit_imports.append(uses_implicit_framework_imports)
+
+    def consume(keys: Collection[str]) -> None:
+        for key in keys:
+            remaining_uses[_emitted_node_key(graph, node_by_key, key)] -= 1
 
     def extension_binding(node_key: str) -> tuple[str, str]:
         source_path, function_name = extension_references[node_key]
@@ -3283,6 +3572,7 @@ def emit_replay_code(
                 setup_node = node_by_key[setup_key]
                 append_code(
                     typing.cast("str", setup_node.payload["code"]),
+                    allowed_accesses=(),
                     group_imports=True,
                 )
                 active_setup_key = setup_key
@@ -3292,8 +3582,8 @@ def emit_replay_code(
                 raise ReplayGraphError("File replay code is not valid Python") from exc
             if not _code_stores_name(code, name):
                 raise ReplayGraphError("File replay code does not assign its output")
-            append_code(code, group_imports=True)
-        elif node.kind == "caller_input":
+            append_code(code, allowed_accesses=(), group_imports=True)
+        elif node.kind in {"caller_input", "external_input"}:
             continue
         elif node.kind == "live_input":
             raise ReplayGraphError("Live inputs cannot be emitted as replay code")
@@ -3303,6 +3593,7 @@ def emit_replay_code(
             if dynamic_restore_name is None:
                 raise ReplayGraphError("Public source view has no restore support")
             parent_name = names[node.parents[0]]
+            consume(node.parents)
             append_code(
                 f"{name} = {dynamic_restore_name}({parent_name}.copy(deep=False))"
             )
@@ -3318,18 +3609,25 @@ def emit_replay_code(
                 input_expression = parent_name
                 if getattr(operation, "op", None) == "source_view":
                     input_expression = f"{parent_name}.copy(deep=False)"
-                append_code(f"{name} = {dynamic_restore_name}({input_expression})")
+                consume(node.parents)
+                append_code(
+                    f"{name} = {dynamic_restore_name}({input_expression})",
+                    allowed_accesses=(parent_name,),
+                )
             elif isinstance(operation, ExtensionRoutineOperation):
                 module_name, function_name = extension_binding(node.key)
+                consume(node.parents)
                 append_code(
                     operation._bound_script_statement_code(
                         parent_name,
                         output_name=name,
                         module_name=module_name,
                         function_name=function_name,
-                    )
+                    ),
+                    allowed_accesses=(parent_name,),
                 )
             else:
+                consume(node.parents)
                 append_code(
                     _operation_replay_code(
                         operation,
@@ -3341,7 +3639,8 @@ def emit_replay_code(
                             | reserved_binding_names
                             | set(names.values())
                         ),
-                    )
+                    ),
+                    allowed_accesses=(parent_name, context_name),
                 )
         elif node.kind == "script":
             codes = list(typing.cast("tuple[str, ...]", node.payload["codes"]))
@@ -3385,7 +3684,8 @@ def emit_replay_code(
             ):
                 input_names.add(input_name)
                 input_value_name = names[input_key]
-                if (node.key, input_name, input_key) in copied_script_bindings:
+                binding = (node.key, input_name, input_key)
+                if protected_graph or binding in copied_script_bindings:
                     generated_input_name = copied_binding_name(input_name)
                     append_code(
                         f"{generated_input_name} = {input_value_name}.copy(deep=True)"
@@ -3393,7 +3693,6 @@ def emit_replay_code(
                     generated_copy_names.add(generated_input_name)
                     if generated_input_name != input_name:
                         input_replacements[input_name] = generated_input_name
-                    materialized_aliases[input_name] = input_value_name
                     continue
                 if input_name == input_value_name:
                     continue
@@ -3416,6 +3715,7 @@ def emit_replay_code(
                 else:
                     append_code(f"{input_name} = {input_value_name}")
                     materialized_aliases[input_name] = input_value_name
+            consume(node.parents)
             if input_replacements:
                 try:
                     codes = [
@@ -3487,33 +3787,17 @@ def emit_replay_code(
             active_setup_key = None
         else:
             raise ReplayGraphError(f"Unknown replay graph node kind {node.kind!r}")
+        owned_names[name] = node.key
 
-    aliases = list(graph.aliases) if include_all_aliases else []
-    if output_name is not None:
-        if graph.output_key is None:
-            raise ReplayGraphError("Replay graph has no output")
-        output_alias = (output_name, graph.output_key)
-        output_node = node_by_key[graph.output_key]
-        omit_mutating_display_alias = (
-            graph.display
-            and output_node.kind == "operation"
-            and bool(
-                getattr(
-                    output_node.payload["operation"],
-                    "statement_mutates_input",
-                    False,
-                )
-            )
-        )
-        if not omit_mutating_display_alias:
-            aliases = [*aliases, output_alias]
     for public_name, key in aliases:
         planned_name = names[key]
+        consume((key,))
         if (
             public_name != planned_name
             and materialized_aliases.get(public_name) != planned_name
         ):
             append_code(f"{public_name} = {planned_name}")
+            owned_names[public_name] = _emitted_node_key(graph, node_by_key, key)
     module_docstring: str | None = None
     future_prologues: list[str] = []
     for index, (chunk, group_imports) in enumerate(chunks):
@@ -3664,29 +3948,40 @@ def emit_replay_code(
 
 
 def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) -> str:
+    resolve_input_provenance = _memoized_input_provenance_resolver()
     reserved_names: set[str] = set()
     for script_input in script_inputs:
         reserved_names.add(script_input.name)
         reserved_names.update(
-            _reserved_names_from_spec(script_input.parsed_provenance_spec())
+            _reserved_names_from_spec(
+                resolve_input_provenance(script_input),
+                resolve_input_provenance,
+            )
         )
     graph = ReplayGraph(reserved_names=reserved_names, display=display)
     for script_input in script_inputs:
-        input_spec = script_input.parsed_provenance_spec()
+        input_spec = resolve_input_provenance(script_input)
         if input_spec is None:
-            raise ReplayGraphError(
-                f"{_script_input_reference_text(script_input)} "
-                "does not contain recorded source provenance"
+            if not display:
+                raise ReplayGraphError(
+                    f"{_script_input_reference_text(script_input)} "
+                    "does not contain recorded source provenance"
+                )
+            input_key = _add_external_input_node(
+                graph,
+                script_input,
             )
-        input_key = _compile_spec(
-            graph,
-            input_spec,
-            display=display,
-            trusted_user_code=False,
-            structured_file_replay=False,
-            external_inputs=None,
-            live_input_resolver=None,
-            allow_unresolved_inputs=False,
-        )
+        else:
+            input_key = _compile_spec(
+                graph,
+                input_spec,
+                display=display,
+                trusted_user_code=False,
+                structured_file_replay=False,
+                external_inputs=None,
+                live_input_resolver=None,
+                allow_unresolved_inputs=False,
+                input_provenance_resolver=resolve_input_provenance,
+            )
         graph.add_alias(script_input.name, input_key)
     return emit_replay_code(graph, include_all_aliases=True)

--- a/src/erlab/interactive/imagetool/_provenance/_graph.py
+++ b/src/erlab/interactive/imagetool/_provenance/_graph.py
@@ -142,6 +142,15 @@ class ReplayGraph:
         """Return names that emitted script code receives from its caller."""
         return set(self._external_names)
 
+    def required_input_keys(self, name: str | None = None) -> tuple[str, ...]:
+        """Return graph inputs that emitted code must receive from its caller."""
+        return tuple(
+            node.key
+            for node in self.nodes
+            if node.kind in {"caller_input", "external_input"}
+            and (name is None or node.payload["name"] == name)
+        )
+
     def add_alias(self, public_name: str, key: str) -> None:
         if _is_semantic_replay_name(public_name):
             self.aliases.append((public_name, key))
@@ -1751,7 +1760,9 @@ def _node_names(
     graph: ReplayGraph,
     *,
     output_name: str | None = None,
+    input_name_overrides: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
+    input_name_overrides = dict(input_name_overrides or {})
     node_by_key = {node.key: node for node in graph.nodes}
 
     def emitted_key(key: str) -> str:
@@ -1764,17 +1775,24 @@ def _node_names(
     preferred_names: dict[str, str] = {}
     for node in graph.nodes:
         if node.kind == "caller_input":
-            preferred_names[node.key] = typing.cast("str", node.payload["name"])
+            preferred_names[node.key] = input_name_overrides.get(
+                node.key, typing.cast("str", node.payload["name"])
+            )
     external_names: set[str] = {
         *_REPLAY_PROTECTED_NAMES,
         *(
-            typing.cast("str", node.payload["name"])
+            preferred_names[node.key]
             for node in graph.nodes
             if node.kind == "caller_input"
         ),
     }
     for node in graph.nodes:
         if node.kind != "external_input":
+            continue
+        override = input_name_overrides.get(node.key)
+        if override is not None:
+            preferred_names[node.key] = override
+            external_names.add(override)
             continue
         base_name = typing.cast("str", node.payload["name"])
         external_name = base_name
@@ -1800,6 +1818,7 @@ def _node_names(
         preferred_names[emitted_key(graph.output_key)] = output_name
 
     reserved_names = graph.reserved_names
+    reserved_names.update(input_name_overrides.values())
     uses_extension_scripts = any(
         _is_extension_loader_node(node)
         or (
@@ -1875,6 +1894,12 @@ def _node_names(
             used.add(preferred_name)
         else:
             names[node.key] = next_temp()
+
+    for key, requested_name in input_name_overrides.items():
+        if names.get(key) != requested_name:
+            raise ReplayGraphError(
+                f"Replay input cannot use the requested name {requested_name!r}"
+            )
 
     for node in graph.nodes:
         if node.kind == "relay" or (
@@ -3326,12 +3351,30 @@ def emit_replay_code(
     *,
     output_name: str | None = None,
     include_all_aliases: bool = False,
+    input_name_overrides: Mapping[str, str] | None = None,
 ) -> str:
     from erlab.interactive.imagetool._provenance._operations._extension import (
         ExtensionRoutineOperation,
     )
 
-    names = _node_names(graph, output_name=output_name)
+    input_name_overrides = dict(input_name_overrides or {})
+    required_input_keys = set(graph.required_input_keys())
+    if unknown_keys := input_name_overrides.keys() - required_input_keys:
+        raise ReplayGraphError(
+            f"Replay input override references unknown key {min(unknown_keys)!r}"
+        )
+    for input_name in input_name_overrides.values():
+        if not input_name.isidentifier() or keyword.iskeyword(input_name):
+            raise ReplayGraphError(
+                f"Replay input name {input_name!r} is not a valid Python identifier"
+            )
+    if len(set(input_name_overrides.values())) != len(input_name_overrides):
+        raise ReplayGraphError("Replay input overrides must use distinct names")
+    names = _node_names(
+        graph,
+        output_name=output_name,
+        input_name_overrides=input_name_overrides,
+    )
     node_by_key = {node.key: node for node in graph.nodes}
     extension_references = _extension_script_references(graph)
     protected_graph = any(node.kind == "external_input" for node in graph.nodes)

--- a/src/erlab/interactive/imagetool/_provenance/_graph.py
+++ b/src/erlab/interactive/imagetool/_provenance/_graph.py
@@ -3381,10 +3381,9 @@ def emit_replay_code(
     copied_script_bindings = _copied_script_bindings(graph)
     aliases = list(graph.aliases) if include_all_aliases else []
     if output_name is not None:
-        if graph.output_key is None:
-            raise ReplayGraphError("Replay graph has no output")
-        output_alias = (output_name, graph.output_key)
-        output_node = node_by_key[graph.output_key]
+        output_key = typing.cast("str", graph.output_key)
+        output_alias = (output_name, output_key)
+        output_node = node_by_key[output_key]
         omit_mutating_display_alias = (
             graph.display
             and output_node.kind == "operation"

--- a/src/erlab/interactive/imagetool/_provenance/_model.py
+++ b/src/erlab/interactive/imagetool/_provenance/_model.py
@@ -149,6 +149,8 @@ from erlab.interactive.imagetool._provenance._code import (
 if typing.TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from erlab.interactive.imagetool._provenance._graph import ReplayGraph
+
 _SourceKind: typing.TypeAlias = typing.Literal["full_data", "public_data", "selection"]
 _ReplayInputPolicy: typing.TypeAlias = typing.Literal["current", "restored"]
 ScriptInputDataRole: typing.TypeAlias = typing.Literal["source", "displayed"]
@@ -3558,12 +3560,12 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         entries.extend(operation.derivation_entry() for operation in self.operations)
         return entries
 
-    def _generated_code(
+    def _generated_replay_graph(
         self,
         *,
         parent_data: xr.DataArray | None = None,
-    ) -> str | None:
-        """Return concise public code that represents the recorded workflow.
+    ) -> tuple[ReplayGraph, str] | None:
+        """Compile the graph used for concise public replay code.
 
         Structured provenance remains the exact replay authority. Copied code omits
         ImageTool rendering repairs and other defensive runtime scaffolding.
@@ -3571,7 +3573,6 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         from erlab.interactive.imagetool._provenance._graph import (
             ReplayGraphError,
             compile_replay_graph,
-            emit_replay_code,
         )
 
         try:
@@ -3588,13 +3589,30 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 source = source.to_replay_spec()
             graph = compile_replay_graph(source, display=True)
             output_name = source.active_name
-            return (
-                emit_replay_code(
-                    graph,
-                    output_name=output_name,
-                )
-                or None
-            )
+            if output_name is None:  # pragma: no cover - model validation guard.
+                return None
+        except ReplayGraphError:
+            return None
+        else:
+            return graph, output_name
+
+    def _generated_code(
+        self,
+        *,
+        parent_data: xr.DataArray | None = None,
+    ) -> str | None:
+        """Return concise public code that represents the recorded workflow."""
+        from erlab.interactive.imagetool._provenance._graph import (
+            ReplayGraphError,
+            emit_replay_code,
+        )
+
+        compiled = self._generated_replay_graph(parent_data=parent_data)
+        if compiled is None:
+            return None
+        graph, output_name = compiled
+        try:
+            return emit_replay_code(graph, output_name=output_name) or None
         except ReplayGraphError:
             return None
 

--- a/src/erlab/interactive/imagetool/_provenance/_model.py
+++ b/src/erlab/interactive/imagetool/_provenance/_model.py
@@ -2474,10 +2474,9 @@ class ScriptInput(pydantic.BaseModel):
             raise TypeError(
                 "script input source spec must be a ToolProvenanceSpec or mapping"
             )
-        live_source_spec = require_live_source_spec(source_spec)
-        if live_source_spec is None:
-            raise ValueError("script input source spec must be a live source spec")
-        return live_source_spec.model_dump(mode="json")
+        source_spec = typing.cast("ToolProvenanceSpec", source_spec)
+        require_live_source_spec(source_spec)
+        return source_spec.model_dump(mode="json")
 
     def parsed_source_spec(self) -> ToolProvenanceSpec | None:
         """Parse the relative transform applied to the live input value."""

--- a/src/erlab/interactive/imagetool/_provenance/_model.py
+++ b/src/erlab/interactive/imagetool/_provenance/_model.py
@@ -24,7 +24,8 @@ set of source forms:
      specs may reference any number of :class:`ScriptInput` records. Each input stores
      an immutable replay name, a historical display label, optional live manager node
      identity and role-specific ``node_snapshot_token``, whether it represents source
-     or displayed data, and an optional nested provenance snapshot.
+     or displayed data, an optional live-source transform, and an optional complete
+     resolved-input provenance fallback.
 
 Each transformation is represented by a frozen
 :class:`ToolProvenanceOperation` model whose serialized fields are safe to persist in
@@ -62,8 +63,7 @@ Adding a new provenance-carrying operation follows the same pattern every time:
    convenience properties for runtime use.
 
 4. Implement :meth:`ToolProvenanceOperation.apply` so it transforms a derived array
-   using only its recorded parameters. Operations are unary so their meaning remains
-   stable when users reorder them.
+   using only its recorded parameters.
 
 5. Implement :meth:`ToolProvenanceOperation.expression_code` and
    :meth:`ToolProvenanceOperation.derivation_label` so copied code and manager
@@ -103,10 +103,11 @@ Adding a new provenance-carrying operation follows the same pattern every time:
     new operation. For grouped operations, also cover full-group copy/paste, partial
     group stripping, group replacement/deletion, and generated-code execution.
 
-Parsing of serialized payloads happens only through :func:`parse_tool_provenance_spec`
-and :func:`parse_tool_provenance_operation`. Runtime authoring code should create specs
-with :func:`full_data`, :func:`public_data`, :func:`selection`, :func:`file_load`, or
-:func:`script`, then instantiate operation models from
+Parsing of serialized payloads happens only through :func:`parse_tool_provenance_spec`,
+:func:`parse_tool_provenance_operation`, and :func:`parse_script_inputs`. Runtime
+authoring code should create specs with :func:`full_data`, :func:`public_data`,
+:func:`selection`, :func:`file_load`, or :func:`script`, then instantiate operation
+models from
 :mod:`erlab.interactive.imagetool._provenance._operations` directly.
 """
 
@@ -117,6 +118,7 @@ import base64
 import contextlib
 import importlib
 import inspect
+import json
 import keyword
 import typing
 import uuid
@@ -2220,14 +2222,18 @@ class ReplayStep(pydantic.BaseModel):
                 names.append(name)
         return tuple(names)
 
-    @pydantic.model_validator(mode="after")
-    def _validate_step(self) -> typing.Self:
+    def _check_step_fields(self) -> None:
+        """Check invariants that depend on several replay-step fields."""
         if self.input_policy is not None and self.legacy_context is not None:
             raise ValueError(
                 "Replay steps cannot define both current and legacy input policies"
             )
         if self.input_policy is not None and not self.operation.live_applicable:
             raise TypeError("Source-backed replay steps require live operations")
+
+    @pydantic.model_validator(mode="after")
+    def _validate_step(self) -> typing.Self:
+        self._check_step_fields()
         return self
 
     @classmethod
@@ -2304,7 +2310,11 @@ def _steps_for_legacy_operations_update(
                 candidate.context_names,
                 candidate.legacy_context,
             )
-            != (first.input_policy, first.context_names, first.legacy_context)
+            != (
+                first.input_policy,
+                first.context_names,
+                first.legacy_context,
+            )
             for candidate in (old_steps[index] for index in candidates[1:])
         ):
             raise ValueError(
@@ -2363,8 +2373,10 @@ class ScriptInput(pydantic.BaseModel):
     ``name`` is the immutable replay variable, ``label`` is the historical display
     label, ``node_uid`` and ``node_snapshot_token`` identify the live manager input
     that was used, ``data_role`` selects its durable source or displayed view, and
-    ``provenance_spec`` stores the historical replay source used when that live input
-    is unavailable. When omitted, ``label`` defaults to ``name``.
+    ``source_spec`` stores an optional immutable transform applied to raw live manager
+    data or to a display-only external placeholder. ``provenance_spec`` stores a
+    complete resolved-input fallback, so replay does not apply ``source_spec`` to it
+    again. When omitted, ``label`` defaults to ``name``.
     """
 
     name: str
@@ -2374,6 +2386,10 @@ class ScriptInput(pydantic.BaseModel):
     data_role: ScriptInputDataRole = pydantic.Field(
         default="displayed",
         exclude_if=lambda value: value == "displayed",
+    )
+    source_spec: dict[str, typing.Any] | None = pydantic.Field(
+        default=None,
+        exclude_if=lambda value: value is None,
     )
     provenance_spec: dict[str, typing.Any] | None = None
 
@@ -2443,6 +2459,28 @@ class ScriptInput(pydantic.BaseModel):
             "script input provenance must be a ToolProvenanceSpec or mapping"
         )
 
+    @pydantic.field_validator("source_spec", mode="before")
+    @classmethod
+    def _validate_source_spec(cls, value: typing.Any) -> dict[str, typing.Any] | None:
+        if value is None:
+            return None
+        if isinstance(value, ToolProvenanceSpec):
+            source_spec = value
+        elif isinstance(value, Mapping):
+            source_spec = parse_tool_provenance_spec(value)
+        else:
+            raise TypeError(
+                "script input source spec must be a ToolProvenanceSpec or mapping"
+            )
+        live_source_spec = require_live_source_spec(source_spec)
+        if live_source_spec is None:
+            raise ValueError("script input source spec must be a live source spec")
+        return live_source_spec.model_dump(mode="json")
+
+    def parsed_source_spec(self) -> ToolProvenanceSpec | None:
+        """Parse the relative transform applied to the live input value."""
+        return require_live_source_spec(parse_tool_provenance_spec(self.source_spec))
+
     def parsed_provenance_spec(self) -> ToolProvenanceSpec | None:
         """Parse the current serialized snapshot.
 
@@ -2451,6 +2489,23 @@ class ScriptInput(pydantic.BaseModel):
         observable and avoids a second cache with separate invalidation rules.
         """
         return parse_tool_provenance_spec(self.provenance_spec)
+
+
+def parse_script_inputs(value: typing.Any) -> tuple[ScriptInput, ...]:
+    """Parse saved named provenance inputs through one validation boundary."""
+    if value is None:
+        return ()
+    if isinstance(value, (str, bytes)):
+        try:
+            value = json.loads(value)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise TypeError("Serialized script inputs must be valid JSON") from exc
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise TypeError("Serialized script inputs must be a sequence")
+    return tuple(
+        item if isinstance(item, ScriptInput) else ScriptInput.model_validate(item)
+        for item in value
+    )
 
 
 def _script_input_reference_text(script_input: ScriptInput) -> str:
@@ -2712,23 +2767,18 @@ class ToolProvenanceSpec(pydantic.BaseModel):
     @pydantic.field_validator("script_inputs", mode="before")
     @classmethod
     def _validate_script_inputs(cls, value: typing.Any) -> tuple[ScriptInput, ...]:
-        if value is None:
-            return ()
-        if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
-            raise TypeError("Serialized script inputs must be a sequence")
-        return tuple(
-            item if isinstance(item, ScriptInput) else ScriptInput.model_validate(item)
-            for item in value
-        )
+        return parse_script_inputs(value)
 
-    @pydantic.model_validator(mode="after")
-    def _validate_kind_fields(self) -> typing.Self:
+    def _check_kind_fields(self) -> None:
+        """Check invariants that depend on the provenance kind."""
+        for step in self.steps:
+            step._check_step_fields()
         if self.kind == "script":
             if self.start_label is None:
                 raise ValueError("script provenance specs must define `start_label`")
             if self.source_operations:
                 raise ValueError("script provenance specs must define replay steps")
-            return self
+            return
         if self.kind == "file":
             if self.start_label is None:
                 raise ValueError("file provenance specs must define `start_label`")
@@ -2751,7 +2801,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 raise ValueError(
                     "file provenance steps must contain live-applicable operations"
                 )
-            return self
+            return
         if (
             self.start_label is not None
             or self.seed_code is not None
@@ -2765,6 +2815,10 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 "`seed_code`, `active_name`, `file_load_source`, `steps`, or "
                 "`script_inputs`"
             )
+
+    @pydantic.model_validator(mode="after")
+    def _validate_kind_fields(self) -> typing.Self:
+        self._check_kind_fields()
         return self
 
     @property
@@ -2853,7 +2907,11 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             normalized["source_operations"] = self._validate_operations(
                 normalized["source_operations"]
             )
-        return super().model_copy(update=normalized, deep=deep)
+        validate_operations = bool({"source_operations", "steps"} & normalized.keys())
+        copied = super().model_copy(update=normalized, deep=deep)
+        if validate_operations:
+            copied._check_kind_fields()
+        return copied
 
     def append_operations(
         self, *operations: ToolProvenanceOperation
@@ -2902,14 +2960,9 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             raise TypeError("Display operations can only be appended to live sources")
         operations = self.operations
         if operations and _operation_is(operations[-1], "rename"):
-            return self.model_copy(
-                update={
-                    "source_operations": (
-                        *operations[:-1],
-                        operation,
-                        operations[-1],
-                    )
-                }
+            return self.drop_trailing_rename().append_operations(
+                operation,
+                operations[-1],
             )
         return self.append_operations(operation)
 
@@ -3463,6 +3516,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
         authorization: object | None = None,
     ) -> xr.DataArray:
         """Apply live operations with extension and stored-code authorization."""
+        self._check_kind_fields()
         require_live_source_spec(self)
         data = self._starting_data_for_kind(
             typing.cast(
@@ -3501,9 +3555,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
                 )
                 for script_input in self.script_inputs
             )
-        for operation in self.operations:
-            entry = operation.derivation_entry()
-            entries.append(entry)
+        entries.extend(operation.derivation_entry() for operation in self.operations)
         return entries
 
     def _generated_code(
@@ -3748,34 +3800,64 @@ def iter_operation_refs(
         )
 
 
+def script_inputs_dependency_refs(
+    script_inputs: Sequence[ScriptInput],
+) -> tuple[ScriptInputDependencyRef, ...]:
+    """Return live manager dependency references stored in named inputs."""
+    return tuple(
+        ScriptInputDependencyRef(
+            name=script_input.name,
+            label=script_input.label,
+            node_uid=script_input.node_uid,
+            node_snapshot_token=script_input.node_snapshot_token,
+            data_role=script_input.data_role,
+        )
+        for script_input in script_inputs
+        if script_input.node_uid
+    )
+
+
 def script_input_dependency_refs(
     value: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
 ) -> tuple[ScriptInputDependencyRef, ...]:
-    """Return all live manager dependency references stored in script inputs."""
+    """Return all manager dependency references stored in a provenance spec."""
     spec = parse_tool_provenance_spec(value)
     if spec is None:
         return ()
 
     refs: list[ScriptInputDependencyRef] = []
-
-    def _collect(current: ToolProvenanceSpec) -> None:
-        for script_input in current.script_inputs:
-            if script_input.node_uid:
-                refs.append(
-                    ScriptInputDependencyRef(
-                        name=script_input.name,
-                        label=script_input.label,
-                        node_uid=script_input.node_uid,
-                        node_snapshot_token=script_input.node_snapshot_token,
-                        data_role=script_input.data_role,
-                    )
-                )
-            nested = script_input.parsed_provenance_spec()
-            if nested is not None:
-                _collect(nested)
-
-    _collect(spec)
+    for script_input in spec.script_inputs:
+        refs.extend(script_inputs_dependency_refs((script_input,)))
+        nested = script_input.parsed_provenance_spec()
+        if nested is not None:
+            refs.extend(script_input_dependency_refs(nested))
     return tuple(refs)
+
+
+def rebase_script_inputs_node_uids(
+    script_inputs: Sequence[ScriptInput],
+    uid_map: Mapping[str, str],
+) -> tuple[ScriptInput, ...]:
+    """Return named inputs with manager node UIDs remapped recursively."""
+    if not uid_map:
+        return tuple(script_inputs)
+
+    rebased_inputs: list[ScriptInput] = []
+    for script_input in script_inputs:
+        updates: dict[str, typing.Any] = {}
+        if script_input.node_uid is not None and script_input.node_uid in uid_map:
+            updates["node_uid"] = uid_map[script_input.node_uid]
+
+        nested = script_input.parsed_provenance_spec()
+        if nested is not None:
+            rebased_nested = rebase_script_input_node_uids(nested, uid_map)
+            if rebased_nested != nested:
+                updates["provenance_spec"] = rebased_nested.model_dump(mode="json")
+
+        rebased_inputs.append(
+            script_input.model_copy(update=updates) if updates else script_input
+        )
+    return tuple(rebased_inputs)
 
 
 def rebase_script_input_node_uids(
@@ -3789,34 +3871,10 @@ def rebase_script_input_node_uids(
     if not uid_map or not spec.script_inputs:
         return spec
 
-    def _rebase(current: ToolProvenanceSpec) -> ToolProvenanceSpec:
-        if not current.script_inputs:
-            return current
-
-        changed = False
-        script_inputs: list[ScriptInput] = []
-        for script_input in current.script_inputs:
-            updates: dict[str, typing.Any] = {}
-            if script_input.node_uid is not None and script_input.node_uid in uid_map:
-                updates["node_uid"] = uid_map[script_input.node_uid]
-
-            nested = script_input.parsed_provenance_spec()
-            if nested is not None:
-                rebased_nested = _rebase(nested)
-                if rebased_nested != nested:
-                    updates["provenance_spec"] = rebased_nested.model_dump(mode="json")
-
-            if updates:
-                changed = True
-                script_inputs.append(script_input.model_copy(update=updates))
-            else:
-                script_inputs.append(script_input)
-
-        if not changed:
-            return current
-        return current.model_copy(update={"script_inputs": tuple(script_inputs)})
-
-    return _rebase(spec)
+    script_inputs = rebase_script_inputs_node_uids(spec.script_inputs, uid_map)
+    if script_inputs == spec.script_inputs:
+        return spec
+    return spec.model_copy(update={"script_inputs": script_inputs})
 
 
 def to_replay_provenance_spec(

--- a/src/erlab/interactive/imagetool/_provenance/_operations/_core.py
+++ b/src/erlab/interactive/imagetool/_provenance/_operations/_core.py
@@ -388,7 +388,7 @@ class ModelFitOperation(ToolProvenanceOperation):
         )
         output = fit_result[result_variable].sel(param=self.parameter, drop=True)
         if self.output == "stderr":
-            output = output.fillna(0.0)
+            output = output.where(np.isfinite(output) & (output > 0))
         return output.rename(self.output_name)
 
     def derivation_label(self) -> str:
@@ -441,6 +441,14 @@ class ModelFitOperation(ToolProvenanceOperation):
         lines[-1] += f".{result_variable}.sel("
         lines.extend((f"    param={self.parameter!r},", "    drop=True,", ")"))
         if self.output == "stderr":
-            lines[-1] += ".fillna(0.0)"
+            lines[-1] += ".where("
+            lines.extend(
+                (
+                    "    lambda error: error.notnull()",
+                    "    & (error > 0)",
+                    '    & (error < float("inf")),',
+                    ")",
+                )
+            )
         lines[-1] += f".rename({self.output_name!r})"
         return "\n".join(lines)

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -17,6 +17,7 @@ from erlab.interactive._file_loaders import builtin_file_loader_for_id
 from erlab.interactive.imagetool import _kspace_conversion
 from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool._provenance._model import (
+    ScriptInput,
     ToolProvenanceOperation,
     ToolProvenanceSpec,
     compose_display_provenance,
@@ -29,6 +30,7 @@ from erlab.interactive.imagetool._provenance._operations import (
     RestoreNonuniformDimsOperation,
 )
 from erlab.interactive.imagetool._provenance._trust import provenance_code_trust_entries
+from erlab.interactive.imagetool.manager._dependency import _combine_source_states
 from erlab.interactive.imagetool.manager._dialogs import (
     _BatchOperationDialog,
     _ConcatDialog,
@@ -343,7 +345,9 @@ class _ActionsController:
         note = node.note
 
         self._manager.tree_view.childtool_removed(uid)
-        self._manager._unregister_node(uid)
+        # The promoted wrapper keeps the same UID. Do not expose the short gap
+        # between unregistering the child and registering the root to dependents.
+        self._manager._unregister_node(uid, refresh_dependents=False)
 
         with self._manager._workspace_load_context():
             new_index = self._manager.add_imagetool(
@@ -903,9 +907,17 @@ class _ActionsController:
             node_uid_counter=self._manager._tool_graph.uid_counter
         )
         duplicated: int | str | None = None
+        uid_map: dict[str, str] = {}
         try:
             with self._manager._workspace_load_context():
-                duplicated = self._manager._duplicate_subtree(target)
+                duplicated = self._duplicate_subtree(
+                    target,
+                    uid_map=uid_map,
+                )
+                self._manager._lineage_controller._rebase_node_dependency_refs(
+                    uid_map.values(),
+                    uid_map,
+                )
             self._finish_duplicated_subtree(duplicated)
         except Exception:
             try:
@@ -919,7 +931,11 @@ class _ActionsController:
         return duplicated
 
     def _duplicate_subtree(
-        self, target: int | str, *, parent_override: int | str | None = None
+        self,
+        target: int | str,
+        *,
+        parent_override: int | str | None = None,
+        uid_map: dict[str, str],
     ) -> int | str:
         node = self._manager._node_for_target(target)
         new_target: int | str | None = None
@@ -940,6 +956,8 @@ class _ActionsController:
                         source_auto_update=persistence.source_auto_update,
                         source_state=persistence.source_state,
                         replay_source_data=node.resolved_replay_source_data(),
+                        snapshot_token=node.snapshot_token,
+                        source_snapshot_token=node.source_snapshot_token,
                         note=node.note,
                     )
                 else:
@@ -959,6 +977,8 @@ class _ActionsController:
                         source_state=persistence.source_state,
                         output_id=persistence.output_id,
                         replay_source_data=persistence.replay_source_data,
+                        snapshot_token=node.snapshot_token,
+                        source_snapshot_token=node.source_snapshot_token,
                         note=node.note,
                     )
             else:
@@ -971,7 +991,11 @@ class _ActionsController:
                         )
                     )
                     new_target = self._manager.add_figuretool(
-                        duplicated_tool, show=False, note=node.note
+                        duplicated_tool,
+                        show=False,
+                        snapshot_token=node.snapshot_token,
+                        source_snapshot_token=node.source_snapshot_token,
+                        note=node.note,
                     )
                 else:
                     parent_target = (
@@ -979,12 +1003,22 @@ class _ActionsController:
                         if parent_override is not None
                         else self._manager._parent_node(node).uid
                     )
-                    new_target = self._manager.add_childtool(
-                        tool.duplicate(), parent_target, show=False, note=node.note
+                    new_target = self._register_childtool(
+                        tool.duplicate(),
+                        parent_target,
+                        show=False,
+                        snapshot_token=node.snapshot_token,
+                        source_snapshot_token=node.source_snapshot_token,
+                        note=node.note,
                     )
 
+            uid_map[node.uid] = self._manager._node_for_target(new_target).uid
             for child_uid in tuple(node._childtool_indices):
-                self._manager._duplicate_subtree(child_uid, parent_override=new_target)
+                self._duplicate_subtree(
+                    child_uid,
+                    parent_override=new_target,
+                    uid_map=uid_map,
+                )
         except Exception:
             if new_target is not None:
                 self._discard_duplicated_subtree(new_target)
@@ -1573,8 +1607,9 @@ class _ActionsController:
     def add_childtool(
         self,
         tool: erlab.interactive.utils.ToolWindow,
-        index: int | str,
         *,
+        script_inputs: Mapping[str, int | str],
+        parent: int | str | None = None,
         show: bool = True,
         uid: str | None = None,
         snapshot_token: str | None = None,
@@ -1591,39 +1626,92 @@ class _ActionsController:
         ----------
         tool
             The tool window to add.
-        index
-            Target of the parent managed window.
+        script_inputs
+            Named Manager targets consumed by the tool.
+        parent
+            Optional named input target used to place the tool in the tree. The
+            primary input target is used when omitted.
         show
             Whether to show the tool window after adding it, by default `True`.
         """
         if tool.manager_collection == "figures":
-            return self._manager.add_figuretool(
-                tool,
-                show=show,
-                uid=uid,
-                snapshot_token=snapshot_token,
-                source_snapshot_token=source_snapshot_token,
-                created_time=created_time,
-                note=note,
+            raise ValueError("Figure tools must be registered with add_figuretool()")
+
+        input_targets = dict(script_inputs)
+        if not input_targets:
+            raise ValueError("script_inputs must not be empty")
+
+        tool_inputs = tool.script_inputs
+        declared_inputs = {item.name: item for item in tool_inputs}
+        if not declared_inputs or set(declared_inputs) != set(input_targets):
+            raise ValueError(
+                "script_inputs must match the ToolWindow input declarations"
             )
+        primary_input = tool.primary_input
+        if primary_input is None:
+            raise ValueError("Child ToolWindows must define a primary input")
+        input_names = tuple(item.name for item in tool_inputs)
+        input_nodes = {
+            name: self._manager._node_for_target(input_targets[name])
+            for name in input_names
+        }
+        parent_target = input_targets[primary_input] if parent is None else parent
+        parent_node = self._manager._node_for_target(parent_target)
+        if all(parent_node is not input_node for input_node in input_nodes.values()):
+            raise ValueError("parent must select one of the named input targets")
+        bound_inputs: list[ScriptInput] = []
+        for name in input_names:
+            declaration = declared_inputs[name]
+            bound_input = self._manager._lineage_controller._script_input_for_node(
+                input_nodes[name],
+                name=name,
+                source_spec=declaration.parsed_source_spec(),
+                data_role=declaration.data_role,
+            )
+            bound_inputs.append(bound_input)
+        source_state = _combine_source_states(
+            (
+                tool.source_state,
+                *(node.source_state for node in input_nodes.values()),
+            )
+        )
+        tool.set_script_inputs(
+            tuple(bound_inputs),
+            primary_input=primary_input,
+            auto_update=tool.source_auto_update,
+            state=source_state,
+        )
+        return self._register_childtool(
+            tool,
+            parent_target,
+            show=show,
+            uid=uid,
+            snapshot_token=snapshot_token,
+            source_snapshot_token=source_snapshot_token,
+            created_time=created_time,
+            note=note,
+        )
 
-        parent = self._manager._node_for_target(index)
-
-        def _parent_source_fetcher(parent_uid: str = parent.uid) -> xr.DataArray:
-            return self._manager._node_for_target(parent_uid).current_source_data()
-
-        def _parent_provenance_fetcher(
-            parent_uid: str = parent.uid,
-        ) -> ToolProvenanceSpec | None:
-            return self._manager._node_for_target(parent_uid).displayed_provenance_spec
-
-        tool.set_input_provenance_spec(None)
-        tool.set_source_parent_fetcher(_parent_source_fetcher)
-        tool.set_input_provenance_parent_fetcher(_parent_provenance_fetcher)
+    def _register_childtool(
+        self,
+        tool: erlab.interactive.utils.ToolWindow,
+        parent: int | str,
+        *,
+        show: bool,
+        uid: str | None = None,
+        snapshot_token: str | None = None,
+        source_snapshot_token: str | None = None,
+        created_time: datetime.datetime | str | bytes | None = None,
+        note: str | bytes | None = None,
+    ) -> str:
+        """Register a ToolWindow whose canonical inputs are already bound."""
+        if not tool.script_inputs or tool.primary_input is None:
+            raise ValueError("Child ToolWindows must define script inputs")
+        parent_node = self._manager._node_for_target(parent)
         node = _ManagedWindowNode(
             self._manager,
             self._manager._next_node_uid(uid),
-            parent.uid,
+            parent_node.uid,
             tool,
             snapshot_token=snapshot_token,
             source_snapshot_token=source_snapshot_token,
@@ -1631,9 +1719,9 @@ class _ActionsController:
             note=note,
         )
         if not tool._tool_display_name:
-            tool._tool_display_name = parent.name
+            tool._tool_display_name = parent_node.name
         self._manager._register_child_node(node)
-        self._manager.tree_view.childtool_added(node.uid, index)
+        self._manager.tree_view.childtool_added(node.uid, parent)
         self._manager._mark_node_added(node.uid)
         if self._manager._is_figure_node(node):
             self._manager._figure_collection.sync(select_uid=node.uid if show else None)
@@ -1767,7 +1855,15 @@ class _ActionsController:
         target = self._manager.target_from_slicer_area(parent_slicer_area)
         if target is not None:
             if isinstance(tool, erlab.interactive.utils.ToolWindow):
-                self._manager.add_childtool(tool, target)
+                if len(tool.script_inputs) != 1 or tool.primary_input is None:
+                    raise ValueError(
+                        "ToolWindows opened from ImageTool must declare one input"
+                    )
+                self._manager.add_childtool(
+                    tool,
+                    script_inputs={tool.script_inputs[0].name: target},
+                    parent=target,
+                )
                 return
             if isinstance(tool, ImageTool):
                 self._manager.add_imagetool_child(tool, target)

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -36,6 +36,7 @@ from erlab.interactive.imagetool.manager._dialogs import (
     _ConcatDialog,
     _RenameDialog,
     _StoreDialog,
+    _WeightedFtoolDialog,
 )
 from erlab.interactive.imagetool.manager._widgets import _WATCHED_VAR_COLORS
 from erlab.interactive.imagetool.manager._window_layout import (
@@ -466,6 +467,60 @@ class _ActionsController:
         """Concatenate the selected data using :func:`xarray.concat`."""
         dlg = self._concat_dialog
         dlg.open()
+
+    def show_weighted_ftool_dialog(self) -> None:
+        """Assign two selected ImageTools as data and uncertainty inputs."""
+        targets = self._manager._selected_imagetool_targets()
+        if len(targets) != 2 or self._manager._selected_tool_uids():
+            return
+        dialog = _WeightedFtoolDialog(
+            self._manager,
+            [(target, self._target_display_text(target)) for target in targets],
+        )
+        if dialog.exec() != int(QtWidgets.QDialog.DialogCode.Accepted):
+            return
+        self.open_weighted_ftool(dialog.data_target, dialog.uncertainty_target)
+
+    def open_weighted_ftool(
+        self,
+        data_target: int | str,
+        uncertainty_target: int | str,
+    ) -> str | None:
+        """Open a managed ftool with separate data and uncertainty inputs."""
+        if data_target == uncertainty_target:
+            raise ValueError("Data and uncertainty must use different ImageTools.")
+        data_node = self._manager._node_for_target(data_target)
+        uncertainty_node = self._manager._node_for_target(uncertainty_target)
+        if not data_node.is_imagetool or not uncertainty_node.is_imagetool:
+            raise TypeError("Weighted ftool inputs must be ImageTools.")
+
+        try:
+            tool = erlab.interactive.ftool(
+                data_node.data_for_role("displayed"),
+                uncertainty=uncertainty_node.data_for_role("displayed"),
+                data_name="data",
+                uncertainty_name="uncertainty",
+                execute=False,
+            )
+        except Exception:
+            self._show_operation_error(
+                "Could not open weighted ftool",
+                "Could not open ftool with the selected data and standard uncertainty.",
+            )
+            return None
+
+        tool.set_script_inputs(
+            (ScriptInput(name="data"), ScriptInput(name="uncertainty")),
+            primary_input="data",
+        )
+        return self.add_childtool(
+            tool,
+            script_inputs={
+                "data": data_target,
+                "uncertainty": uncertainty_target,
+            },
+            parent=data_target,
+        )
 
     @property
     def _batch_dialog(self) -> _BatchOperationDialog:
@@ -1378,12 +1433,10 @@ class _ActionsController:
             if replacement is None:
                 # A notebook-side update replaces the watched variable itself, so
                 # prior ImageTool operations no longer describe the displayed array.
-                wrapper.set_detached_provenance(
+                wrapper.replace_with_detached_data(
+                    prepared.data,
                     None,
                     replay_source_data=None,
-                )
-                self._manager.get_imagetool(idx).slicer_area.replace_source_data(
-                    prepared.data
                 )
             else:
                 # Rebuild provenance from the updated watched source and only the

--- a/src/erlab/interactive/imagetool/manager/_console.py
+++ b/src/erlab/interactive/imagetool/manager/_console.py
@@ -1228,6 +1228,18 @@ class ToolNamespace(_ConsoleDataHandleBase):
         else:
             raw_value = value
         if provenance_spec is not None:
+            provenance_spec = provenance_spec.model_copy(
+                update={
+                    "script_inputs": tuple(
+                        script_input.model_copy(
+                            update={"node_uid": None, "node_snapshot_token": None}
+                        )
+                        if script_input.node_uid == self.uid
+                        else script_input
+                        for script_input in provenance_spec.script_inputs
+                    )
+                }
+            )
             self._wrapper.set_detached_provenance(
                 provenance_spec,
                 replay_source_data=None,
@@ -1296,22 +1308,9 @@ class ToolNamespace(_ConsoleDataHandleBase):
     def _script_input(
         self,
     ) -> ScriptInput:
-        label = self._console_label
-        if self._wrapper.name:
-            label += f": {self._wrapper.name}"
-        wrapper_provenance = self._wrapper.displayed_provenance_spec
-        provenance_spec = (
-            wrapper_provenance.model_dump(mode="json")
-            if wrapper_provenance is not None
-            else None
-        )
-        return ScriptInput(
+        return self._wrapper.manager._lineage_controller._script_input_for_node(
+            self._wrapper,
             name=self._console_input_name,
-            label=label,
-            node_uid=self._wrapper.uid,
-            node_snapshot_token=self._wrapper.snapshot_token_for_role("displayed"),
-            data_role="displayed",
-            provenance_spec=provenance_spec,
         )
 
     def _console_operand(self) -> _ConsoleOperand:

--- a/src/erlab/interactive/imagetool/manager/_dependency.py
+++ b/src/erlab/interactive/imagetool/manager/_dependency.py
@@ -2,20 +2,51 @@
 
 from __future__ import annotations
 
+import typing
+
 from erlab.interactive.imagetool._provenance._model import (
     ScriptInputDependencyRef,
     script_input_dependency_refs,
+    script_inputs_dependency_refs,
 )
 
 __all__ = ["_DependencyStatus", "_ManagerDependencyTracker"]
 
-import typing
-
 if typing.TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from erlab.interactive.imagetool._provenance._model import ScriptInput
     from erlab.interactive.imagetool.manager._tool_graph import _ManagerToolGraph
     from erlab.interactive.imagetool.manager._wrapper import _ManagedWindowNode
 
 _DependencyStatus = typing.Literal["current", "changed", "missing"]
+_SourceState = typing.Literal["fresh", "stale", "unavailable"]
+
+
+def _combine_source_states(states: Iterable[_SourceState]) -> _SourceState:
+    """Return the most severe state from a set of source states."""
+    aggregate: _SourceState = "fresh"
+    for state in states:
+        if state == "unavailable":
+            return "unavailable"
+        if state == "stale":
+            aggregate = "stale"
+    return aggregate
+
+
+def _effective_script_input_dependency_refs(
+    script_inputs: Sequence[ScriptInput],
+) -> tuple[ScriptInputDependencyRef, ...]:
+    """Return the live dependencies selected by named input resolution."""
+    refs: list[ScriptInputDependencyRef] = []
+    for script_input in script_inputs:
+        if script_input.node_uid:
+            refs.extend(script_inputs_dependency_refs((script_input,)))
+            continue
+        fallback = script_input.parsed_provenance_spec()
+        if fallback is not None:
+            refs.extend(_effective_script_input_dependency_refs(fallback.script_inputs))
+    return tuple(refs)
 
 
 class _ManagerDependencyTracker:
@@ -38,7 +69,7 @@ class _ManagerDependencyTracker:
         self._dependents_by_source_uid: dict[str, dict[str, None]] = {}
         self._unindexed_uids: dict[str, None] = {}
         self._status_cache: dict[str, _DependencyStatus | None] = {}
-        self._pending_source_refresh_targets: dict[str, set[str]] = {}
+        self._pending_source_refresh_targets: dict[str, dict[str, bool]] = {}
 
     def note_uid(self, uid: str) -> None:
         self._unindexed_uids[uid] = None
@@ -59,12 +90,9 @@ class _ManagerDependencyTracker:
         if node is None:
             self.invalidate_uid(uid)
             return ()
-        spec = (
-            node.passive_displayed_provenance_spec
-            if node.tool_window is not None
-            else node.provenance_spec
-        )
-        if spec is None:
+        script_inputs = () if node.is_imagetool else node.tool_script_inputs
+        spec = node.provenance_spec if node.is_imagetool else None
+        if spec is None and not script_inputs:
             self._remove_reverse_refs(uid)
             self._ref_cache.pop(uid, None)
             self._unindexed_uids.pop(uid, None)
@@ -78,7 +106,11 @@ class _ManagerDependencyTracker:
         ):
             self._unindexed_uids.pop(uid, None)
             return cached[2]
-        refs = script_input_dependency_refs(spec)
+        refs = (
+            _effective_script_input_dependency_refs(script_inputs)
+            if script_inputs
+            else script_input_dependency_refs(spec)
+        )
         self._remove_reverse_refs(uid)
         source_uids = {ref.node_uid for ref in refs}
         self._source_uids_by_dependent[uid] = source_uids
@@ -131,7 +163,7 @@ class _ManagerDependencyTracker:
         for blocker_uid, target_uids in list(
             self._pending_source_refresh_targets.items()
         ):
-            target_uids.discard(uid)
+            target_uids.pop(uid, None)
             if not target_uids:
                 self._pending_source_refresh_targets.pop(blocker_uid, None)
 
@@ -145,13 +177,45 @@ class _ManagerDependencyTracker:
             if not dependents:
                 self._dependents_by_source_uid.pop(source_uid, None)
 
-    def queue_source_refresh(self, blocker_uid: str, target_uid: str) -> None:
-        self._pending_source_refresh_targets.setdefault(blocker_uid, set()).add(
-            target_uid
+    def queue_source_refresh(
+        self,
+        blocker_uid: str,
+        target_uid: str,
+        *,
+        automatic: bool = False,
+    ) -> None:
+        """Queue a deferred refresh continuation.
+
+        A manual continuation remains manual when an automatic update later queues
+        the same target. This lets a disabled automatic-update setting cancel only
+        automatic self-refreshes.
+        """
+        target_uids = self._pending_source_refresh_targets.setdefault(blocker_uid, {})
+        existing = target_uids.get(target_uid)
+        target_uids[target_uid] = (
+            automatic if existing is None else existing and automatic
         )
 
     def pop_source_refreshes(self, blocker_uid: str) -> set[str]:
-        return self._pending_source_refresh_targets.pop(blocker_uid, set())
+        return set(self.pop_source_refresh_intents(blocker_uid))
+
+    def pop_source_refresh_intents(self, blocker_uid: str) -> dict[str, bool]:
+        """Return deferred targets mapped to whether they are automatic."""
+        return self._pending_source_refresh_targets.pop(blocker_uid, {})
+
+    def source_refresh_queued(self, blocker_uid: str, target_uid: str) -> bool:
+        return target_uid in self._pending_source_refresh_targets.get(blocker_uid, ())
+
+    def discard_source_refreshes(self, blocker_uids: Iterable[str]) -> None:
+        """Discard deferred continuation chains below the given blockers."""
+        pending = list(blocker_uids)
+        seen: set[str] = set()
+        while pending:
+            blocker_uid = pending.pop()
+            if blocker_uid in seen:
+                continue
+            seen.add(blocker_uid)
+            pending.extend(self.pop_source_refreshes(blocker_uid))
 
     def has_pending_source_refreshes(self) -> bool:
         return bool(self._pending_source_refresh_targets)

--- a/src/erlab/interactive/imagetool/manager/_dependency.py
+++ b/src/erlab/interactive/imagetool/manager/_dependency.py
@@ -90,8 +90,14 @@ class _ManagerDependencyTracker:
         if node is None:
             self.invalidate_uid(uid)
             return ()
-        script_inputs = () if node.is_imagetool else node.tool_script_inputs
-        spec = node.provenance_spec if node.is_imagetool else None
+        if node.is_imagetool:
+            script_inputs = ()
+            spec = node.provenance_spec
+        else:
+            script_inputs = node.tool_script_inputs
+            spec = None if script_inputs else node.provenance_spec
+            if spec is not None:
+                script_inputs = spec.script_inputs
         if spec is None and not script_inputs:
             self._remove_reverse_refs(uid)
             self._ref_cache.pop(uid, None)

--- a/src/erlab/interactive/imagetool/manager/_dependency.py
+++ b/src/erlab/interactive/imagetool/manager/_dependency.py
@@ -223,5 +223,22 @@ class _ManagerDependencyTracker:
             seen.add(blocker_uid)
             pending.extend(self.pop_source_refreshes(blocker_uid))
 
+    def discard_source_refresh_chain(self, uid: str) -> None:
+        """Discard queued refreshes that reach or depend on a failed target."""
+        pending = [uid]
+        seen: set[str] = set()
+        while pending:
+            target_uid = pending.pop()
+            if target_uid in seen:
+                continue
+            seen.add(target_uid)
+            pending.extend(self.pop_source_refreshes(target_uid))
+            for blocker_uid, target_uids in list(
+                self._pending_source_refresh_targets.items()
+            ):
+                target_uids.pop(target_uid, None)
+                if not target_uids:
+                    self._pending_source_refresh_targets.pop(blocker_uid, None)
+
     def has_pending_source_refreshes(self) -> bool:
         return bool(self._pending_source_refresh_targets)

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -1820,6 +1820,9 @@ class _DetailsPanelController:
         self._manager.concat_action.setEnabled(
             multiple_selected and len(selection_children) == 0
         )
+        self._manager.weighted_ftool_action.setEnabled(
+            len(imagetool_targets) == 2 and not selection_children
+        )
         self._manager.batch_action.setEnabled(self._manager.batch_target_count() >= 2)
         self._manager.metadata_editor_action.setEnabled(bool(imagetool_targets))
         self._manager.create_figure_action.setEnabled(

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -300,6 +300,8 @@ class _DetailsPanelController:
         self._metadata_multi_node_uids = ()
         self._set_notes_node(node)
         displayed_spec = node.passive_displayed_provenance_spec
+        if displayed_spec is None and node.tool_window is not None:
+            displayed_spec = node.displayed_provenance_spec
         self._manager._metadata_full_code_available = (
             displayed_spec is not None or node.tool_window is not None
         )
@@ -548,7 +550,7 @@ class _DetailsPanelController:
         graph = self._manager._tool_graph
         keys: list[tuple[str, str | None]] = []
         seen: set[str] = set()
-        for ref in self._manager._dependency_refs_for_uid(node.uid):
+        for ref in self._manager._lineage_controller._dependency_refs_for_uid(node.uid):
             if ref.node_uid in seen:
                 continue
             seen.add(ref.node_uid)
@@ -1774,7 +1776,9 @@ class _DetailsPanelController:
         imagetool_targets = self._manager._selected_imagetool_targets()
         promotable_child_uid = self._manager._selected_promotable_child_imagetool_uid()
         source_update_child_uid = self._manager._selected_source_update_child_uid()
-        reload_candidates = self._manager._selected_reload_candidates()
+        reload_candidates = (
+            self._manager._lineage_controller._selected_reload_candidates()
+        )
 
         selection_watched: list[int] = []
         selection_offloadable: list[int | str] = []

--- a/src/erlab/interactive/imagetool/manager/_details_panel.py
+++ b/src/erlab/interactive/imagetool/manager/_details_panel.py
@@ -14,10 +14,6 @@ import erlab
 import erlab.interactive.imagetool.slicer
 import erlab.interactive.utils
 from erlab.interactive._widgets import _CenteredIconToolButton
-from erlab.interactive.imagetool._provenance._code import (
-    rebase_default_replay_input,
-    uses_default_replay_input,
-)
 from erlab.interactive.imagetool._provenance._graph import (
     ReplayGraphError,
     compile_replay_graph,
@@ -1513,21 +1509,59 @@ class _DetailsPanelController:
         )
         if node is None or not self._manager._metadata_full_code_available:
             return
-        code = node.derivation_code
-        if not code:
+        compiled = node._derivation_replay_graph()
+        if compiled is None:
             self._show_unavailable_replay_code_dialog(node)
             return
-        if uses_default_replay_input(code):
-            load_source = self._manager._load_source_for_replay(node)
-            if load_source is None:
-                source_name = self._manager._prompt_replay_input_name(node)
-                if source_name is None:
-                    return
-                code = rebase_default_replay_input(code, source_name)
-            else:
-                source_name, load_code = load_source
-                rebased_code = rebase_default_replay_input(code, source_name)
-                code = "\n\n".join(part for part in (load_code, rebased_code) if part)
+        graph, output_name = compiled
+        source_input_keys = graph.required_input_keys("data")
+        if len(source_input_keys) > 1:
+            self._show_unavailable_replay_code_dialog(node)
+            return
+        input_name_overrides: dict[str, str] = {}
+        load_code: str | None = None
+        if source_input_keys:
+            source_input_key = source_input_keys[0]
+            source_input_node = next(
+                graph_node
+                for graph_node in graph.nodes
+                if graph_node.key == source_input_key
+            )
+            source_name: str | None = None
+            if source_input_node.kind == "caller_input":
+                input_name = typing.cast("str", source_input_node.payload["name"])
+                current = node
+                while True:
+                    if (
+                        isinstance(current, _ImageToolWrapper)
+                        and current.watched
+                        and current._watched_varname == input_name
+                    ):
+                        source_name = input_name
+                        break
+                    if current.parent_uid is None or current.provenance_spec is None:
+                        break
+                    current = self._manager._parent_node(current)
+            if source_name is None:
+                load_source = self._manager._load_source_for_replay(node)
+                if load_source is None:
+                    source_name = self._manager._prompt_replay_input_name(node)
+                    if source_name is None:
+                        return
+                else:
+                    source_name, load_code = load_source
+            input_name_overrides[source_input_key] = source_name
+        try:
+            code = emit_replay_code(
+                graph,
+                output_name=output_name,
+                input_name_overrides=input_name_overrides,
+            )
+        except ReplayGraphError:
+            self._show_unavailable_replay_code_dialog(node)
+            return
+        if load_code is not None:
+            code = "\n\n".join(part for part in (load_code, code) if part)
         if code:
             erlab.interactive.utils.copy_to_clipboard(code)
 

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -525,18 +525,20 @@ class _ConcatDialog(QtWidgets.QDialog):
                 result_data = xr.concat(to_concat, **concat_kwargs)
                 replacement_target = self.replacement_target()
                 if replacement_target is None:
-                    created_index = manager._show_multi_input_script_result(
-                        result_data,
-                        selected,
-                        operation_label="Concatenate selected ImageTools",
-                        operation_code=operation_code,
-                        data_role="source",
+                    created_index = (
+                        manager._lineage_controller._show_multi_input_script_result(
+                            result_data,
+                            selected,
+                            operation_label="Concatenate selected ImageTools",
+                            operation_code=operation_code,
+                            data_role="source",
+                        )
                     )
                 else:
                     replacement_node = manager._node_for_target(replacement_target)
                     replacement_node.replace_with_detached_data(
                         result_data,
-                        manager._multi_input_script_provenance(
+                        manager._lineage_controller._multi_input_script_provenance(
                             selected,
                             operation_label="Concatenate selected ImageTools",
                             operation_code=operation_code,

--- a/src/erlab/interactive/imagetool/manager/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_dialogs.py
@@ -16,7 +16,7 @@ import erlab
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Mapping
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 
     import xarray
 
@@ -572,6 +572,72 @@ class _ConcatDialog(QtWidgets.QDialog):
                         preserved_target=replacement_target,
                     )
         super().accept()
+
+
+class _WeightedFtoolDialog(QtWidgets.QDialog):
+    """Assign the data and uncertainty inputs for a weighted ftool."""
+
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget | None,
+        targets: Sequence[tuple[int | str, str]],
+    ) -> None:
+        super().__init__(parent)
+        if len(targets) != 2:
+            raise ValueError("Weighted ftool requires exactly two targets.")
+        if targets[0][0] == targets[1][0]:
+            raise ValueError("Weighted ftool targets must be distinct.")
+        self._targets = tuple(targets)
+
+        self.setWindowTitle("Open in ftool")
+        self.setModal(True)
+        self.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose, False)
+
+        layout = QtWidgets.QFormLayout(self)
+        self._data_label = QtWidgets.QLabel(self)
+        self._data_label.setObjectName("manager_weighted_ftool_data_target")
+        self._uncertainty_label = QtWidgets.QLabel(self)
+        self._uncertainty_label.setObjectName(
+            "manager_weighted_ftool_uncertainty_target"
+        )
+        self._data_label.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        self._uncertainty_label.setTextFormat(QtCore.Qt.TextFormat.PlainText)
+        layout.addRow("Data", self._data_label)
+        layout.addRow("Standard uncertainty", self._uncertainty_label)
+
+        self._swap_button = QtWidgets.QPushButton("Swap", self)
+        self._swap_button.setObjectName("manager_weighted_ftool_swap_button")
+        self._swap_button.clicked.connect(self._swap_targets)
+        layout.addRow(self._swap_button)
+
+        self._button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        self._button_box.setObjectName("manager_weighted_ftool_button_box")
+        self._button_box.accepted.connect(self.accept)
+        self._button_box.rejected.connect(self.reject)
+        layout.addRow(self._button_box)
+        self._update_target_labels()
+
+    @property
+    def data_target(self) -> int | str:
+        return self._targets[0][0]
+
+    @property
+    def uncertainty_target(self) -> int | str:
+        return self._targets[1][0]
+
+    def _update_target_labels(self) -> None:
+        self._data_label.setText(self._targets[0][1])
+        self._uncertainty_label.setText(self._targets[1][1])
+
+    @QtCore.Slot()
+    def _swap_targets(self) -> None:
+        self._targets = self._targets[::-1]
+        self._update_target_labels()
 
 
 class _RenameDialog(QtWidgets.QDialog):

--- a/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
@@ -221,7 +221,7 @@ class _FigureComposerWorkflowController(QtCore.QObject):
         )
 
         source = FigureSourceState.from_script_input(
-            self._host._script_input_for_node(node)
+            self._host._lineage_controller._script_input_for_node(node)
         )
         alias = _source_unique_name(
             _source_alias_candidate(data) or source.name, reserved
@@ -582,7 +582,9 @@ class _FigureComposerWorkflowController(QtCore.QObject):
         data_role = current_source.data_role
         data = source_node.data_for_role(data_role)
         source = FigureSourceState.from_script_input(
-            self._host._script_input_for_node(source_node, data_role=data_role)
+            self._host._lineage_controller._script_input_for_node(
+                source_node, data_role=data_role
+            )
         )
         if not tool.replace_source(source_name, source, data):
             return False

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -660,7 +660,7 @@ class _LineageController:
                 return None
 
             capability = _replay_capability(spec, live_input_resolver=resolve)
-            return capability.replayable or capability.requires_trust
+            return capability.replayable_with_code
 
         def plan_inputs(
             inputs: Sequence[ScriptInput],
@@ -908,7 +908,7 @@ class _LineageController:
                 if boundary_tool is not None and boundary_tool._source_refresh_deferred:
                     blocker = boundary
             if blocker is None:
-                if kind == "apply" and tracker.source_refresh_queued(uid, target_uid):
+                if tracker.source_refresh_queued(uid, target_uid):
                     deferred = True
                     continue
                 return "failed"
@@ -996,9 +996,7 @@ class _LineageController:
                     extension_executor=(
                         self._manager._extensions.execution.run_operation
                     ),
-                    extension_loader_executor=(
-                        self._manager._extensions.replay_loader
-                    ),
+                    extension_loader_executor=self._manager._extensions.replay_loader,
                     authorize=self._provenance_execution_authorizer(
                         reason="reload this tool input"
                     ),
@@ -1159,7 +1157,7 @@ class _LineageController:
                 spec,
                 live_input_resolver=resolve_live,
             )
-            if capability.replayable:
+            if capability.replayable_with_code:
                 return None
             return "The recorded script steps cannot be reloaded."
         details = node._load_source_details()

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -16,7 +16,7 @@ import erlab.interactive.imagetool.slicer
 from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool._provenance._execution import (
     _memoized_live_input_resolver,
-    _replay_capability,
+    _script_replay_validation,
     can_reload_without_trust,
     file_load_source_status,
     rebuild_script_inputs,
@@ -659,8 +659,8 @@ class _LineageController:
                     return typing.cast("xr.DataArray", None), item
                 return None
 
-            capability = _replay_capability(spec, live_input_resolver=resolve)
-            return capability.replayable_with_code
+            validation = _script_replay_validation(spec, live_input_resolver=resolve)
+            return validation.permissive_replayable
 
         def plan_inputs(
             inputs: Sequence[ScriptInput],
@@ -1153,11 +1153,11 @@ class _LineageController:
                     return typing.cast("xr.DataArray", None), item
                 return None
 
-            capability = _replay_capability(
+            validation = _script_replay_validation(
                 spec,
                 live_input_resolver=resolve_live,
             )
-            if capability.replayable_with_code:
+            if validation.permissive_replayable:
                 return None
             return "The recorded script steps cannot be reloaded."
         details = node._load_source_details()

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import functools
+import itertools
+import json
 import logging
 import pathlib
 import traceback
@@ -13,27 +15,33 @@ import erlab
 import erlab.interactive.imagetool.slicer
 from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool._provenance._execution import (
+    _memoized_live_input_resolver,
+    _replay_capability,
     can_reload_without_trust,
     file_load_source_status,
+    rebuild_script_inputs,
     rebuild_script_provenance,
-    script_provenance_replayable,
 )
-from erlab.interactive.imagetool._provenance._graph import ReplayGraphError
+from erlab.interactive.imagetool._provenance._graph import (
+    LiveInputResolver,
+    ReplayGraphError,
+)
 from erlab.interactive.imagetool._provenance._model import (
     ScriptInput,
     ScriptInputDataRole,
     ScriptInputDependencyRef,
     ToolProvenanceSpec,
+    compose_full_provenance,
     has_file_load_source,
     rebase_script_input_node_uids,
+    rebase_script_inputs_node_uids,
     script,
-    script_input_dependency_refs,
+    to_replay_provenance_spec,
 )
 from erlab.interactive.imagetool._provenance._operations import ScriptCodeOperation
-from erlab.interactive.imagetool._provenance._trust import (
-    provenance_code_trust_entries,
-    script_replay_source_input_names,
-)
+from erlab.interactive.imagetool._provenance._trust import provenance_code_trust_entries
+from erlab.interactive.imagetool.manager._dependency import _combine_source_states
+from erlab.interactive.imagetool.manager._node_change import _ManagedNodeChange
 from erlab.interactive.imagetool.manager._widgets import (
     _DEPENDENCY_STATUS_BADGES,
     _DEPENDENCY_STATUS_LABELS,
@@ -48,7 +56,7 @@ from erlab.interactive.imagetool.manager._wrapper import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable, Mapping, Sequence
 
     import xarray as xr
 
@@ -58,21 +66,21 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_InputResolutionAction = tuple[typing.Literal["reload", "refresh", "apply"], str]
+
+
+class _InputResolutionPlan(typing.NamedTuple):
+    target_uid: str | None
+    script_inputs: tuple[ScriptInput, ...]
+    actions: tuple[_InputResolutionAction, ...]
+    live_uids: frozenset[str]
+    unavailable_reason: str | None
+
 
 class _LineageController:
     def __init__(self, manager: ImageToolManager) -> None:
         self._manager = manager
-
-    @staticmethod
-    def _script_provenance_runnable(
-        spec: ToolProvenanceSpec,
-    ) -> bool:
-        input_names = set(script_replay_source_input_names(spec))
-        return script_provenance_replayable(
-            spec,
-            external_input_names=input_names or None,
-            allow_code=True,
-        )
+        self._tool_input_refresh_uids: set[str] = set()
 
     def _authorize_provenance_execution(
         self,
@@ -165,22 +173,20 @@ class _LineageController:
             return None
         tooltip = _DEPENDENCY_STATUS_TOOLTIPS[status]
         node = self._manager._tool_graph.nodes.get(uid)
-        if node is not None and self._manager._node_can_reload_script_inputs(node):
+        if node is not None and self._node_can_reload_script_inputs(node):
             tooltip += " Click for Reload Data options."
-        if (
-            status == "missing"
-            and self._manager._missing_dependencies_have_recorded_file(uid)
-        ):
+        if status == "missing" and self._missing_dependencies_have_recorded_file(uid):
             tooltip += " Recorded source files found for at least one missing input."
         return tooltip
 
     def dependency_input_summary_for_uid(self, uid: str) -> str | None:
-        refs = self._manager._dependency_refs_for_uid(uid)
+        refs = self._dependency_refs_for_uid(uid)
         if not refs:
             return None
 
-        node = self._manager._tool_graph.nodes.get(uid)
-        spec = None if node is None else node.provenance_spec
+        script_inputs = self._dependency_script_inputs(
+            self._manager._tool_graph.nodes.get(uid)
+        )
         parts: list[str] = []
         seen: set[tuple[str, str, str | None, str]] = set()
         for ref in refs:
@@ -200,7 +206,11 @@ class _LineageController:
                 current = f"currently {parent.display_text}"
             else:
                 current = "parent no longer open"
-                if self._manager._dependency_ref_has_recorded_file(spec, ref):
+                has_recorded_file = self._dependency_ref_has_recorded_file_in_inputs(
+                    script_inputs,
+                    ref,
+                )
+                if has_recorded_file:
                     current += "; recorded source file found"
             name = " ".join(ref.name.split())
             label = " ".join(ref.label.split())
@@ -226,7 +236,7 @@ class _LineageController:
         if details:
             msg_box.setDetailedText(details)
 
-        if not self._manager._node_can_reload_script_inputs(node):
+        if not self._node_can_reload_script_inputs(node):
             msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
             msg_box.setText("This result cannot be reloaded from its recorded inputs.")
             msg_box.setInformativeText(
@@ -251,7 +261,7 @@ class _LineageController:
         msg_box.setDefaultButton(typing.cast("QtWidgets.QPushButton", reload_button))
         msg_box.exec()
         if msg_box.clickedButton() is reload_button:
-            self._manager._reload_script_derived_target(target)
+            self._reload_script_derived_target(target)
         elif msg_box.clickedButton() is cancel_button:
             return
 
@@ -284,29 +294,16 @@ class _LineageController:
         )
         load_source = spec.file_load_source
         if source_status == "no-file-load-source" or load_source is None:
-            return (
-                f"{label} has no recorded source file. Reopen the input or recreate "
-                "the result from reloadable inputs, then try again."
-            )
+            return f"{label} has no recorded source file."
         file_path = pathlib.Path(load_source.path)
         if source_status == "missing-file":
-            return (
-                f"The source file for {label} is not available:\n"
-                f"{file_path}\n\n"
-                "Reconnect the drive or restore the file, then try again."
-            )
+            return f"The source file for {label} is not available:\n{file_path}"
         replay_call = load_source.replay_call
         if source_status == "no-replay-call" or replay_call is None:
-            return (
-                f"{label} has file provenance, but the loader information needed "
-                "to read it is missing. Reopen the input or recreate the result "
-                "from reloadable inputs, then try again."
-            )
+            return f"{label} does not have recorded loader information."
         if source_status == "missing-loader":
             return (
-                f"The saved loader {replay_call.target!r} for {label} is not "
-                "available in this ImageTool session. Reopen the input from its "
-                "file with an available loader."
+                f"The saved loader {replay_call.target!r} for {label} is unavailable."
             )
         if source_status == "extension-disabled":
             return (
@@ -346,14 +343,12 @@ class _LineageController:
             )
         return None
 
-    def _dependency_ref_has_recorded_file(
+    def _dependency_ref_has_recorded_file_in_inputs(
         self,
-        spec: ToolProvenanceSpec | None,
+        script_inputs: Sequence[ScriptInput],
         ref: ScriptInputDependencyRef,
     ) -> bool:
-        if spec is None:
-            return False
-        for script_input in spec.script_inputs:
+        for script_input in script_inputs:
             if (
                 script_input.name == ref.name
                 and script_input.node_uid == ref.node_uid
@@ -362,28 +357,67 @@ class _LineageController:
                 and self._script_input_has_recorded_file(script_input)
             ):
                 return True
-            if self._dependency_ref_has_recorded_file(
-                script_input.parsed_provenance_spec(), ref
+            fallback = script_input.parsed_provenance_spec()
+            if self._dependency_ref_has_recorded_file_in_inputs(
+                () if fallback is None else fallback.script_inputs,
+                ref,
             ):
                 return True
         return False
 
+    @staticmethod
+    def _dependency_script_inputs(
+        node: _ImageToolWrapper | _ManagedWindowNode | None,
+    ) -> tuple[ScriptInput, ...]:
+        if node is None or node.tool_script_inputs:
+            return () if node is None else node.tool_script_inputs
+        spec = node.provenance_spec
+        return () if spec is None else spec.script_inputs
+
     def _missing_dependencies_have_recorded_file(self, uid: str) -> bool:
-        node = self._manager._tool_graph.nodes.get(uid)
-        spec = None if node is None else node.provenance_spec
+        script_inputs = self._dependency_script_inputs(
+            self._manager._tool_graph.nodes.get(uid)
+        )
         return any(
             self._manager._tool_graph.nodes.get(ref.node_uid) is None
-            and self._manager._dependency_ref_has_recorded_file(spec, ref)
-            for ref in self._manager._dependency_refs_for_uid(uid)
+            and self._dependency_ref_has_recorded_file_in_inputs(script_inputs, ref)
+            for ref in self._dependency_refs_for_uid(uid)
         )
-
-    def _dependency_dependent_uids(self, uid: str) -> list[str]:
-        return self._manager._dependency_tracker.dependent_uids(uid)
 
     def _refresh_dependency_dependents(self, uid: str) -> None:
         refresh_figures = False
         tree_uids: list[str] = []
-        for dependent_uid in self._manager._dependency_dependent_uids(uid):
+        for dependent_uid in self._manager._dependency_tracker.dependent_uids(uid):
+            dependent = self._manager._tool_graph.nodes.get(dependent_uid)
+            if dependent is not None and dependent.tool_script_inputs:
+                state = self._tool_input_source_state(dependent)
+                status = self._manager._dependency_tracker.status_for_uid(dependent_uid)
+                tool = dependent.tool_window
+                if state == "unavailable":
+                    self._propagate_source_state_from_uid(
+                        dependent.uid,
+                        "unavailable",
+                    )
+                elif state == "stale" or (
+                    status == "changed"
+                    and (tool is None or not tool.source_auto_update)
+                ):
+                    self._propagate_source_state_from_uid(
+                        dependent.uid,
+                        "stale",
+                    )
+                elif status == "changed":
+                    if tool is not None and tool._source_refresh_deferred:
+                        self._manager._dependency_tracker.queue_source_refresh(
+                            dependent_uid,
+                            dependent_uid,
+                            automatic=True,
+                        )
+                    else:
+                        self._refresh_tool_inputs(
+                            dependent_uid,
+                            allow_recorded=False,
+                        )
             self._manager._schedule_details_refresh(dependent_uid)
             if self._manager._is_figure_uid(dependent_uid):
                 refresh_figures = True
@@ -392,6 +426,27 @@ class _LineageController:
         self._manager.tree_view.refresh_many(tree_uids)
         if refresh_figures:
             self._manager._figure_collection.sync()
+
+    def _tool_input_source_state(
+        self,
+        node: _ManagedWindowNode,
+        *,
+        state_overrides: Mapping[str, _ManagedWindowNode._source_state_type]
+        | None = None,
+    ) -> _ManagedWindowNode._source_state_type:
+        """Return the aggregate availability state of all live ToolWindow inputs.
+
+        Snapshot changes are separate. A fresh input with a changed snapshot can be
+        refreshed automatically, while a stale input cannot.
+        """
+        overrides = {} if state_overrides is None else state_overrides
+        source_states: list[_ManagedWindowNode._source_state_type] = []
+        for ref in self._dependency_refs_for_uid(node.uid):
+            source = self._manager._tool_graph.nodes.get(ref.node_uid)
+            if source is None:
+                return "unavailable"
+            source_states.append(overrides.get(ref.node_uid, source.source_state))
+        return _combine_source_states(source_states)
 
     def _script_input_name_for_node(
         self, node: _ImageToolWrapper | _ManagedWindowNode
@@ -410,15 +465,29 @@ class _LineageController:
         self,
         node: _ImageToolWrapper | _ManagedWindowNode,
         *,
+        name: str | None = None,
+        source_spec: ToolProvenanceSpec | None = None,
+        fallback_provenance_spec: dict[str, typing.Any] | None = None,
         detached_input_uid: str | None = None,
         data_role: ScriptInputDataRole = "displayed",
     ) -> ScriptInput:
-        input_provenance = node.provenance_for_role(data_role)
-        provenance_spec = (
-            input_provenance.model_dump(mode="json")
-            if input_provenance is not None
-            else None
+        input_provenance = to_replay_provenance_spec(
+            node.provenance_for_role(data_role)
         )
+        resolved_provenance = (
+            None
+            if input_provenance is None
+            else compose_full_provenance(input_provenance, source_spec)
+        )
+        provenance_spec = (
+            resolved_provenance.model_dump(mode="json")
+            if resolved_provenance is not None
+            else fallback_provenance_spec
+        )
+        source_payload = (
+            None if source_spec is None else source_spec.model_dump(mode="json")
+        )
+        input_name = self._script_input_name_for_node(node) if name is None else name
         if isinstance(node, _ImageToolWrapper):
             label = f"ImageTool {node.index}"
         else:
@@ -432,17 +501,19 @@ class _LineageController:
             label += f": {node.name}"
         if node.uid == detached_input_uid:
             return ScriptInput(
-                name=self._manager._script_input_name_for_node(node),
+                name=input_name,
                 label=label,
                 data_role=data_role,
+                source_spec=source_payload,
                 provenance_spec=provenance_spec,
             )
         return ScriptInput(
-            name=self._manager._script_input_name_for_node(node),
+            name=input_name,
             label=label,
             node_uid=node.uid,
             node_snapshot_token=node.snapshot_token_for_role(data_role),
             data_role=data_role,
+            source_spec=source_payload,
             provenance_spec=provenance_spec,
         )
 
@@ -465,7 +536,7 @@ class _LineageController:
             start_label=start_label,
             active_name=active_name,
             script_inputs=tuple(
-                self._manager._script_input_for_node(
+                self._script_input_for_node(
                     self._manager._node_for_target(target),
                     detached_input_uid=detached_input_uid,
                     data_role=data_role,
@@ -491,7 +562,7 @@ class _LineageController:
             tool,
             show=True,
             activate=True,
-            provenance_spec=self._manager._multi_input_script_provenance(
+            provenance_spec=self._multi_input_script_provenance(
                 input_targets,
                 operation_label=operation_label,
                 operation_code=operation_code,
@@ -499,18 +570,21 @@ class _LineageController:
             ),
         )
 
-    def _script_provenance_inputs_current(self, spec: ToolProvenanceSpec) -> bool:
-        for ref in script_input_dependency_refs(spec):
-            parent = self._manager._tool_graph.nodes.get(ref.node_uid)
-            if parent is None:
-                return False
-            if (
-                ref.node_snapshot_token is not None
-                and parent.snapshot_token_for_role(ref.data_role)
-                != ref.node_snapshot_token
-            ):
-                return False
-        return True
+    def _live_script_input_node(
+        self,
+        script_input: ScriptInput,
+        target_node_uid: str | None = None,
+    ) -> _ImageToolWrapper | _ManagedWindowNode | None:
+        uid = script_input.node_uid
+        node = self._manager._tool_graph.nodes.get(uid or "")
+        if (
+            uid == target_node_uid
+            or node is None
+            or node.source_state != "fresh"
+            or self.dependency_status_for_uid(node.uid) in {"changed", "missing"}
+        ):
+            return None
+        return node
 
     def _resolve_live_script_input_for_reload(
         self,
@@ -518,66 +592,441 @@ class _LineageController:
         *,
         target_node_uid: str | None = None,
     ) -> tuple[xr.DataArray, ScriptInput] | None:
-        spec = script_input.parsed_provenance_spec()
-        if script_input.node_uid is None:
-            return None
-        if target_node_uid is not None and script_input.node_uid == target_node_uid:
-            return None
-        node = self._manager._tool_graph.nodes.get(script_input.node_uid)
+        node = self._live_script_input_node(
+            script_input, target_node_uid=target_node_uid
+        )
         if node is None:
             return None
-        if (
-            spec is not None
-            and spec.kind == "script"
-            and not self._manager._script_provenance_inputs_current(spec)
-        ):
-            return None
-        data = node.data_for_role(script_input.data_role)
-        return (
-            data,
-            self._manager._script_input_for_node(
-                node,
-                data_role=script_input.data_role,
-            ).model_copy(update={"name": script_input.name}),
+        owner_node = self._manager._tool_graph.nodes.get(target_node_uid or "")
+        data = node.data_for_role(script_input.data_role, owner_node=owner_node)
+        source_spec = script_input.parsed_source_spec()
+        if source_spec is not None:
+            data = source_spec.apply(
+                data,
+                extension_executor=self._manager._extensions.execution.run_operation,
+            )
+        return data, self._script_input_for_node(
+            node,
+            name=script_input.name,
+            source_spec=source_spec,
+            data_role=script_input.data_role,
         )
 
-    def _script_input_can_reload(
+    def _live_input_resolver(
         self,
-        script_input: ScriptInput,
         *,
         target_node_uid: str | None = None,
-    ) -> bool:
-        spec = script_input.parsed_provenance_spec()
-        is_target_input = (
-            target_node_uid is not None and script_input.node_uid == target_node_uid
-        )
-        if script_input.node_uid is not None and not is_target_input:
-            node = self._manager._tool_graph.nodes.get(script_input.node_uid)
-            if node is not None and (
-                spec is None
-                or spec.kind != "script"
-                or self._manager._script_provenance_inputs_current(spec)
-            ):
-                return True
-        if spec is None:
-            return False
-        source_status = file_load_source_status(
-            spec,
-            extension_status_resolver=self._manager._extensions.capability_status,
-        )
-        if source_status != "no-file-load-source" and source_status != "loadable":
-            return False
-        if spec.kind == "file":
-            return source_status == "loadable"
-        if spec.kind != "script":
-            return False
-        return self._script_provenance_runnable(spec) and all(
-            self._manager._script_input_can_reload(
-                nested_input,
-                target_node_uid=target_node_uid,
+        live_uids: frozenset[str] | None = None,
+    ) -> LiveInputResolver | None:
+        return _memoized_live_input_resolver(
+            lambda item: (
+                self._resolve_live_script_input_for_reload(
+                    item, target_node_uid=target_node_uid
+                )
+                if live_uids is None or item.node_uid in live_uids
+                else None
             )
-            for nested_input in spec.script_inputs
         )
+
+    def _input_resolution_plan(
+        self,
+        script_inputs: Sequence[ScriptInput],
+        *,
+        target_node_uid: str | None = None,
+        allow_recorded: bool = True,
+        force_live_reload: bool = False,
+        reload_node: _ImageToolWrapper | _ManagedWindowNode | None = None,
+    ) -> _InputResolutionPlan:
+        root_inputs = tuple(script_inputs)
+        actions: list[_InputResolutionAction] = []
+        live_uids: set[str] = set()
+
+        def add_action(
+            kind: typing.Literal["reload", "refresh", "apply"], uid: str
+        ) -> None:
+            if (action := (kind, uid)) not in actions:
+                actions.append(action)
+
+        def provenance_runnable(
+            spec: ToolProvenanceSpec, target_uid: str | None
+        ) -> bool:
+            def resolve(item: ScriptInput):
+                if (
+                    self._live_script_input_node(item, target_node_uid=target_uid)
+                    is not None
+                    or item.node_uid in live_uids
+                ):
+                    return typing.cast("xr.DataArray", None), item
+                return None
+
+            capability = _replay_capability(spec, live_input_resolver=resolve)
+            return capability.replayable or capability.requires_trust
+
+        def plan_inputs(
+            inputs: Sequence[ScriptInput],
+            target_uid: str | None,
+            force: bool,
+            visiting: frozenset[str],
+            depth: int,
+        ) -> str | None:
+            if depth > 20:
+                return "Nested inputs exceeded the maximum reload depth."
+            for script_input in inputs:
+                reason = plan_input(script_input, target_uid, force, visiting, depth)
+                if reason is not None:
+                    return reason
+            return None
+
+        def plan_node(
+            node: _ImageToolWrapper | _ManagedWindowNode,
+            force: bool,
+            visiting: frozenset[str],
+            depth: int,
+        ) -> str | None:
+            if depth > 20:
+                return "Nested inputs exceeded the maximum reload depth."
+            if not node.is_imagetool and node.tool_window is None:
+                return "This tool cannot be reloaded directly."
+            if node.uid in visiting:
+                return "The named inputs contain a dependency cycle."
+            visiting = visiting | {node.uid}
+
+            extension_reason = self._manager._extensions.unavailable_reason_for_node(
+                node.uid
+            )
+            if extension_reason is not None:
+                return extension_reason
+
+            tool = node.tool_window
+            if tool is not None:
+                inputs = tool.script_inputs
+                if not inputs:
+                    return "This tool does not have recorded source inputs."
+                if reason := plan_inputs(inputs, node.uid, force, visiting, depth + 1):
+                    return reason
+                add_action("apply", node.uid)
+                return None
+
+            if node.imagetool is None:
+                if node.pending_workspace_memory_payload is None:
+                    return "This ImageTool window is not open."
+                spec = node.provenance_spec
+                script_inputs = (
+                    spec.script_inputs
+                    if spec is not None and spec.kind == "script"
+                    else ()
+                )
+                if script_inputs and (
+                    reason := plan_inputs(
+                        script_inputs,
+                        node.uid,
+                        False,
+                        visiting,
+                        depth + 1,
+                    )
+                ):
+                    return reason
+                reason = self._pending_imagetool_reload_unavailable_reason(
+                    node,
+                    resolved_live_uids=(
+                        frozenset(live_uids) if script_inputs else None
+                    ),
+                )
+                if reason is None:
+                    add_action("reload", node.uid)
+                return reason
+            spec = node.provenance_spec
+            if node.slicer_area._direct_reloadable():
+                add_action("reload", node.uid)
+                return None
+            if spec is not None and spec.kind == "script" and spec.script_inputs:
+                if reason := plan_inputs(
+                    spec.script_inputs, node.uid, False, visiting, depth + 1
+                ):
+                    return reason
+                if not provenance_runnable(spec, node.uid):
+                    return "This result contains code that cannot be replayed."
+                add_action("reload", node.uid)
+                return None
+            if node.slicer_area._provenance_reloadable():
+                add_action("reload", node.uid)
+                return None
+            if spec is not None and (spec.kind == "file" or has_file_load_source(spec)):
+                if reason := self._file_load_source_unavailable_reason(
+                    spec, "This result"
+                ):
+                    return reason
+                if spec.kind == "file":
+                    add_action("reload", node.uid)
+                    return None
+            if spec is not None and spec.kind == "script" and not spec.script_inputs:
+                return "This result has no recorded inputs."
+            return node.slicer_area._local_reload_unavailable_reason()
+
+        def plan_input(
+            script_input: ScriptInput,
+            target_uid: str | None,
+            force: bool,
+            visiting: frozenset[str],
+            depth: int,
+        ) -> str | None:
+            source_uid = script_input.node_uid
+            if source_uid is not None and source_uid == target_uid:
+                return "The named inputs contain a dependency cycle."
+            if (
+                self._live_script_input_node(script_input, target_node_uid=target_uid)
+                is not None
+                and not force
+            ):
+                live_uids.add(typing.cast("str", script_input.node_uid))
+                return None
+            if not allow_recorded:
+                return f"{script_input.label} is not available in this Manager."
+
+            source = (
+                None
+                if source_uid is None
+                else self._manager._tool_graph.nodes.get(source_uid)
+            )
+            if source is not None:
+                boundary = source
+                if not source.tool_script_inputs and not isinstance(
+                    source, _ImageToolWrapper
+                ):
+                    boundary = None
+                    if source.is_imagetool:
+                        boundary = self._reload_boundary_for_child(source.uid) or source
+                if boundary is not None:
+                    action_count = len(actions)
+                    previous_live_uids = set(live_uids)
+                    reason = plan_node(boundary, force, visiting, depth + 1)
+                    if reason is None:
+                        if boundary.uid != source.uid:
+                            add_action("refresh", source.uid)
+                        live_uids.add(source.uid)
+                        return None
+                    if force:
+                        return reason
+                    del actions[action_count:]
+                    live_uids.intersection_update(previous_live_uids)
+                elif force:
+                    return f"{script_input.label} is not connected to a reload source."
+
+            spec = script_input.parsed_provenance_spec()
+            if spec is None:
+                return f"{script_input.label} has no recorded reload source."
+            if spec.kind == "file" or has_file_load_source(spec):
+                if reason := self._file_load_source_unavailable_reason(
+                    spec, script_input.label
+                ):
+                    return reason
+                if spec.kind == "file":
+                    return None
+            if spec.kind != "script":
+                return f"{script_input.label} has no replayable recorded provenance."
+            reason = plan_inputs(
+                spec.script_inputs, target_uid, False, visiting, depth + 1
+            )
+            if reason is not None:
+                return reason
+            if not provenance_runnable(spec, target_uid):
+                return f"{script_input.label} contains code that cannot be replayed."
+            return None
+
+        unavailable_reason = (
+            plan_inputs(root_inputs, target_node_uid, force_live_reload, frozenset(), 0)
+            if reload_node is None
+            else plan_node(reload_node, force_live_reload, frozenset(), 0)
+        )
+        return _InputResolutionPlan(
+            target_node_uid,
+            root_inputs,
+            tuple(actions),
+            frozenset(live_uids),
+            unavailable_reason,
+        )
+
+    def _execute_input_resolution_plan(
+        self,
+        plan: _InputResolutionPlan,
+        *,
+        allow_recorded: bool = True,
+        reloaded_uids: set[str],
+    ) -> _InputResolutionPlan | typing.Literal["deferred", "failed"]:
+        if plan.unavailable_reason is not None:
+            return "failed"
+        deferred = False
+        target_uid = plan.target_uid
+        if target_uid is None:
+            return "failed"
+        tracker = self._manager._dependency_tracker
+        for kind, uid in plan.actions:
+            node = self._manager._tool_graph.nodes.get(uid)
+            if node is None:
+                return "failed"
+            if kind != "refresh" and uid in reloaded_uids:
+                continue
+            if (
+                kind == "apply"
+                and node.source_state == "fresh"
+                and self.dependency_status_for_uid(uid) == "current"
+                and any(
+                    item.node_uid in plan.live_uids for item in node.tool_script_inputs
+                )
+            ):
+                reloaded_uids.add(uid)
+                continue
+            if kind == "reload" and self._node_can_reload_script_inputs(node):
+                updated = self._reload_script_derived_target(
+                    uid,
+                    continuation_uids=() if target_uid == uid else (target_uid,),
+                    reloaded_uids=reloaded_uids,
+                )
+            elif kind == "reload":
+                updated = node.reload_source_data()
+            elif kind == "refresh":
+                updated = self._refresh_source_chain_to_uid(uid)
+            else:
+                updated = self._refresh_tool_inputs(
+                    uid,
+                    allow_recorded=True,
+                    continuation_uids=() if target_uid == uid else (target_uid,),
+                    reloaded_uids=reloaded_uids,
+                )
+            if updated:
+                if kind != "refresh":
+                    reloaded_uids.add(uid)
+                continue
+
+            tool = node.tool_window
+            blocker = (
+                node if tool is not None and tool._source_refresh_deferred else None
+            )
+            if blocker is None and not isinstance(node, _ImageToolWrapper):
+                boundary = self._reload_boundary_for_child(uid)
+                boundary_tool = None if boundary is None else boundary.tool_window
+                if boundary_tool is not None and boundary_tool._source_refresh_deferred:
+                    blocker = boundary
+            if blocker is None:
+                if kind == "apply" and tracker.source_refresh_queued(uid, target_uid):
+                    deferred = True
+                    continue
+                return "failed"
+            if blocker.uid != uid:
+                tracker.queue_source_refresh(blocker.uid, uid)
+            tracker.queue_source_refresh(uid, target_uid)
+            deferred = True
+        if deferred:
+            return "deferred"
+        plan = self._input_resolution_plan(
+            plan.script_inputs,
+            target_node_uid=target_uid,
+            allow_recorded=allow_recorded,
+        )
+        return (
+            plan if plan.unavailable_reason is None and not plan.actions else "failed"
+        )
+
+    def _refresh_tool_inputs(
+        self,
+        target_uid: str,
+        *,
+        allow_recorded: bool,
+        continuation_uids: Sequence[str] = (),
+        force_live_reload: bool = False,
+        reloaded_uids: set[str] | None = None,
+    ) -> bool:
+        reloaded_uids = set() if reloaded_uids is None else reloaded_uids
+        if target_uid in reloaded_uids:
+            return True
+        if target_uid in self._tool_input_refresh_uids:
+            return False
+        self._tool_input_refresh_uids.add(target_uid)
+        try:
+            node = self._manager._child_node(target_uid)
+            tool = node.tool_window
+            inputs = () if tool is None else tool.script_inputs
+            if tool is None or not inputs:
+                self._manager._dependency_tracker.pop_source_refreshes(target_uid)
+                return False
+
+            def fail_refresh() -> bool:
+                self._manager._dependency_tracker.pop_source_refreshes(target_uid)
+                return False
+
+            def defer_refresh() -> bool:
+                for continuation_uid in continuation_uids:
+                    self._manager._dependency_tracker.queue_source_refresh(
+                        target_uid,
+                        continuation_uid,
+                    )
+                return False
+
+            if tool._source_refresh_deferred:
+                return defer_refresh()
+
+            plan = self._input_resolution_plan(
+                inputs,
+                target_node_uid=target_uid,
+                allow_recorded=allow_recorded,
+                force_live_reload=force_live_reload,
+            )
+            plan = self._execute_input_resolution_plan(
+                plan,
+                allow_recorded=allow_recorded,
+                reloaded_uids=reloaded_uids,
+            )
+            if plan == "deferred":
+                return defer_refresh()
+            if plan == "failed":
+                return fail_refresh()
+            resolve_live = self._live_input_resolver(
+                target_node_uid=plan.target_uid,
+                live_uids=plan.live_uids,
+            )
+
+            try:
+                resolved, refreshed_inputs = rebuild_script_inputs(
+                    plan.script_inputs,
+                    live_input_resolver=resolve_live,
+                    extension_executor=(
+                        self._manager._extensions.execution.run_operation
+                    ),
+                    extension_loader_executor=(
+                        self._manager._extensions.replay_loader
+                    ),
+                    authorize=self._provenance_execution_authorizer(
+                        reason="reload this tool input"
+                    ),
+                    allow_recorded=allow_recorded,
+                )
+                with node._suspend_descendant_propagation():
+                    updated = tool._apply_inputs(resolved, refreshed_inputs)
+            except _TrustedProvenanceReplayCancelled:
+                return fail_refresh()
+            except Exception as exc:
+                if not isinstance(exc, ReplayGraphError):
+                    logger.exception(
+                        "Failed to update %s from named Manager inputs", tool.tool_name
+                    )
+                self._propagate_source_state_from_uid(node.uid, "unavailable")
+                return fail_refresh()
+
+            if updated:
+                self._propagate_source_change_from_uid(target_uid)
+                self._resume_pending_source_refreshes(target_uid)
+            elif tool.source_state != "fresh":
+                self._propagate_source_state_from_uid(target_uid, tool.source_state)
+                if tool._source_refresh_deferred:
+                    defer_refresh()
+                else:
+                    fail_refresh()
+            node._notify_change(_ManagedNodeChange.ROW)
+            if updated:
+                reloaded_uids.add(target_uid)
+            return updated
+        finally:
+            self._tool_input_refresh_uids.discard(target_uid)
 
     def _script_input_unavailable_reason(
         self,
@@ -585,50 +1034,9 @@ class _LineageController:
         *,
         target_node_uid: str | None = None,
     ) -> str | None:
-        spec = script_input.parsed_provenance_spec()
-        is_target_input = (
-            target_node_uid is not None and script_input.node_uid == target_node_uid
-        )
-        if script_input.node_uid is not None and not is_target_input:
-            node = self._manager._tool_graph.nodes.get(script_input.node_uid)
-            if node is not None and (
-                spec is None
-                or spec.kind != "script"
-                or self._manager._script_provenance_inputs_current(spec)
-            ):
-                return None
-        if spec is None:
-            return (
-                f"{script_input.label} has no recorded reload source. Reopen the "
-                "input or recreate the result from reloadable inputs, then try "
-                "again."
-            )
-        if spec.kind == "file" or has_file_load_source(spec):
-            reason = self._file_load_source_unavailable_reason(spec, script_input.label)
-            if reason is not None:
-                return reason
-            if spec.kind == "file":
-                return None
-        if spec.kind != "script":
-            return (
-                f"{script_input.label} has recorded provenance that cannot be "
-                "reloaded. Reopen the input or recreate the result from "
-                "reloadable inputs, then try again."
-            )
-        if not self._script_provenance_runnable(spec):
-            return (
-                f"{script_input.label} was created from recorded code that "
-                "cannot be replayed. Recreate the result from reloadable "
-                "inputs to enable reload."
-            )
-        for nested_input in spec.script_inputs:
-            reason = self._manager._script_input_unavailable_reason(
-                nested_input,
-                target_node_uid=target_node_uid,
-            )
-            if reason is not None:
-                return reason
-        return None
+        return self._input_resolution_plan(
+            (script_input,), target_node_uid=target_node_uid
+        ).unavailable_reason
 
     def _rebuild_script_provenance(
         self,
@@ -637,19 +1045,9 @@ class _LineageController:
         target_node_uid: str | None = None,
         authorization: object | None = None,
     ) -> _ScriptRebuildResult:
-        def _resolve_live_input(
-            script_input: ScriptInput,
-        ) -> (
-            tuple[
-                xr.DataArray,
-                ScriptInput,
-            ]
-            | None
-        ):
-            return self._manager._resolve_live_script_input_for_reload(
-                script_input,
-                target_node_uid=target_node_uid,
-            )
+        resolve_live = self._live_input_resolver(
+            target_node_uid=target_node_uid,
+        )
 
         def authorize(entries):
             if authorization is None:
@@ -662,7 +1060,7 @@ class _LineageController:
         try:
             data, rebuilt_spec = rebuild_script_provenance(
                 spec,
-                live_input_resolver=_resolve_live_input,
+                live_input_resolver=resolve_live,
                 extension_executor=self._manager._extensions.execution.run_operation,
                 extension_loader_executor=self._manager._extensions.replay_loader,
                 authorize=authorize,
@@ -695,122 +1093,79 @@ class _LineageController:
             and spec is not None
             and spec.kind == "script"
             and bool(spec.script_inputs)
-            and self._script_provenance_runnable(spec)
-            and all(
-                self._manager._script_input_can_reload(
-                    script_input,
-                    target_node_uid=node.uid,
-                )
-                for script_input in spec.script_inputs
-            )
+            and self._node_reload_unavailable_reason(node) is None
         )
 
     def _node_reload_unavailable_reason(
         self, node: _ImageToolWrapper | _ManagedWindowNode
     ) -> str | None:
         if not node.is_imagetool:
-            return (
-                "This tool cannot be reloaded directly. Recreate it from a "
-                "reloadable ImageTool input to enable reload."
-            )
-        if node.imagetool is None:
-            if node.pending_workspace_memory_payload is not None:
-                return self._pending_imagetool_reload_unavailable_reason(node)
-            return (
-                "This ImageTool window is not open. Show or reopen the data, "
-                "then try again."
-            )
+            return "This tool cannot be reloaded directly."
+        return self._input_resolution_plan(
+            (),
+            target_node_uid=node.uid,
+            reload_node=node,
+        ).unavailable_reason
+
+    def _pending_imagetool_reload_unavailable_reason(
+        self,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        *,
+        resolved_live_uids: frozenset[str] | None = None,
+    ) -> str | None:
+        spec = node.provenance_spec
         extension_reason = self._manager._extensions.unavailable_reason_for_node(
             node.uid
         )
         if extension_reason is not None:
             return extension_reason
-        if (
-            node.slicer_area._direct_reloadable()
-            or node.slicer_area._provenance_reloadable()
-        ):
-            return None
-
-        spec = node.provenance_spec
-        if spec is not None and (spec.kind == "file" or has_file_load_source(spec)):
-            reason = self._file_load_source_unavailable_reason(spec, "This result")
-            if reason is not None:
-                return reason
-        if spec is not None and spec.kind == "script":
-            if not spec.script_inputs:
-                return (
-                    "This result has no recorded inputs. Reopen or recreate it "
-                    "from reloadable inputs to enable reload."
-                )
-            if not self._script_provenance_runnable(spec):
-                return (
-                    "This result was created from recorded code that cannot be "
-                    "replayed. Recreate it from reloadable inputs to enable reload."
-                )
-            for script_input in spec.script_inputs:
-                reason = self._manager._script_input_unavailable_reason(
-                    script_input,
-                    target_node_uid=node.uid,
-                )
+        if spec is not None:
+            if can_reload_without_trust(
+                spec,
+                extension_status_resolver=self._manager._extensions.capability_status,
+            ):
+                return None
+            if spec.kind == "file" or has_file_load_source(spec):
+                reason = self._file_load_source_unavailable_reason(spec, "This result")
                 if reason is not None:
                     return reason
-            return None
-
-        return node.slicer_area._local_reload_unavailable_reason()
-
-    def _pending_imagetool_reload_unavailable_reason(
-        self, node: _ImageToolWrapper | _ManagedWindowNode
-    ) -> str | None:
-        spec = node.provenance_spec
-        if spec is not None and can_reload_without_trust(
-            spec,
-            extension_status_resolver=self._manager._extensions.capability_status,
-        ):
-            return None
-        if spec is not None and (spec.kind == "file" or has_file_load_source(spec)):
-            reason = self._file_load_source_unavailable_reason(spec, "This result")
-            if reason is not None:
-                return reason
         if spec is not None and spec.kind == "script":
-            if not spec.script_inputs:
-                return (
-                    "This result has no recorded inputs. Reopen or recreate it "
-                    "from reloadable inputs to enable reload."
+            if spec.script_inputs and resolved_live_uids is None:
+                plan = self._input_resolution_plan(
+                    spec.script_inputs,
+                    target_node_uid=node.uid,
                 )
-            if self._script_provenance_runnable(spec):
-                for script_input in spec.script_inputs:
-                    reason = self._manager._script_input_unavailable_reason(
-                        script_input,
+                if plan.unavailable_reason is not None:
+                    return plan.unavailable_reason
+                resolved_live_uids = plan.live_uids
+
+            def resolve_live(item: ScriptInput):
+                if item.node_uid in (resolved_live_uids or ()) or (
+                    resolved_live_uids is None
+                    and self._live_script_input_node(
+                        item,
                         target_node_uid=node.uid,
                     )
-                    if reason is not None:
-                        return reason
+                    is not None
+                ):
+                    return typing.cast("xr.DataArray", None), item
                 return None
-            return (
-                "This data was created from recorded script steps that cannot be "
-                "reloaded automatically from the saved provenance. Reopen or recreate "
-                "it from reloadable inputs to enable reload."
+
+            capability = _replay_capability(
+                spec,
+                live_input_resolver=resolve_live,
             )
+            if capability.replayable:
+                return None
+            return "The recorded script steps cannot be reloaded."
         details = node._load_source_details()
-        if details is not None:
-            if not details.path.exists():
-                return (
-                    "The source file for this data is not available:\n"
-                    f"{details.path}\n\n"
-                    "Reconnect the drive or restore the file, then try again."
-                )
-            if details.load_code is not None:
-                return None
-            return (
-                "This data has file metadata, but the loader information needed "
-                "to read it is missing. Reopen the input from its file with an "
-                "available loader."
-            )
-        return (
-            "This data was not opened from a reloadable file or recorded input. "
-            "Reopen it from a file, or recreate it from reloadable ImageTool inputs, "
-            "to enable reload."
-        )
+        if details is None:
+            return "This data does not have a reloadable source."
+        if not details.path.exists():
+            return f"The source file is not available:\n{details.path}"
+        if details.load_code is None:
+            return "The source file does not have loader information."
+        return None
 
     def _script_reload_from_slicer_area(
         self,
@@ -818,19 +1173,18 @@ class _LineageController:
         *,
         execute: bool,
     ) -> bool:
-        """Check or reload script provenance for a managed slicer area."""
         target = self._manager.target_from_slicer_area(slicer_area)
         if target is None:
             return False
-        if not self._manager._node_can_reload_script_inputs(
+        if not self._node_can_reload_script_inputs(
             self._manager._node_for_target(target)
         ):
             return False
-        return not execute or self._manager._reload_script_derived_target(target)
+        return not execute or self._reload_script_derived_target(target)
 
-    def _workspace_loaded_uid_map(
+    def _rebase_loaded_workspace_dependency_refs(
         self, loaded_targets_by_uid: Mapping[str, int | str]
-    ) -> dict[str, str]:
+    ) -> None:
         uid_map: dict[str, str] = {}
         for saved_uid, target in loaded_targets_by_uid.items():
             try:
@@ -839,42 +1193,107 @@ class _LineageController:
                 continue
             if actual_uid != saved_uid:
                 uid_map[saved_uid] = actual_uid
-        return uid_map
-
-    def _rebase_loaded_workspace_dependency_refs(
-        self,
-        loaded_targets_by_uid: Mapping[str, int | str],
-    ) -> None:
-        """Rebase loaded-node dependencies within the incoming workspace scope."""
-        uid_map = self._manager._workspace_loaded_uid_map(loaded_targets_by_uid)
         if not uid_map:
             return
-        for target in loaded_targets_by_uid.values():
+
+        self._rebase_node_dependency_refs(loaded_targets_by_uid.values(), uid_map)
+
+    @staticmethod
+    def _rebase_tool_data_reference_node_uids(
+        references: Mapping[str, Mapping[str, typing.Any]],
+        uid_map: Mapping[str, str],
+    ) -> dict[str, dict[str, typing.Any]]:
+        rebased = {name: dict(reference) for name, reference in references.items()}
+        for reference in rebased.values():
+            if reference.get("kind") != "manager_node":
+                continue
+            node_uid = reference.get("node_uid")
+            if isinstance(node_uid, str) and node_uid in uid_map:
+                reference["node_uid"] = uid_map[node_uid]
+        return rebased
+
+    def _rebase_node_dependency_refs(
+        self,
+        targets: Iterable[int | str],
+        uid_map: Mapping[str, str],
+    ) -> None:
+        """Rebase all framework and tool-owned references for selected nodes."""
+        if not uid_map:
+            return
+
+        for target in targets:
             try:
                 node = self._manager._node_for_target(target)
             except KeyError:
                 continue
+            if node.tool_window is not None:
+                tool = node.tool_window
+                rebased_inputs = rebase_script_inputs_node_uids(
+                    tool.script_inputs,
+                    uid_map,
+                )
+                if rebased_inputs != tool.script_inputs:
+                    tool.set_script_inputs(
+                        rebased_inputs,
+                        primary_input=tool.primary_input,
+                        auto_update=tool.source_auto_update,
+                        state=tool.source_state,
+                    )
+                tool.rebase_source_node_uids(uid_map)
+                references = node._workspace_tool_data_references
+                rebased_references = self._rebase_tool_data_reference_node_uids(
+                    references, uid_map
+                )
+                if rebased_references != references:
+                    node._set_workspace_tool_data_references(rebased_references)
+            elif node.pending_workspace_payload_kind == "tool":
+                attrs = node.pending_workspace_payload_attrs
+                tool_inputs = node.tool_script_inputs
+                rebased_inputs = rebase_script_inputs_node_uids(tool_inputs, uid_map)
+                updated_attrs: dict[str, typing.Any] | None = None
+                if attrs is not None and rebased_inputs != tool_inputs:
+                    updated_attrs = dict(attrs)
+                    updated_attrs.update(
+                        erlab.interactive.utils.ToolWindow._saved_script_input_attrs(
+                            rebased_inputs, node.tool_primary_input
+                        )
+                    )
+                if attrs is not None:
+                    raw_references = attrs.get(
+                        erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR
+                    )
+                    if isinstance(raw_references, (str, bytes, bytearray)):
+                        try:
+                            references = json.loads(raw_references)
+                        except (TypeError, ValueError, UnicodeDecodeError):
+                            pass
+                        else:
+                            if (
+                                isinstance(references, dict)
+                                and (
+                                    rebased_references := (
+                                        self._rebase_tool_data_reference_node_uids(
+                                            references, uid_map
+                                        )
+                                    )
+                                )
+                                != references
+                            ):
+                                if updated_attrs is None:
+                                    updated_attrs = dict(attrs)
+                                updated_attrs[
+                                    erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR
+                                ] = json.dumps(rebased_references)
+                if updated_attrs is not None:
+                    node.update_pending_workspace_payload_attrs(updated_attrs)
             if node.provenance_spec is None:
                 continue
-            if node.tool_window is not None:
-                node.tool_window.rebase_source_node_uids(uid_map)
             rebased = rebase_script_input_node_uids(
                 node.provenance_spec,
                 uid_map,
             )
             if rebased != node.provenance_spec:
                 node.set_displayed_provenance(rebased, advance_snapshot=False)
-
-    def _selected_reload_targets(
-        self,
-    ) -> tuple[list[int | str], dict[int | str, list[str]]] | None:
-        selected_reload_candidates = self._manager._selected_reload_candidates()
-        if selected_reload_candidates is None:
-            return None
-        reload_targets, child_targets, unavailable_reason = selected_reload_candidates
-        if unavailable_reason is not None:
-            return None
-        return reload_targets, child_targets
 
     def _selected_reload_candidates(
         self,
@@ -895,23 +1314,24 @@ class _LineageController:
             reload_targets.append(target)
 
         for index in selected_roots:
-            unavailable_reason = self._manager._reload_unavailable_reason_for_target(
-                index
-            )
+            unavailable_reason = self._reload_unavailable_reason_for_target(index)
             if unavailable_reason is not None:
                 return [], {}, unavailable_reason
             _add_reload_target(index)
 
         for uid in selected_children:
-            reload_target = self._manager._reload_target_for_child(uid)
+            reload_target = self._reload_target_for_child(uid)
             if reload_target is None:
-                return [], {}, self._manager._reload_unavailable_reason_for_child(uid)
+                return [], {}, self._reload_unavailable_reason_for_child(uid)
             _add_reload_target(reload_target)
-            child_targets.setdefault(reload_target, []).append(uid)
+            if reload_target != uid:
+                child_targets.setdefault(reload_target, []).append(uid)
 
         return reload_targets, child_targets, None
 
-    def _reload_target_for_child(self, uid: str) -> int | str | None:
+    def _reload_boundary_for_child(
+        self, uid: str
+    ) -> _ImageToolWrapper | _ManagedWindowNode | None:
         try:
             current: _ImageToolWrapper | _ManagedWindowNode = self._manager._child_node(
                 uid
@@ -921,25 +1341,32 @@ class _LineageController:
         if not current.has_source_binding:
             return None
 
-        reload_target: int | str | None = None
+        reload_boundary: _ImageToolWrapper | _ManagedWindowNode | None = None
         while True:
+            if current.tool_script_inputs:
+                return current
+            if (
+                current.is_imagetool
+                and self._node_reload_unavailable_reason(current) is None
+            ):
+                reload_boundary = current
+            if isinstance(current, _ImageToolWrapper):
+                break
             try:
-                parent = self._manager._parent_node(current)
+                current = self._manager._parent_node(current)
             except KeyError:
                 break
-            if (
-                parent.is_imagetool
-                and self._node_reload_unavailable_reason(parent) is None
-            ):
-                reload_target = (
-                    parent.index
-                    if isinstance(parent, _ImageToolWrapper)
-                    else parent.uid
-                )
-            if isinstance(parent, _ImageToolWrapper):
-                break
-            current = parent
-        return reload_target
+        return reload_boundary
+
+    def _reload_target_for_child(self, uid: str) -> int | str | None:
+        boundary = self._reload_boundary_for_child(uid)
+        if boundary is None:
+            return None
+        if boundary.tool_script_inputs and not boundary.can_reload_source_data():
+            return None
+        if isinstance(boundary, _ImageToolWrapper):
+            return boundary.index
+        return boundary.uid
 
     def _reload_unavailable_reason_for_child(self, uid: str) -> str:
         try:
@@ -950,6 +1377,12 @@ class _LineageController:
             return (
                 "This tool does not have a recorded source input. Reopen or "
                 "recreate it from reloadable ImageTool data to enable reload."
+            )
+        boundary = self._reload_boundary_for_child(uid)
+        if boundary is not None and boundary.tool_script_inputs:
+            return boundary.reload_unavailable_reason() or (
+                "One or more named inputs cannot be reloaded. Restore or reopen "
+                "the missing inputs, then try again."
             )
         return (
             "This tool cannot reload because its source chain has no reloadable "
@@ -962,19 +1395,65 @@ class _LineageController:
         except KeyError:
             return "The selected item is no longer available. Select an open item."
         if isinstance(target, str):
-            if self._manager._reload_target_for_child(target) is not None:
+            if self._reload_target_for_child(target) is not None:
                 return None
-            return self._manager._reload_unavailable_reason_for_child(target)
+            return self._reload_unavailable_reason_for_child(target)
         return self._node_reload_unavailable_reason(node)
 
     def _reload_source_chain_for_child(self, uid: str) -> bool:
-        """Reload the nearest reloadable ancestor, then refresh a child node."""
-        reload_target = self._manager._reload_target_for_child(uid)
+        reload_target = self._reload_target_for_child(uid)
         if reload_target is None:
             return False
-        if not self._manager.get_imagetool(reload_target).slicer_area._reload():
+        return self._reload_target_with_continuations(
+            reload_target,
+            () if reload_target == uid else (uid,),
+        )
+
+    def _reload_target_with_continuations(
+        self,
+        target: int | str,
+        target_uids: Sequence[str],
+        *,
+        reloaded_uids: set[str] | None = None,
+    ) -> bool:
+        node = self._manager._node_for_target(target)
+        reloaded_uids = set() if reloaded_uids is None else reloaded_uids
+        if node.uid in reloaded_uids:
+            reloaded = True
+        elif node.tool_script_inputs:
+            reloaded = self._refresh_tool_inputs(
+                node.uid,
+                allow_recorded=True,
+                continuation_uids=target_uids,
+                force_live_reload=True,
+                reloaded_uids=reloaded_uids,
+            )
+        elif self._node_can_reload_script_inputs(node):
+            reloaded = self._reload_script_derived_target(
+                target,
+                continuation_uids=target_uids,
+                reloaded_uids=reloaded_uids,
+            )
+        else:
+            reloaded = node.reload_source_data()
+        if not reloaded:
+            tool = node.tool_window
+            if (
+                tool is not None
+                and tool.source_state == "stale"
+                and tool._source_refresh_deferred
+            ):
+                for target_uid in target_uids:
+                    self._manager._dependency_tracker.queue_source_refresh(
+                        node.uid,
+                        target_uid,
+                    )
             return False
-        return self._manager._refresh_source_chain_to_uid(uid)
+        reloaded_uids.add(node.uid)
+        refreshed = True
+        for target_uid in target_uids:
+            refreshed &= self._refresh_source_chain_to_uid(target_uid)
+        return refreshed
 
     def show_selected_source_updates(self) -> None:
         """Show automatic update controls for the selected child window."""
@@ -983,11 +1462,19 @@ class _LineageController:
             return
         self._manager._child_node(uid).show_source_update_dialog(parent=self._manager)
 
-    def _child_targets_of(self, target: int | str) -> list[str]:
-        return list(self._manager._node_for_target(target)._childtool_indices)
-
     def _refresh_source_chain_to_uid(self, uid: str) -> bool:
-        """Refresh stale ancestors before refreshing a managed child node."""
+        node = self._manager._tool_graph.nodes.get(uid)
+        if (
+            node is not None
+            and not node.has_source_binding
+            and self._node_can_reload_script_inputs(node)
+        ):
+            if (
+                node.source_state == "fresh"
+                and self.dependency_status_for_uid(uid) == "current"
+            ):
+                return True
+            return self._reload_script_derived_target(uid)
         try:
             node = self._manager._child_node(uid)
         except KeyError:
@@ -1004,26 +1491,31 @@ class _LineageController:
             refresh_chain.append(parent)
             node = parent
 
-        for node in reversed(refresh_chain):
+        refresh_chain.reverse()
+        for index, node in enumerate(refresh_chain):
             current_uid = node.uid
 
             if not node.has_source_binding or node.source_state == "fresh":
                 continue
             updated = node._update_from_parent_source()
             if updated and node.source_state == "fresh":
+                self._resume_pending_source_refreshes(current_uid)
                 continue
             tool = node.tool_window
             if (
                 tool is not None
                 and tool.source_state == "stale"
-                and getattr(tool, "_source_refresh_deferred", False)
+                and tool._source_refresh_deferred
             ):
-                self._manager._dependency_tracker.queue_source_refresh(current_uid, uid)
+                for blocker, target in itertools.pairwise(refresh_chain[index:]):
+                    self._manager._dependency_tracker.queue_source_refresh(
+                        blocker.uid,
+                        target.uid,
+                    )
                 return False
             if node.source_state != "fresh":
-                self._manager._mark_descendants_source_state(
-                    current_uid, node.source_state
-                )
+                self._propagate_source_state_from_uid(current_uid, node.source_state)
+            self._manager._dependency_tracker.pop_source_refreshes(current_uid)
             return False
 
         try:
@@ -1031,33 +1523,126 @@ class _LineageController:
         except KeyError:
             return False
 
-    def _resume_pending_source_refreshes(self, uid: str) -> None:
-        target_uids = self._manager._dependency_tracker.pop_source_refreshes(uid)
+    def _resume_pending_source_refreshes(
+        self,
+        uid: str,
+        *,
+        require_self_refresh: bool = False,
+    ) -> bool:
+        target_intents = self._manager._dependency_tracker.pop_source_refresh_intents(
+            uid
+        )
+        target_uids = set(target_intents)
+        if require_self_refresh and uid not in target_uids:
+            self._manager._dependency_tracker.discard_source_refreshes(target_uids)
+            return False
+        self_refresh = uid in target_uids
+        if self_refresh:
+            target_uids.remove(uid)
+            source = self._manager._tool_graph.nodes.get(uid)
+            if (
+                target_intents[uid]
+                and all(target_intents.values())
+                and source is not None
+                and source.tool_window is not None
+                and not source.tool_window.source_auto_update
+            ):
+                source._set_source_state("stale")
+                return False
+            refreshed = bool(
+                source is not None
+                and source.tool_script_inputs
+                and self._refresh_tool_inputs(uid, allow_recorded=True)
+            )
+            if not refreshed:
+                if (
+                    source is not None
+                    and source.tool_window is not None
+                    and source.tool_window._source_refresh_deferred
+                ):
+                    for target_uid in target_uids:
+                        self._manager._dependency_tracker.queue_source_refresh(
+                            uid,
+                            target_uid,
+                        )
+                    return True
+                self._manager._dependency_tracker.discard_source_refreshes(target_uids)
+                return False
         for target_uid in list(target_uids):
-            if target_uid not in self._manager._tool_graph.nodes:
+            target = self._manager._tool_graph.nodes.get(target_uid)
+            if target is None:
                 continue
-            self._manager._refresh_source_chain_to_uid(target_uid)
+            if target.tool_script_inputs:
+                if target.source_state == "fresh" and self.dependency_status_for_uid(
+                    target_uid
+                ) not in {"changed", "missing"}:
+                    continue
+                self._refresh_tool_inputs(
+                    target_uid,
+                    allow_recorded=True,
+                )
+            else:
+                self._refresh_source_chain_to_uid(target_uid)
+        return self_refresh
 
     def _parent_source_data_for_uid(self, uid: str) -> xr.DataArray:
         node = self._manager._child_node(uid)
         parent = self._manager._parent_node(node)
         return parent.current_source_data()
 
-    def _mark_descendants_source_state(
+    def _propagate_source_state_from_uid(
         self,
         uid: str,
         state: _ManagedWindowNode._source_state_type,
     ) -> None:
-        for child_uid in self._manager._iter_descendant_uids(uid):
-            node = self._manager._child_node(child_uid)
-            if node.tool_window is not None and node.tool_window.has_source_binding:
-                if node.tool_window.source_state != state:
-                    node.tool_window._set_source_state(state)
-            elif node.has_source_binding:
-                node._set_source_state(state)
+        if state == "fresh":
+            raise ValueError("fresh source state requires a completed data update")
+        source = self._manager._tool_graph.nodes.get(uid)
+        if source is not None:
+            source._set_source_state(state)
+        pending = [uid]
+        seen = {uid}
+        propagated_states = {uid: state}
+        while pending:
+            source_uid = pending.pop()
+            source = self._manager._tool_graph.nodes.get(source_uid)
+            if source is None:
+                continue
 
-    def _mark_descendants_source_unavailable(self, uid: str) -> None:
-        self._manager._mark_descendants_source_state(uid, "unavailable")
+            target_uids: list[str] = []
+            for child_uid in source._childtool_indices:
+                child = self._manager._tool_graph.nodes.get(child_uid)
+                if (
+                    child is not None
+                    and child.is_imagetool
+                    and child.has_source_binding
+                ):
+                    target_uids.append(child_uid)
+            for dependent_uid in self._manager._dependency_tracker.dependent_uids(
+                source_uid
+            ):
+                dependent = self._manager._tool_graph.nodes.get(dependent_uid)
+                if dependent is not None and dependent.tool_script_inputs:
+                    target_uids.append(dependent_uid)
+
+            for target_uid in target_uids:
+                if target_uid in seen:
+                    continue
+                seen.add(target_uid)
+                target = self._manager._tool_graph.nodes.get(target_uid)
+                if target is None:
+                    continue
+                target_state = propagated_states[source_uid]
+                if target.tool_script_inputs:
+                    target_state = self._tool_input_source_state(
+                        target,
+                        state_overrides=propagated_states,
+                    )
+                    if target_state == "fresh":
+                        continue
+                target._set_source_state(target_state)
+                propagated_states[target_uid] = target_state
+                pending.append(target_uid)
 
     def _propagate_source_change_from_uid(
         self, uid: str, parent_data: xr.DataArray | None = None
@@ -1066,23 +1651,25 @@ class _LineageController:
             try:
                 parent_data = self._manager._node_for_target(uid).current_source_data()
             except Exception:
-                self._manager._mark_descendants_source_unavailable(uid)
+                self._propagate_source_state_from_uid(uid, "unavailable")
                 return
         for child_uid in list(self._manager._node_for_target(uid)._childtool_indices):
             try:
                 child = self._manager._child_node(child_uid)
             except KeyError:
                 continue
+            if not child.is_imagetool:
+                # The dependency graph owns named-input refreshes. The tree edge
+                # only selects where the tool appears.
+                continue
             previous_state = child.source_state
             updated = child.handle_parent_source_replaced(parent_data)
             if updated or child.source_state != previous_state:
                 self._manager.tree_view.refresh(child_uid)
             if updated:
-                self._manager._propagate_source_change_from_uid(child_uid)
+                self._propagate_source_change_from_uid(child_uid)
             elif child.source_state != "fresh":
-                self._manager._mark_descendants_source_state(
-                    child_uid, child.source_state
-                )
+                self._propagate_source_state_from_uid(child_uid, child.source_state)
 
     def show_selected(self) -> None:
         """Show selected windows."""
@@ -1108,8 +1695,7 @@ class _LineageController:
             node.hide()
 
     def reload_selected(self) -> None:
-        """Reload data in selected ImageTool windows."""
-        selected_reload_candidates = self._manager._selected_reload_candidates()
+        selected_reload_candidates = self._selected_reload_candidates()
         if selected_reload_candidates is None:
             return
 
@@ -1121,16 +1707,13 @@ class _LineageController:
             )
             return
 
-        reloaded_targets: set[int | str] = set()
+        reloaded_uids: set[str] = set()
         for target in reload_targets:
-            if self._manager.get_imagetool(target).slicer_area._reload():
-                reloaded_targets.add(target)
-
-        for target, child_uids in child_targets.items():
-            if target not in reloaded_targets:
-                continue
-            for uid in child_uids:
-                self._manager._refresh_source_chain_to_uid(uid)
+            self._reload_target_with_continuations(
+                target,
+                child_targets.get(target, ()),
+                reloaded_uids=reloaded_uids,
+            )
 
     @staticmethod
     def _reload_incompatibility_details(
@@ -1218,18 +1801,41 @@ class _LineageController:
             replay_source_data=node.replay_source_data,
         )
         self._manager.tree_view.refresh(node.uid)
+        self._resume_pending_source_refreshes(node.uid)
 
-    def _reload_script_derived_target(self, target: int | str) -> bool:
-        """Reload a script-derived ImageTool from its recorded inputs."""
+    def _reload_script_derived_target(
+        self,
+        target: int | str,
+        *,
+        continuation_uids: Sequence[str] = (),
+        reloaded_uids: set[str] | None = None,
+    ) -> bool:
         node = self._manager._node_for_target(target)
         spec = node.provenance_spec
         if spec is None:
+            return False
+        reloaded_uids = set() if reloaded_uids is None else reloaded_uids
+        plan = self._input_resolution_plan(
+            spec.script_inputs,
+            target_node_uid=node.uid,
+        )
+        plan = self._execute_input_resolution_plan(
+            plan,
+            reloaded_uids=reloaded_uids,
+        )
+        if isinstance(plan, str):
+            if plan == "deferred":
+                for continuation_uid in continuation_uids:
+                    self._manager._dependency_tracker.queue_source_refresh(
+                        node.uid,
+                        continuation_uid,
+                    )
             return False
         with (
             self._manager._extensions.execution.capture_replay_sources()
         ) as publication:
             try:
-                result = self._manager._rebuild_script_provenance(
+                result = self._rebuild_script_provenance(
                     spec,
                     target_node_uid=node.uid,
                 )
@@ -1249,18 +1855,16 @@ class _LineageController:
                 current, result.data
             ):
                 publication.require_current_for_publication()
-                self._manager._replace_script_reload_target(node, result)
+                self._replace_script_reload_target(node, result)
                 self._manager._status_bar.showMessage("Reloaded data from inputs", 5000)
                 publication.publish()
                 return True
 
-            details = self._manager._reload_incompatibility_details(
-                current, result.data
-            )
-            match self._manager._prompt_incompatible_reload_commit(details):
+            details = self._reload_incompatibility_details(current, result.data)
+            match self._prompt_incompatible_reload_commit(details):
                 case "replace":
                     publication.require_current_for_publication()
-                    self._manager._replace_script_reload_target(node, result)
+                    self._replace_script_reload_target(node, result)
                     self._manager._status_bar.showMessage(
                         "Reloaded data from inputs", 5000
                     )
@@ -1306,7 +1910,7 @@ class _LineageController:
         num_selected_children: int = len(child_uids)
         num_implicit_children: int = 0
         for i in indices:
-            for uid in self._manager._child_targets_of(i):
+            for uid in self._manager._node_for_target(i)._childtool_indices:
                 if uid not in child_uids:  # pragma: no branch
                     num_implicit_children += 1
 

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -751,14 +751,16 @@ class _LineageController:
             if node.slicer_area._provenance_reloadable():
                 add_action("reload", node.uid)
                 return None
-            if spec is not None and (spec.kind == "file" or has_file_load_source(spec)):
-                if reason := self._file_load_source_unavailable_reason(
-                    spec, "This result"
-                ):
-                    return reason
-                if spec.kind == "file":
-                    add_action("reload", node.uid)
-                    return None
+            if (
+                spec is not None
+                and (spec.kind == "file" or has_file_load_source(spec))
+                and (
+                    reason := self._file_load_source_unavailable_reason(
+                        spec, "This result"
+                    )
+                )
+            ):
+                return reason
             if spec is not None and spec.kind == "script" and not spec.script_inputs:
                 return "This result has no recorded inputs."
             return node.slicer_area._local_reload_unavailable_reason()

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -947,11 +947,15 @@ class _LineageController:
             tool = node.tool_window
             inputs = () if tool is None else tool.script_inputs
             if tool is None or not inputs:
-                self._manager._dependency_tracker.pop_source_refreshes(target_uid)
+                self._manager._dependency_tracker.discard_source_refresh_chain(
+                    target_uid
+                )
                 return False
 
             def fail_refresh() -> bool:
-                self._manager._dependency_tracker.pop_source_refreshes(target_uid)
+                self._manager._dependency_tracker.discard_source_refresh_chain(
+                    target_uid
+                )
                 return False
 
             def defer_refresh() -> bool:

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -544,6 +544,13 @@ class ImageToolManager(_ImageToolManagerBase):
         self.concat_action.triggered.connect(self.concat_selected)
         self.concat_action.setToolTip("Concatenate data in selected windows")
 
+        self.weighted_ftool_action = QtWidgets.QAction("Open in ftool…", self)
+        self.weighted_ftool_action.setObjectName("manager_open_weighted_ftool_action")
+        self.weighted_ftool_action.triggered.connect(self.show_weighted_ftool_dialog)
+        self.weighted_ftool_action.setToolTip(
+            "Open two selected ImageTools as data and standard uncertainty in ftool"
+        )
+
         self.batch_action = QtWidgets.QAction("Batch Operation…", self)
         self.batch_action.setObjectName("manager_batch_operation_action")
         self.batch_action.triggered.connect(self.show_batch_operations)
@@ -696,6 +703,7 @@ class ImageToolManager(_ImageToolManagerBase):
         self.edit_menu.addAction(self.reindex_action)
         self.edit_menu.addSeparator()
         self.edit_menu.addAction(self.concat_action)
+        self.edit_menu.addAction(self.weighted_ftool_action)
         self.edit_menu.addAction(self.metadata_editor_action)
         self.edit_menu.addAction(self.batch_action)
         self.edit_menu.addAction(self.create_figure_action)
@@ -2643,6 +2651,19 @@ class ImageToolManager(_ImageToolManagerBase):
 
     def concat_selected(self) -> None:
         self._actions_controller.concat_selected()
+
+    def show_weighted_ftool_dialog(self) -> None:
+        self._actions_controller.show_weighted_ftool_dialog()
+
+    def open_weighted_ftool(
+        self,
+        data_target: int | str,
+        uncertainty_target: int | str,
+    ) -> str | None:
+        return self._actions_controller.open_weighted_ftool(
+            data_target,
+            uncertainty_target,
+        )
 
     def batch_target_count(self) -> int:
         return self._actions_controller.batch_target_count()

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1501,6 +1501,9 @@ class ImageToolManager(_ImageToolManagerBase):
             self._tool_graph.reindex_roots()
 
         self.tree_view.refresh()
+        self._figure_workflows._refresh_figure_source_controls()
+        if self._metadata_node_uid is not None:
+            self._schedule_details_refresh(self._metadata_node_uid)
         self._mark_workspace_structure_dirty("Reindexed root windows")
 
     @QtCore.Slot(int)

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -2422,9 +2422,6 @@ class ImageToolManager(_ImageToolManagerBase):
             data_role=data_role,
         )
 
-    def _script_provenance_inputs_current(self, spec: ToolProvenanceSpec) -> bool:
-        return self._lineage_controller._script_provenance_inputs_current(spec)
-
     def _resolve_live_script_input_for_reload(
         self,
         script_input: ScriptInput,
@@ -2432,17 +2429,6 @@ class ImageToolManager(_ImageToolManagerBase):
         target_node_uid: str | None = None,
     ) -> tuple[xr.DataArray, ScriptInput] | None:
         return self._lineage_controller._resolve_live_script_input_for_reload(
-            script_input,
-            target_node_uid=target_node_uid,
-        )
-
-    def _script_input_can_reload(
-        self,
-        script_input: ScriptInput,
-        *,
-        target_node_uid: str | None = None,
-    ) -> bool:
-        return self._lineage_controller._script_input_can_reload(
             script_input,
             target_node_uid=target_node_uid,
         )
@@ -2837,7 +2823,6 @@ class ImageToolManager(_ImageToolManagerBase):
         created_time: datetime.datetime | str | bytes | None = None,
         note: str | bytes | None = None,
     ) -> str:
-        tool.set_input_provenance_spec(None)
         node = _ManagedWindowNode(
             self,
             self._next_node_uid(uid),

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -105,7 +105,6 @@ if typing.TYPE_CHECKING:
     from erlab.interactive.imagetool._provenance._model import (
         ScriptInput,
         ScriptInputDataRole,
-        ScriptInputDependencyRef,
         ToolProvenanceSpec,
         _ProvenanceDisplayRow,
     )
@@ -1256,9 +1255,6 @@ class ImageToolManager(_ImageToolManagerBase):
     def _next_node_uid(self, preferred: str | None = None) -> str:
         return self._tool_graph.next_uid(preferred)
 
-    def _consume_node_uid(self, uid: str) -> None:
-        self._tool_graph.consume_uid(uid)
-
     def _register_root_wrapper(self, wrapper: _ImageToolWrapper) -> None:
         self._tool_graph.register_root(wrapper)
         self._dependency_tracker.note_uid(wrapper.uid)
@@ -1293,7 +1289,7 @@ class ImageToolManager(_ImageToolManagerBase):
         if node.tool_window is not None:
             node.tool_window._refresh_reload_data_action()
 
-    def _unregister_node(self, uid: str) -> None:
+    def _unregister_node(self, uid: str, *, refresh_dependents: bool = True) -> None:
         node = self._tool_graph.unregister_node(uid)
         if node is None:
             return
@@ -1301,7 +1297,7 @@ class ImageToolManager(_ImageToolManagerBase):
             self._invalidate_workspace_link_color_cache()
         self._cancel_managed_node_change(uid)
         self._dependency_tracker.clear_uid(uid)
-        if not self._workspace_state.closing_document:
+        if refresh_dependents and not self._workspace_state.closing_document:
             self._refresh_dependency_dependents(uid)
             self._figure_workflows._refresh_figure_source_controls()
         if self._workspace_state.loading_depth == 0:
@@ -1332,9 +1328,6 @@ class ImageToolManager(_ImageToolManagerBase):
             if child is None or isinstance(child, _ImageToolWrapper):
                 continue
             self._unregister_node(child_uid)
-            if child.tool_window is not None:
-                child.tool_window.set_source_parent_fetcher(None)
-                child.tool_window.set_input_provenance_parent_fetcher(None)
             child.dispose()
 
     def _workspace_link_keys_for_subtree(self, uid: str) -> set[str]:
@@ -2289,11 +2282,6 @@ class ImageToolManager(_ImageToolManagerBase):
     def open(self, *, native: bool = True) -> None:
         self._data_ingress.open(native=native)
 
-    def _dependency_refs_for_uid(
-        self, uid: str
-    ) -> tuple[ScriptInputDependencyRef, ...]:
-        return self._lineage_controller._dependency_refs_for_uid(uid)
-
     def dependency_status_for_uid(self, uid: str) -> _DependencyStatus | None:
         return self._lineage_controller.dependency_status_for_uid(uid)
 
@@ -2308,28 +2296,6 @@ class ImageToolManager(_ImageToolManagerBase):
 
     def dependency_input_summary_for_uid(self, uid: str) -> str | None:
         return self._lineage_controller.dependency_input_summary_for_uid(uid)
-
-    def _show_dependency_reload_dialog(self, target: int | str) -> None:
-        self._lineage_controller._show_dependency_reload_dialog(target)
-
-    def _script_input_has_recorded_file(
-        self,
-        script_input: ScriptInput,
-    ) -> bool:
-        return self._lineage_controller._script_input_has_recorded_file(script_input)
-
-    def _dependency_ref_has_recorded_file(
-        self,
-        spec: ToolProvenanceSpec | None,
-        ref: ScriptInputDependencyRef,
-    ) -> bool:
-        return self._lineage_controller._dependency_ref_has_recorded_file(spec, ref)
-
-    def _missing_dependencies_have_recorded_file(self, uid: str) -> bool:
-        return self._lineage_controller._missing_dependencies_have_recorded_file(uid)
-
-    def _dependency_dependent_uids(self, uid: str) -> list[str]:
-        return self._lineage_controller._dependency_dependent_uids(uid)
 
     def _refresh_dependency_dependents(self, uid: str) -> None:
         if self._workspace_ui_refresh_defer_depth > 0:
@@ -2538,70 +2504,19 @@ class ImageToolManager(_ImageToolManagerBase):
             execute=execute,
         )
 
-    def _workspace_loaded_uid_map(
-        self, loaded_targets_by_uid: Mapping[str, int | str]
-    ) -> dict[str, str]:
-        return self._lineage_controller._workspace_loaded_uid_map(loaded_targets_by_uid)
-
-    def _rebase_loaded_workspace_dependency_refs(
-        self,
-        loaded_targets_by_uid: Mapping[str, int | str],
-    ) -> None:
-        self._lineage_controller._rebase_loaded_workspace_dependency_refs(
-            loaded_targets_by_uid,
-        )
-
-    def _selected_reload_targets(
-        self,
-    ) -> tuple[list[int | str], dict[int | str, list[str]]] | None:
-        return self._lineage_controller._selected_reload_targets()
-
-    def _selected_reload_candidates(
-        self,
-    ) -> tuple[list[int | str], dict[int | str, list[str]], str | None] | None:
-        return self._lineage_controller._selected_reload_candidates()
-
-    def _reload_target_for_child(self, uid: str) -> int | str | None:
-        return self._lineage_controller._reload_target_for_child(uid)
-
-    def _reload_unavailable_reason_for_child(self, uid: str) -> str:
-        return self._lineage_controller._reload_unavailable_reason_for_child(uid)
-
     def _reload_unavailable_reason_for_target(self, target: int | str) -> str | None:
         return self._lineage_controller._reload_unavailable_reason_for_target(target)
 
+    def _reload_target_for_child(self, uid: str) -> int | str | None:
+        """Return the reload boundary used by an attached ImageTool."""
+        return self._lineage_controller._reload_target_for_child(uid)
+
     def _reload_source_chain_for_child(self, uid: str) -> bool:
+        """Reload the source chain requested by an attached ImageTool."""
         return self._lineage_controller._reload_source_chain_for_child(uid)
 
     def show_selected_source_updates(self) -> None:
         self._lineage_controller.show_selected_source_updates()
-
-    def _child_targets_of(self, target: int | str) -> list[str]:
-        return self._lineage_controller._child_targets_of(target)
-
-    def _refresh_source_chain_to_uid(self, uid: str) -> bool:
-        return self._lineage_controller._refresh_source_chain_to_uid(uid)
-
-    def _resume_pending_source_refreshes(self, uid: str) -> None:
-        self._lineage_controller._resume_pending_source_refreshes(uid)
-
-    def _parent_source_data_for_uid(self, uid: str) -> xr.DataArray:
-        return self._lineage_controller._parent_source_data_for_uid(uid)
-
-    def _mark_descendants_source_state(
-        self,
-        uid: str,
-        state: _ManagedWindowNode._source_state_type,
-    ) -> None:
-        self._lineage_controller._mark_descendants_source_state(uid, state)
-
-    def _mark_descendants_source_unavailable(self, uid: str) -> None:
-        self._lineage_controller._mark_descendants_source_unavailable(uid)
-
-    def _propagate_source_change_from_uid(
-        self, uid: str, parent_data: xr.DataArray | None = None
-    ) -> None:
-        self._lineage_controller._propagate_source_change_from_uid(uid, parent_data)
 
     def reveal_nodes(self, uids: Iterable[str]) -> bool:
         """Reveal manager nodes in their corresponding manager collection."""
@@ -2692,25 +2607,6 @@ class ImageToolManager(_ImageToolManagerBase):
     def reload_selected(self) -> None:
         self._lineage_controller.reload_selected()
 
-    @staticmethod
-    def _reload_incompatibility_details(
-        current: xr.DataArray, rebuilt: xr.DataArray
-    ) -> str:
-        return _LineageController._reload_incompatibility_details(current, rebuilt)
-
-    def _prompt_incompatible_reload_commit(self, details: str) -> str:
-        return self._lineage_controller._prompt_incompatible_reload_commit(details)
-
-    def _replace_script_reload_target(
-        self,
-        node: _ImageToolWrapper | _ManagedWindowNode,
-        result: _ScriptRebuildResult,
-    ) -> None:
-        self._lineage_controller._replace_script_reload_target(node, result)
-
-    def _reload_script_derived_target(self, target: int | str) -> bool:
-        return self._lineage_controller._reload_script_derived_target(target)
-
     def remove_selected(self) -> None:
         self._lineage_controller.remove_selected()
 
@@ -2775,13 +2671,6 @@ class ImageToolManager(_ImageToolManagerBase):
 
     def rename_imagetool(self, index: int, new_name: str) -> None:
         self._actions_controller.rename_imagetool(index, new_name)
-
-    def _duplicate_subtree(
-        self, target: int | str, *, parent_override: int | str | None = None
-    ) -> int | str:
-        return self._actions_controller._duplicate_subtree(
-            target, parent_override=parent_override
-        )
 
     def duplicate_imagetool(self, index: int | str) -> int | str:
         return self._actions_controller.duplicate_imagetool(index)
@@ -2891,8 +2780,9 @@ class ImageToolManager(_ImageToolManagerBase):
     def add_childtool(
         self,
         tool: erlab.interactive.utils.ToolWindow,
-        index: int | str,
         *,
+        script_inputs: Mapping[str, int | str],
+        parent: int | str | None = None,
         show: bool = True,
         uid: str | None = None,
         snapshot_token: str | None = None,
@@ -2902,7 +2792,8 @@ class ImageToolManager(_ImageToolManagerBase):
     ) -> str:
         return self._actions_controller.add_childtool(
             tool,
-            index,
+            script_inputs=script_inputs,
+            parent=parent,
             show=show,
             uid=uid,
             snapshot_token=snapshot_token,

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -1919,6 +1919,7 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
         self._menu.addAction(manager.reindex_action)
         self._menu.addSeparator()
         self._menu.addAction(manager.concat_action)
+        self._menu.addAction(manager.weighted_ftool_action)
         self._menu.addAction(manager.metadata_editor_action)
         self._menu.addAction(manager.batch_action)
         self._menu.addAction(manager.create_figure_action)

--- a/src/erlab/interactive/imagetool/manager/_modelview.py
+++ b/src/erlab/interactive/imagetool/manager/_modelview.py
@@ -2130,7 +2130,9 @@ class _ImageToolWrapperTreeView(QtWidgets.QTreeView):
                     target = None
                 if target is None:
                     return
-                self._model.manager._show_dependency_reload_dialog(target)
+                self._model.manager._lineage_controller._show_dependency_reload_dialog(
+                    target
+                )
 
     def _show_dask_badge_menu(
         self,

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
@@ -2021,7 +2021,7 @@ class _ProvenanceEditController:
             ) as publication:
                 candidate = dialog.provenance_spec(
                     active_name=_file_load_edit_active_name(spec),
-                    replay_steps=spec.steps,
+                    replay_steps=() if spec.kind == "script" else spec.steps,
                 )
                 if spec.kind == "script":
                     candidate = _replace_file_load_fields(spec, candidate)

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
@@ -298,9 +298,11 @@ class _ProvenanceEditController:
             if external_input_names and not node.has_replay_source:
                 return "The original replay source is no longer available."
             for script_input in spec.script_inputs:
-                reason = self._manager._script_input_unavailable_reason(
-                    script_input,
-                    target_node_uid=node.uid,
+                reason = (
+                    self._manager._lineage_controller._script_input_unavailable_reason(
+                        script_input,
+                        target_node_uid=node.uid,
+                    )
                 )
                 if reason is not None:
                     return reason
@@ -670,7 +672,7 @@ class _ProvenanceEditController:
                             authorize=self._capability_authorizer(authorization),
                         )
                     else:
-                        data = self._manager._apply_provenance(
+                        data = self._manager._lineage_controller._apply_provenance(
                             local,
                             current_data,
                             reason="paste these provenance steps",
@@ -925,10 +927,11 @@ class _ProvenanceEditController:
             if not self._script_spec_replayable_for_node(node, candidate):
                 return False, "This script step cannot be replayed."
             if not all(
-                self._manager._script_input_can_reload(
+                self._manager._lineage_controller._script_input_unavailable_reason(
                     script_input,
                     target_node_uid=node.uid,
                 )
+                is None
                 for script_input in candidate.script_inputs
             ):
                 return False, "This script step has unavailable inputs."
@@ -2891,7 +2894,7 @@ class _ProvenanceEditController:
             if scope == "source" and node.parent_uid is not None:
                 parent = self._manager._parent_node(node)
                 return (
-                    self._manager._apply_provenance(
+                    self._manager._lineage_controller._apply_provenance(
                         spec,
                         parent.current_source_data(),
                         reason="apply this provenance order",
@@ -2903,7 +2906,7 @@ class _ProvenanceEditController:
             if parent_data is None:
                 raise RuntimeError("Live provenance needs a parent source to replay")
             return (
-                self._manager._apply_provenance(
+                self._manager._lineage_controller._apply_provenance(
                     spec,
                     parent_data,
                     reason="apply this provenance order",
@@ -2930,7 +2933,7 @@ class _ProvenanceEditController:
                         ),
                         authorize=(
                             functools.partial(
-                                self._manager._authorize_provenance_execution,
+                                self._manager._lineage_controller._authorize_provenance_execution,
                                 reason="apply this provenance order",
                             )
                             if authorization is None
@@ -2939,7 +2942,7 @@ class _ProvenanceEditController:
                     ),
                     spec,
                 )
-            result = self._manager._rebuild_script_provenance(
+            result = self._manager._lineage_controller._rebuild_script_provenance(
                 spec,
                 target_node_uid=node.uid,
                 authorization=authorization,
@@ -2984,7 +2987,7 @@ class _ProvenanceEditController:
             },
             authorize=(
                 functools.partial(
-                    self._manager._authorize_provenance_execution,
+                    self._manager._lineage_controller._authorize_provenance_execution,
                     reason="apply this provenance order",
                 )
                 if authorization is None
@@ -3024,7 +3027,7 @@ class _ProvenanceEditController:
                     ),
                     extension_loader_executor=(self._manager._extensions.replay_loader),
                     authorize=functools.partial(
-                        self._manager._authorize_provenance_execution,
+                        self._manager._lineage_controller._authorize_provenance_execution,
                         reason="reload this file provenance",
                     ),
                 )

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_files.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_files.py
@@ -504,7 +504,7 @@ class _FileLoadEditDialog(QtWidgets.QDialog):
             path=self._peer_path(peer),
             selection=replay_call.selection,
             active_name=_file_load_edit_active_name(peer.spec),
-            replay_steps=peer.spec.steps,
+            replay_steps=() if peer.spec.kind == "script" else peer.spec.steps,
         )
 
     def _provenance_spec_for(
@@ -661,7 +661,6 @@ def _replace_file_load_fields(
             "start_label": replacement.start_label,
             "seed_code": replacement.seed_code,
             "file_load_source": replacement.file_load_source,
-            "steps": replacement.steps,
         }
     )
 

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -542,7 +542,11 @@ class _WorkspaceController:
         )
 
     def _tool_data_reference_matches_current_data(
-        self, reference: Mapping[str, typing.Any], data: xr.DataArray
+        self,
+        reference: Mapping[str, typing.Any],
+        data: xr.DataArray,
+        *,
+        owner_node: _ManagedWindowNode,
     ) -> bool:
         if not self._tool_data_reference_matches_current_snapshot(reference):
             return False
@@ -556,6 +560,44 @@ class _WorkspaceController:
         )
         try:
             resolved = node.data_for_role(data_role)
+            tool = owner_node.tool_window
+            if tool is None:
+                return False
+            input_name = reference.get("input_name")
+            script_input = next(
+                (
+                    (index, item)
+                    for index, item in enumerate(tool.script_inputs)
+                    if item.name == input_name
+                ),
+                None,
+            )
+            authorization = None
+            if script_input is not None:
+                index, item = script_input
+                entries = tuple(
+                    tool._source_spec_code_trust_entries(
+                        item.parsed_source_spec(),
+                        location_prefix=f"tool-inputs/{index}:{item.name}/source",
+                    )
+                )
+                if entries:
+                    entries = self._locate_tool_code_trust_entries(
+                        entries,
+                        location_getter=lambda: (
+                            self.saving._workspace_node_path_for_node(owner_node)
+                        ),
+                    )
+                    authorization = self.issue_code_execution_capability(entries)
+                    if authorization is None:
+                        return False
+            resolved = (
+                erlab.interactive.utils.ToolWindow._apply_saved_tool_data_reference(
+                    reference,
+                    resolved,
+                    authorization=authorization,
+                )
+            )
         except Exception:
             return False
         return erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -399,23 +399,6 @@ class _WorkspaceLoader:
             with contextlib.suppress(Exception):
                 dataset.close()
 
-    @staticmethod
-    def _workspace_reference_key(
-        workspace_path: str | os.PathLike[str], payload_path: str
-    ) -> tuple[pathlib.Path, str]:
-        normalized = workspace_arrays._normalized_file_path(workspace_path)
-        return pathlib.Path(
-            os.fsdecode(workspace_path) if normalized is None else normalized
-        ), payload_path.strip("/")
-
-    @staticmethod
-    def _open_workspace_imagetool_reference_dataset(
-        workspace_path: str | os.PathLike[str], payload_path: str
-    ) -> xr.Dataset:
-        return workspace_arrays.open_workspace_dataset(
-            workspace_path, payload_path, chunks={}
-        )
-
     def _workspace_imagetool_reference_dataset(
         self,
         node: _ImageToolWrapper | _ManagedWindowNode,
@@ -442,11 +425,17 @@ class _WorkspaceLoader:
         owner_node: _ImageToolWrapper | _ManagedWindowNode | None = None,
         reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] | None = None,
     ) -> xr.Dataset:
-        key = self._workspace_reference_key(workspace_path, payload_path)
+        normalized = workspace_arrays._normalized_file_path(workspace_path)
+        key = (
+            pathlib.Path(
+                os.fsdecode(workspace_path) if normalized is None else normalized
+            ),
+            payload_path.strip("/"),
+        )
 
         def _open() -> xr.Dataset:
-            return self._open_workspace_imagetool_reference_dataset(
-                workspace_path, payload_path
+            return workspace_arrays.open_workspace_dataset(
+                workspace_path, payload_path, chunks={}
             )
 
         if reference_datasets is not None:
@@ -605,9 +594,12 @@ class _WorkspaceLoader:
         tool_cls = erlab.interactive.utils.ToolWindow
         tool_data_references = tool_cls._saved_tool_data_references(ds)
         source_parent_data: xr.DataArray | None = None
-        if parent_target is not None and any(
-            reference.get("kind") == "parent_source"
-            for reference in tool_data_references.values()
+        if parent_target is not None and (
+            any(
+                reference.get("kind") == "parent_source"
+                for reference in tool_data_references.values()
+            )
+            or erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR in ds.attrs
         ):
             source_parent_data = _source_data_for_target(parent_target)
 
@@ -635,7 +627,7 @@ class _WorkspaceLoader:
                     )
                     if pending_owner is None:
                         return None
-                    return self._saved_workspace_reference_source_data_for_uid(
+                    resolved = self._saved_workspace_reference_source_data_for_uid(
                         node_uid,
                         snapshot_token=(
                             snapshot_token
@@ -647,6 +639,9 @@ class _WorkspaceLoader:
                         reference_datasets=reference_datasets,
                         workspace_path=pending_owner[0],
                     )
+                    if resolved is None:
+                        return None
+                    return resolved
                 if (
                     isinstance(snapshot_token, str)
                     and snapshot_token
@@ -662,8 +657,7 @@ class _WorkspaceLoader:
                     if saved_data is not None:
                         return saved_data
                 return _source_data_for_target(
-                    target,
-                    typing.cast("ScriptInputDataRole", data_role),
+                    target, typing.cast("ScriptInputDataRole", data_role)
                 )
             except resolver_error_types:
                 if log_resolver_errors:
@@ -702,6 +696,58 @@ class _WorkspaceLoader:
             attrs.get(erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR)
         )
         return erlab.interactive.utils._normalize_tool_source_state(source_state)
+
+    def _workspace_tool_dataset_with_canonical_inputs(
+        self,
+        ds: xr.Dataset,
+        *,
+        parent_target: int | str | None,
+    ) -> xr.Dataset:
+        """Convert released unary ToolWindow metadata to one canonical input."""
+        inputs_attr = erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR
+        if parent_target is None or inputs_attr in ds.attrs:
+            return ds
+
+        legacy_attrs = (
+            erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR,
+            erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR,
+            erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR,
+        )
+        if not any(key in ds.attrs for key in legacy_attrs):
+            return ds
+
+        tool_cls = erlab.interactive.utils.ToolWindow
+        try:
+            script_inputs, primary_input = tool_cls._saved_script_input_metadata(
+                ds.attrs
+            )
+            primary_index = tuple(item.name for item in script_inputs).index(
+                primary_input
+            )
+            primary_script_input = script_inputs[primary_index]
+            source_spec = primary_script_input.parsed_source_spec()
+        except Exception:
+            logger.warning("Ignoring invalid saved ToolWindow input", exc_info=True)
+            return ds
+
+        parent_node = self._manager._node_for_target(parent_target)
+        bound_input = self._manager._lineage_controller._script_input_for_node(
+            parent_node,
+            name=primary_input,
+            source_spec=source_spec,
+            fallback_provenance_spec=primary_script_input.provenance_spec,
+            data_role="displayed",
+        )
+        updated_inputs = list(script_inputs)
+        updated_inputs[primary_index] = bound_input
+        migrated = ds.copy(deep=False)
+        migrated.attrs = dict(ds.attrs)
+        migrated.attrs.update(
+            tool_cls._saved_script_input_attrs(updated_inputs, primary_input)
+        )
+        if source_spec is not None:
+            migrated.attrs.pop(erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR, None)
+        return migrated
 
     def _root_workspace_imagetool_kwargs(
         self, ds: xr.Dataset, kwargs: dict[str, typing.Any]
@@ -1087,6 +1133,10 @@ class _WorkspaceLoader:
         reserved_uids: Mapping[str, str] | None = None,
     ) -> int | str:
         if pending_workspace_tool_payload is not None:
+            ds = self._workspace_tool_dataset_with_canonical_inputs(
+                ds,
+                parent_target=parent_target,
+            )
             self.pending._validate_pending_workspace_tool_dataset(
                 ds, parent_target=parent_target
             )
@@ -1123,6 +1173,10 @@ class _WorkspaceLoader:
 
         reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] = {}
         try:
+            ds = self._workspace_tool_dataset_with_canonical_inputs(
+                ds,
+                parent_target=parent_target,
+            )
             with _workspace_load_stage(profiler, "tool reference restore"):
                 source_parent_data, tool_data_reference_resolver = (
                     self._workspace_tool_restore_references(
@@ -1166,7 +1220,7 @@ class _WorkspaceLoader:
                         note=ds.attrs.get("manager_node_note"),
                     )
                 else:
-                    target = self._manager.add_childtool(
+                    target = self._manager._actions_controller._register_childtool(
                         tool,
                         parent_target,
                         show=_workspace_dataset_window_visible(ds, "tool"),
@@ -1178,15 +1232,6 @@ class _WorkspaceLoader:
                         created_time=ds.attrs.get("manager_node_added_at"),
                         note=ds.attrs.get("manager_node_note"),
                     )
-                    parent_uid = self._manager._node_for_target(parent_target).uid
-                    registered_node = self._manager._node_for_target(target)
-
-                    def _source_parent_fetcher() -> xr.DataArray:
-                        return self._workspace_tool_reference_source_data(
-                            parent_uid, owner_node=registered_node
-                        )
-
-                    tool.set_source_parent_fetcher(_source_parent_fetcher)
                 registered_node = self._manager._node_for_target(target)
                 registered_node._set_workspace_tool_data_references(
                     type(tool)._saved_tool_data_references(ds)
@@ -1958,8 +2003,8 @@ class _WorkspaceLoader:
                 if loaded_count == 0 and self._skipped_workspace_nodes:
                     self._raise_no_workspace_windows_loaded()
                 with profiler.stage("link/layout restore"):
-                    self._manager._rebase_loaded_workspace_dependency_refs(
-                        loaded_targets_by_uid,
+                    self._manager._lineage_controller._rebase_loaded_workspace_dependency_refs(
+                        loaded_targets_by_uid
                     )
                     self._restore_workspace_link_groups(manifest, loaded_targets_by_uid)
                 if replace:
@@ -2160,7 +2205,7 @@ class _WorkspaceLoader:
                     if loaded_count == 0 and self._skipped_workspace_nodes:
                         self._raise_no_workspace_windows_loaded()
                     with profiler.stage("link/layout restore"):
-                        self._manager._rebase_loaded_workspace_dependency_refs(
+                        self._manager._lineage_controller._rebase_loaded_workspace_dependency_refs(
                             loaded_targets_by_uid
                         )
                         self._restore_workspace_link_groups(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -1156,7 +1156,6 @@ class _WorkspaceLoader:
             )
             return target
 
-        ds = self._tool_dataset_without_saved_input_provenance(ds)
         uid = self._manager._next_node_uid(self._workspace_saved_uid_from_dataset(ds))
         if parent_target is None:
             location_prefix = f"figures/{uid}"
@@ -1177,6 +1176,7 @@ class _WorkspaceLoader:
                 ds,
                 parent_target=parent_target,
             )
+            ds = self._tool_dataset_without_saved_input_provenance(ds)
             with _workspace_load_stage(profiler, "tool reference restore"):
                 source_parent_data, tool_data_reference_resolver = (
                     self._workspace_tool_restore_references(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -27,14 +27,8 @@ from erlab.interactive.imagetool import _serialization
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME, ImageTool
 from erlab.interactive.imagetool._provenance._model import (
     ScriptInputDataRole,
-    ToolProvenanceSpec,
     mark_promoted_1d_source,
     parse_tool_provenance_operation,
-    parse_tool_provenance_spec,
-    require_live_source_spec,
-)
-from erlab.interactive.imagetool._provenance._operations import (
-    ImageToolSelectionSourceBinding,
 )
 from erlab.interactive.imagetool._provenance._trust import (
     provenance_operation_requires_code_trust,
@@ -54,6 +48,7 @@ if typing.TYPE_CHECKING:
     import h5py
     import xarray as xr
 
+    from erlab.interactive.imagetool._provenance._model import ToolProvenanceSpec
     from erlab.interactive.imagetool.manager._workspace._controller import (
         _WorkspaceController,
     )
@@ -826,57 +821,6 @@ class _PendingWorkspacePayloads:
                 name = name.decode()
         return "" if name is None else str(name)
 
-    def _workspace_tool_source_metadata(
-        self, attrs: Mapping[str, typing.Any]
-    ) -> tuple[
-        ToolProvenanceSpec | None,
-        ImageToolSelectionSourceBinding | None,
-        bool,
-        _ManagedWindowNode._source_state_type,
-    ]:
-        source_spec = None
-        raw_source_spec = attrs.get(erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR)
-        if raw_source_spec is not None:
-            try:
-                source_spec = require_live_source_spec(
-                    parse_tool_provenance_spec(
-                        typing.cast(
-                            "Mapping[str, typing.Any]",
-                            json.loads(raw_source_spec),
-                        )
-                    )
-                )
-            except Exception:
-                logger.warning(
-                    "Ignoring invalid saved tool source provenance",
-                    exc_info=True,
-                )
-        source_binding = None
-        if (
-            source_spec is None
-            and erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR in attrs
-        ):
-            try:
-                source_binding = ImageToolSelectionSourceBinding.model_validate(
-                    typing.cast(
-                        "Mapping[str, typing.Any]",
-                        json.loads(
-                            attrs[erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR]
-                        ),
-                    )
-                )
-            except Exception:
-                logger.warning(
-                    "Ignoring invalid saved tool source binding",
-                    exc_info=True,
-                )
-        return (
-            source_spec,
-            source_binding,
-            bool(attrs.get(erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR)),
-            self._loader._workspace_tool_source_state_from_attrs(attrs),
-        )
-
     def _register_pending_workspace_imagetool(
         self,
         ds: xr.Dataset,
@@ -1113,6 +1057,8 @@ class _PendingWorkspacePayloads:
                         _code_trust_entry_locator=entry_locator,
                     )
                 )
+                tool._set_source_auto_update(node.source_auto_update)
+                tool._set_source_state(node.source_state)
                 if node.parent_uid is None:
                     self._loader._require_workspace_root_tool_is_figure(tool)
                     tool.set_input_provenance_spec(None)
@@ -1704,20 +1650,16 @@ class _PendingWorkspacePayloads:
             )
             self._manager._register_child_node(node)
             self._manager.tree_view.childtool_added(node.uid, parent_target)
-        source_spec, source_binding, auto_update, source_state = (
-            self._workspace_tool_source_metadata(attrs)
-        )
-        node.set_restored_source_binding_metadata(
-            source_spec,
-            source_binding,
-            auto_update=auto_update,
-            state=source_state,
-        )
         node.set_pending_workspace_payload(
             "tool",
             *pending_workspace_tool_payload,
             payload_attrs=attrs,
         )
+        node._source_auto_update = bool(
+            attrs.get(erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR)
+        )
+        source_state = self._loader._workspace_tool_source_state_from_attrs(attrs)
+        node._source_state = source_state if node.tool_script_inputs else "fresh"
         self._controller._mark_node_added(node.uid)
         self._loader._record_workspace_loaded_node_target(
             ds, node.uid, loaded_targets_by_uid

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -48,7 +48,6 @@ if typing.TYPE_CHECKING:
     import h5py
     import xarray as xr
 
-    from erlab.interactive.imagetool._provenance._model import ToolProvenanceSpec
     from erlab.interactive.imagetool.manager._workspace._controller import (
         _WorkspaceController,
     )
@@ -1026,6 +1025,10 @@ class _PendingWorkspacePayloads:
             if pending_attrs is not None:
                 ds = ds.copy(deep=False)
                 ds.attrs = dict(pending_attrs)
+            ds = self._loader._workspace_tool_dataset_with_canonical_inputs(
+                ds,
+                parent_target=node.parent_uid,
+            )
             ds = self._loader._tool_dataset_without_saved_input_provenance(ds)
 
             source_parent_data, tool_data_reference_resolver = (
@@ -1061,7 +1064,6 @@ class _PendingWorkspacePayloads:
                 tool._set_source_state(node.source_state)
                 if node.parent_uid is None:
                     self._loader._require_workspace_root_tool_is_figure(tool)
-                    tool.set_input_provenance_spec(None)
                     node.window = tool
                     if not tool._tool_display_name:
                         tool._tool_display_name = node.name
@@ -1069,23 +1071,6 @@ class _PendingWorkspacePayloads:
                     self._manager._figure_collection.sync(select_uid=None)
                 else:
                     parent = self._manager._node_for_target(node.parent_uid)
-                    parent_uid = parent.uid
-
-                    def _source_parent_fetcher() -> xr.DataArray:
-                        return self._loader._workspace_tool_reference_source_data(
-                            parent_uid, owner_node=node
-                        )
-
-                    def _input_provenance_parent_fetcher() -> ToolProvenanceSpec | None:
-                        return self._manager._node_for_target(
-                            parent_uid
-                        ).displayed_provenance_spec
-
-                    tool.set_input_provenance_spec(None)
-                    tool.set_source_parent_fetcher(_source_parent_fetcher)
-                    tool.set_input_provenance_parent_fetcher(
-                        _input_provenance_parent_fetcher
-                    )
                     node.window = tool
                     if not tool._tool_display_name:
                         tool._tool_display_name = parent.name

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import json
 import logging
 import os
@@ -404,8 +405,8 @@ class _WorkspaceSaver:
                 if node.display_text:
                     message += f": {node.display_text!r}"
                 message += f" ({node.uid})"
-                unavailable_uids = (
-                    self._pending_workspace_tool_unavailable_reference_uids(node)
+                _, unavailable_uids = self._pending_workspace_tool_reference_status(
+                    node
                 )
                 if unavailable_uids:
                     message += ". Unavailable manager-node references: " + ", ".join(
@@ -418,7 +419,10 @@ class _WorkspaceSaver:
             with tool._save_tool_data_reference_context(
                 self._manager._tool_graph.nodes,
                 reference_validator=(
-                    self._controller._tool_data_reference_matches_current_data
+                    functools.partial(
+                        self._controller._tool_data_reference_matches_current_data,
+                        owner_node=node,
+                    )
                 ),
             ):
                 ds = tool.to_dataset()
@@ -737,7 +741,7 @@ class _WorkspaceSaver:
             if node.is_imagetool:
                 continue
             if node.pending_workspace_tool_payload is not None:
-                if not self._pending_workspace_tool_references_available(node):
+                if not self._pending_workspace_tool_reference_status(node)[0]:
                     rewrite_uids.append(uid)
                 continue
             tool = typing.cast("erlab.interactive.utils.ToolWindow", node.tool_window)
@@ -751,19 +755,14 @@ class _WorkspaceSaver:
             references = node._workspace_tool_data_references
             if not references:
                 continue
-            if not self._workspace_tool_references_match_current_snapshots(
-                references.values()
+            if not all(
+                self._controller._tool_data_reference_matches_current_snapshot(
+                    reference
+                )
+                for reference in references.values()
             ):
                 rewrite_uids.append(uid)
         return sorted(rewrite_uids, key=self._workspace_node_path)
-
-    def _workspace_tool_references_match_current_snapshots(
-        self, references: Iterable[Mapping[str, typing.Any]]
-    ) -> bool:
-        return all(
-            self._controller._tool_data_reference_matches_current_snapshot(reference)
-            for reference in references
-        )
 
     def _save_workspace_document(
         self,
@@ -942,21 +941,38 @@ class _WorkspaceSaver:
         else:
             attrs["tool_title"] = node.name
 
-        source_spec = node.source_spec
-        if source_spec is None:
-            attrs.pop(erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR, None)
-        else:
-            attrs[erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR] = json.dumps(
-                source_spec.model_dump(mode="json")
+        script_inputs = node.tool_script_inputs
+        references = self._pending_workspace_tool_references(attrs) or {}
+        has_legacy_parent_reference = any(
+            isinstance(reference, dict) and reference.get("kind") == "parent_source"
+            for reference in references.values()
+        )
+        if script_inputs:
+            primary_input = node.tool_primary_input
+            attrs.update(
+                erlab.interactive.utils.ToolWindow._saved_script_input_attrs(
+                    script_inputs, primary_input
+                )
             )
-        source_binding = node.source_binding
-        if source_spec is not None or source_binding is None:
-            attrs.pop(erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR, None)
-        else:
-            attrs[erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR] = json.dumps(
-                source_binding.model_dump(mode="json")
+            if not has_legacy_parent_reference:
+                attrs.pop(erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR, None)
+            if not any(
+                item.name == primary_input and item.source_spec is None
+                for item in script_inputs
+            ):
+                attrs.pop(erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR, None)
+            attrs.pop(erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR, None)
+        elif erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR not in attrs:
+            attrs.pop(erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR, None)
+        has_saved_inputs = bool(script_inputs) or any(
+            key in attrs
+            for key in (
+                erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR,
+                erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR,
+                erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR,
             )
-        if node.has_source_binding:
+        )
+        if has_saved_inputs:
             attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = node.source_state
             attrs[erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR] = bool(
                 node.source_auto_update
@@ -1000,88 +1016,68 @@ class _WorkspaceSaver:
             case _:
                 return None
 
-    def _pending_workspace_tool_references_available(
-        self, node: _ImageToolWrapper | _ManagedWindowNode
-    ) -> bool:
-        attrs = node.pending_workspace_payload_attrs
+    @staticmethod
+    def _pending_workspace_tool_references(
+        attrs: Mapping[str, typing.Any] | None,
+    ) -> dict[str, typing.Any] | None:
+        """Decode pending ToolWindow references, or return ``None`` if invalid."""
         if attrs is None:
-            return True
-        payload = attrs.get(erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR)
+            return {}
+        payload = workspace_format._decode_workspace_attr_text(
+            attrs.get(erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR)
+        )
         if payload is None:
-            return True
-        if isinstance(payload, bytes):
-            with contextlib.suppress(UnicodeDecodeError):
-                payload = payload.decode()
-        if not isinstance(payload, str):
-            return False
+            return (
+                {}
+                if erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR not in attrs
+                else None
+            )
         try:
             references = json.loads(payload)
-        except Exception:
-            return False
-        if not isinstance(references, dict):
-            return False
-        for reference in references.values():
-            if not isinstance(reference, dict):
-                return False
-            kind = reference.get("kind")
-            if kind == "parent_source":
-                if (
-                    node.parent_uid is None
-                    or node.parent_uid not in self._manager._tool_graph.nodes
-                ):
-                    return False
-                continue
-            if kind != "manager_node":
-                return False
-            if not self._controller._tool_data_reference_matches_current_snapshot(
-                reference
-            ):
-                return False
-        return True
+        except (TypeError, ValueError):
+            return None
+        return references if isinstance(references, dict) else None
 
-    def _pending_workspace_tool_unavailable_reference_uids(
+    def _pending_workspace_tool_reference_status(
         self, node: _ImageToolWrapper | _ManagedWindowNode
-    ) -> tuple[str, ...]:
-        attrs = node.pending_workspace_payload_attrs
-        if attrs is None:
-            return ()
-        payload = attrs.get(erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR)
-        if isinstance(payload, bytes):
-            with contextlib.suppress(UnicodeDecodeError):
-                payload = payload.decode()
-        if not isinstance(payload, str):
-            return ()
-        try:
-            references = json.loads(payload)
-        except Exception:
-            return ()
-        if not isinstance(references, dict):
-            return ()
+    ) -> tuple[bool, tuple[str, ...]]:
+        """Return reference availability and unavailable node UIDs."""
+        references = self._pending_workspace_tool_references(
+            node.pending_workspace_payload_attrs
+        )
+        if references is None:
+            return False, ()
+
+        available = True
         unavailable_uids: set[str] = set()
         for reference in references.values():
             if not isinstance(reference, dict):
+                available = False
                 continue
             kind = reference.get("kind")
             if kind == "parent_source":
                 parent_uid = node.parent_uid
                 if (
-                    isinstance(parent_uid, str)
-                    and parent_uid not in self._manager._tool_graph.nodes
+                    parent_uid is None
+                    or parent_uid not in self._manager._tool_graph.nodes
                 ):
-                    unavailable_uids.add(parent_uid)
+                    available = False
+                    if isinstance(parent_uid, str):
+                        unavailable_uids.add(parent_uid)
                 continue
             if kind != "manager_node":
+                available = False
                 continue
             node_uid = reference.get("node_uid")
-            if (
-                isinstance(node_uid, str)
-                and node_uid
-                and not self._controller._tool_data_reference_matches_current_snapshot(
-                    reference
-                )
+            if not isinstance(node_uid, str) or not node_uid:
+                available = False
+                continue
+            if not self._controller._tool_data_reference_matches_current_snapshot(
+                reference
             ):
+                available = False
                 unavailable_uids.add(node_uid)
-        return tuple(sorted(unavailable_uids))
+        return available, tuple(sorted(unavailable_uids))
 
     def _workspace_save_snapshot(
         self, fname: str | os.PathLike[str]

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -1248,7 +1248,7 @@ class _WorkspaceSaver:
                         kind != "tool"
                         or (
                             not has_saved_input_provenance
-                            and self._pending_workspace_tool_references_available(node)
+                            and self._pending_workspace_tool_reference_status(node)[0]
                         )
                     )
                 )

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -961,7 +961,6 @@ class _WorkspaceSaver:
                 for item in script_inputs
             ):
                 attrs.pop(erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR, None)
-            attrs.pop(erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR, None)
         elif erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR not in attrs:
             attrs.pop(erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR, None)
         has_saved_inputs = bool(script_inputs) or any(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
@@ -31,6 +31,9 @@ _MANAGER_LIVE_SOURCE_SPEC_ATTR = "manager_node_live_source_spec"
 _MANAGER_PROVENANCE_SPEC_ATTR = "manager_node_provenance_spec"
 _ITOOL_PROVENANCE_SPEC_ATTR = "itool_provenance_spec"
 _TOOL_SOURCE_SPEC_ATTR = "tool_source_spec"
+_TOOL_SCRIPT_INPUTS_ATTR = "tool_script_inputs"
+_TOOL_PRIMARY_INPUT_ATTR = "tool_primary_input"
+_TOOL_DATA_REFERENCES_ATTR = "tool_data_references"
 _PROVENANCE_ATTRS = (_MANAGER_PROVENANCE_SPEC_ATTR, _ITOOL_PROVENANCE_SPEC_ATTR)
 _SOURCE_ATTRS = {
     _MANAGER_LIVE_SOURCE_SPEC_ATTR: "source",
@@ -44,6 +47,9 @@ _CODE_TRUST_ATTRS = frozenset(
         CODE_PAYLOAD_ENTRIES_ATTR,
         "tool_cls_qualname",
         "tool_state",
+        _TOOL_SCRIPT_INPUTS_ATTR,
+        _TOOL_PRIMARY_INPUT_ATTR,
+        _TOOL_DATA_REFERENCES_ATTR,
     )
 )
 

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -45,7 +45,6 @@ from erlab.interactive.imagetool._load_source import (
     _default_load_source_name,
     _deserialize_loader_kwargs,
     _file_path_stem,
-    _load_code_from_file_details,
     _load_source_details_from_file,
     _load_source_details_from_provenance,
     _LoadFunc,
@@ -61,6 +60,7 @@ if typing.TYPE_CHECKING:
     import os
     from collections.abc import Callable, Iterator, Mapping, Sequence
 
+    from erlab.interactive.imagetool._provenance._graph import ReplayGraph
     from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
     from erlab.interactive.imagetool.slicer import ArraySlicer
     from erlab.interactive.imagetool.viewer import ImageSlicerArea
@@ -1399,17 +1399,6 @@ class _ManagedWindowNode(QtCore.QObject):
         return None
 
     def load_source_code(self, *, assign: str = "data") -> str | None:
-        if self.imagetool is not None:
-            file_path = self.slicer_area._file_path
-            if file_path is None:
-                return None
-            return _load_code_from_file_details(
-                file_path,
-                self.slicer_area._load_func,
-                assign=assign,
-                source_input_dtype=self._load_source_input_dtype(),
-            )
-
         details = self._load_source_details()
         if details is None or details.load_code is None:
             return None
@@ -1426,11 +1415,6 @@ class _ManagedWindowNode(QtCore.QObject):
             return None
 
     def default_load_source_name(self) -> str | None:
-        if self.imagetool is not None:
-            file_path = self.slicer_area._file_path
-            if file_path is None:
-                return None
-            return _default_load_source_name(file_path)
         details = self._load_source_details()
         if details is None:
             return None
@@ -2303,14 +2287,16 @@ class _ManagedWindowNode(QtCore.QObject):
         return [entry.label for entry in self.derivation_entries]
 
     @property
-    def derivation_code(self) -> str | None:
+    def _derivation_provenance_spec(self) -> ToolProvenanceSpec | None:
         if self.tool_window is not None:
-            provenance_spec = self._tool_provenance_spec(
+            return self._tool_provenance_spec(
                 flush_deferred_restore=True,
                 refresh=True,
             )
-        else:
-            provenance_spec = self.displayed_provenance_spec
+        return self.displayed_provenance_spec
+
+    def _derivation_replay_graph(self) -> tuple[ReplayGraph, str] | None:
+        provenance_spec = self._derivation_provenance_spec
         if provenance_spec is None:
             return None
         if self.manager._is_figure_uid(self.uid) and provenance_spec.script_inputs:
@@ -2323,7 +2309,23 @@ class _ManagedWindowNode(QtCore.QObject):
                 compile_replay_graph(provenance_spec, trusted_user_code=True)
             except ReplayGraphError:
                 return None
-        return provenance_spec.display_code()
+        return provenance_spec._generated_replay_graph()
+
+    @property
+    def derivation_code(self) -> str | None:
+        from erlab.interactive.imagetool._provenance._graph import (
+            ReplayGraphError,
+            emit_replay_code,
+        )
+
+        compiled = self._derivation_replay_graph()
+        if compiled is None:
+            return None
+        graph, output_name = compiled
+        try:
+            return emit_replay_code(graph, output_name=output_name) or None
+        except ReplayGraphError:
+            return None
 
     def add_child_reference(self, uid: str, window: QtWidgets.QWidget | None) -> None:
         if uid not in self._childtool_indices:

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -2313,6 +2313,16 @@ class _ManagedWindowNode(QtCore.QObject):
             provenance_spec = self.displayed_provenance_spec
         if provenance_spec is None:
             return None
+        if self.manager._is_figure_uid(self.uid) and provenance_spec.script_inputs:
+            from erlab.interactive.imagetool._provenance._graph import (
+                ReplayGraphError,
+                compile_replay_graph,
+            )
+
+            try:
+                compile_replay_graph(provenance_spec, trusted_user_code=True)
+            except ReplayGraphError:
+                return None
         return provenance_spec.display_code()
 
     def add_child_reference(self, uid: str, window: QtWidgets.QWidget | None) -> None:

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from erlab.interactive.imagetool._provenance._code import _replace_code_identifiers
 from erlab.interactive.imagetool._provenance._model import (
     DerivationEntry,
+    ScriptInput,
     ScriptInputDataRole,
     ToolProvenanceSpec,
     _ProvenanceDisplayRow,
@@ -315,9 +316,9 @@ class _NodePersistenceView:
 class _NodeProvenanceOwnerSnapshot:
     """Exact provenance state owned by one managed node.
 
-    A ToolWindow owns its live source and input provenance. Pending ToolWindow
-    payloads own the serialized input copy. The managed node owns all other source
-    and displayed provenance. Keeping these values in one snapshot makes a script
+    A ToolWindow owns its live and pending named inputs. Pending ToolWindow payloads
+    own the serialized input copy. The managed node owns all other source and
+    displayed provenance. Keeping these values in one snapshot makes a script
     identity change atomic across those owners.
     """
 
@@ -327,9 +328,9 @@ class _NodeProvenanceOwnerSnapshot:
     pending_payload_kind: typing.Literal["imagetool", "tool"] | None
     node_source_spec: ToolProvenanceSpec | None
     node_provenance_spec: ToolProvenanceSpec | None
-    tool_source_spec: ToolProvenanceSpec | None
-    tool_input_provenance_spec: ToolProvenanceSpec | None
-    tool_input_from_parent: bool
+    tool_script_inputs: tuple[ScriptInput, ...] | None
+    tool_primary_input: str | None
+    tool_pending_script_inputs: tuple[ScriptInput, ...] | None
     pending_payload_attrs: dict[str, typing.Any] | None
 
 
@@ -610,6 +611,10 @@ class _ManagedWindowNode(QtCore.QObject):
                 old.sigProvenanceChanged.disconnect(
                     self._handle_tool_provenance_changed
                 )
+            with contextlib.suppress(TypeError, RuntimeError):
+                old._sigSourceRefreshAborted.disconnect(
+                    self._handle_tool_source_refresh_aborted
+                )
             destroyed_callback = self._tool_window_destroyed_callback
             if destroyed_callback is not None:
                 with contextlib.suppress(TypeError, RuntimeError):
@@ -620,8 +625,7 @@ class _ManagedWindowNode(QtCore.QObject):
             old._set_managed_source_reload(None)
             old._set_managed_secondary_window_callback(None)
             old._set_managed_reveal_callback(None)
-            old.set_source_parent_fetcher(None)
-            old.set_input_provenance_parent_fetcher(None)
+            old._set_input_resolver(None)
             old.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose)
             old.close()
             self._tool_window = None
@@ -695,6 +699,7 @@ class _ManagedWindowNode(QtCore.QObject):
         tool.sigStateChanged.connect(self._handle_tool_state_changed)
         tool.sigDataChanged.connect(self._handle_tool_data_changed)
         tool.sigProvenanceChanged.connect(self._handle_tool_provenance_changed)
+        tool._sigSourceRefreshAborted.connect(self._handle_tool_source_refresh_aborted)
         self._tool_window_destroyed_callback = functools.partial(
             self._handle_tool_window_destroyed,
             tool,
@@ -938,6 +943,29 @@ class _ManagedWindowNode(QtCore.QObject):
             return None
         return dict(self._pending_workspace_payload_attrs)
 
+    def _tool_input_metadata(self) -> tuple[tuple[ScriptInput, ...], str | None]:
+        """Return live or deferred canonical ToolWindow input metadata."""
+        if self.tool_window is not None:
+            return self.tool_window.script_inputs, self.tool_window.primary_input
+        if (
+            self._pending_workspace_payload_kind != "tool"
+            or self._pending_workspace_payload_attrs is None
+        ):
+            return (), None
+        return erlab.interactive.utils.ToolWindow._saved_script_input_metadata(
+            self._pending_workspace_payload_attrs
+        )
+
+    @property
+    def tool_script_inputs(self) -> tuple[ScriptInput, ...]:
+        """Return live or deferred canonical inputs for a ToolWindow node."""
+        return self._tool_input_metadata()[0]
+
+    @property
+    def tool_primary_input(self) -> str | None:
+        """Return the primary input for a live or deferred ToolWindow node."""
+        return self._tool_input_metadata()[1]
+
     def update_pending_workspace_payload_attrs(
         self, attrs: Mapping[str, typing.Any]
     ) -> None:
@@ -950,6 +978,7 @@ class _ManagedWindowNode(QtCore.QObject):
         self._pending_workspace_preview_cache = None
         self._pending_workspace_curve_cache = None
         self._notify_info_and_type_badge_change(previous_type_badge)
+        self._notify_change(_ManagedNodeChange.DEPENDENCY_INDEX)
 
     def set_pending_workspace_payload(
         self,
@@ -974,6 +1003,7 @@ class _ManagedWindowNode(QtCore.QObject):
         self._pending_workspace_preview_cache = None
         self._pending_workspace_curve_cache = None
         self._notify_info_and_type_badge_change(previous_type_badge)
+        self._notify_change(_ManagedNodeChange.DEPENDENCY_INDEX)
 
     def set_pending_workspace_memory_payload(
         self,
@@ -1507,12 +1537,14 @@ class _ManagedWindowNode(QtCore.QObject):
             pending_payload_kind=self._pending_workspace_payload_kind,
             node_source_spec=self._source_spec,
             node_provenance_spec=self._provenance_spec,
-            tool_source_spec=None if tool is None else tool.source_spec,
-            tool_input_provenance_spec=(
-                None if tool is None else tool.input_provenance_spec
-            ),
-            tool_input_from_parent=(
-                False if tool is None else tool._input_provenance_snapshot_from_parent
+            tool_script_inputs=None if tool is None else tool.script_inputs,
+            tool_primary_input=None if tool is None else tool.primary_input,
+            tool_pending_script_inputs=(
+                None
+                if tool is None or tool._pending_script_inputs is None
+                else tuple(
+                    item.model_copy(deep=True) for item in tool._pending_script_inputs
+                )
             ),
             pending_payload_attrs=(
                 None
@@ -1537,23 +1569,35 @@ class _ManagedWindowNode(QtCore.QObject):
             return require_live_source_spec(remapped)
         return remapped
 
-    @staticmethod
-    def _pending_tool_provenance(
-        attrs: Mapping[str, typing.Any], key: str
-    ) -> ToolProvenanceSpec | None:
-        """Parse one valid pending ToolWindow provenance attribute."""
-        value = attrs.get(key)
-        if isinstance(value, bytes):
-            try:
-                value = value.decode()
-            except UnicodeDecodeError:
-                return None
-        if not isinstance(value, str):
-            return None
-        try:
-            return parse_tool_provenance_spec(json.loads(value))
-        except (TypeError, ValueError):
-            return None
+    @classmethod
+    def _remap_script_input(
+        cls,
+        script_input: ScriptInput,
+        remap: Callable[[ToolProvenanceSpec], ToolProvenanceSpec],
+    ) -> ScriptInput:
+        """Remap both provenance values owned by one named tool input."""
+        source_spec = script_input.parsed_source_spec()
+        provenance_spec = script_input.parsed_provenance_spec()
+        remapped_source = cls._remap_provenance_value(
+            source_spec, remap, live_source=True
+        )
+        remapped_provenance = cls._remap_provenance_value(provenance_spec, remap)
+        if remapped_source == source_spec and remapped_provenance == provenance_spec:
+            return script_input
+        return script_input.model_copy(
+            update={
+                "source_spec": (
+                    None
+                    if remapped_source is None
+                    else remapped_source.model_dump(mode="json")
+                ),
+                "provenance_spec": (
+                    None
+                    if remapped_provenance is None
+                    else remapped_provenance.model_dump(mode="json")
+                ),
+            }
+        )
 
     def _apply_provenance_owner_snapshot(
         self, snapshot: _NodeProvenanceOwnerSnapshot
@@ -1574,6 +1618,8 @@ class _ManagedWindowNode(QtCore.QObject):
         provenance_attr_keys = (
             erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR,
             erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR,
+            erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR,
+            erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR,
         )
         current_attrs = self._pending_workspace_payload_attrs or {}
         replacement_attrs = snapshot.pending_payload_attrs or {}
@@ -1590,21 +1636,29 @@ class _ManagedWindowNode(QtCore.QObject):
 
         tool = snapshot.tool_window
         if tool is not None:
-            source_changed = tool.source_spec != snapshot.tool_source_spec
             input_changed = (
-                tool.input_provenance_spec != snapshot.tool_input_provenance_spec
-                or tool._input_provenance_snapshot_from_parent
-                != snapshot.tool_input_from_parent
+                tool.script_inputs != snapshot.tool_script_inputs
+                or tool.primary_input != snapshot.tool_primary_input
+                or tool._pending_script_inputs != snapshot.tool_pending_script_inputs
             )
-            with tool._coalesce_provenance_changes():
-                if source_changed:
-                    tool._source_spec = snapshot.tool_source_spec
-                    tool._notify_provenance_changed()
-                if input_changed:
-                    tool._set_input_provenance_snapshot(
-                        snapshot.tool_input_provenance_spec,
-                        from_parent=snapshot.tool_input_from_parent,
+            if input_changed:
+                script_inputs = typing.cast(
+                    "tuple[ScriptInput, ...]", snapshot.tool_script_inputs
+                )
+                with tool._coalesce_provenance_changes():
+                    tool._script_inputs = tuple(
+                        item.model_copy(deep=True) for item in script_inputs
                     )
+                    tool._primary_input = snapshot.tool_primary_input
+                    tool._pending_script_inputs = (
+                        None
+                        if snapshot.tool_pending_script_inputs is None
+                        else tuple(
+                            item.model_copy(deep=True)
+                            for item in snapshot.tool_pending_script_inputs
+                        )
+                    )
+                    tool._notify_provenance_changed()
 
         if snapshot.imagetool is not None and node_provenance_changed:
             snapshot.imagetool.set_provenance_spec(self.provenance_spec)
@@ -1629,11 +1683,21 @@ class _ManagedWindowNode(QtCore.QObject):
         node_provenance_spec = self._remap_provenance_value(
             before.node_provenance_spec, remap
         )
-        tool_source_spec = self._remap_provenance_value(
-            before.tool_source_spec, remap, live_source=True
+        tool_script_inputs = (
+            None
+            if before.tool_script_inputs is None
+            else tuple(
+                self._remap_script_input(script_input, remap)
+                for script_input in before.tool_script_inputs
+            )
         )
-        tool_input_provenance_spec = self._remap_provenance_value(
-            before.tool_input_provenance_spec, remap
+        tool_pending_script_inputs = (
+            None
+            if before.tool_pending_script_inputs is None
+            else tuple(
+                self._remap_script_input(script_input, remap)
+                for script_input in before.tool_pending_script_inputs
+            )
         )
 
         attrs = (
@@ -1643,35 +1707,30 @@ class _ManagedWindowNode(QtCore.QObject):
         )
         pending_attrs_changed = False
         if attrs is not None and before.pending_payload_kind == "tool":
-            source_key = erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR
-            if node_source_spec != before.node_source_spec and source_key in attrs:
-                # A remap cannot remove a provenance value. It returns a validated
-                # ToolProvenanceSpec for every non-null input.
-                attrs[source_key] = json.dumps(
-                    typing.cast("ToolProvenanceSpec", node_source_spec).model_dump(
-                        mode="json"
+            pending_inputs, pending_primary_input = (
+                erlab.interactive.utils.ToolWindow._saved_script_input_metadata(attrs)
+            )
+            remapped_pending_inputs = tuple(
+                self._remap_script_input(script_input, remap)
+                for script_input in pending_inputs
+            )
+            if remapped_pending_inputs != pending_inputs:
+                attrs.update(
+                    erlab.interactive.utils.ToolWindow._saved_script_input_attrs(
+                        remapped_pending_inputs, pending_primary_input
                     )
                 )
-                pending_attrs_changed = True
-
-            input_key = erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
-            pending_input = self._pending_tool_provenance(attrs, input_key)
-            remapped_pending_input = self._remap_provenance_value(pending_input, remap)
-            if remapped_pending_input != pending_input:
-                # The changed case starts from a non-null parsed value, so the remap
-                # result is also a validated ToolProvenanceSpec.
-                attrs[input_key] = json.dumps(
-                    typing.cast(
-                        "ToolProvenanceSpec", remapped_pending_input
-                    ).model_dump(mode="json")
+                attrs.pop(erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR, None)
+                attrs.pop(
+                    erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR, None
                 )
                 pending_attrs_changed = True
 
         changed = (
             node_source_spec != before.node_source_spec
             or node_provenance_spec != before.node_provenance_spec
-            or tool_source_spec != before.tool_source_spec
-            or tool_input_provenance_spec != before.tool_input_provenance_spec
+            or tool_script_inputs != before.tool_script_inputs
+            or tool_pending_script_inputs != before.tool_pending_script_inputs
             or pending_attrs_changed
         )
         if not changed:
@@ -1684,9 +1743,9 @@ class _ManagedWindowNode(QtCore.QObject):
             pending_payload_kind=before.pending_payload_kind,
             node_source_spec=node_source_spec,
             node_provenance_spec=node_provenance_spec,
-            tool_source_spec=tool_source_spec,
-            tool_input_provenance_spec=tool_input_provenance_spec,
-            tool_input_from_parent=before.tool_input_from_parent,
+            tool_script_inputs=tool_script_inputs,
+            tool_primary_input=before.tool_primary_input,
+            tool_pending_script_inputs=tool_pending_script_inputs,
             pending_payload_attrs=attrs,
         )
         try:
@@ -1712,8 +1771,6 @@ class _ManagedWindowNode(QtCore.QObject):
     def source_spec(
         self,
     ) -> ToolProvenanceSpec | None:
-        if self.tool_window is not None:
-            return self.tool_window.source_spec
         return self._source_spec
 
     @property
@@ -1729,8 +1786,6 @@ class _ManagedWindowNode(QtCore.QObject):
     def source_binding(
         self,
     ) -> ImageToolSelectionSourceBinding | None:
-        if self.tool_window is not None:
-            return self.tool_window.source_binding
         return self._source_binding
 
     @property
@@ -1974,8 +2029,20 @@ class _ManagedWindowNode(QtCore.QObject):
             return self.provenance_spec
         return self.displayed_provenance_spec
 
-    def data_for_role(self, data_role: ScriptInputDataRole) -> xr.DataArray:
+    def data_for_role(
+        self,
+        data_role: ScriptInputDataRole,
+        *,
+        owner_node: _ManagedWindowNode | None = None,
+    ) -> xr.DataArray:
         """Return the live array represented by a script-input data role."""
+        if self.pending_workspace_memory_payload is not None:
+            loader = self.manager._workspace_controller.loading
+            return loader._workspace_tool_reference_source_data(
+                self.uid,
+                data_role=data_role,
+                owner_node=self if owner_node is None else owner_node,
+            )
         if (
             self.pending_workspace_payload is not None
             and not self.materialize_pending_workspace_payload()
@@ -2116,7 +2183,9 @@ class _ManagedWindowNode(QtCore.QObject):
     @property
     def has_source_binding(self) -> bool:
         if self.tool_window is not None:
-            return self.tool_window.has_source_binding
+            return bool(self.tool_window.script_inputs)
+        if not self.is_imagetool:
+            return bool(self.tool_script_inputs)
         return (
             self._source_spec is not None
             or self._source_binding is not None
@@ -2284,6 +2353,8 @@ class _ManagedWindowNode(QtCore.QObject):
         state
             Current refresh state for manager status UI.
         """
+        if not self.is_imagetool:
+            raise TypeError("Source bindings are only valid for ImageTool nodes")
         if source_spec is not None and not isinstance(
             source_spec,
             ToolProvenanceSpec,
@@ -2332,33 +2403,6 @@ class _ManagedWindowNode(QtCore.QObject):
         self._set_source_state(state if self.has_source_binding else "fresh")
         self.manager._mark_node_state_dirty(self.uid)
 
-    def set_restored_source_binding_metadata(
-        self,
-        source_spec: ToolProvenanceSpec | None,
-        source_binding: ImageToolSelectionSourceBinding | None,
-        *,
-        auto_update: bool,
-        state: _source_state_type,
-    ) -> None:
-        """Restore saved source metadata without reading parent data."""
-        if source_spec is not None and not isinstance(
-            source_spec,
-            ToolProvenanceSpec,
-        ):
-            raise TypeError("source_spec must be a ToolProvenanceSpec or None")
-        if source_binding is not None and not isinstance(
-            source_binding,
-            ImageToolSelectionSourceBinding,
-        ):
-            raise TypeError("source_binding must be an ImageToolSelectionSourceBinding")
-        self._replay_source_data = None
-        self._replay_source_pending = False
-        self._source_spec = require_live_source_spec(source_spec)
-        self._mark_provenance_changed()
-        self._source_binding = None if self._source_spec is not None else source_binding
-        self._source_auto_update = bool(auto_update)
-        self._source_state = state if self.has_source_binding else "fresh"
-
     def set_output_binding(
         self,
         output_id: str,
@@ -2367,6 +2411,8 @@ class _ManagedWindowNode(QtCore.QObject):
         auto_update: bool = False,
         state: _source_state_type = "fresh",
     ) -> None:
+        if not self.is_imagetool:
+            raise TypeError("Output bindings are only valid for ImageTool nodes")
         if output_id is None:
             raise ValueError("output_id must not be None")
         if not isinstance(output_id, str):
@@ -2399,6 +2445,8 @@ class _ManagedWindowNode(QtCore.QObject):
         *,
         replay_source_data: xr.DataArray | None,
     ) -> None:
+        if not self.is_imagetool:
+            raise TypeError("Detached provenance is only valid for ImageTool nodes")
         if provenance_spec is not None and not isinstance(
             provenance_spec,
             ToolProvenanceSpec,
@@ -2508,14 +2556,18 @@ class _ManagedWindowNode(QtCore.QObject):
             None if replay_source_data is None else replay_source_data.copy(deep=False)
         )
         self._replay_source_pending = False
-        self._advance_snapshot_token()
+        self._advance_snapshot_token(defer_refresh=not propagate_descendants)
         self._set_source_state(state)
         self.manager._mark_node_data_dirty(self.uid)
         if propagate_descendants:
             if state == "fresh":
-                self.manager._propagate_source_change_from_uid(self.uid)
+                self.manager._lineage_controller._propagate_source_change_from_uid(
+                    self.uid
+                )
             else:
-                self.manager._mark_descendants_source_state(self.uid, state)
+                self.manager._lineage_controller._propagate_source_state_from_uid(
+                    self.uid, state
+                )
 
     def replace_with_detached_data(
         self,
@@ -2540,15 +2592,38 @@ class _ManagedWindowNode(QtCore.QObject):
         )
 
     def _handle_tool_data_changed(self) -> None:
+        manager = self.manager
+        if (
+            not self._suspend_descendant_signal_propagation
+            and manager._dependency_tracker.source_refresh_queued(self.uid, self.uid)
+        ):
+            manager._queue_idle_work(
+                ("tool-source-rerun", self.uid),
+                functools.partial(self._resume_tool_source_refresh, self.uid),
+            )
+            return
         self._sync_tool_provenance_revision()
-        self.manager._mark_node_data_dirty(self.uid)
+        manager._mark_node_data_dirty(self.uid)
         self._advance_snapshot_token(defer_refresh=True)
         if self._suspend_descendant_signal_propagation:
             return
-        self.manager._queue_idle_work(
+        manager._queue_idle_work(
             ("tool-data-refresh", self.uid),
             functools.partial(self._flush_tool_data_changed, self.uid),
         )
+
+    def _resume_tool_source_refresh(self, uid: str) -> None:
+        """Resume a queued self-refresh after its prior callback has returned."""
+        if uid != self.uid:
+            return
+        manager = self._manager()
+        if manager is None or not erlab.interactive.utils.qt_is_valid(manager):
+            return
+        if manager._tool_graph.nodes.get(self.uid) is not self:
+            return
+        if manager._lineage_controller._resume_pending_source_refreshes(self.uid):
+            return
+        self._handle_tool_data_changed()
 
     def _flush_tool_data_changed(self, uid: str) -> None:
         if uid != self.uid:
@@ -2562,11 +2637,35 @@ class _ManagedWindowNode(QtCore.QObject):
         if tool_window is None:
             return
         if tool_window.source_state == "fresh":
-            manager._propagate_source_change_from_uid(self.uid)
+            manager._lineage_controller._propagate_source_change_from_uid(self.uid)
         else:
-            manager._mark_descendants_source_state(self.uid, tool_window.source_state)
+            manager._lineage_controller._propagate_source_state_from_uid(
+                self.uid,
+                tool_window.source_state,
+            )
         if tool_window.source_state == "fresh":
-            manager._resume_pending_source_refreshes(self.uid)
+            manager._lineage_controller._resume_pending_source_refreshes(self.uid)
+
+    @QtCore.Slot()
+    def _handle_tool_source_refresh_aborted(self) -> None:
+        manager = self._manager()
+        if manager is None or not erlab.interactive.utils.qt_is_valid(manager):
+            return
+        if manager._tool_graph.nodes.get(self.uid) is not self:
+            return
+        tool_window = self.tool_window
+        if tool_window is None:
+            return
+        if self._suspend_descendant_signal_propagation:
+            return
+        manager._lineage_controller._propagate_source_state_from_uid(
+            self.uid,
+            tool_window.source_state,
+        )
+        manager._lineage_controller._resume_pending_source_refreshes(
+            self.uid,
+            require_self_refresh=True,
+        )
 
     def _set_source_auto_update(self, value: bool) -> None:
         self._source_auto_update = bool(value)
@@ -2574,9 +2673,12 @@ class _ManagedWindowNode(QtCore.QObject):
         self.manager._mark_node_state_dirty(self.uid)
 
     def _set_source_state(self, state: _source_state_type) -> None:
-        if self._source_state == state:
+        tool = self.tool_window
+        if self._source_state == state and (tool is None or tool.source_state == state):
             return
         self._source_state = state
+        if tool is not None and tool.source_state != state:
+            tool._set_source_state(state)
         self._notify_change(_ManagedNodeChange.ROW)
         self.manager._mark_node_state_dirty(self.uid)
 
@@ -2614,7 +2716,7 @@ class _ManagedWindowNode(QtCore.QObject):
         raise ValueError("Managed node is not available")
 
     def parent_source_data(self) -> xr.DataArray:
-        return self.manager._parent_source_data_for_uid(self.uid)
+        return self.manager._lineage_controller._parent_source_data_for_uid(self.uid)
 
     def eventFilter(
         self, obj: QtCore.QObject | None = None, event: QtCore.QEvent | None = None
@@ -2709,24 +2811,35 @@ class _ManagedWindowNode(QtCore.QObject):
             self.slicer_area.reload()
 
     def reload_source_data(self) -> bool:
+        """Reload this node through its one applicable framework path."""
         if self.tool_window is None:
-            return False
-        return self.manager._reload_source_chain_for_child(self.uid)
-
-    def can_reload_source_data(self) -> bool:
-        return (
-            self.tool_window is not None
-            and self.manager._reload_target_for_child(self.uid) is not None
+            if not self.is_imagetool:
+                return False
+            try:
+                tool = self.manager.get_imagetool(self.uid)
+            except (KeyError, ValueError):
+                return False
+            return tool.slicer_area._reload()
+        return self.manager._lineage_controller._refresh_tool_inputs(
+            self.uid,
+            allow_recorded=True,
+            force_live_reload=True,
         )
 
-    def reload_unavailable_reason(self) -> str | None:
-        if self.tool_window is None:
-            return "The selected tool is no longer available. Select an open item."
-        return self.manager._reload_unavailable_reason_for_child(self.uid)
+    def can_reload_source_data(self) -> bool:
+        if self.tool_window is not None:
+            return self.reload_unavailable_reason() is None
+        return False
 
-    @QtCore.Slot()
-    def _refresh_node_info(self) -> None:
-        self._notify_change(_ManagedNodeChange.ROW)
+    def reload_unavailable_reason(self) -> str | None:
+        tool = self.tool_window
+        if tool is None:
+            return "The selected tool is no longer available. Select an open item."
+        return self.manager._lineage_controller._input_resolution_plan(
+            tool.script_inputs,
+            target_node_uid=self.uid,
+            force_live_reload=True,
+        ).unavailable_reason
 
     @QtCore.Slot()
     def _handle_tool_info_changed(self) -> None:
@@ -2786,24 +2899,17 @@ class _ManagedWindowNode(QtCore.QObject):
 
     def _update_from_parent_source(self) -> bool:
         if self.tool_window is not None:
-            with self._suspend_descendant_propagation():
-                updated = self.tool_window._update_from_parent_source()
-            if updated and self.tool_window.source_state == "fresh":
-                self.manager._propagate_source_change_from_uid(self.uid)
-            elif self.tool_window.source_state != "fresh":
-                self.manager._mark_descendants_source_state(
-                    self.uid, self.tool_window.source_state
-                )
-            self._notify_change(_ManagedNodeChange.ROW)
-            return updated
+            return self.manager._lineage_controller._refresh_tool_inputs(
+                self.uid,
+                allow_recorded=True,
+            )
 
         with self.manager._extensions.execution.capture_replay_sources() as publication:
             try:
                 if self._output_id is not None:
                     parent_tool = self.manager._parent_node(self).tool_window
                     if parent_tool is not None and parent_tool.source_state != "fresh":
-                        self._set_source_state(parent_tool.source_state)
-                        self.manager._mark_descendants_source_state(
+                        self.manager._lineage_controller._propagate_source_state_from_uid(
                             self.uid, parent_tool.source_state
                         )
                         return False
@@ -2836,8 +2942,9 @@ class _ManagedWindowNode(QtCore.QObject):
                     preserve_filter=True,
                 )
             except Exception:
-                self._set_source_state("unavailable")
-                self.manager._mark_descendants_source_unavailable(self.uid)
+                self.manager._lineage_controller._propagate_source_state_from_uid(
+                    self.uid, "unavailable"
+                )
                 return False
             publication.publish()
 
@@ -2845,11 +2952,9 @@ class _ManagedWindowNode(QtCore.QObject):
 
     def handle_parent_source_replaced(self, parent_data: xr.DataArray) -> bool:
         if self.tool_window is not None:
-            if not self.tool_window.has_source_binding:
-                return False
-            with self._suspend_descendant_propagation():
-                self.tool_window.handle_parent_source_replaced(parent_data)
-            return self.tool_window.source_state == "fresh"
+            # The dependency tracker owns every ToolWindow input edge. The tree
+            # parent controls placement only.
+            return False
 
         if self._output_id is not None and (
             not self._source_auto_update or self.imagetool is None
@@ -2929,7 +3034,7 @@ class _ManagedWindowNode(QtCore.QObject):
             else:
                 self._set_source_auto_update(dialog.auto_update_check.isChecked())
             if dialog.update_requested and self.source_state == "stale":
-                self.manager._refresh_source_chain_to_uid(self.uid)
+                self.manager._lineage_controller._refresh_source_chain_to_uid(self.uid)
         return result
 
     @QtCore.Slot(object)
@@ -2946,9 +3051,14 @@ class _ManagedWindowNode(QtCore.QObject):
             try:
                 parent_data = self.current_source_data()
             except Exception:
-                self.manager._mark_descendants_source_unavailable(self.uid)
+                self.manager._lineage_controller._propagate_source_state_from_uid(
+                    self.uid,
+                    "unavailable",
+                )
                 return
-        self.manager._propagate_source_change_from_uid(self.uid, parent_data)
+        self.manager._lineage_controller._propagate_source_change_from_uid(
+            self.uid, parent_data
+        )
 
 
 class _ImageToolWrapper(_ManagedWindowNode):

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -22,6 +22,7 @@ from erlab.interactive.imagetool._provenance._code import (
     _restore_nonuniform_dims_expression,
 )
 from erlab.interactive.imagetool._provenance._model import (
+    ScriptInput,
     ToolProvenanceOperation,
     ToolProvenanceSpec,
     compose_display_provenance,
@@ -1414,6 +1415,22 @@ class ItoolPlotItem(pg.PlotItem):
             operations.append(SqueezeOperation())
         return selection(*operations)
 
+    @staticmethod
+    def _bind_tool_source_input(
+        tool: QtWidgets.QWidget, source_spec: ToolProvenanceSpec
+    ) -> None:
+        if not isinstance(tool, erlab.interactive.utils.ToolWindow):
+            return
+        tool.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    source_spec=source_spec.model_dump(mode="json"),
+                ),
+            ),
+            primary_input="data",
+        )
+
     @property
     def is_guidelines_visible(self) -> bool:
         return len(self._guidelines_items) != 0
@@ -1684,8 +1701,7 @@ class ItoolPlotItem(pg.PlotItem):
                 tool = erlab.interactive.goldtool(
                     data, data_name=self.get_selection_code(), execute=False
                 )
-                if isinstance(tool, erlab.interactive.utils.ToolWindow):
-                    tool.set_source_binding(self.make_tool_source_spec())
+                self._bind_tool_source_input(tool, self.make_tool_source_spec())
                 self.slicer_area.add_tool_window(tool)
             except Exception:
                 erlab.interactive.utils.MessageDialog.critical(
@@ -1707,8 +1723,7 @@ class ItoolPlotItem(pg.PlotItem):
             tool = erlab.interactive.restool(
                 data, data_name=self.get_selection_code(), execute=False
             )
-            if isinstance(tool, erlab.interactive.utils.ToolWindow):
-                tool.set_source_binding(self.make_tool_source_spec())
+            self._bind_tool_source_input(tool, self.make_tool_source_spec())
             self.slicer_area.add_tool_window(tool)
 
     @QtCore.Slot()
@@ -1719,8 +1734,9 @@ class ItoolPlotItem(pg.PlotItem):
                 data_name=self.get_selection_code(),
                 execute=False,
             )
-            if isinstance(tool, erlab.interactive.utils.ToolWindow):
-                tool.set_source_binding(self.make_tool_source_spec(transpose=True))
+            self._bind_tool_source_input(
+                tool, self.make_tool_source_spec(transpose=True)
+            )
             self.slicer_area.add_tool_window(tool)
 
     @QtCore.Slot()
@@ -1730,8 +1746,7 @@ class ItoolPlotItem(pg.PlotItem):
             data_name=self.get_selection_code(),
             execute=False,
         )
-        if isinstance(tool, erlab.interactive.utils.ToolWindow):
-            tool.set_source_binding(self.make_tool_source_spec(squeeze=True))
+        self._bind_tool_source_input(tool, self.make_tool_source_spec(squeeze=True))
         self.slicer_area.add_tool_window(tool)
 
     @QtCore.Slot()

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -48,6 +48,7 @@ from erlab.interactive.imagetool._provenance._execution import (
 )
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
+    ScriptInput,
     ToolProvenanceOperation,
     ToolProvenanceSpec,
     compose_full_provenance,
@@ -2722,9 +2723,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
         ):
             return True
         manager = self._manager_instance if self._in_manager else None
-        return manager is not None and manager._script_reload_from_slicer_area(
-            self, execute=False
-        )
+        if (
+            manager is not None
+            and self.provenance_spec is not None
+            and self.provenance_spec.kind == "script"
+            and self.provenance_spec.script_inputs
+        ):
+            return manager._script_reload_from_slicer_area(self, execute=False)
+        return False
 
     def _managed_source_chain_reload_target(
         self,
@@ -3129,11 +3135,17 @@ class ImageSlicerArea(QtWidgets.QWidget):
             manager, target = managed_reload
             return manager._reload_source_chain_for_child(target)
         manager = self._manager_instance if self._in_manager else None
-        if (
-            manager is not None
+        direct_reloadable = self._direct_reloadable()
+        managed_script_reload = (
+            not direct_reloadable
+            and manager is not None
             and self.provenance_spec is not None
             and self.provenance_spec.kind == "script"
             and self.provenance_spec.script_inputs
+        )
+        if (
+            manager is not None
+            and managed_script_reload
             and manager._script_reload_from_slicer_area(self, execute=False)
         ):
             return manager._script_reload_from_slicer_area(self, execute=True)
@@ -3194,17 +3206,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             return True
         if manager is not None:
             return manager._script_reload_from_slicer_area(self, execute=True)
-        if not self.reloadable:
-            return False
-        try:
-            data, kwargs = self._fetch_reload_data()
-            self._replace_reload_data(data, kwargs)
-        except Exception:
-            erlab.interactive.utils.MessageDialog.critical(
-                self, "Error", "An error occurred while reloading data."
-            )
-            return False
-        return True
+        return False
 
     def _replace_reload_data(
         self,
@@ -4115,10 +4117,59 @@ class ImageSlicerArea(QtWidgets.QWidget):
                     manager.add_widget(widget)
                 return
 
-        if isinstance(widget, erlab.interactive.utils.ToolWindow):
-            widget.set_source_parent_fetcher(lambda: self._tool_source_parent_data())
-            self.sigSourceDataReplaced.connect(widget.handle_parent_source_replaced)
-            widget.set_input_provenance_parent_fetcher(self.displayed_provenance_spec)
+        if (
+            isinstance(widget, erlab.interactive.utils.ToolWindow)
+            and widget.script_inputs
+        ):
+            if len(widget.script_inputs) != 1 or widget.primary_input is None:
+                raise ValueError(
+                    "ToolWindows opened from ImageTool must declare one input"
+                )
+            script_input = widget.script_inputs[0]
+
+            def _resolve_inputs() -> tuple[
+                dict[str, xr.DataArray], tuple[ScriptInput, ...]
+            ]:
+                if script_input.data_role == "source":
+                    parent_data, _state = self.persistence_data_and_state()
+                    parent_provenance = self.provenance_spec
+                else:
+                    parent_data = self.displayed_data
+                    parent_provenance = self.displayed_provenance_spec()
+                source_spec = script_input.parsed_source_spec()
+                resolved = (
+                    parent_data
+                    if source_spec is None
+                    else source_spec.apply(parent_data)
+                )
+                provenance_spec = (
+                    None
+                    if parent_provenance is None
+                    else compose_full_provenance(parent_provenance, source_spec)
+                )
+                refreshed = script_input.model_copy(
+                    update={
+                        "node_uid": None,
+                        "node_snapshot_token": None,
+                        "provenance_spec": (
+                            None
+                            if provenance_spec is None
+                            else provenance_spec.model_dump(mode="json")
+                        ),
+                    }
+                )
+                return {script_input.name: resolved}, (refreshed,)
+
+            _, refreshed_inputs = _resolve_inputs()
+            widget.set_script_inputs(
+                refreshed_inputs,
+                primary_input=widget.primary_input,
+                auto_update=widget.source_auto_update,
+                state=widget.source_state,
+            )
+            widget._set_input_resolver(_resolve_inputs)
+            widget._set_managed_source_reload(widget._update_from_input_source)
+            self.sigSourceDataReplaced.connect(widget.handle_input_sources_replaced)
 
         uid: str = str(uuid.uuid4())
         with self._assoc_tools_lock:
@@ -4129,6 +4180,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
         def new_close_event(event: QtGui.QCloseEvent) -> None:
             old_close_event(event)
             if event.isAccepted():
+                if isinstance(widget, erlab.interactive.utils.ToolWindow):
+                    widget._set_input_resolver(None)
                 with self._assoc_tools_lock:
                     if uid in self._associated_tools:
                         tool = self._associated_tools.pop(uid)
@@ -4138,6 +4191,20 @@ class ImageSlicerArea(QtWidgets.QWidget):
         widget.show()
         widget.raise_()
         widget.activateWindow()
+
+    @staticmethod
+    def _declare_full_data_tool_input(widget: QtWidgets.QWidget) -> None:
+        if not isinstance(widget, erlab.interactive.utils.ToolWindow):
+            return
+        widget.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    source_spec=full_data().model_dump(mode="json"),
+                ),
+            ),
+            primary_input="data",
+        )
 
     @QtCore.Slot()
     def open_in_ktool(self) -> None:
@@ -4169,8 +4236,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         )
         if tool is None:
             return
-        if isinstance(tool, erlab.interactive.utils.ToolWindow):
-            tool.set_source_binding(full_data())
+        self._declare_full_data_tool_input(tool)
         self.add_tool_window(tool)
 
     @QtCore.Slot()
@@ -4179,8 +4245,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
         tool = erlab.interactive.meshtool(
             self.data, data_name=self.watched_data_name, execute=False
         )
-        if isinstance(tool, erlab.interactive.utils.ToolWindow):
-            tool.set_source_binding(full_data())
+        self._declare_full_data_tool_input(tool)
         self.add_tool_window(tool)
 
     def adjust_layout(

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -2717,20 +2717,28 @@ class ImageSlicerArea(QtWidgets.QWidget):
             and provenance_requires_code_trust(provenance_spec)
             and self._stored_code_authorizer is None
         )
-        if self._managed_source_chain_reload_target() is not None or (
-            not stored_code_without_host
-            and (self._direct_reloadable() or self._provenance_reloadable())
-        ):
+        if self._managed_source_chain_reload_target() is not None:
             return True
-        manager = self._manager_instance if self._in_manager else None
-        if (
-            manager is not None
-            and self.provenance_spec is not None
-            and self.provenance_spec.kind == "script"
-            and self.provenance_spec.script_inputs
-        ):
+        if not stored_code_without_host and self._direct_reloadable():
+            return True
+        if (manager := self._script_input_reload_manager()) is not None:
             return manager._script_reload_from_slicer_area(self, execute=False)
-        return False
+        return not stored_code_without_host and self._provenance_reloadable()
+
+    def _script_input_reload_manager(
+        self,
+    ) -> erlab.interactive.imagetool.manager.ImageToolManager | None:
+        """Return the manager that owns this script's named-input reload."""
+        manager = self._manager_instance if self._in_manager else None
+        provenance_spec = self.provenance_spec
+        if (
+            manager is None
+            or provenance_spec is None
+            or provenance_spec.kind != "script"
+            or not provenance_spec.script_inputs
+        ):
+            return None
+        return manager
 
     def _managed_source_chain_reload_target(
         self,
@@ -3002,12 +3010,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
             and self._stored_code_authorizer is None
         ):
             return self._provenance_reload_unavailable_reason()
-        if self._direct_reloadable() or self._provenance_reloadable():
+        if self._direct_reloadable():
             return None
-        if manager is not None:
+        if (manager := self._script_input_reload_manager()) is not None:
             target = manager.target_from_slicer_area(self)
             if target is not None:
                 return manager._reload_unavailable_reason_for_target(target)
+        if self._provenance_reloadable():
+            return None
         return self._local_reload_unavailable_reason()
 
     def _fetch_for_reload(self) -> xr.DataArray:
@@ -3108,6 +3118,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             provenance_spec is not None
             and authorize is not None
             and provenance_requires_code_trust(provenance_spec)
+            and self._provenance_reloadable()
         ):
             return (
                 self._fetch_for_provenance_reload(authorize=authorize),
@@ -3136,19 +3147,14 @@ class ImageSlicerArea(QtWidgets.QWidget):
             return manager._reload_source_chain_for_child(target)
         manager = self._manager_instance if self._in_manager else None
         direct_reloadable = self._direct_reloadable()
-        managed_script_reload = (
-            not direct_reloadable
-            and manager is not None
-            and self.provenance_spec is not None
-            and self.provenance_spec.kind == "script"
-            and self.provenance_spec.script_inputs
-        )
         if (
-            manager is not None
-            and managed_script_reload
-            and manager._script_reload_from_slicer_area(self, execute=False)
+            not direct_reloadable
+            and (script_input_manager := self._script_input_reload_manager())
+            is not None
         ):
-            return manager._script_reload_from_slicer_area(self, execute=True)
+            return script_input_manager._script_reload_from_slicer_area(
+                self, execute=True
+            )
         provenance_spec = self.provenance_spec
         if (
             provenance_spec is not None
@@ -3176,11 +3182,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
             and self._stored_code_authorizer is not None
             else None
         )
-        if (
-            execution_authorizer is not None
-            or self._direct_reloadable()
-            or self._provenance_reloadable()
-        ):
+        if direct_reloadable or self._provenance_reloadable():
             try:
                 replay_capture = (
                     contextlib.nullcontext(None)

--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -1278,9 +1278,9 @@ class KspaceTool(KspaceToolGUI):
             self.calculate_bounds()
             self.calculate_resolution()
 
-    def update_data(self, new_data: xr.DataArray) -> None:
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
         status = self.tool_status
-        parsed_new_data = erlab.interactive.utils.parse_data(new_data)
+        parsed_new_data = inputs["data"]
         if not parsed_new_data.kspace._interactive_compatible:
             raise ValueError(
                 "Updated data is not compatible with the interactive tool."
@@ -1295,7 +1295,7 @@ class KspaceTool(KspaceToolGUI):
                 parent=self,
             )
             if source_result is None:
-                return
+                return False
             source_configuration, source_values, source_edited_names = source_result
             control_data = _kspace_conversion.assign_kspace_input_coordinates(
                 _kspace_conversion.assign_kspace_configuration(
@@ -1321,7 +1321,7 @@ class KspaceTool(KspaceToolGUI):
             parent=self,
         )
         if resolved_input_coordinates is None:
-            return
+            return False
         _, input_coordinates, edited_names = resolved_input_coordinates
         edited_names = frozenset((*source_edited_names, *edited_names)) & set(
             input_coordinates
@@ -1346,7 +1346,7 @@ class KspaceTool(KspaceToolGUI):
                 ),
             },
         )
-        new_data = self.validate_update_data(
+        new_data = self._validate_data_input(
             _kspace_conversion.assign_kspace_input_coordinates(
                 control_data,
                 input_coordinates,
@@ -1388,8 +1388,14 @@ class KspaceTool(KspaceToolGUI):
             self.tool_status = status
         self._notify_data_changed()
         self._reset_history_stack()
+        return True
 
-    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+    def validate_update_inputs(
+        self, inputs: Mapping[str, xr.DataArray]
+    ) -> Mapping[str, xr.DataArray]:
+        return {"data": self._validate_data_input(inputs["data"])}
+
+    def _validate_data_input(self, new_data: xr.DataArray) -> xr.DataArray:
         data = erlab.interactive.utils.parse_data(new_data)
         current_offset_keys = tuple(self.data.kspace._valid_offset_keys)
         current_momentum_axes = tuple(self.data.kspace.momentum_axes)
@@ -1797,16 +1803,16 @@ class KspaceTool(KspaceToolGUI):
     def _copy_seed_code(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
-        input_reference = self._copy_input_reference(input_name)
-        return f"{self._copy_assign_target(input_name)} = {input_reference}"
+        input_reference = self._copy_input_reference(primary_input)
+        return f"{self._copy_assign_target(primary_input)} = {input_reference}"
 
     def _copy_operations(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> tuple[ToolProvenanceOperation, ...]:
         alpha_normal, beta_normal = self._current_normal_emission_angles()
@@ -1828,11 +1834,11 @@ class KspaceTool(KspaceToolGUI):
 
     def _copy_assign_target(
         self,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         *,
         data: xr.DataArray | None = None,
     ) -> str:
-        input_ref = self._copy_input_reference(input_name)
+        input_ref = self._copy_input_reference(primary_input)
         input_data_name = (
             input_ref
             if erlab.utils.misc._is_valid_identifier(input_ref)

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -1686,10 +1686,6 @@ def save_fit_ui(
     dialog.setNameFilters(["HDF5 Files (*.h5)", "All files (*)"])
     dialog.setDefaultSuffix("h5")
 
-    if os.environ.get("PYTEST_VERSION") is not None:
-        # If running in pytest, do not use native file dialog
-        dialog.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog)
-
     recent_dir: str = erlab.interactive.imagetool.manager._get_recent_directory()
     if recent_dir:
         dialog.setDirectory(recent_dir)
@@ -1726,10 +1722,6 @@ def load_fit_ui(*, parent: QtWidgets.QWidget | None = None) -> xr.Dataset | None
     dialog.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFile)
     dialog.setNameFilters(["HDF5 Files (*.h5)", "All files (*)"])
     dialog.setDefaultSuffix("h5")
-
-    if os.environ.get("PYTEST_VERSION") is not None:
-        # If running in pytest, do not use native file dialog
-        dialog.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog)
 
     if dialog.exec():
         file_name: str = dialog.selectedFiles()[0]

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -96,13 +96,10 @@ if typing.TYPE_CHECKING:
         CodeTrustManifest,
     )
     from erlab.interactive.imagetool._provenance._model import (
+        ScriptInput,
         ToolProvenanceOperation,
         ToolProvenanceSpec,
     )
-    from erlab.interactive.imagetool._provenance._operations import (
-        ImageToolSelectionSourceBinding,
-    )
-
 else:
     import lazy_loader as _lazy
 
@@ -1130,6 +1127,8 @@ _TOOL_SOURCE_BINDING_ATTR = "tool_source_binding"
 _TOOL_SOURCE_STATE_ATTR = "tool_source_state"
 _TOOL_SOURCE_AUTO_UPDATE_ATTR = "tool_source_auto_update"
 _TOOL_INPUT_PROVENANCE_SPEC_ATTR = "tool_input_provenance_spec"
+_TOOL_SCRIPT_INPUTS_ATTR = "tool_script_inputs"
+_TOOL_PRIMARY_INPUT_ATTR = "tool_primary_input"
 _TOOL_DATA_REFERENCES_ATTR = "tool_data_references"
 _TOOL_DATA_BLOB_NAME_ATTR = "tool_data_blob_name"
 _SAVED_TOOL_DATA_NAME = "<saved-tool-data>"
@@ -3316,21 +3315,23 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
       work is materialized only when its data is needed, such as for show, save, copy,
       or output access. Closing a tool discards any work that was never needed.
 
-    For tools that support refreshing their data from an ImageTool source, subclasses
-    should also override the following hooks:
+    For tools that support refreshing their inputs, subclasses should also override
+    the following hooks:
 
-    - `update_data` must apply replacement data to the existing window without
-      recreating it. Return `False` when the incoming data is recognized but cannot be
-      applied yet, so the tool remains marked as stale.
+    - `update_inputs` must apply all replacement inputs to the existing window without
+      recreating it. Return `False` when the input was not applied. If asynchronous
+      work will apply it later, call `_defer_source_refresh()` before returning
+      `False`.
 
-    - `validate_update_data` can normalize or reject incoming source data before
-      `update_data` runs. Raise an exception to mark the source as unavailable.
+    - `validate_update_inputs` can normalize or reject the complete input mapping
+      before `update_inputs` runs. Raise an exception to mark the source as
+      unavailable.
 
     - `rebase_source_node_uids` should update any internal source-node references
       when a manager workspace is imported and saved node IDs are remapped.
 
     - `_cancel_background_work` can stop worker threads or other asynchronous work
-      before `update_data` mutates the tool state. Override
+      before `update_inputs` mutates the tool state. Override
       `BACKGROUND_TASK_TIMEOUT_MS` as needed to change the default wait timeout.
 
     For full compatibility with the ImageTool manager, the following optional
@@ -3393,6 +3394,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     sigStateChanged = QtCore.Signal()  #: :meta private:
     sigDataChanged = QtCore.Signal()  #: :meta private:
     sigProvenanceChanged = QtCore.Signal()  #: :meta private:
+    _sigSourceRefreshAborted = QtCore.Signal()  #: :meta private:
 
     def __init_subclass__(cls, **kwargs: typing.Any) -> None:
         """Put each concrete status setter inside the mutation boundary."""
@@ -3459,29 +3461,27 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._code_trust_entry_locator: (
             Callable[[Iterable[CodeTrustEntry]], tuple[CodeTrustEntry, ...]] | None
         ) = None
-
-        self._source_spec: ToolProvenanceSpec | None = None
-        self._source_binding: ImageToolSelectionSourceBinding | None = None
-        self._input_provenance_spec: ToolProvenanceSpec | None = None
-        self._input_provenance_snapshot_from_parent = False
+        self._script_inputs: tuple[ScriptInput, ...] = ()
+        self._pending_script_inputs: tuple[ScriptInput, ...] | None = None
+        self._primary_input: str | None = None
         self._provenance_revision = 0
         self._provenance_change_depth = 0
         self._provenance_change_pending = False
         if not self._PROVENANCE_IS_MODEL_OWNED:
             self.sigStateChanged.connect(self._advance_provenance_revision)
             self.sigDataChanged.connect(self._advance_provenance_revision)
-        self._input_provenance_parent_fetcher: (
+        self._input_resolver: (
             Callable[
                 [],
-                ToolProvenanceSpec | None,
+                tuple[Mapping[str, xr.DataArray], tuple[ScriptInput, ...]],
             ]
             | None
         ) = None
         self._source_refreshing: bool = False
         self._source_refresh_deferred: bool = False
+        self._source_refresh_rerun_requested: bool = False
         self._source_state: typing.Literal["fresh", "stale", "unavailable"] = "fresh"
         self._source_auto_update: bool = False
-        self._source_parent_fetcher: Callable[[], xr.DataArray] | None = None
         self._managed_source_update_dialog: Callable[..., int] | None = None
         self._managed_source_reload: Callable[[], bool] | None = None
         self._managed_source_reload_available: Callable[[], bool] | None = None
@@ -4160,166 +4160,14 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             flush_deferred_restore=flush_deferred_restore,
         )
 
-    @property
-    def input_provenance_spec(
-        self,
-    ) -> ToolProvenanceSpec | None:
-        """Return the replay provenance snapshot for the displayed tool input data."""
-        return self._input_provenance_spec
-
-    def set_input_provenance_spec(
-        self,
-        provenance_spec: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
-    ) -> None:
-        """Set the replay provenance snapshot for the displayed tool input data."""
-        from erlab.interactive.imagetool._provenance._model import (
-            to_replay_provenance_spec,
-        )
-
-        self._set_input_provenance_snapshot(
-            to_replay_provenance_spec(provenance_spec),
-            from_parent=False,
-        )
-
-    def set_input_provenance_parent_fetcher(
-        self,
-        fetcher: Callable[
-            [],
-            ToolProvenanceSpec | None,
-        ]
-        | None,
-    ) -> None:
-        """Set the callback used to resolve provenance for future source refreshes."""
-        fetcher_changed = fetcher is not self._input_provenance_parent_fetcher
-        with self._provenance_mutation(changed=fetcher_changed):
-            self._input_provenance_parent_fetcher = fetcher
-            if (
-                fetcher is not None
-                and self.has_source_binding
-                and self._source_state == "fresh"
-            ):
-                self._sync_input_provenance_snapshot()
-
-    def _parent_input_provenance(
-        self,
-    ) -> ToolProvenanceSpec | None:
-        if self._input_provenance_parent_fetcher is None:
-            return None
-        from erlab.interactive.imagetool._provenance._model import (
-            to_replay_provenance_spec,
-        )
-
-        return to_replay_provenance_spec(self._input_provenance_parent_fetcher())
-
-    def _snapshot_input_provenance(
-        self,
-    ) -> ToolProvenanceSpec | None:
-        from erlab.interactive.imagetool._provenance._model import (
-            compose_display_provenance,
-        )
-
-        parent_data, source_spec = self._input_source_context()
-        parent_provenance = None
-        if self._input_provenance_parent_fetcher is not None:
-            parent_provenance = self._parent_input_provenance()
-        return compose_display_provenance(
-            parent_provenance,
-            source_spec,
-            parent_data=parent_data,
-        )
-
-    def _input_source_context(
-        self,
-    ) -> tuple[
-        xr.DataArray | None,
-        ToolProvenanceSpec | None,
-    ]:
-        parent_data: xr.DataArray | None = None
-        if self._source_parent_fetcher is not None:
-            try:
-                parent_data = self._source_parent_fetcher()
-            except Exception:
-                parent_data = None
-
-        return parent_data, self._source_spec
-
-    @typing.final
-    def _set_input_provenance_snapshot(
-        self,
-        provenance_spec: ToolProvenanceSpec | None,
-        *,
-        from_parent: bool,
-    ) -> None:
-        """Set the stored input snapshot through the provenance revision boundary."""
-        if (
-            provenance_spec is self._input_provenance_spec
-            and from_parent == self._input_provenance_snapshot_from_parent
-        ):
-            return
-        self._input_provenance_spec = provenance_spec
-        self._input_provenance_snapshot_from_parent = from_parent
-        self._notify_provenance_changed()
-
-    def _sync_input_provenance_snapshot(self) -> None:
-        """Refresh the stored input provenance snapshot for the displayed tool data."""
-        self._set_input_provenance_snapshot(
-            self._snapshot_input_provenance(),
-            from_parent=True,
-        )
-
-    def _effective_input_provenance_spec(
-        self,
-    ) -> ToolProvenanceSpec | None:
-        if self._input_provenance_spec is not None:
-            return self._input_provenance_spec
-        return self._snapshot_input_provenance()
-
-    def _copy_input_provenance_spec(
-        self,
-    ) -> ToolProvenanceSpec | None:
-        from erlab.interactive.imagetool._provenance._model import (
-            compose_display_provenance,
-            direct_replay_input_name,
-        )
-
-        if self.has_source_binding:
-            parent_data, source_spec = self._input_source_context()
-            parent_provenance = None
-            if self._input_provenance_parent_fetcher is not None:
-                fetched_parent = self._parent_input_provenance()
-                if direct_replay_input_name(fetched_parent) is not None:
-                    parent_provenance = fetched_parent
-
-            return compose_display_provenance(
-                parent_provenance,
-                source_spec,
-                parent_data=parent_data,
-            )
-        if (
-            self._input_provenance_spec is not None
-            and not self._input_provenance_snapshot_from_parent
-        ):
-            return self._input_provenance_spec
-        if self._input_provenance_parent_fetcher is None:
-            return self._input_provenance_spec
-        return None
-
     def _call_script_provenance_method(
         self,
         method_name: str,
         *,
-        input_name: str | None,
+        primary_input: str | None,
         data: xr.DataArray | None,
     ) -> typing.Any:
-        return getattr(self, method_name)(input_name=input_name, data=data)
-
-    def _script_provenance_input_name(self) -> str | None:
-        """Return the saved caller expression for standalone copied code."""
-        status = self.tool_status
-        if "data_name" not in type(status).model_fields:
-            return None
-        value = status.model_dump(include={"data_name"}).get("data_name")
-        return value if isinstance(value, str) else None
+        return getattr(self, method_name)(primary_input=primary_input, data=data)
 
     def _normalize_script_provenance(
         self,
@@ -4342,27 +4190,14 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self,
         definition: ToolScriptProvenanceDefinition,
         *,
-        input_name: str | None,
         data: xr.DataArray | None,
+        script_inputs: Sequence[ScriptInput] = (),
+        primary_input: str | None = None,
     ) -> ToolProvenanceSpec | None:
         from erlab.interactive.imagetool._provenance._model import script
         from erlab.interactive.imagetool._provenance._operations import (
             ScriptCodeOperation,
         )
-
-        source_input_name = input_name
-        if input_name in {
-            "eplt",
-            "era",
-            "erlab",
-            "eri",
-            "np",
-            "numpy",
-            "pathlib",
-            "xr",
-            "xarray",
-        }:
-            input_name = "input_data"
 
         operations: tuple[
             ToolProvenanceOperation,
@@ -4375,7 +4210,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     "str | None",
                     self._call_script_provenance_method(
                         definition.label_method,
-                        input_name=input_name,
+                        primary_input=primary_input,
                         data=data,
                     ),
                 )
@@ -4383,7 +4218,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 "str | None",
                 self._call_script_provenance_method(
                     typing.cast("str", definition.expression_method),
-                    input_name=input_name,
+                    primary_input=primary_input,
                     data=data,
                 ),
             )
@@ -4391,7 +4226,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             if definition.assign_method is not None:
                 raw_assign = self._call_script_provenance_method(
                     definition.assign_method,
-                    input_name=input_name,
+                    primary_input=primary_input,
                     data=data,
                 )
             if not label or not expression or raw_assign is None:
@@ -4411,7 +4246,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     "str | None",
                     self._call_script_provenance_method(
                         definition.prelude_method,
-                        input_name=input_name,
+                        primary_input=primary_input,
                         data=data,
                     ),
                 )
@@ -4432,7 +4267,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     "str | None",
                     self._call_script_provenance_method(
                         definition.active_name_method,
-                        input_name=input_name,
+                        primary_input=primary_input,
                         data=data,
                     ),
                 )
@@ -4474,7 +4309,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     ),
                     self._call_script_provenance_method(
                         definition.operations_method,
-                        input_name=input_name,
+                        primary_input=primary_input,
                         data=data,
                     ),
                 )
@@ -4487,10 +4322,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     "str | None",
                     self._call_script_provenance_method(
                         definition.active_name_method,
-                        input_name=input_name,
+                        primary_input=primary_input,
                         data=data,
                     ),
                 )
+            if active_name is None and primary_input is not None:
+                active_name = primary_input
 
         operations = tuple(
             operation.model_copy(update={"uses_implicit_framework_imports": True})
@@ -4505,21 +4342,26 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 "str | None",
                 self._call_script_provenance_method(
                     definition.seed_code_method,
-                    input_name=input_name,
+                    primary_input=primary_input,
                     data=data,
                 ),
             )
-        if source_input_name != input_name:
-            input_alias = f"{input_name} = {source_input_name}"
-            seed_code = "\n".join(
-                part for part in (input_alias, seed_code) if part is not None
-            )
+        if (
+            seed_code is None
+            and script_inputs
+            and definition.operations_method is not None
+            and active_name is not None
+            and primary_input is not None
+            and active_name != primary_input
+        ):
+            seed_code = f"{active_name} = {primary_input}"
 
         return script(
             *operations,
             start_label=definition.start_label,
             seed_code=seed_code,
             active_name=active_name,
+            script_inputs=script_inputs,
         )
 
     def _resolve_script_provenance(
@@ -4527,52 +4369,18 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         definition: ToolScriptProvenanceDefinition | None,
         *,
         data: xr.DataArray | None = None,
-        include_parent_provenance: bool = True,
         flush_deferred_restore: bool = True,
     ) -> ToolProvenanceSpec | None:
-        from erlab.interactive.imagetool._provenance._model import (
-            compose_full_provenance,
-            direct_replay_input_name,
-            replay_input_name,
-            to_replay_provenance_spec,
-        )
-
         if flush_deferred_restore and not self._flushing_restore_work:
             self._flush_restore_work()
         if definition is None:
             return None
-        input_provenance = (
-            self._effective_input_provenance_spec()
-            if include_parent_provenance
-            else self._copy_input_provenance_spec()
-        )
-        direct_input_name = (
-            direct_replay_input_name(input_provenance)
-            if input_provenance is not None
-            else None
-        )
-        input_name = replay_input_name(input_provenance)
-        local_spec = self._build_script_provenance(
+        return self._build_script_provenance(
             definition,
-            input_name=(
-                input_name
-                if input_provenance is not None
-                else self._script_provenance_input_name()
-            ),
             data=data,
+            script_inputs=self._script_inputs,
+            primary_input=self._primary_input,
         )
-        if direct_input_name is not None:
-            if input_provenance is None:
-                raise RuntimeError("Direct replay input requires input provenance.")
-            if local_spec is None:
-                return None
-            replay_spec = to_replay_provenance_spec(local_spec)
-            if replay_spec is None:
-                raise RuntimeError("Could not convert local provenance to replay spec.")
-            return replay_spec.model_copy(
-                update={"start_label": typing.cast("str", input_provenance.start_label)}
-            )
-        return compose_full_provenance(input_provenance, local_spec)
 
     def output_imagetool_data(self, output_id: str | enum.Enum) -> xr.DataArray | None:
         """Return the current data for a manager-tracked output declared in the class.
@@ -4636,7 +4444,6 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         return self._copy_provenance_code(
             self._resolve_script_provenance(
                 self.COPY_PROVENANCE,
-                include_parent_provenance=False,
             )
         )
 
@@ -4724,7 +4531,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     ) -> erlab.interactive.imagetool.ImageTool | None:
         manager, parent_uid = self._managed_output_imagetool_parent()
         output_source_state: typing.Literal["fresh", "stale", "unavailable"] = (
-            self.source_state if self.has_source_binding else "fresh"
+            self.source_state if self._script_inputs else "fresh"
         )
 
         if output_id is None:
@@ -4844,18 +4651,14 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         )
 
     @property
-    def source_spec(
-        self,
-    ) -> ToolProvenanceSpec | None:
-        """Return the current ImageTool source specification."""
-        return self._source_spec
+    def script_inputs(self) -> tuple[ScriptInput, ...]:
+        """Return the fixed named inputs consumed by this tool."""
+        return tuple(item.model_copy(deep=True) for item in self._script_inputs)
 
     @property
-    def source_binding(
-        self,
-    ) -> ImageToolSelectionSourceBinding | None:
-        """Return legacy ImageTool selection state awaiting one-time materialization."""
-        return self._source_binding
+    def primary_input(self) -> str | None:
+        """Return the input used as the primary tool data source."""
+        return self._primary_input
 
     @property
     def source_state(self) -> typing.Literal["fresh", "stale", "unavailable"]:
@@ -4868,14 +4671,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         return self._source_auto_update
 
     @property
-    def has_source_binding(self) -> bool:
-        """Return `True` when this tool is bound to ImageTool source data."""
-        return self._source_spec is not None or self._source_binding is not None
-
-    @property
     def source_status_text(self) -> str:
         """Return the status label shown for source bindings that need attention."""
-        if not self.has_source_binding:
+        if not self._script_inputs:
             return ""
         if self._source_state == "stale":
             return "Update Available"
@@ -4885,88 +4683,69 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             return "Automatic Updates Enabled"
         return ""
 
-    def set_source_binding(
+    def set_script_inputs(
         self,
-        source_spec: ToolProvenanceSpec | None,
+        script_inputs: Sequence[ScriptInput],
         *,
-        source_binding: ImageToolSelectionSourceBinding | None = None,
+        primary_input: str | None = None,
         auto_update: bool = False,
         state: typing.Literal["fresh", "stale", "unavailable"] = "fresh",
     ) -> None:
-        """Bind this tool to data selected from a parent ImageTool.
+        """Set the fixed named input bindings for this tool."""
+        from erlab.interactive.imagetool._provenance._model import ScriptInput
 
-        Parameters
-        ----------
-        source_spec
-            Current source spec used for derivation display and refresh. When provided,
-            refresh applies this spec as stored.
-        source_binding
-            Legacy selection state from an ImageTool plot. Used only to materialize a
-            missing ``source_spec`` once; explicit ``source_spec`` values take priority.
-        auto_update
-            Whether compatible parent changes should update this tool automatically.
-        state
-            Current refresh state for manager and tool status UI.
-        """
-        from erlab.interactive.imagetool._provenance._model import (
-            ToolProvenanceSpec,
-            require_live_source_spec,
-        )
-        from erlab.interactive.imagetool._provenance._operations import (
-            ImageToolSelectionSourceBinding,
-        )
-
-        if source_spec is not None and not isinstance(
-            source_spec,
-            ToolProvenanceSpec,
-        ):
-            raise TypeError(
-                "source_spec must be a ToolProvenanceSpec or None. Use "
-                "parse_tool_provenance_spec() when deserializing saved payloads."
+        provided = tuple(script_inputs)
+        if any(not isinstance(item, ScriptInput) for item in provided):
+            raise TypeError("script_inputs must contain ScriptInput values")
+        normalized = tuple(item.model_copy(deep=True) for item in provided)
+        names = tuple(item.name for item in normalized)
+        if len(set(names)) != len(names):
+            raise ValueError("script input names must be unique")
+        if normalized and primary_input is None:
+            raise ValueError("script inputs require an explicit primary_input")
+        if self._script_inputs:
+            current_signature = tuple(
+                (item.name, item.data_role, item.source_spec)
+                for item in self._script_inputs
             )
-        if source_binding is not None and not isinstance(
-            source_binding,
-            ImageToolSelectionSourceBinding,
-        ):
-            raise TypeError("source_binding must be an ImageToolSelectionSourceBinding")
-        if source_spec is None and source_binding is not None:
-            with contextlib.suppress(Exception):
-                if self._source_parent_fetcher is not None:
-                    source_spec = source_binding.materialize(
-                        self._source_parent_fetcher()
-                    )
-        live_source_spec = require_live_source_spec(source_spec)
-        live_source_binding = None if live_source_spec is not None else source_binding
-        source_changed = (
-            live_source_spec is not self._source_spec
-            or live_source_binding is not self._source_binding
+            new_signature = tuple(
+                (item.name, item.data_role, item.source_spec) for item in normalized
+            )
+            if (
+                new_signature != current_signature
+                or primary_input != self._primary_input
+            ):
+                raise ValueError(
+                    "script input names, roles, transforms, order, and primary input "
+                    "are fixed"
+                )
+        if normalized:
+            if primary_input not in names:
+                raise ValueError("primary_input must name a script input")
+        elif primary_input is not None:
+            raise ValueError("primary_input requires at least one script input")
+
+        self._pending_script_inputs = None
+        changed = (
+            normalized != self._script_inputs or primary_input != self._primary_input
         )
         with self._coalesce_provenance_changes():
-            self._source_spec = live_source_spec
-            self._source_binding = live_source_binding
+            self._script_inputs = normalized
+            self._primary_input = primary_input
             self._source_auto_update = bool(auto_update)
-            if source_changed:
+            if changed:
                 self._notify_provenance_changed()
-            if self.has_source_binding and state == "fresh":
-                self._sync_input_provenance_snapshot()
-        self._set_source_state(state if self.has_source_binding else "fresh")
+        self._set_source_state(state if normalized else "fresh")
 
-    def set_source_parent_fetcher(
-        self, fetcher: Callable[[], xr.DataArray] | None
+    def _set_input_resolver(
+        self,
+        resolver: Callable[
+            [], tuple[Mapping[str, xr.DataArray], tuple[ScriptInput, ...]]
+        ]
+        | None,
     ) -> None:
-        """Set the callback used to fetch the latest parent ImageTool data."""
-        fetcher_changed = fetcher is not self._source_parent_fetcher
-        with self._provenance_mutation(changed=fetcher_changed):
-            self._source_parent_fetcher = fetcher
-            if fetcher is not None and self._source_binding is not None:
-                with contextlib.suppress(Exception):
-                    self._materialized_source_spec(fetcher())
-            if (
-                fetcher is not None
-                and self.has_source_binding
-                and self._source_state == "fresh"
-            ):
-                self._sync_input_provenance_snapshot()
+        """Set the standalone owner callback that resolves all current inputs."""
+        self._input_resolver = resolver
 
     def _set_managed_source_update_dialog(
         self, callback: Callable[..., int] | None
@@ -5077,11 +4856,53 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     def finalize_source_refresh(self) -> None:
         """Record that the current source refresh has been applied to the tool."""
+        rerun_requested = self._source_refresh_rerun_requested
+        self._source_refresh_rerun_requested = False
         with self._coalesce_provenance_changes():
+            pending_inputs = self._pending_script_inputs
+            self._pending_script_inputs = None
+            if pending_inputs is not None:
+                with self._provenance_mutation(
+                    changed=pending_inputs != self._script_inputs
+                ):
+                    self._script_inputs = pending_inputs
             self._source_refresh_deferred = False
-            self._sync_input_provenance_snapshot()
-            self._set_source_state("fresh")
+            self._set_source_state(
+                "stale" if rerun_requested and not self._source_auto_update else "fresh"
+            )
             self.sigDataChanged.emit()
+        if rerun_requested and self._source_auto_update:
+            single_shot(self, 0, self._rerun_source_refresh)
+
+    def _rerun_source_refresh(self) -> None:
+        """Apply a queued standalone refresh after terminal callback cleanup."""
+        if self._source_refreshing or self._source_refresh_deferred:
+            return
+        if not self._source_auto_update:
+            self._set_source_state("stale")
+            return
+        self._update_from_input_source()
+
+    def _defer_source_refresh(self) -> None:
+        """Keep the current input transaction pending until explicit completion."""
+        if not self._source_refreshing or self._pending_script_inputs is None:
+            raise RuntimeError(
+                "source refresh can only be deferred from update_inputs()"
+            )
+        self._source_refresh_deferred = True
+
+    def abort_source_refresh(self) -> None:
+        """Discard a pending input transaction after deferred work fails or stops."""
+        if self._pending_script_inputs is None and not self._source_refresh_deferred:
+            return
+        rerun_requested = self._source_refresh_rerun_requested
+        self._source_refresh_rerun_requested = False
+        self._pending_script_inputs = None
+        self._source_refresh_deferred = False
+        self._set_source_state("stale")
+        self._sigSourceRefreshAborted.emit()
+        if rerun_requested and self._source_auto_update:
+            single_shot(self, 0, self._rerun_source_refresh)
 
     def _set_source_auto_update(self, value: bool) -> None:
         """Update the auto-refresh flag and notify manager-facing UI state."""
@@ -5095,13 +4916,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Update the source state, refresh the banner, and emit info changes."""
         if state != "stale":
             self._source_refresh_deferred = False
+            self._source_refresh_rerun_requested = False
+            self._pending_script_inputs = None
         self._source_state = state
         self._refresh_source_status_widget()
         self.sigInfoChanged.emit()
 
     def _refresh_source_status_widget(self) -> None:
         """Refresh the inline banner that reports update availability."""
-        if not self.has_source_binding or (
+        if not self._script_inputs or (
             self._source_state == "fresh" and not self._source_auto_update
         ):
             self._source_status_bar.hide()
@@ -5157,38 +4980,19 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             return False
         return self._managed_source_reload()
 
-    def _materialized_source_spec(
-        self, parent_data: xr.DataArray
-    ) -> ToolProvenanceSpec:
-        """Return the source spec to apply to ``parent_data``."""
-        if self._source_spec is not None:
-            return self._source_spec
-        if self._source_binding is not None:
-            with self._coalesce_provenance_changes():
-                self._source_spec = self._source_binding.materialize(parent_data)
-                self._source_binding = None
-                self._notify_provenance_changed()
-            return self._source_spec
-        raise RuntimeError("Tool is not bound to an ImageTool source.")
+    def validate_update_inputs(
+        self, inputs: Mapping[str, xr.DataArray]
+    ) -> Mapping[str, xr.DataArray]:
+        """Validate or normalize the complete named input mapping."""
+        return dict(inputs)
 
-    def _resolve_source_data(self, parent_data: xr.DataArray) -> xr.DataArray:
-        """Apply the current source spec or selection state to ``parent_data``."""
-        source_spec = self._materialized_source_spec(parent_data)
-        capability = self._issue_code_execution_capability(
-            lambda: self._source_spec_code_trust_entries(source_spec)
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool | None:
+        """Apply a validated complete input mapping to the existing window."""
+        del inputs
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement update_inputs() to support "
+            "source updates."
         )
-        if capability is None:
-            raise PermissionError("Tool source provenance contains untrusted code")
-        return source_spec.apply(parent_data, authorization=capability)
-
-    def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
-        """Validate or normalize source data before `update_data` consumes it.
-
-        Subclasses can override this to enforce dimension, coordinate, or metadata
-        requirements for refreshed source data. Raise an exception to mark the source as
-        unavailable.
-        """
-        return new_data
 
     def _cancel_background_work(self, *, timeout_ms: int) -> bool:
         """Stop any running background work before mutating the tool state.
@@ -5197,26 +5001,6 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         shutdown before tearing down widgets or replacing internal state.
         """
         return True
-
-    def _perform_source_update(
-        self,
-        new_data: xr.DataArray,
-        *,
-        apply_update: Callable[[xr.DataArray], bool | None],
-        timeout_ms: int | None = None,
-    ) -> bool:
-        """Run an update from ImageTool without tearing down active worker UI."""
-        self._source_refresh_deferred = False
-        validated = self.validate_update_data(new_data)
-        if timeout_ms is None:
-            timeout_ms = self.BACKGROUND_TASK_TIMEOUT_MS
-        if not self._cancel_background_work(timeout_ms=timeout_ms):
-            logger.warning(
-                "Timed out waiting for background work to stop while updating %s",
-                self.tool_name,
-            )
-            return False
-        return apply_update(validated) is not False
 
     @staticmethod
     def _wait_for_threadpool(
@@ -5241,82 +5025,91 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             return True
         return bool(threadpool.waitForDone(timeout_ms))
 
-    def _update_from_parent_source(self) -> bool:
-        """Fetch the latest parent data and apply it through `update_data`."""
-        if self._source_parent_fetcher is None:
-            return False
-        try:
-            parent_data = self._source_parent_fetcher()
-        except Exception:
-            return False
-        try:
-            resolved = self._resolve_source_data(parent_data)
-        except Exception:
-            self._set_source_state("unavailable")
-            return False
+    def _apply_inputs(
+        self,
+        inputs: Mapping[str, xr.DataArray],
+        refreshed_script_inputs: Sequence[ScriptInput],
+    ) -> bool:
+        """Validate and apply one complete input transaction."""
+        if not self._script_inputs:
+            raise RuntimeError("ToolWindow does not define script inputs")
+        refreshed_inputs = tuple(
+            item.model_copy(deep=True) for item in refreshed_script_inputs
+        )
+        expected_signature = tuple(
+            (item.name, item.data_role, item.source_spec)
+            for item in self._script_inputs
+        )
+        refreshed_signature = tuple(
+            (item.name, item.data_role, item.source_spec) for item in refreshed_inputs
+        )
+        expected_names = {name for name, _role, _source in expected_signature}
+        if refreshed_signature != expected_signature:
+            raise ValueError("refreshed inputs do not match the fixed input binding")
 
-        try:
-            resolved = self.validate_update_data(resolved)
-        except Exception:
-            self._set_source_state("unavailable")
-            return False
-
-        try:
+        def _update(validated: Mapping[str, xr.DataArray]) -> bool | None:
             self._source_refresh_deferred = False
             self._source_refreshing = True
-            update_complete = self.update_data(resolved)
-        except Exception:
-            logger.exception(
-                "Failed to update %s from ImageTool source data", self.tool_name
-            )
-            self._set_source_state("unavailable")
-            return False
-        finally:
-            self._source_refreshing = False
+            self._pending_script_inputs = refreshed_inputs
+            try:
+                return self.update_inputs(validated)
+            except Exception:
+                self.abort_source_refresh()
+                raise
+            finally:
+                self._source_refreshing = False
+
+        update_complete = self._update_inputs_transaction(
+            inputs, expected_names=expected_names, update=_update
+        )
         if update_complete is False:
+            if not self._source_refresh_deferred:
+                self._pending_script_inputs = None
+                self._source_refresh_rerun_requested = False
             self._set_source_state("stale")
             return False
         self.finalize_source_refresh()
         return True
 
-    def handle_parent_source_replaced(self, parent_data: xr.DataArray) -> None:
-        """React to replacement of the parent ImageTool data source."""
-        if not self.has_source_binding:
+    def _update_from_input_source(self) -> bool:
+        """Resolve and apply all inputs owned by a standalone source."""
+        if self._input_resolver is None:
+            return False
+        try:
+            inputs, refreshed_inputs = self._input_resolver()
+            return self._apply_inputs(inputs, refreshed_inputs)
+        except Exception:
+            logger.exception("Failed to update %s from its inputs", self.tool_name)
+            self._set_source_state("unavailable")
+            return False
+
+    def handle_input_sources_replaced(self, _source: object = None) -> None:
+        """React to replacement of a standalone input producer."""
+        if self._input_resolver is None or not self._script_inputs:
+            return
+        if self._source_refreshing or self._source_refresh_deferred:
+            self._source_refresh_rerun_requested = True
+            self._set_source_state("stale")
             return
         try:
-            resolved = self._resolve_source_data(parent_data)
+            inputs, refreshed_inputs = self._input_resolver()
         except Exception:
             self._set_source_state("unavailable")
             return
-
-        try:
-            resolved = self.validate_update_data(resolved)
-        except Exception:
-            self._set_source_state("unavailable")
-            return
-
-        self._source_refresh_deferred = False
         if self._source_auto_update:
             try:
-                self._source_refreshing = True
-                update_complete = self.update_data(resolved)
+                self._apply_inputs(inputs, refreshed_inputs)
             except Exception:
-                logger.exception(
-                    "Failed to auto-update %s from ImageTool source data",
-                    self.tool_name,
-                )
+                logger.exception("Failed to auto-update %s inputs", self.tool_name)
                 self._set_source_state("unavailable")
-                return
-            finally:
-                self._source_refreshing = False
-            if update_complete is False:
-                if self._source_state != "stale":
-                    self._set_source_state("stale")
-                return
-            self.finalize_source_refresh()
-        else:
-            if self._source_state != "stale":
-                self._set_source_state("stale")
+            return
+        try:
+            self.validate_update_inputs(inputs)
+        except Exception:
+            self._set_source_state("unavailable")
+            return
+        if self._source_state != "stale":
+            self._set_source_state("stale")
 
     def show_source_update_dialog(
         self, *, parent: QtWidgets.QWidget | None = None
@@ -5325,7 +5118,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if self._managed_source_update_dialog is not None:
             return self._managed_source_update_dialog(parent=parent)
 
-        if not self.has_source_binding:
+        if not self._script_inputs:
             return int(QtWidgets.QDialog.DialogCode.Rejected)
 
         dialog = _ToolSourceUpdateDialog(
@@ -5337,23 +5130,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if result == int(QtWidgets.QDialog.DialogCode.Accepted):
             self._set_source_auto_update(dialog.auto_update_check.isChecked())
             if dialog.update_requested and self._source_state == "stale":
-                self._update_from_parent_source()
+                self._update_from_input_source()
         return result
 
-    def update_data(self, new_data: xr.DataArray) -> bool | None:
-        """Apply refreshed source data to the existing tool window.
-
-        Subclasses must override this when they support updates from ImageTool data.
-        Return `False` to leave the tool marked as stale when the new data is recognized
-        but cannot be published as a fresh result immediately.
-        """
-        raise NotImplementedError(
-            "Subclasses of ToolWindow must implement update_data() to support "
-            "updates from ImageTool data."
-        )
-
     def rebase_source_node_uids(self, uid_map: Mapping[str, str]) -> None:
-        """Rebase internal source-node references after workspace import."""
+        """Rebase subclass-owned source-node references after workspace import."""
+        del uid_map
 
     @property
     def preview_imageitem(self) -> pg.ImageItem | None:
@@ -5403,19 +5185,32 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         view_state = self._plot_state_registry.state_json()
         if view_state is not None:
             attrs[TOOL_VIEW_STATE_ATTR] = view_state
-        if self._source_spec is not None:
-            attrs[_TOOL_SOURCE_SPEC_ATTR] = json.dumps(
-                self._source_spec.model_dump(mode="json")
-            )
-        if self.has_source_binding:
+        attrs.update(
+            self._saved_script_input_attrs(self._script_inputs, self._primary_input)
+        )
+        if self._script_inputs:
             attrs[_TOOL_SOURCE_STATE_ATTR] = self._source_state
             attrs[_TOOL_SOURCE_AUTO_UPDATE_ATTR] = bool(self._source_auto_update)
-        input_provenance = self._effective_input_provenance_spec()
-        if input_provenance is not None:
-            attrs[_TOOL_INPUT_PROVENANCE_SPEC_ATTR] = json.dumps(
-                input_provenance.model_dump(mode="json")
-            )
         return attrs
+
+    @staticmethod
+    def _saved_script_input_attrs(
+        script_inputs: Sequence[ScriptInput], primary_input: str | None
+    ) -> dict[str, typing.Any]:
+        """Encode one canonical saved-input attribute pair."""
+        inputs = tuple(script_inputs)
+        if not inputs:
+            if primary_input is not None:
+                raise ValueError("primary input requires at least one script input")
+            return {}
+        if primary_input not in {item.name for item in inputs}:
+            raise ValueError("primary input must name a script input")
+        return {
+            _TOOL_SCRIPT_INPUTS_ATTR: json.dumps(
+                [item.model_dump(mode="json") for item in inputs]
+            ),
+            _TOOL_PRIMARY_INPUT_ATTR: primary_input,
+        }
 
     def _saved_tool_status(self) -> M:
         """Return the state model to serialize for this tool."""
@@ -5461,29 +5256,76 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     def _restore_persistence_data_items(
         self, data_items: Mapping[str, xr.DataArray], ds: xr.Dataset
-    ) -> None:
+    ) -> bool | None:
         """Restore named data artifacts saved by `_persistence_data_items()`."""
         del data_items, ds
+        return False
+
+    def _persistence_input_item_keys(self) -> dict[str, str]:
+        """Map canonical input names to their saved data item keys."""
+        return {
+            item.name: (
+                _SAVED_TOOL_DATA_NAME if item.name == self._primary_input else item.name
+            )
+            for item in self._script_inputs
+        }
+
+    def _update_inputs_transaction(
+        self,
+        inputs: Mapping[str, xr.DataArray],
+        *,
+        expected_names: Collection[str],
+        update: Callable[[Mapping[str, xr.DataArray]], bool | None],
+    ) -> bool | None:
+        """Validate, stop background work, and apply one complete input update."""
+        expected = set(expected_names)
+        if set(inputs) != expected:
+            raise ValueError("inputs do not match the declared input names")
+        validated = dict(self.validate_update_inputs(inputs))
+        if set(validated) != expected:
+            raise ValueError("validated inputs do not match the declared input names")
+        if not self._cancel_background_work(timeout_ms=self.BACKGROUND_TASK_TIMEOUT_MS):
+            logger.warning(
+                "Timed out waiting for background work to stop while updating %s",
+                self.tool_name,
+            )
+            return False
+        return update(validated)
 
     def _replace_persistence_data_items(
         self, data_items: Mapping[str, xr.DataArray], ds: xr.Dataset
     ) -> None:
         """Replace saved data artifacts in an already constructed tool window."""
-        primary_data = data_items.get(_SAVED_TOOL_DATA_NAME)
-        if primary_data is not None:
-            update_overridden = type(self).update_data is not ToolWindow.update_data
-            restore_overridden = (
-                type(self)._restore_persistence_data_items
-                is not ToolWindow._restore_persistence_data_items
-            )
-            if update_overridden:
-                current_name = self.tool_data.name
-                self.update_data(primary_data.rename(current_name))
-            elif not restore_overridden:
+        if not self._script_inputs:
+            if self._restore_persistence_data_items(data_items, ds) is False:
                 raise NotImplementedError(
-                    f"{type(self).__name__} must implement update_data() or "
-                    "_restore_persistence_data_items() to replace saved data."
+                    f"{type(self).__name__} must implement "
+                    "_restore_persistence_data_items()"
                 )
+            return
+        if len(self._script_inputs) == 1:
+            self._restore_persistence_data_items(data_items, ds)
+            return
+
+        primary_input = typing.cast("str", self._primary_input)
+        item_keys = self._persistence_input_item_keys()
+        try:
+            inputs = {name: data_items[key] for name, key in item_keys.items()}
+        except KeyError as exc:
+            raise ValueError(
+                f"{type(self).__name__}._persistence_data_items() must include each "
+                f"script input persistence item; missing {exc.args[0]!r}"
+            ) from exc
+        inputs[primary_input] = inputs[primary_input].rename(self.tool_data.name)
+        if (
+            self._update_inputs_transaction(
+                inputs, expected_names=inputs, update=self.update_inputs
+            )
+            is False
+        ):
+            raise RuntimeError(
+                "Persisted ToolWindow input replacement was deferred or cancelled"
+            )
         self._restore_persistence_data_items(data_items, ds)
 
     def _flush_restore_work_for_save(self) -> None:
@@ -5532,20 +5374,53 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if (
             not self._save_tool_data_references
             or variable_name != _SAVED_TOOL_DATA_NAME
-            or not self.has_source_binding
             or self.source_state != "fresh"
-            or self._source_parent_fetcher is None
+            or len(self._script_inputs) != 1
         ):
             return None
-        try:
-            parent_data = self._source_parent_fetcher()
-            resolved = self._resolve_source_data(parent_data)
-            resolved = self.validate_update_data(resolved)
-        except Exception:
+        script_input = self._script_inputs[0]
+        if (
+            script_input.name != self._primary_input
+            or script_input.node_uid is None
+            or (
+                self._save_tool_data_reference_node_uids is not None
+                and script_input.node_uid
+                not in self._save_tool_data_reference_node_uids
+            )
+        ):
             return None
-        if not self._reference_resolves_current_tool_data(resolved, data):
-            return None
-        return {"kind": "parent_source"}
+        payload: dict[str, typing.Any] = {
+            "kind": "manager_node",
+            "input_name": script_input.name,
+            "node_uid": script_input.node_uid,
+            "node_snapshot_token": script_input.node_snapshot_token,
+            "data_role": script_input.data_role,
+        }
+        if script_input.source_spec is not None:
+            payload["source_spec"] = script_input.source_spec
+        return payload
+
+    @staticmethod
+    def _apply_saved_tool_data_reference(
+        reference: Mapping[str, typing.Any],
+        data: xr.DataArray,
+        *,
+        authorization: object | None = None,
+    ) -> xr.DataArray:
+        """Apply the optional canonical transform stored on a data reference."""
+        from erlab.interactive.imagetool._provenance._model import (
+            parse_tool_provenance_spec,
+            require_live_source_spec,
+        )
+
+        source_spec = require_live_source_spec(
+            parse_tool_provenance_spec(reference.get("source_spec"))
+        )
+        return (
+            data
+            if source_spec is None
+            else source_spec.apply(data, authorization=authorization)
+        )
 
     def _reference_saved_tool_data(
         self, variable_name: str, data: xr.DataArray
@@ -5565,10 +5440,14 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     def _saved_tool_data_dataset(self) -> xr.Dataset:
         data_items = self._persistence_data_items()
-        if _SAVED_TOOL_DATA_NAME not in data_items:
+        required_items = {_SAVED_TOOL_DATA_NAME}
+        required_items.update(self._persistence_input_item_keys().values())
+        missing_items = required_items.difference(data_items)
+        if missing_items:
+            missing = min(missing_items)
             raise ValueError(
                 f"{type(self).__name__}._persistence_data_items() must include "
-                f"{_SAVED_TOOL_DATA_NAME!r}"
+                f"the canonical input item {missing!r}"
             )
 
         variables: dict[str, xr.DataArray] = {}
@@ -5622,7 +5501,13 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     def _saved_tool_data_references(
         ds: xr.Dataset,
     ) -> dict[str, dict[str, typing.Any]]:
-        payload = ds.attrs.get(_TOOL_DATA_REFERENCES_ATTR)
+        return ToolWindow._saved_tool_data_references_from_metadata(ds.attrs)
+
+    @staticmethod
+    def _saved_tool_data_references_from_metadata(
+        attrs: Mapping[str, typing.Any],
+    ) -> dict[str, dict[str, typing.Any]]:
+        payload = attrs.get(_TOOL_DATA_REFERENCES_ATTR)
         if payload is None:
             return {}
         if not isinstance(payload, str):
@@ -5642,35 +5527,165 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         return references
 
     @staticmethod
-    def _saved_source_spec_from_metadata(
+    def _saved_script_input_metadata(
         attrs: Mapping[str, typing.Any],
-    ) -> ToolProvenanceSpec:
+        *,
+        source_parent_data: xr.DataArray | None = None,
+    ) -> tuple[tuple[ScriptInput, ...], str | None]:
+        """Decode canonical inputs and the released unary metadata format."""
         from erlab.interactive.imagetool._provenance._model import (
+            ScriptInput,
+            parse_script_inputs,
             parse_tool_provenance_spec,
             require_live_source_spec,
         )
-
-        payload = attrs.get(_TOOL_SOURCE_SPEC_ATTR)
-        if not isinstance(payload, str):
-            raise TypeError("Referenced tool data is missing source provenance")
-        source_spec = parse_tool_provenance_spec(
-            typing.cast("Mapping[str, typing.Any]", json.loads(payload))
+        from erlab.interactive.imagetool._provenance._operations import (
+            ImageToolSelectionSourceBinding,
         )
-        live_source_spec = require_live_source_spec(source_spec)
-        if live_source_spec is None:
-            raise ValueError("Referenced tool data source provenance is not replayable")
-        return live_source_spec
+
+        def _legacy_value(name: str, decode: Callable[[typing.Any], typing.Any]):
+            raw_value = attrs.get(name)
+            if raw_value is None:
+                return None
+            try:
+                return decode(json.loads(raw_value))
+            except Exception:
+                logger.warning(
+                    "Ignoring invalid legacy ToolWindow input metadata", exc_info=True
+                )
+                return None
+
+        def _materialized_source_spec(source_binding):
+            if source_binding is None or source_parent_data is None:
+                return None
+            try:
+                return source_binding.materialize(source_parent_data)
+            except Exception:
+                logger.warning(
+                    "Ignoring invalid legacy ToolWindow input metadata", exc_info=True
+                )
+                return None
+
+        raw_script_inputs = attrs.get(_TOOL_SCRIPT_INPUTS_ATTR)
+        if raw_script_inputs is not None:
+            try:
+                script_inputs = parse_script_inputs(raw_script_inputs)
+                raw_primary = attrs.get(_TOOL_PRIMARY_INPUT_ATTR)
+                if isinstance(raw_primary, bytes):
+                    raw_primary = raw_primary.decode()
+                primary_input = raw_primary if isinstance(raw_primary, str) else None
+                ToolWindow._saved_script_input_attrs(script_inputs, primary_input)
+            except Exception:
+                logger.warning(
+                    "Ignoring invalid saved ToolWindow script inputs", exc_info=True
+                )
+            else:
+                if (
+                    script_inputs
+                    and source_parent_data is not None
+                    and _TOOL_SOURCE_BINDING_ATTR in attrs
+                ):
+                    primary_index = tuple(item.name for item in script_inputs).index(
+                        primary_input
+                    )
+                    if script_inputs[primary_index].source_spec is None:
+                        source_spec = _materialized_source_spec(
+                            _legacy_value(
+                                _TOOL_SOURCE_BINDING_ATTR,
+                                ImageToolSelectionSourceBinding.model_validate,
+                            )
+                        )
+                        if source_spec is not None:
+                            updated = list(script_inputs)
+                            updated[primary_index] = script_inputs[
+                                primary_index
+                            ].model_copy(
+                                update={
+                                    "source_spec": source_spec.model_dump(mode="json")
+                                }
+                            )
+                            script_inputs = tuple(updated)
+                return script_inputs, primary_input
+
+        raw_source_spec = attrs.get(_TOOL_SOURCE_SPEC_ATTR)
+        raw_source_binding = attrs.get(_TOOL_SOURCE_BINDING_ATTR)
+        raw_input_provenance = attrs.get(_TOOL_INPUT_PROVENANCE_SPEC_ATTR)
+        if (
+            raw_source_spec is None
+            and raw_source_binding is None
+            and raw_input_provenance is None
+        ):
+            return (), None
+        source_spec = _legacy_value(
+            _TOOL_SOURCE_SPEC_ATTR,
+            lambda value: require_live_source_spec(parse_tool_provenance_spec(value)),
+        )
+        source_binding = (
+            None
+            if source_spec is not None
+            else _legacy_value(
+                _TOOL_SOURCE_BINDING_ATTR,
+                ImageToolSelectionSourceBinding.model_validate,
+            )
+        )
+        if source_spec is None:
+            source_spec = _materialized_source_spec(source_binding)
+        provenance_spec = _legacy_value(
+            _TOOL_INPUT_PROVENANCE_SPEC_ATTR, parse_tool_provenance_spec
+        )
+        if source_spec is None and provenance_spec is None and source_binding is None:
+            return (), None
+        return (
+            ScriptInput(
+                name="data",
+                source_spec=(
+                    None if source_spec is None else source_spec.model_dump(mode="json")
+                ),
+                provenance_spec=(
+                    None
+                    if provenance_spec is None
+                    else provenance_spec.model_dump(mode="json")
+                ),
+            ),
+        ), "data"
 
     @classmethod
-    def _saved_source_spec_from_attrs(
+    def _saved_provenance_capability(
         cls,
-        ds: xr.Dataset,
-    ) -> ToolProvenanceSpec:
-        return cls._saved_source_spec_from_metadata(ds.attrs)
+        source_spec: ToolProvenanceSpec,
+        *,
+        location_prefix: str,
+        document_trust: _DocumentTrust | None,
+        entry_locator: (
+            Callable[[Iterable[CodeTrustEntry]], tuple[CodeTrustEntry, ...]] | None
+        ),
+    ) -> object | None:
+        entries = tuple(
+            cls._source_spec_code_trust_entries(
+                source_spec,
+                location_prefix=location_prefix,
+            )
+        )
+        if not entries:
+            return None
+        if entry_locator is not None:
+            entries = entry_locator(entries)
+        capability = None
+        if document_trust is not None:
+            _trust, capability = issue_complete_execution_capability(
+                document_trust,
+                entries,
+            )
+        if capability is None:
+            raise _MissingSavedToolDataReferenceError(
+                "Saved tool source provenance contains untrusted code"
+            )
+        return capability
 
     @classmethod
     def _resolve_saved_tool_data_reference(
         cls,
+        variable_name: str,
         reference: Mapping[str, typing.Any],
         ds: xr.Dataset,
         *,
@@ -5682,6 +5697,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             Callable[[Iterable[CodeTrustEntry]], tuple[CodeTrustEntry, ...]] | None
         ) = None,
     ) -> xr.DataArray:
+        from erlab.interactive.imagetool._provenance._model import (
+            parse_tool_provenance_spec,
+            require_live_source_spec,
+        )
+
         kind = reference.get("kind")
         if kind == "parent_source":
             if source_parent_data is None:
@@ -5689,20 +5709,32 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     "Saved tool data references parent ImageTool data, but the "
                     "parent data is unavailable."
                 )
-            source_spec = cls._saved_source_spec_from_attrs(ds)
-            capability = None
-            if document_trust is not None:
-                entries = tuple(cls._source_spec_code_trust_entries(source_spec))
-                if entry_locator is not None:
-                    entries = entry_locator(entries)
-                _trust, capability = issue_complete_execution_capability(
-                    document_trust,
-                    entries,
+            script_inputs, primary_input = cls._saved_script_input_metadata(
+                ds.attrs, source_parent_data=source_parent_data
+            )
+            source_index, source_input = next(
+                (
+                    (index, item)
+                    for index, item in enumerate(script_inputs)
+                    if item.name == primary_input
+                ),
+                (None, None),
+            )
+            source_spec = (
+                None if source_input is None else source_input.parsed_source_spec()
+            )
+            if source_spec is None:
+                raise ValueError(
+                    "Referenced tool data source provenance is not replayable"
                 )
-                if capability is None:
-                    raise _MissingSavedToolDataReferenceError(
-                        "Saved tool source provenance contains untrusted code"
-                    )
+            capability = cls._saved_provenance_capability(
+                source_spec,
+                location_prefix=(
+                    f"tool-inputs/{source_index}:{source_input.name}/source"
+                ),
+                document_trust=document_trust,
+                entry_locator=entry_locator,
+            )
             return source_spec.apply(
                 source_parent_data,
                 authorization=capability,
@@ -5720,7 +5752,22 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     "Saved tool data references a manager node that could not be "
                     f"resolved: {node_uid!r}"
                 )
-            return resolved
+            source_spec = require_live_source_spec(
+                parse_tool_provenance_spec(reference.get("source_spec"))
+            )
+            if source_spec is None:
+                return resolved
+            capability = cls._saved_provenance_capability(
+                source_spec,
+                location_prefix=f"tool-data-references/{variable_name}/source",
+                document_trust=document_trust,
+                entry_locator=entry_locator,
+            )
+            return cls._apply_saved_tool_data_reference(
+                reference,
+                resolved,
+                authorization=capability,
+            )
         raise ValueError(f"Unsupported saved tool data reference kind: {kind!r}")
 
     @classmethod
@@ -5757,6 +5804,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 continue
             try:
                 resolved = cls._resolve_saved_tool_data_reference(
+                    variable_name,
                     reference,
                     ds,
                     source_parent_data=source_parent_data,
@@ -5915,50 +5963,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             with tool._history_suppressed():
                 tool.tool_status = saved_status
             tool._tool_display_name = ds.attrs.get("tool_display_name", "")
-            source_spec = None
-            if _TOOL_SOURCE_SPEC_ATTR in ds.attrs:
-                try:
-                    from erlab.interactive.imagetool._provenance._model import (
-                        parse_tool_provenance_spec,
-                        require_live_source_spec,
-                    )
+            script_inputs, primary_input = cls_obj._saved_script_input_metadata(
+                ds.attrs,
+                source_parent_data=source_parent_data,
+            )
 
-                    source_spec = parse_tool_provenance_spec(
-                        typing.cast(
-                            "Mapping[str, typing.Any]",
-                            json.loads(ds.attrs[_TOOL_SOURCE_SPEC_ATTR]),
-                        )
-                    )
-                    source_spec = require_live_source_spec(source_spec)
-                except Exception:
-                    logger.warning(
-                        "Ignoring invalid saved tool source provenance for %s",
-                        cls_obj.__qualname__,
-                        exc_info=True,
-                    )
-            source_binding = None
-            if source_spec is None and _TOOL_SOURCE_BINDING_ATTR in ds.attrs:
-                try:
-                    from erlab.interactive.imagetool._provenance._operations import (
-                        ImageToolSelectionSourceBinding,
-                    )
-
-                    source_binding = ImageToolSelectionSourceBinding.model_validate(
-                        typing.cast(
-                            "Mapping[str, typing.Any]",
-                            json.loads(ds.attrs[_TOOL_SOURCE_BINDING_ATTR]),
-                        )
-                    )
-                except Exception:
-                    logger.warning(
-                        "Ignoring invalid saved tool source binding for %s",
-                        cls_obj.__qualname__,
-                        exc_info=True,
-                    )
-            if source_spec is not None or source_binding is not None:
-                tool.set_source_binding(
-                    source_spec,
-                    source_binding=source_binding,
+            if script_inputs:
+                tool.set_script_inputs(
+                    script_inputs,
+                    primary_input=primary_input,
                     auto_update=bool(
                         ds.attrs.get(_TOOL_SOURCE_AUTO_UPDATE_ATTR, False)
                     ),
@@ -5966,22 +5979,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                         ds.attrs.get(_TOOL_SOURCE_STATE_ATTR)
                     ),
                 )
-            if _TOOL_INPUT_PROVENANCE_SPEC_ATTR in ds.attrs:
-                try:
-                    tool.set_input_provenance_spec(
-                        typing.cast(
-                            "Mapping[str, typing.Any]",
-                            json.loads(ds.attrs[_TOOL_INPUT_PROVENANCE_SPEC_ATTR]),
-                        )
-                    )
-                except Exception:
-                    logger.warning(
-                        "Ignoring invalid saved tool input provenance for %s",
-                        cls_obj.__qualname__,
-                        exc_info=True,
-                    )
-            tool._restore_persistence_payload(ds)
-            tool._restore_persistence_data_items(data_items, ds)
+            if script_inputs:
+                tool._replace_persistence_data_items(data_items, ds)
+                tool._restore_persistence_payload(ds)
+            else:
+                tool._restore_persistence_payload(ds)
+                tool._restore_persistence_data_items(data_items, ds)
             tool._plot_state_registry.restore_json(ds.attrs.get(TOOL_VIEW_STATE_ATTR))
             tool.setWindowTitle(ds.attrs["tool_title"])
             if (
@@ -6097,18 +6100,16 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Return executable content from saved state and opaque-payload metadata."""
         if cls._CODE_TRUST_DOMAIN is None:
             return None
-        source_spec = (
-            cls._saved_source_spec_from_metadata(attrs)
-            if _TOOL_SOURCE_SPEC_ATTR in attrs
-            else None
-        )
+        script_inputs, _primary_input = cls._saved_script_input_metadata(attrs)
+        references = cls._saved_tool_data_references_from_metadata(attrs)
         return create_manifest(
             cls._CODE_TRUST_DOMAIN,
             cls._CODE_TRUST_POLICY_VERSION,
             (
                 *cls._code_trust_entries_from_status(status),
                 *code_payload_entries_from_metadata(attrs),
-                *cls._source_spec_code_trust_entries(source_spec),
+                *cls._script_inputs_code_trust_entries(script_inputs),
+                *cls._saved_reference_code_trust_entries(references),
             ),
         )
 
@@ -6122,13 +6123,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             (
                 *self._code_trust_entries_from_status(self._saved_tool_status()),
                 *self._code_trust_payload_entries(),
-                *self._source_spec_code_trust_entries(self._source_spec),
+                *self._script_inputs_code_trust_entries(self._script_inputs),
             ),
         )
 
     @staticmethod
     def _source_spec_code_trust_entries(
         source_spec: ToolProvenanceSpec | None,
+        *,
+        location_prefix: str = "tool-source/provenance",
     ) -> Iterable[CodeTrustEntry]:
         if source_spec is None:
             return ()
@@ -6138,8 +6141,43 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
         return provenance_code_trust_entries(
             source_spec,
-            location_prefix="tool-source/provenance",
+            location_prefix=location_prefix,
         )
+
+    @classmethod
+    def _script_inputs_code_trust_entries(
+        cls,
+        script_inputs: Sequence[ScriptInput],
+    ) -> Iterable[CodeTrustEntry]:
+        for index, script_input in enumerate(script_inputs):
+            prefix = f"tool-inputs/{index}:{script_input.name}"
+            yield from cls._source_spec_code_trust_entries(
+                script_input.parsed_source_spec(),
+                location_prefix=f"{prefix}/source",
+            )
+            yield from cls._source_spec_code_trust_entries(
+                script_input.parsed_provenance_spec(),
+                location_prefix=f"{prefix}/provenance",
+            )
+
+    @classmethod
+    def _saved_reference_code_trust_entries(
+        cls,
+        references: Mapping[str, Mapping[str, typing.Any]],
+    ) -> Iterable[CodeTrustEntry]:
+        from erlab.interactive.imagetool._provenance._model import (
+            parse_tool_provenance_spec,
+            require_live_source_spec,
+        )
+
+        for variable_name, reference in references.items():
+            source_spec = require_live_source_spec(
+                parse_tool_provenance_spec(reference.get("source_spec"))
+            )
+            yield from cls._source_spec_code_trust_entries(
+                source_spec,
+                location_prefix=f"tool-data-references/{variable_name}/source",
+            )
 
     @classmethod
     def _code_trust_entries_from_status(cls, status: M) -> Iterable[CodeTrustEntry]:

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -1132,6 +1132,8 @@ _TOOL_PRIMARY_INPUT_ATTR = "tool_primary_input"
 _TOOL_DATA_REFERENCES_ATTR = "tool_data_references"
 _TOOL_DATA_BLOB_NAME_ATTR = "tool_data_blob_name"
 _SAVED_TOOL_DATA_NAME = "<saved-tool-data>"
+_TOOL_INPUT_CODE_TRUST_DOMAIN = "erlab.tool-inputs"
+_TOOL_INPUT_CODE_TRUST_POLICY_VERSION = 1
 
 
 def _normalize_tool_source_state(
@@ -5727,6 +5729,8 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 raise ValueError(
                     "Referenced tool data source provenance is not replayable"
                 )
+            source_input = typing.cast("ScriptInput", source_input)
+            source_index = typing.cast("int", source_index)
             capability = cls._saved_provenance_capability(
                 source_spec,
                 location_prefix=(
@@ -6098,32 +6102,50 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         attrs: Mapping[str, typing.Any],
     ) -> CodeTrustManifest | None:
         """Return executable content from saved state and opaque-payload metadata."""
-        if cls._CODE_TRUST_DOMAIN is None:
-            return None
         script_inputs, _primary_input = cls._saved_script_input_metadata(attrs)
         references = cls._saved_tool_data_references_from_metadata(attrs)
+        input_entries = tuple(cls._script_inputs_code_trust_entries(script_inputs))
+        reference_entries = tuple(cls._saved_reference_code_trust_entries(references))
+        if cls._CODE_TRUST_DOMAIN is None:
+            entries = (*input_entries, *reference_entries)
+            if not entries:
+                return None
+            return create_manifest(
+                _TOOL_INPUT_CODE_TRUST_DOMAIN,
+                _TOOL_INPUT_CODE_TRUST_POLICY_VERSION,
+                entries,
+            )
         return create_manifest(
             cls._CODE_TRUST_DOMAIN,
             cls._CODE_TRUST_POLICY_VERSION,
             (
                 *cls._code_trust_entries_from_status(status),
                 *code_payload_entries_from_metadata(attrs),
-                *cls._script_inputs_code_trust_entries(script_inputs),
-                *cls._saved_reference_code_trust_entries(references),
+                *input_entries,
+                *reference_entries,
             ),
         )
 
     def _current_code_trust_manifest(self) -> CodeTrustManifest | None:
         """Return executable content for the current in-memory document."""
+        input_entries = tuple(
+            self._script_inputs_code_trust_entries(self._script_inputs)
+        )
         if self._CODE_TRUST_DOMAIN is None:
-            return None
+            if not input_entries:
+                return None
+            return create_manifest(
+                _TOOL_INPUT_CODE_TRUST_DOMAIN,
+                _TOOL_INPUT_CODE_TRUST_POLICY_VERSION,
+                input_entries,
+            )
         return create_manifest(
             self._CODE_TRUST_DOMAIN,
             self._CODE_TRUST_POLICY_VERSION,
             (
                 *self._code_trust_entries_from_status(self._saved_tool_status()),
                 *self._code_trust_payload_entries(),
-                *self._script_inputs_code_trust_entries(self._script_inputs),
+                *input_entries,
             ),
         )
 

--- a/tests/interactive/imagetool/manager/figurecomposer/_common.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/_common.py
@@ -1,7 +1,7 @@
 import functools
 import typing
 import warnings
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import matplotlib as mpl
@@ -44,6 +44,7 @@ from erlab.interactive.imagetool._provenance._graph import (
 from erlab.interactive.imagetool._provenance._model import (
     FileLoadSource,
     FileReplayCall,
+    ScriptInput,
     ToolProvenanceSpec,
     file_load,
     script,
@@ -71,6 +72,10 @@ class _SourcePickerDummyTool(
         super().__init__()
         self._data = data
         self._status = _SourcePickerDummyState()
+        self.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
 
     @property
     def tool_data(self) -> xr.DataArray:
@@ -83,6 +88,9 @@ class _SourcePickerDummyTool(
     @tool_status.setter
     def tool_status(self, status: _SourcePickerDummyState) -> None:
         self._status = status
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self._data = inputs["data"]
 
 
 def _delete_test_widgets(*widgets: QtWidgets.QWidget | None) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -1615,7 +1615,9 @@ def test_manager_figure_workspace_reference_helper_edges(
         with monkeypatch.context() as context:
             context.setattr(root_node, "data_for_role", unavailable_data)
             assert not controller._tool_data_reference_matches_current_data(
-                current_reference, data
+                current_reference,
+                data,
+                owner_node=figure_node,
             )
 
         saved_references = {"source": current_reference}

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_sources.py
@@ -738,7 +738,7 @@ def test_manager_figure_source_picker_selects_imagetool_rows_only(
         root_uid = manager._tool_graph.root_wrappers[0].uid
         dummy_uid = manager.add_childtool(
             _SourcePickerDummyTool(root_data.rename("dummy")),
-            0,
+            script_inputs={"data": 0},
             show=False,
         )
         child_uid = manager.add_imagetool_child(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -4147,7 +4147,7 @@ def test_figure_composer_full_code_keeps_needed_base_and_selected_sources(
     xr.testing.assert_identical(captured[1], data.qsel(hv=39.274))
 
 
-def test_figure_composer_full_code_falls_back_for_live_selected_source(
+def test_figure_composer_display_code_uses_live_selected_source(
     qtbot,
     monkeypatch,
 ) -> None:
@@ -4185,7 +4185,8 @@ def test_figure_composer_full_code_falls_back_for_live_selected_source(
     spec = tool.current_provenance_spec()
     assert spec is not None
     assert tuple(script_input.name for script_input in spec.script_inputs) == ("live",)
-    assert spec.display_code() is None
+    display_code = spec.display_code()
+    assert display_code is not None
 
     code = tool.generated_code()
     assert "data_3_selected = data_3.qsel(hv=39.274)" in code
@@ -4197,6 +4198,10 @@ def test_figure_composer_full_code_falls_back_for_live_selected_source(
         "plot_array",
         lambda arr, **_kwargs: captured.append(arr),
     )
+    display_namespace = _exec_generated_code(display_code, {"data_3": data})
+    assert isinstance(display_namespace["fig"], Figure)
+    xr.testing.assert_identical(captured.pop(), data.qsel(hv=39.274))
+
     namespace = _exec_generated_code(code, {"data_3": data})
     assert isinstance(namespace["fig"], Figure)
     xr.testing.assert_identical(captured[0], data.qsel(hv=39.274))

--- a/tests/interactive/imagetool/manager/helpers.py
+++ b/tests/interactive/imagetool/manager/helpers.py
@@ -638,10 +638,9 @@ def copy_full_code_for_uid(
     monkeypatch,
     manager: ImageToolManager,
     uid: str,
-    *,
-    source_name: str = "data",
 ) -> str:
     copied: list[str] = []
+    unexpected_prompts: list[str] = []
     monkeypatch.setattr(
         erlab.interactive.utils,
         "copy_to_clipboard",
@@ -650,7 +649,7 @@ def copy_full_code_for_uid(
     monkeypatch.setattr(
         manager,
         "_prompt_replay_input_name",
-        lambda _node: source_name,
+        lambda node: unexpected_prompts.append(node.uid) or None,
     )
     manager.tree_view.clearSelection()
     select_child_tool(manager, uid)
@@ -663,5 +662,9 @@ def copy_full_code_for_uid(
         or manager._details_panel._unavailable_replay_code_details(node)
     )
     trigger_menu_action(menu, manager._metadata_copy_full_action)
+    assert not unexpected_prompts, (
+        "Copy Full Code unexpectedly requested a source variable for "
+        f"node {unexpected_prompts[0]!r}"
+    )
     assert copied
     return copied[-1]

--- a/tests/interactive/imagetool/manager/helpers.py
+++ b/tests/interactive/imagetool/manager/helpers.py
@@ -15,10 +15,11 @@ import erlab.interactive.imagetool.manager._registry as manager_registry
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
+from erlab.interactive.imagetool._provenance._model import ScriptInput
 
 if typing.TYPE_CHECKING:
     import pathlib
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
     from erlab.interactive.fermiedge import GoldTool
     from erlab.interactive.imagetool.manager import ImageToolManager
@@ -360,6 +361,10 @@ class _UnserializableChildTool(
         super().__init__()
         self._data = data
         self._status = _UnserializableChildState()
+        self.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
 
     @property
     def tool_data(self) -> xr.DataArray:
@@ -372,6 +377,9 @@ class _UnserializableChildTool(
     @tool_status.setter
     def tool_status(self, status: _UnserializableChildState) -> None:
         self._status = status
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self._data = inputs["data"]
 
     def _raise_serialization_error(self) -> typing.NoReturn:
         raise ValueError(
@@ -402,7 +410,15 @@ def make_fit2d_child(
         data, model=exp_decay_model, params=params, execute=False
     )
     assert isinstance(tool, Fit2DTool)
-    child_uid = manager.add_childtool(tool, parent, show=False)
+    tool.set_script_inputs(
+        (ScriptInput(name="data", data_role="displayed"),),
+        primary_input="data",
+    )
+    child_uid = manager.add_childtool(
+        tool,
+        script_inputs={"data": parent},
+        show=False,
+    )
     return child_uid, tool
 
 
@@ -421,7 +437,15 @@ def make_fit1d_child(
         data, model=exp_decay_model, params=params, execute=False
     )
     assert isinstance(tool, Fit1DTool)
-    child_uid = manager.add_childtool(tool, parent, show=False)
+    tool.set_script_inputs(
+        (ScriptInput(name="data", data_role="displayed"),),
+        primary_input="data",
+    )
+    child_uid = manager.add_childtool(
+        tool,
+        script_inputs={"data": parent},
+        show=False,
+    )
     return child_uid, tool
 
 
@@ -633,6 +657,11 @@ def copy_full_code_for_uid(
     manager._update_info(uid=uid)
     menu = manager._build_metadata_derivation_menu()
     assert menu is not None
+    node = manager._node_for_target(uid)
+    assert node.derivation_code, (
+        manager._details_panel._unavailable_replay_code_traceback(node)
+        or manager._details_panel._unavailable_replay_code_details(node)
+    )
     trigger_menu_action(menu, manager._metadata_copy_full_action)
     assert copied
     return copied[-1]

--- a/tests/interactive/imagetool/manager/provenance/_common.py
+++ b/tests/interactive/imagetool/manager/provenance/_common.py
@@ -223,6 +223,8 @@ def _seed_fit2d_param_results(child: Fit2DTool, params_list: list[typing.Any]) -
     child._result_ds_full = [
         _fit2d_param_result_dataset(params) for params in params_list
     ]
+    child._fit_is_current = True
+    child._update_full_fit_saveable()
     child._update_param_plot_options()
 
 
@@ -233,7 +235,7 @@ def _fake_edit_controller(
     nodes: dict[str, typing.Any] | None = None,
     metadata_uid: str | None = None,
     selected_targets: tuple[str, ...] = (),
-    script_input_can_reload: Callable[..., bool] | None = None,
+    script_input_unavailable_reason: Callable[..., str | None] | None = None,
 ) -> provenance_edit_controller._ProvenanceEditController:
     graph_nodes = (
         nodes if nodes is not None else ({} if node is None else {"node": node})
@@ -246,6 +248,24 @@ def _fake_edit_controller(
             raise RuntimeError("missing parent")
         return parent
 
+    lineage_controller = types.SimpleNamespace(
+        _script_input_unavailable_reason=(
+            script_input_unavailable_reason
+            if script_input_unavailable_reason is not None
+            else lambda *_args, **_kwargs: None
+        ),
+        _rebuild_script_provenance=lambda spec, **_kwargs: types.SimpleNamespace(
+            data=xr.DataArray([1.0], dims=("x",)),
+            provenance_spec=spec,
+        ),
+        _apply_provenance=lambda spec, data, **kwargs: spec.apply(
+            data,
+            authorization=kwargs.get("authorization"),
+        ),
+        _authorize_provenance_execution=(
+            lambda entries, **_kwargs: _authorize_execution(entries)
+        ),
+    )
     manager = types.SimpleNamespace(
         _metadata_node_uid=metadata_uid,
         _tool_graph=types.SimpleNamespace(nodes=graph_nodes),
@@ -268,29 +288,13 @@ def _fake_edit_controller(
                 ),
             ),
         ),
-        _available_file_loaders=erlab.interactive.utils.file_loaders,
-        _script_input_can_reload=(
-            script_input_can_reload
-            if script_input_can_reload is not None
-            else lambda *_args, **_kwargs: True
-        ),
-        _rebuild_script_provenance=lambda spec, **_kwargs: types.SimpleNamespace(
-            data=xr.DataArray([1.0], dims=("x",)),
-            provenance_spec=spec,
-        ),
-        _apply_provenance=lambda spec, data, **kwargs: spec.apply(
-            data,
-            authorization=kwargs.get("authorization"),
-        ),
-        _authorize_provenance_execution=(
-            lambda entries, **_kwargs: _authorize_execution(entries)
-        ),
         _workspace_controller=types.SimpleNamespace(
             local_code_edit=_authorize_local_edit,
             saving=types.SimpleNamespace(
                 _workspace_node_path_for_node=lambda current: f"nodes/{current.uid}"
             ),
         ),
+        _lineage_controller=lineage_controller,
         _update_info=lambda **_kwargs: None,
         _workspace_ui_refresh_context=contextlib.nullcontext,
         _sigDataReplaced=types.SimpleNamespace(emit=lambda: None),

--- a/tests/interactive/imagetool/manager/provenance/_common.py
+++ b/tests/interactive/imagetool/manager/provenance/_common.py
@@ -272,6 +272,7 @@ def _fake_edit_controller(
         _selected_imagetool_targets=lambda: selected_targets,
         _node_for_target=lambda target: graph_nodes[target],
         _parent_node=_parent_node,
+        _available_file_loaders=erlab.interactive.utils.file_loaders,
         _extensions=types.SimpleNamespace(
             replay_loader=lambda *_args, **_kwargs: pytest.fail(
                 "built-in provenance must not use extension loader execution"

--- a/tests/interactive/imagetool/manager/provenance/test_clipboard.py
+++ b/tests/interactive/imagetool/manager/provenance/test_clipboard.py
@@ -141,6 +141,9 @@ def test_manager_provenance_step_clipboard_payload_validation() -> None:
 
 
 def test_manager_selected_derivation_step_payload_filters_rows() -> None:
+    class _NonLiveOperation(ToolProvenanceOperation):
+        live_applicable: typing.ClassVar[bool] = False
+
     def item(
         row: _ProvenanceDisplayRow | str,
         *,
@@ -200,7 +203,7 @@ def test_manager_selected_derivation_step_payload_filters_rows() -> None:
             )
         ),
         non_live_row: types.SimpleNamespace(
-            _operation_for_ref=lambda _ref: types.SimpleNamespace(live_applicable=False)
+            _operation_for_ref=lambda _ref: _NonLiveOperation()
         ),
     }
     edit_controller = types.SimpleNamespace(
@@ -283,7 +286,9 @@ def test_manager_metadata_derivation_rows_render_as_tree(qtbot) -> None:
         ),
         _set_metadata_fields=lambda _fields: None,
         _update_metadata_pane=lambda: None,
-        _dependency_refs_for_uid=lambda _uid: (),
+        _lineage_controller=types.SimpleNamespace(
+            _dependency_refs_for_uid=lambda _uid: ()
+        ),
     )
     controller = manager_details_panel._DetailsPanelController(
         typing.cast("typing.Any", manager)
@@ -411,7 +416,9 @@ def test_manager_metadata_derivation_tree_populates_only_expanded_branches(
         ),
         _set_metadata_fields=lambda _fields: None,
         _update_metadata_pane=lambda: None,
-        _dependency_refs_for_uid=lambda _uid: (),
+        _lineage_controller=types.SimpleNamespace(
+            _dependency_refs_for_uid=lambda _uid: ()
+        ),
     )
     controller = manager_details_panel._DetailsPanelController(
         typing.cast("typing.Any", manager)
@@ -486,7 +493,9 @@ def test_manager_metadata_derivation_state_restore_uses_indexed_lookups(
         ),
         _set_metadata_fields=lambda _fields: None,
         _update_metadata_pane=lambda: None,
-        _dependency_refs_for_uid=lambda _uid: (),
+        _lineage_controller=types.SimpleNamespace(
+            _dependency_refs_for_uid=lambda _uid: ()
+        ),
     )
     controller = manager_details_panel._DetailsPanelController(
         typing.cast("typing.Any", manager)
@@ -545,7 +554,9 @@ def test_manager_metadata_derivation_refresh_uses_stable_cache_key(qtbot) -> Non
         ),
         _set_metadata_fields=lambda _fields: None,
         _update_metadata_pane=lambda: None,
-        _dependency_refs_for_uid=lambda _uid: (),
+        _lineage_controller=types.SimpleNamespace(
+            _dependency_refs_for_uid=lambda _uid: ()
+        ),
     )
     controller = manager_details_panel._DetailsPanelController(
         typing.cast("typing.Any", manager)
@@ -608,7 +619,9 @@ def test_manager_metadata_row_mapping_keeps_collapsed_rows_consistent(
         ),
         _set_metadata_fields=lambda _fields: None,
         _update_metadata_pane=lambda: None,
-        _dependency_refs_for_uid=lambda _uid: (),
+        _lineage_controller=types.SimpleNamespace(
+            _dependency_refs_for_uid=lambda _uid: ()
+        ),
     )
     controller = manager_details_panel._DetailsPanelController(
         typing.cast("typing.Any", manager)
@@ -690,7 +703,9 @@ def test_manager_metadata_script_input_labels_use_current_nodes(qtbot) -> None:
         ),
         _set_metadata_fields=lambda _fields: None,
         _update_metadata_pane=lambda: None,
-        _dependency_refs_for_uid=lambda _uid: script_input_dependency_refs(spec),
+        _lineage_controller=types.SimpleNamespace(
+            _dependency_refs_for_uid=lambda _uid: script_input_dependency_refs(spec)
+        ),
     )
     controller = manager_details_panel._DetailsPanelController(
         typing.cast("typing.Any", manager)
@@ -750,7 +765,9 @@ def test_manager_metadata_missing_script_input_uses_neutral_label(qtbot) -> None
         ),
         _set_metadata_fields=lambda _fields: None,
         _update_metadata_pane=lambda: None,
-        _dependency_refs_for_uid=lambda _uid: script_input_dependency_refs(spec),
+        _lineage_controller=types.SimpleNamespace(
+            _dependency_refs_for_uid=lambda _uid: script_input_dependency_refs(spec)
+        ),
     )
     controller = manager_details_panel._DetailsPanelController(
         typing.cast("typing.Any", manager)
@@ -766,15 +783,11 @@ def test_manager_metadata_missing_script_input_uses_neutral_label(qtbot) -> None
     )
 
     controller._set_metadata_node(node)
-    details = controller._unavailable_replay_code_details(
-        typing.cast("typing.Any", node)
-    )
 
     input_item = derivation_list.topLevelItem(1)
     assert input_item is not None
     assert input_item.text() == "Missing source for data_10"
     assert "ImageTool 10" not in input_item.text()
-    assert "Missing source for data_10 (recorded as ImageTool 10: stale)" in details
 
 
 def test_manager_copy_selected_derivation_code_fallbacks(

--- a/tests/interactive/imagetool/manager/provenance/test_clipboard.py
+++ b/tests/interactive/imagetool/manager/provenance/test_clipboard.py
@@ -14,7 +14,6 @@ import erlab.interactive.imagetool.manager._details_panel as manager_details_pan
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 from erlab.interactive.imagetool import _kspace_conversion, itool
-from erlab.interactive.imagetool._provenance._code import uses_default_replay_input
 from erlab.interactive.imagetool._provenance._execution import (
     replay_file_provenance,
     replay_script_provenance,
@@ -2320,7 +2319,6 @@ def test_manager_divide_by_coord_child_refresh_and_code(
         menu = manager._build_metadata_derivation_menu()
         assert menu is not None
         trigger_menu_action(menu, manager._metadata_copy_full_action)
-        assert not uses_default_replay_input(copied[-1])
 
         namespace = _exec_generated_code(
             copied[-1], {"source_data": data.copy(deep=True)}

--- a/tests/interactive/imagetool/manager/provenance/test_dependencies.py
+++ b/tests/interactive/imagetool/manager/provenance/test_dependencies.py
@@ -4,7 +4,7 @@ import json
 import pathlib
 import types
 import typing
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 import numpy as np
 import pydantic
@@ -14,6 +14,7 @@ import xarray as xr
 from qtpy import QtCore, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool.manager._lineage as manager_lineage
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 from erlab.interactive._fit2d import Fit2DTool
@@ -22,9 +23,11 @@ from erlab.interactive.fermiedge import GoldTool
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._code import uses_default_replay_input
+from erlab.interactive.imagetool._provenance._execution import rebuild_script_inputs
 from erlab.interactive.imagetool._provenance._model import (
     DerivationEntry,
     FileDataSelection,
+    ScriptInput,
     ToolProvenanceSpec,
     _ProvenanceDisplayRow,
     full_data,
@@ -67,6 +70,165 @@ from ._common import (
     _set_selection_point,
     _set_selection_range,
 )
+
+
+class _ManagedInputTestState(pydantic.BaseModel):
+    pass
+
+
+class _ManagedSumTool(erlab.interactive.utils.ToolWindow[_ManagedInputTestState]):
+    StateModel = _ManagedInputTestState
+    tool_name = "managed-sum-test"
+
+    def __init__(self, data: xr.DataArray, weights: xr.DataArray | None = None) -> None:
+        super().__init__()
+        self._input_data = data
+        self._input_weights = xr.zeros_like(data) if weights is None else weights
+        self._data = data + self._input_weights
+        self._status = _ManagedInputTestState()
+        self.set_script_inputs(
+            (
+                ScriptInput(name="data", data_role="source"),
+                ScriptInput(name="weights", data_role="source"),
+            ),
+            primary_input="data",
+        )
+
+    @property
+    def tool_data(self) -> xr.DataArray:
+        return self._data
+
+    @property
+    def tool_status(self) -> _ManagedInputTestState:
+        return self._status
+
+    @tool_status.setter
+    def tool_status(self, status: _ManagedInputTestState) -> None:
+        self._status = status
+
+    def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
+        return {
+            "<saved-tool-data>": self._input_data,
+            "weights": self._input_weights,
+        }
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self._input_data = inputs["data"]
+        self._input_weights = inputs["weights"]
+        self._data = self._input_data + self._input_weights
+
+
+class _ReloadCountingManagedSumTool(_ManagedSumTool):
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__(data)
+        self.update_calls = 0
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self.update_calls += 1
+        super().update_inputs(inputs)
+
+
+class _ManagedUnaryTool(erlab.interactive.utils.ToolWindow[_ManagedInputTestState]):
+    StateModel = _ManagedInputTestState
+    tool_name = "managed-unary-test"
+
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__()
+        self._data = data
+        self._status = _ManagedInputTestState()
+        self.update_calls = 0
+        self.set_script_inputs(
+            (ScriptInput(name="data", data_role="source"),),
+            primary_input="data",
+        )
+
+    @property
+    def tool_data(self) -> xr.DataArray:
+        return self._data
+
+    @property
+    def tool_status(self) -> _ManagedInputTestState:
+        return self._status
+
+    @tool_status.setter
+    def tool_status(self, status: _ManagedInputTestState) -> None:
+        self._status = status
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self.update_calls += 1
+        self._data = inputs["data"]
+
+
+class _DeferredManagedSumTool(_ManagedSumTool):
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__(data)
+        self.pending_inputs: dict[str, xr.DataArray] | None = None
+        self.update_calls = 0
+        self.defer_updates = True
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+        self.update_calls += 1
+        if not self.defer_updates:
+            return False
+        self.pending_inputs = dict(inputs)
+        self._defer_source_refresh()
+        return False
+
+    def finish_deferred_update(self) -> None:
+        if self.pending_inputs is None:
+            raise RuntimeError("No deferred inputs are pending")
+        self._data = self.pending_inputs["data"] + self.pending_inputs["weights"]
+        self.pending_inputs = None
+        self.finalize_source_refresh()
+
+
+def _add_deferred_intermediate_managed_chain(
+    manager: erlab.interactive.imagetool.manager.ImageToolManager,
+    data: xr.DataArray,
+    weights: xr.DataArray,
+) -> tuple[
+    _DeferredManagedSumTool,
+    _ManagedUnaryTool,
+    _ManagedUnaryTool,
+    str,
+]:
+    for value in (data, weights):
+        root = itool(value, manager=False, execute=False)
+        if not isinstance(root, erlab.interactive.imagetool.ImageTool):
+            raise TypeError("Expected ImageTool test input")
+        manager.add_imagetool(root, show=False)
+
+    upstream = _DeferredManagedSumTool(data + weights)
+    upstream_uid = manager.add_childtool(
+        upstream,
+        script_inputs={"data": 0, "weights": 1},
+        show=False,
+    )
+    upstream.set_script_inputs(
+        upstream.script_inputs,
+        primary_input="data",
+        auto_update=False,
+    )
+
+    intermediate = _ManagedUnaryTool(upstream.tool_data)
+    intermediate_uid = manager.add_childtool(
+        intermediate,
+        script_inputs={"data": upstream_uid},
+        show=False,
+    )
+
+    target = _ManagedUnaryTool(intermediate.tool_data)
+    target_uid = manager.add_childtool(
+        target,
+        script_inputs={"data": intermediate_uid},
+        show=False,
+    )
+    target.set_script_inputs(
+        target.script_inputs,
+        primary_input="data",
+        auto_update=False,
+    )
+    return upstream, intermediate, target, target_uid
 
 
 def test_elided_value_label_keeps_full_text_during_resize(qtbot) -> None:
@@ -289,8 +451,10 @@ def test_manager_childtool_from_filtered_parent_uses_display_provenance(
 
         child_uid = manager._tool_graph.root_wrappers[0]._childtool_indices[0]
         child = manager.get_childtool(child_uid)
-        assert child.input_provenance_spec is not None
-        display_code = child.input_provenance_spec.display_code()
+        assert child.script_inputs[0].data_role == "displayed"
+        input_provenance = child.script_inputs[0].parsed_provenance_spec()
+        assert input_provenance is not None
+        display_code = input_provenance.display_code()
         assert display_code is not None
         assert "gaussian_filter" in display_code
         namespace = {"data": data.copy(deep=True)}
@@ -590,6 +754,10 @@ def test_manager_operation_filter_preserves_output_binding(
             super().__init__()
             self._data = data
             self._status = _OutputToolState()
+            self.set_script_inputs(
+                (ScriptInput(name="data", data_role="source"),),
+                primary_input="data",
+            )
 
         @property
         def tool_status(self) -> _OutputToolState:
@@ -602,6 +770,9 @@ def test_manager_operation_filter_preserves_output_binding(
         @property
         def tool_data(self) -> xr.DataArray:
             return self._data
+
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
         def output_imagetool_data(
             self, output_id: str | enum.Enum
@@ -636,7 +807,11 @@ def test_manager_operation_filter_preserves_output_binding(
         manager.add_imagetool(root_tool, show=False)
 
         child = _OutputTool(data)
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = manager.add_childtool(
+            child,
+            script_inputs={"data": 0},
+            show=False,
+        )
         child_node = manager._child_node(child_uid)
         assert child_node.displayed_source_spec == child_node.source_spec
         initial_output = typing.cast("xr.DataArray", child.output_imagetool_data("out"))
@@ -697,6 +872,10 @@ def test_manager_non_imagetool_node_displayed_provenance_uses_tool_provenance(
             self._data = data
             self._status = _StaticToolState()
             self._provenance_spec = provenance_spec
+            self.set_script_inputs(
+                (ScriptInput(name="data", data_role="source"),),
+                primary_input="data",
+            )
 
         @property
         def tool_status(self) -> _StaticToolState:
@@ -710,8 +889,8 @@ def test_manager_non_imagetool_node_displayed_provenance_uses_tool_provenance(
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> bool:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            self._data = inputs["data"]
             return True
 
         def current_provenance_spec(
@@ -738,12 +917,2489 @@ def test_manager_non_imagetool_node_displayed_provenance_uses_tool_provenance(
 
         child_uid = manager.add_childtool(
             _StaticTool(data, provenance_spec),
-            0,
+            script_inputs={"data": 0},
             show=False,
         )
         child_node = manager._child_node(child_uid)
 
         assert child_node.displayed_provenance_spec == provenance_spec
+
+
+def test_manager_toolwindow_named_inputs_refresh_atomically(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    class _MultiInputToolState(pydantic.BaseModel):
+        value: int = 0
+
+    class _MultiInputTool(erlab.interactive.utils.ToolWindow[_MultiInputToolState]):
+        StateModel = _MultiInputToolState
+        tool_name = "multi-input-dummy"
+
+        def __init__(self, data: xr.DataArray) -> None:
+            super().__init__()
+            self._data = data
+            self._status = _MultiInputToolState()
+            self.update_calls = 0
+            self.set_script_inputs(
+                (
+                    ScriptInput(name="data", data_role="source"),
+                    ScriptInput(name="weights", data_role="source"),
+                ),
+                primary_input="data",
+            )
+
+        @property
+        def tool_status(self) -> _MultiInputToolState:
+            return self._status
+
+        @tool_status.setter
+        def tool_status(self, status: _MultiInputToolState) -> None:
+            self._status = status
+
+        @property
+        def tool_data(self) -> xr.DataArray:
+            return self._data
+
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self.update_calls += 1
+            self._data = inputs["data"] + inputs["weights"]
+
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("y", "x"),
+        name="data",
+    )
+    weights = xr.ones_like(data).rename("weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights, data + 100.0):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        rejected_tool = _MultiInputTool(data)
+        qtbot.addWidget(rejected_tool)
+        with pytest.raises(KeyError):
+            manager.add_childtool(
+                rejected_tool,
+                script_inputs={"data": 0, "weights": "missing"},
+                show=False,
+            )
+        assert all(item.node_uid is None for item in rejected_tool.script_inputs)
+        with pytest.raises(ValueError, match="must match the ToolWindow"):
+            manager.add_childtool(
+                rejected_tool,
+                script_inputs={"data": 0},
+                show=False,
+            )
+        with pytest.raises(KeyError):
+            manager.add_childtool(
+                rejected_tool,
+                script_inputs={"data": 0, "weights": 1},
+                parent="missing",
+                show=False,
+            )
+        with pytest.raises(ValueError, match="one of the named input targets"):
+            manager.add_childtool(
+                rejected_tool,
+                script_inputs={"data": 0, "weights": 1},
+                parent=2,
+                show=False,
+            )
+        assert all(item.node_uid is None for item in rejected_tool.script_inputs)
+
+        tool = _MultiInputTool(data + weights)
+        child_uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        tool.set_script_inputs(
+            tool.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+
+        child_node = manager._child_node(child_uid)
+        assert child_node.parent_uid == manager._node_for_target(0).uid
+        assert {
+            ref.name
+            for ref in manager._lineage_controller._dependency_refs_for_uid(child_uid)
+        } == {
+            "data",
+            "weights",
+        }
+
+        updated_weights = (weights * 3).rename("weights")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(1, updated_weights)
+        qtbot.wait_until(lambda: tool.update_calls == 1, timeout=5000)
+        xr.testing.assert_identical(tool.tool_data, data + updated_weights)
+        assert tool.source_state == "fresh"
+
+        auto_updated_data = (data + 10).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, auto_updated_data)
+        qtbot.wait_until(
+            lambda: not manager._interaction_gate.pending_keys,
+            timeout=5000,
+        )
+        assert tool.update_calls == 2
+        xr.testing.assert_identical(tool.tool_data, auto_updated_data + updated_weights)
+        assert tool.source_state == "fresh"
+
+        tool.set_script_inputs(
+            tool.script_inputs,
+            primary_input="data",
+            auto_update=False,
+        )
+
+        downstream = _ManagedUnaryTool(tool.tool_data)
+        downstream_uid = manager.add_childtool(
+            downstream,
+            script_inputs={"data": child_uid},
+            show=False,
+        )
+        downstream.set_script_inputs(
+            downstream.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+
+        updated_data = (data + 20).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated_data)
+        qtbot.wait_until(lambda: tool.source_state == "stale", timeout=5000)
+        assert tool.update_calls == 2
+        assert downstream.source_state == "stale"
+
+        late_downstream = _ManagedUnaryTool(tool.tool_data)
+        late_downstream_uid = manager.add_childtool(
+            late_downstream,
+            script_inputs={"data": child_uid},
+            show=False,
+        )
+        assert late_downstream.source_state == "stale"
+
+        assert manager._lineage_controller._refresh_source_chain_to_uid(downstream_uid)
+        assert tool.update_calls == 3
+        assert downstream.update_calls == 1
+        xr.testing.assert_equal(tool.tool_data, updated_data + updated_weights)
+        xr.testing.assert_identical(
+            downstream.tool_data,
+            updated_data + updated_weights,
+        )
+        assert downstream.source_state == "fresh"
+        qtbot.wait_until(
+            lambda: not manager._interaction_gate.pending_keys,
+            timeout=5000,
+        )
+        assert downstream.update_calls == 1
+
+        tree_parent = _ManagedUnaryTool(updated_data)
+        tree_parent_uid = manager.add_childtool(
+            tree_parent,
+            script_inputs={"data": 0},
+            show=False,
+        )
+        nested_tool = _MultiInputTool(updated_data + updated_weights)
+        manager.add_childtool(
+            nested_tool,
+            script_inputs={"data": tree_parent_uid, "weights": 1},
+            show=False,
+        )
+        nested_tool.set_script_inputs(
+            nested_tool.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+        qtbot.wait_until(
+            lambda: not manager._interaction_gate.pending_keys,
+            timeout=5000,
+        )
+
+        nested_data = (updated_data + 5).rename("data")
+        tree_parent._data = nested_data
+        tree_parent.sigDataChanged.emit()
+        qtbot.wait_until(
+            lambda: not manager._interaction_gate.pending_keys,
+            timeout=5000,
+        )
+        assert nested_tool.update_calls == 1
+        xr.testing.assert_identical(
+            nested_tool.tool_data,
+            nested_data + updated_weights,
+        )
+
+        manager.remove_imagetool(1)
+        qtbot.wait_until(lambda: tool.source_state == "unavailable", timeout=5000)
+        qtbot.wait_until(
+            lambda: downstream.source_state == "unavailable",
+            timeout=5000,
+        )
+        assert late_downstream.source_state == "unavailable"
+        assert child_uid in manager._tool_graph.nodes
+        assert downstream_uid in manager._tool_graph.nodes
+        assert late_downstream_uid in manager._tool_graph.nodes
+
+
+def test_managed_input_ancestor_refreshes_descendant_from_current_inputs(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        parent = _ManagedSumTool(data + weights)
+        parent_uid = manager.add_childtool(
+            parent,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        parent.set_script_inputs(
+            parent.script_inputs,
+            primary_input="data",
+            auto_update=False,
+        )
+
+        descendant = _ManagedUnaryTool(parent.tool_data)
+        descendant_uid = manager.add_childtool(
+            descendant,
+            script_inputs={"data": parent_uid},
+            show=False,
+        )
+        descendant_node = manager._child_node(descendant_uid)
+
+        updated_data = (data + 100.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated_data)
+        qtbot.wait_until(lambda: parent.source_state == "stale", timeout=5000)
+        qtbot.wait_until(
+            lambda: descendant.source_state == "stale",
+            timeout=5000,
+        )
+
+        assert manager._reload_target_for_child(descendant_uid) is None
+        assert manager._lineage_controller._refresh_source_chain_to_uid(descendant_uid)
+        xr.testing.assert_equal(parent.tool_data, updated_data + weights)
+        xr.testing.assert_equal(descendant.tool_data, updated_data + weights)
+        assert parent.source_state == "fresh"
+        assert descendant.source_state == "fresh"
+
+        manager.remove_imagetool(1)
+        qtbot.wait_until(
+            lambda: parent.source_state == "unavailable",
+            timeout=5000,
+        )
+        assert (
+            manager._lineage_controller._reload_boundary_for_child(descendant_uid)
+            is descendant_node
+        )
+        assert manager._reload_target_for_child(descendant_uid) is None
+
+
+@pytest.mark.parametrize("reload_mode", ["direct", "selected"])
+def test_deferred_managed_reload_resumes_selected_descendant(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+    reload_mode: str,
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        paths = (tmp_path / "data.h5", tmp_path / "weights.h5")
+        for index, (value, path) in enumerate(
+            zip((data, weights), paths, strict=True),
+            start=1,
+        ):
+            value.to_netcdf(path, engine="h5netcdf")
+            itool(
+                value,
+                manager=True,
+                file_path=path,
+                load_func=(
+                    xr.load_dataarray,
+                    {"engine": "h5netcdf"},
+                    FileDataSelection(kind="dataarray"),
+                ),
+            )
+            qtbot.wait_until(
+                lambda expected_count=index: manager.ntools == expected_count,
+                timeout=5000,
+            )
+
+        parent = _DeferredManagedSumTool(data + weights)
+        parent_uid = manager.add_childtool(
+            parent,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        parent.set_script_inputs(
+            parent.script_inputs,
+            primary_input="data",
+            auto_update=False,
+        )
+        descendant = _ManagedUnaryTool(parent.tool_data)
+        descendant_uid = manager.add_childtool(
+            descendant,
+            script_inputs={"data": parent_uid},
+            show=False,
+        )
+
+        updated_data = (data + 100.0).rename("data")
+        updated_data.to_netcdf(paths[0], engine="h5netcdf")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated_data)
+        qtbot.wait_until(lambda: parent.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: descendant.source_state == "stale", timeout=5000)
+
+        if reload_mode == "direct":
+            assert not manager._child_node(descendant_uid).reload_source_data()
+        else:
+            manager.tree_view.selectionModel().clearSelection()
+            select_child_tool(manager, descendant_uid)
+            manager.reload_selected()
+
+        assert parent.pending_inputs is not None
+        assert manager._dependency_tracker.has_pending_source_refreshes()
+
+        parent.finish_deferred_update()
+
+        qtbot.wait_until(lambda: parent.source_state == "fresh", timeout=5000)
+        qtbot.wait_until(lambda: descendant.source_state == "fresh", timeout=5000)
+        xr.testing.assert_equal(parent.tool_data, updated_data + weights)
+        xr.testing.assert_equal(descendant.tool_data, updated_data + weights)
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+def test_unrelated_pending_refresh_does_not_defer_failed_input_plan(
+    monkeypatch,
+) -> None:
+    pending = {("unrelated", "dependent")}
+    tracker = types.SimpleNamespace(
+        has_pending_source_refreshes=lambda: bool(pending),
+        source_refresh_queued=lambda blocker, target: (blocker, target) in pending,
+    )
+    source = types.SimpleNamespace(
+        source_state="stale",
+        tool_window=types.SimpleNamespace(_source_refresh_deferred=False),
+    )
+    manager = types.SimpleNamespace(
+        _dependency_tracker=tracker,
+        _tool_graph=types.SimpleNamespace(nodes={"source": source}),
+    )
+    controller = manager_lineage._LineageController(manager)
+    monkeypatch.setattr(
+        controller,
+        "_refresh_tool_inputs",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        controller,
+        "_reload_boundary_for_child",
+        lambda _uid: None,
+    )
+    plan = manager_lineage._InputResolutionPlan(
+        "target",
+        (),
+        (("apply", "source"),),
+        frozenset(),
+        None,
+    )
+
+    assert (
+        controller._execute_input_resolution_plan(
+            plan,
+            allow_recorded=True,
+            reloaded_uids=set(),
+        )
+        == "failed"
+    )
+
+
+def test_input_resolution_plan_classifies_each_live_fallback_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    live_input = ScriptInput(name="live", node_uid="live")
+    recorded = script(
+        ScriptCodeOperation(
+            label="Use trusted code",
+            code="import os\nresult = live + int(os.path.exists(os.devnull))",
+        ),
+        start_label="Build recorded input",
+        active_name="result",
+        script_inputs=(live_input,),
+    )
+    controller = manager_lineage._LineageController(types.SimpleNamespace())
+    calls: dict[str, int] = {}
+
+    def resolve_live(script_input: ScriptInput, **_kwargs):
+        calls[script_input.name] = calls.get(script_input.name, 0) + 1
+        return object() if script_input.name == "live" else None
+
+    monkeypatch.setattr(controller, "_live_script_input_node", resolve_live)
+
+    plan = controller._input_resolution_plan(
+        (ScriptInput(name="recorded", provenance_spec=recorded),),
+        target_node_uid="target",
+    )
+
+    assert plan.unavailable_reason is None
+    assert calls == {"recorded": 1, "live": 2}
+
+
+def test_pending_script_reload_rejects_missing_recorded_input() -> None:
+    spec = script(
+        start_label="Copy missing input",
+        seed_code="result = missing",
+        active_name="result",
+        script_inputs=(ScriptInput(name="missing"),),
+    )
+    manager = types.SimpleNamespace(
+        _extensions=types.SimpleNamespace(
+            unavailable_reason_for_node=lambda _uid: None,
+        ),
+        _tool_graph=types.SimpleNamespace(nodes={}),
+    )
+    controller = manager_lineage._LineageController(manager)
+    node = types.SimpleNamespace(
+        uid="pending",
+        is_imagetool=True,
+        tool_window=None,
+        imagetool=None,
+        pending_workspace_memory_payload=object(),
+        provenance_spec=spec,
+    )
+
+    reason = controller._node_reload_unavailable_reason(node)
+
+    assert reason is not None
+    assert "no recorded reload source" in reason
+
+
+def test_deferred_live_managed_input_resumes_downstream_once(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        source = _DeferredManagedSumTool(data + weights)
+        source_uid = manager.add_childtool(
+            source,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        source.set_script_inputs(
+            source.script_inputs,
+            primary_input="data",
+            auto_update=False,
+        )
+        downstream = _ManagedUnaryTool(source.tool_data)
+        downstream_uid = manager.add_childtool(
+            downstream,
+            script_inputs={"data": source_uid},
+            show=False,
+        )
+        downstream.set_script_inputs(
+            downstream.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+        descendant = _ManagedUnaryTool(downstream.tool_data)
+        descendant_uid = manager.add_childtool(
+            descendant,
+            script_inputs={"data": downstream_uid},
+            show=False,
+        )
+
+        updated_data = (data + 100.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated_data)
+        qtbot.wait_until(lambda: source.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: downstream.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: descendant.source_state == "stale", timeout=5000)
+
+        assert not manager._lineage_controller._refresh_source_chain_to_uid(
+            descendant_uid
+        )
+        assert source.pending_inputs is not None
+        assert manager._dependency_tracker.has_pending_source_refreshes()
+        assert source.update_calls == 1
+        assert downstream.update_calls == 0
+
+        assert not manager._lineage_controller._refresh_source_chain_to_uid(
+            downstream_uid
+        )
+        assert source.update_calls == 1
+
+        source.finish_deferred_update()
+
+        expected = updated_data + weights
+        qtbot.wait_until(lambda: source.source_state == "fresh", timeout=5000)
+        qtbot.wait_until(lambda: downstream.source_state == "fresh", timeout=5000)
+        qtbot.wait_until(lambda: descendant.source_state == "fresh", timeout=5000)
+        qtbot.wait_until(
+            lambda: not manager._interaction_gate.pending_keys,
+            timeout=5000,
+        )
+        xr.testing.assert_identical(source.tool_data, expected)
+        xr.testing.assert_identical(downstream.tool_data, expected)
+        xr.testing.assert_identical(descendant.tool_data, expected)
+        assert downstream.update_calls == 1
+        assert descendant.update_calls == 1
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+@pytest.mark.parametrize("queued_update", ["deferred", "rejected"])
+def test_deferred_managed_self_rerun_publication_order(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+    queued_update: str,
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        source = _DeferredManagedSumTool(data + weights)
+        source_uid = manager.add_childtool(
+            source,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        source.set_script_inputs(
+            source.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+        source_node = manager._child_node(source_uid)
+        initial_snapshot = source_node.snapshot_token
+
+        named = _ManagedUnaryTool(source.tool_data)
+        named_uid = manager.add_childtool(
+            named,
+            script_inputs={"data": source_uid},
+            show=False,
+        )
+        named.set_script_inputs(
+            named.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+
+        tree_tool = itool(source.tool_data, manager=False, execute=False)
+        assert isinstance(tree_tool, erlab.interactive.imagetool.ImageTool)
+        tree_uid = manager.add_imagetool_child(
+            tree_tool,
+            source_uid,
+            show=False,
+            source_spec=full_data(),
+            source_auto_update=True,
+        )
+        tree_node = manager._child_node(tree_uid)
+        tree_updates: list[xr.DataArray] = []
+        replace_tree_data = tree_node.handle_parent_source_replaced
+
+        def record_tree_update(parent_data: xr.DataArray) -> bool:
+            tree_updates.append(parent_data.copy(deep=True))
+            return replace_tree_data(parent_data)
+
+        monkeypatch.setattr(
+            tree_node,
+            "handle_parent_source_replaced",
+            record_tree_update,
+        )
+
+        first = (data + 100.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, first)
+        qtbot.wait_until(lambda: source.update_calls == 1, timeout=5000)
+        assert source._source_refresh_deferred is True
+
+        latest = (data + 200.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, latest)
+        qtbot.wait_until(
+            lambda: manager._dependency_tracker.source_refresh_queued(
+                source_uid,
+                source_uid,
+            ),
+            timeout=5000,
+        )
+
+        dirty_uids: list[str] = []
+        mark_node_data_dirty = manager._mark_node_data_dirty
+
+        def record_node_data_dirty(uid: str) -> None:
+            dirty_uids.append(uid)
+            mark_node_data_dirty(uid)
+
+        monkeypatch.setattr(manager, "_mark_node_data_dirty", record_node_data_dirty)
+        if queued_update == "rejected":
+            source.defer_updates = False
+        source.finish_deferred_update()
+
+        assert source.update_calls == 1
+        qtbot.wait_until(lambda: source.update_calls == 2, timeout=5000)
+        if queued_update == "rejected":
+            qtbot.wait_until(
+                lambda: not manager._interaction_gate.pending_keys,
+                timeout=5000,
+            )
+            expected = first + weights
+            assert source._source_refresh_deferred is False
+            assert source.source_state == "stale"
+            assert source_node.snapshot_token != initial_snapshot
+            assert dirty_uids.count(source_uid) == 1
+            assert named.update_calls == 0
+            assert tree_updates == []
+            assert manager._dependency_tracker.status_for_uid(named_uid) == "changed"
+            xr.testing.assert_identical(source.tool_data, expected)
+            xr.testing.assert_identical(named.tool_data, data + weights)
+            xr.testing.assert_identical(fetch(tree_uid), data + weights)
+            assert not manager._dependency_tracker.has_pending_source_refreshes()
+            return
+
+        assert source._source_refresh_deferred is True
+        assert source_node.snapshot_token == initial_snapshot
+        assert source_uid not in dirty_uids
+        assert named.update_calls == 0
+        assert tree_updates == []
+        xr.testing.assert_identical(named.tool_data, data + weights)
+        xr.testing.assert_identical(fetch(tree_uid), data + weights)
+
+        source.finish_deferred_update()
+
+        qtbot.wait_until(lambda: named.update_calls == 1, timeout=5000)
+        qtbot.wait_until(lambda: len(tree_updates) == 1, timeout=5000)
+        qtbot.wait_until(
+            lambda: not manager._interaction_gate.pending_keys,
+            timeout=5000,
+        )
+        expected = latest + weights
+        xr.testing.assert_identical(source.tool_data, expected)
+        xr.testing.assert_identical(named.tool_data, expected)
+        xr.testing.assert_identical(fetch(tree_uid), expected)
+        xr.testing.assert_identical(tree_updates[0], expected)
+        assert named.update_calls == 1
+        assert len(tree_updates) == 1
+        assert source_node.snapshot_token != initial_snapshot
+        assert dirty_uids.count(source_uid) == 1
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+@pytest.mark.parametrize("manual_reload", [False, True])
+def test_deferred_managed_self_rerun_respects_disabled_auto_update(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+    manual_reload: bool,
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        source, _intermediate, target, target_uid = (
+            _add_deferred_intermediate_managed_chain(manager, data, weights)
+        )
+        source_uid = manager._node_uid_from_window(source)
+        assert source_uid is not None
+        source.set_script_inputs(
+            source.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, (data + 100.0).rename("data"))
+        qtbot.wait_until(lambda: source.update_calls == 1, timeout=5000)
+        assert source._source_refresh_deferred
+
+        latest = (data + 200.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, latest)
+        qtbot.wait_until(
+            lambda: manager._dependency_tracker.source_refresh_queued(
+                source_uid,
+                source_uid,
+            ),
+            timeout=5000,
+        )
+
+        source._set_source_auto_update(False)
+        if manual_reload:
+            assert not manager._lineage_controller._reload_target_with_continuations(
+                source_uid,
+                (target_uid,),
+            )
+
+        source.finish_deferred_update()
+
+        if not manual_reload:
+            qtbot.wait_until(
+                lambda: not manager._interaction_gate.pending_keys,
+                timeout=5000,
+            )
+            assert source.update_calls == 1
+            assert source.source_state == "stale"
+            assert target.source_state == "stale"
+            assert not manager._dependency_tracker.has_pending_source_refreshes()
+            return
+
+        expected = latest + weights
+        qtbot.wait_until(lambda: source.update_calls == 2, timeout=5000)
+        assert source._source_refresh_deferred
+        source.finish_deferred_update()
+        qtbot.wait_until(lambda: target.source_state == "fresh", timeout=5000)
+        xr.testing.assert_identical(source.tool_data, expected)
+        xr.testing.assert_identical(target.tool_data, expected)
+        assert source.update_calls == 2
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+def test_deferred_reload_resumes_managed_target_after_intermediate_update(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        upstream, intermediate, target, target_uid = (
+            _add_deferred_intermediate_managed_chain(manager, data, weights)
+        )
+
+        updated_data = (data + 100.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated_data)
+        qtbot.wait_until(lambda: upstream.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: intermediate.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: target.source_state == "stale", timeout=5000)
+
+        assert not manager._lineage_controller._refresh_source_chain_to_uid(target_uid)
+        assert upstream.pending_inputs is not None
+        assert manager._dependency_tracker.has_pending_source_refreshes()
+
+        upstream.finish_deferred_update()
+
+        qtbot.wait_until(lambda: target.source_state == "fresh", timeout=5000)
+        qtbot.wait_until(
+            lambda: not manager._interaction_gate.pending_keys,
+            timeout=5000,
+        )
+        expected = updated_data + weights
+        xr.testing.assert_identical(upstream.tool_data, expected)
+        xr.testing.assert_identical(intermediate.tool_data, expected)
+        xr.testing.assert_identical(target.tool_data, expected)
+        assert intermediate.update_calls == 1
+        assert target.update_calls == 1
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+def test_deferred_abort_runs_newest_input_before_descendant_continuations(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        upstream, intermediate, target, target_uid = (
+            _add_deferred_intermediate_managed_chain(manager, data, weights)
+        )
+        upstream_uid = manager._node_uid_from_window(upstream)
+        assert upstream_uid is not None
+        upstream.set_script_inputs(
+            upstream.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+        upstream_node = manager._child_node(upstream_uid)
+        initial_snapshot = upstream_node.snapshot_token
+
+        first = (data + 100.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, first)
+        qtbot.wait_until(lambda: upstream.update_calls == 1, timeout=5000)
+        assert upstream._source_refresh_deferred is True
+        assert not manager._lineage_controller._refresh_source_chain_to_uid(target_uid)
+        assert manager._dependency_tracker.has_pending_source_refreshes()
+
+        latest = (data + 200.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, latest)
+        qtbot.wait_until(
+            lambda: (
+                upstream_uid
+                in manager._dependency_tracker._pending_source_refresh_targets.get(
+                    upstream_uid, set()
+                )
+            ),
+            timeout=5000,
+        )
+
+        upstream.abort_source_refresh()
+
+        assert upstream.update_calls == 2
+        assert upstream._source_refresh_deferred is True
+        assert upstream_node.snapshot_token == initial_snapshot
+        assert intermediate.update_calls == 0
+        assert target.update_calls == 0
+        assert manager._dependency_tracker.has_pending_source_refreshes()
+
+        upstream.finish_deferred_update()
+
+        expected = latest + weights
+        qtbot.wait_until(lambda: target.source_state == "fresh", timeout=5000)
+        xr.testing.assert_identical(upstream.tool_data, expected)
+        xr.testing.assert_identical(intermediate.tool_data, expected)
+        xr.testing.assert_identical(target.tool_data, expected)
+        assert intermediate.update_calls == 1
+        assert target.update_calls == 1
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+def test_deferred_abort_discards_descendant_continuations_without_rerun(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        upstream, intermediate, target, target_uid = (
+            _add_deferred_intermediate_managed_chain(manager, data, weights)
+        )
+        upstream_uid = manager._node_uid_from_window(upstream)
+        assert upstream_uid is not None
+        upstream_node = manager._child_node(upstream_uid)
+        initial_snapshot = upstream_node.snapshot_token
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, (data + 100.0).rename("data"))
+        qtbot.wait_until(lambda: target.source_state == "stale", timeout=5000)
+        assert not manager._lineage_controller._refresh_source_chain_to_uid(target_uid)
+        assert upstream._source_refresh_deferred is True
+        assert manager._dependency_tracker.has_pending_source_refreshes()
+
+        upstream.abort_source_refresh()
+
+        assert upstream_node.snapshot_token == initial_snapshot
+        assert upstream.source_state == "stale"
+        assert intermediate.source_state == "stale"
+        assert target.source_state == "stale"
+        assert intermediate.update_calls == 0
+        assert target.update_calls == 0
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+def test_deferred_reload_clears_managed_target_after_intermediate_failure(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        upstream, intermediate, target, target_uid = (
+            _add_deferred_intermediate_managed_chain(manager, data, weights)
+        )
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, data + 100.0)
+        qtbot.wait_until(lambda: upstream.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: intermediate.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: target.source_state == "stale", timeout=5000)
+
+        assert not manager._lineage_controller._refresh_source_chain_to_uid(target_uid)
+        assert manager._dependency_tracker.has_pending_source_refreshes()
+
+        def fail_update(_inputs: Mapping[str, xr.DataArray]) -> None:
+            raise RuntimeError("intermediate update failed")
+
+        monkeypatch.setattr(intermediate, "update_inputs", fail_update)
+        upstream.finish_deferred_update()
+
+        qtbot.wait_until(
+            lambda: intermediate.source_state == "unavailable", timeout=5000
+        )
+        assert target.source_state == "unavailable"
+        assert target.update_calls == 0
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+def test_deferred_managed_input_failure_clears_descendant_continuation(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        source = _DeferredManagedSumTool(data + weights)
+        source_uid = manager.add_childtool(
+            source,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        source.set_script_inputs(
+            source.script_inputs,
+            primary_input="data",
+            auto_update=False,
+        )
+        target = _ManagedUnaryTool(source.tool_data)
+        target_uid = manager.add_childtool(
+            target,
+            script_inputs={"data": source_uid},
+            show=False,
+        )
+        target.set_script_inputs(
+            target.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+        descendant = _ManagedUnaryTool(target.tool_data)
+        descendant_uid = manager.add_childtool(
+            descendant,
+            script_inputs={"data": target_uid},
+            show=False,
+        )
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, data + 100.0)
+        qtbot.wait_until(lambda: source.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: target.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: descendant.source_state == "stale", timeout=5000)
+
+        assert not manager._lineage_controller._refresh_source_chain_to_uid(
+            descendant_uid
+        )
+        assert manager._dependency_tracker.has_pending_source_refreshes()
+
+        def fail_update(_inputs: Mapping[str, xr.DataArray]) -> None:
+            raise RuntimeError("target update failed")
+
+        monkeypatch.setattr(target, "update_inputs", fail_update)
+        source.finish_deferred_update()
+
+        qtbot.wait_until(lambda: target.source_state == "unavailable", timeout=5000)
+        assert descendant.source_state == "unavailable"
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+def test_failed_live_input_reload_does_not_detach_to_recorded_fallback(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+    recorded_fallback = script(
+        start_label="Create fallback data",
+        seed_code="data = xr.DataArray([-1.0, -2.0], dims='x')",
+        active_name="data",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        source = _ManagedSumTool(data + weights)
+        source_uid = manager.add_childtool(
+            source,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        source.set_script_inputs(
+            source.script_inputs,
+            primary_input="data",
+            auto_update=False,
+        )
+        downstream = _ManagedUnaryTool(source.tool_data)
+        downstream_uid = manager.add_childtool(
+            downstream,
+            script_inputs={"data": source_uid},
+            show=False,
+        )
+        binding = downstream.script_inputs[0].model_copy(
+            update={"provenance_spec": recorded_fallback.model_dump(mode="json")}
+        )
+        downstream.set_script_inputs(
+            (binding,),
+            primary_input="data",
+            auto_update=False,
+        )
+
+        updated_data = (data + 100.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated_data)
+        qtbot.wait_until(lambda: source.source_state == "stale", timeout=5000)
+        qtbot.wait_until(lambda: downstream.source_state == "stale", timeout=5000)
+        original = downstream.tool_data
+        monkeypatch.setattr(
+            manager._child_node(source_uid),
+            "reload_source_data",
+            lambda: False,
+        )
+
+        assert not manager._child_node(downstream_uid).reload_source_data()
+        assert downstream.source_state == "stale"
+        assert downstream.update_calls == 0
+        assert downstream.script_inputs[0].node_uid == source_uid
+        xr.testing.assert_identical(downstream.tool_data, original)
+
+
+def test_managed_input_reload_cycle_fails_without_recursion(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        first = _ManagedUnaryTool(data)
+        first_uid = manager.add_childtool(
+            first,
+            script_inputs={"data": 0},
+            show=False,
+        )
+        second = _ManagedUnaryTool(data)
+        second_uid = manager.add_childtool(
+            second,
+            script_inputs={"data": 0},
+            show=False,
+        )
+
+        first.set_script_inputs(
+            (
+                first.script_inputs[0].model_copy(
+                    update={
+                        "node_uid": second_uid,
+                        "node_snapshot_token": "stale",
+                        "provenance_spec": None,
+                    }
+                ),
+            ),
+            primary_input="data",
+            state="stale",
+        )
+        second.set_script_inputs(
+            (
+                second.script_inputs[0].model_copy(
+                    update={
+                        "node_uid": first_uid,
+                        "node_snapshot_token": "stale",
+                        "provenance_spec": None,
+                    }
+                ),
+            ),
+            primary_input="data",
+            state="stale",
+        )
+
+        assert not manager._child_node(first_uid).reload_source_data()
+        assert first.source_state == "stale"
+        assert second.source_state == "stale"
+
+
+def test_managed_input_self_cycle_does_not_use_recorded_fallback(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    fallback = script(
+        start_label="Create fallback data",
+        seed_code="data = xr.DataArray([-1.0, -2.0], dims='x')",
+        active_name="data",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        tool = _ManagedUnaryTool(data)
+        uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
+        tool.set_script_inputs(
+            (
+                tool.script_inputs[0].model_copy(
+                    update={
+                        "node_uid": uid,
+                        "node_snapshot_token": "stale",
+                        "provenance_spec": fallback.model_dump(mode="json"),
+                    }
+                ),
+            ),
+            primary_input="data",
+            state="stale",
+        )
+        node = manager._child_node(uid)
+
+        assert "cycle" in (node.reload_unavailable_reason() or "").lower()
+        assert not node.reload_source_data()
+        assert tool.update_calls == 0
+        assert tool.script_inputs[0].node_uid == uid
+        xr.testing.assert_identical(tool.tool_data, data)
+
+
+def test_script_imagetool_self_cycle_is_not_reported_as_reloadable(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    fallback = script(
+        start_label="Create fallback data",
+        seed_code="data = xr.DataArray([-1.0, -2.0], dims='x')",
+        active_name="data",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        tool = itool(data, manager=False, execute=False)
+        assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+        target = manager.add_imagetool(tool, show=False)
+        node = manager._node_for_target(target)
+        node.set_displayed_provenance(
+            script(
+                start_label="Copy input",
+                seed_code="derived = data",
+                active_name="derived",
+                script_inputs=(
+                    ScriptInput(
+                        name="data",
+                        node_uid=node.uid,
+                        provenance_spec=fallback.model_dump(mode="json"),
+                    ),
+                ),
+            )
+        )
+
+        reason = manager._lineage_controller._node_reload_unavailable_reason(node)
+        assert reason is not None
+        assert "cycle" in reason.lower()
+        assert not node.slicer_area.reloadable
+        assert not node.reload_source_data()
+        xr.testing.assert_identical(node.current_public_data(), data)
+
+        updated = data + 10.0
+        source_path = tmp_path / "source.h5"
+        updated.to_netcdf(source_path, engine="h5netcdf")
+        node.slicer_area._file_path = source_path
+        node.slicer_area._load_func = (
+            xr.load_dataarray,
+            {"engine": "h5netcdf"},
+            FileDataSelection(kind="dataarray"),
+        )
+        node.set_displayed_provenance(
+            script(
+                start_label="Copy input",
+                seed_code="derived = data",
+                active_name="derived",
+                script_inputs=(ScriptInput(name="data", node_uid=node.uid),),
+            )
+        )
+
+        assert manager._lineage_controller._node_reload_unavailable_reason(node) is None
+        assert node.slicer_area.reloadable
+        assert node.reload_source_data()
+        xr.testing.assert_identical(node.current_public_data(), updated)
+
+
+def test_managed_input_state_keeps_unavailable_over_stale(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        data_input = _ManagedUnaryTool(data)
+        data_input_uid = manager.add_childtool(
+            data_input,
+            script_inputs={"data": 0},
+            show=False,
+        )
+
+        dependent = _ManagedSumTool(data + weights)
+        dependent_uid = manager.add_childtool(
+            dependent,
+            script_inputs={"data": data_input_uid, "weights": 1},
+            show=False,
+        )
+        dependent.set_script_inputs(
+            dependent.script_inputs,
+            primary_input="data",
+            auto_update=False,
+        )
+        downstream = _ManagedUnaryTool(dependent.tool_data)
+        manager.add_childtool(
+            downstream,
+            script_inputs={"data": dependent_uid},
+            show=False,
+        )
+
+        manager.remove_imagetool(1)
+        qtbot.wait_until(
+            lambda: dependent.source_state == "unavailable",
+            timeout=5000,
+        )
+        qtbot.wait_until(
+            lambda: downstream.source_state == "unavailable",
+            timeout=5000,
+        )
+
+        updated_data = (data + 100.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated_data)
+        qtbot.wait_until(lambda: data_input.source_state == "stale", timeout=5000)
+
+        assert dependent.source_state == "unavailable"
+        assert downstream.source_state == "unavailable"
+
+
+def test_managed_inputs_refresh_once_after_sibling_outputs_update(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    class _State(pydantic.BaseModel):
+        pass
+
+    class _OutputTool(erlab.interactive.utils.ToolWindow[_State]):
+        StateModel = _State
+        tool_name = "multi-output-dummy"
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._generation = 0
+            self._status = _State()
+            self.set_script_inputs(
+                (ScriptInput(name="data", data_role="source"),),
+                primary_input="data",
+            )
+
+        @property
+        def tool_status(self) -> _State:
+            return self._status
+
+        @tool_status.setter
+        def tool_status(self, status: _State) -> None:
+            self._status = status
+
+        @property
+        def tool_data(self) -> xr.DataArray:
+            return xr.DataArray([self._generation], dims="x")
+
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            del inputs
+
+        def output_imagetool_data(
+            self, output_id: str | enum.Enum
+        ) -> xr.DataArray | None:
+            offset = {"values": 0.0, "uncertainty": 10.0}[str(output_id)]
+            return xr.DataArray(
+                [self._generation + offset], dims="x", name=str(output_id)
+            )
+
+        def output_imagetool_provenance(
+            self, output_id: str | enum.Enum, data: xr.DataArray
+        ) -> ToolProvenanceSpec | None:
+            del output_id, data
+            return None
+
+    class _ConsumerTool(erlab.interactive.utils.ToolWindow[_State]):
+        StateModel = _State
+        tool_name = "multi-input-consumer-dummy"
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._status = _State()
+            self._data = xr.DataArray([10.0], dims="x")
+            self.update_calls = 0
+            self.seen: list[tuple[float, float]] = []
+            self.set_script_inputs(
+                (
+                    ScriptInput(name="values", data_role="source"),
+                    ScriptInput(name="uncertainty", data_role="source"),
+                ),
+                primary_input="values",
+            )
+
+        @property
+        def tool_status(self) -> _State:
+            return self._status
+
+        @tool_status.setter
+        def tool_status(self, status: _State) -> None:
+            self._status = status
+
+        @property
+        def tool_data(self) -> xr.DataArray:
+            return self._data
+
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self.update_calls += 1
+            self.seen.append(
+                (
+                    float(inputs["values"].item()),
+                    float(inputs["uncertainty"].item()),
+                )
+            )
+            self._data = inputs["values"] + inputs["uncertainty"]
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        root = itool(xr.DataArray([0.0], dims="x"), manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+
+        output_tool = _OutputTool()
+        output_tool_uid = manager.add_childtool(
+            output_tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
+        output_uids: dict[str, str] = {}
+        output_imagetools: list[erlab.interactive.imagetool.ImageTool] = []
+        for output_id in ("values", "uncertainty"):
+            output_data = typing.cast(
+                "xr.DataArray", output_tool.output_imagetool_data(output_id)
+            )
+            output_imagetool = itool(output_data, manager=False, execute=False)
+            assert isinstance(output_imagetool, erlab.interactive.imagetool.ImageTool)
+            output_imagetools.append(output_imagetool)
+            output_uids[output_id] = manager.add_imagetool_child(
+                output_imagetool,
+                output_tool_uid,
+                show=False,
+                source_auto_update=True,
+                output_id=output_id,
+            )
+
+        consumer = _ConsumerTool()
+        manager.add_childtool(
+            consumer,
+            script_inputs=output_uids,
+            parent=output_uids["values"],
+            show=False,
+        )
+        consumer.set_script_inputs(
+            consumer.script_inputs,
+            primary_input="values",
+            auto_update=True,
+        )
+
+        output_tool._generation = 1
+        output_tool.sigDataChanged.emit()
+        qtbot.wait_until(
+            lambda: float(fetch(output_uids["uncertainty"]).item()) == 11.0,
+            timeout=5000,
+        )
+        qtbot.wait_until(lambda: consumer.update_calls == 1, timeout=5000)
+
+        assert consumer.update_calls == 1
+        assert consumer.seen == [(1.0, 11.0)]
+
+
+def test_managed_input_reload_resolves_live_data_before_trust(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    recorded_spec = script(
+        ScriptCodeOperation(
+            label="Evaluate recorded expression",
+            code=("import os\nwith open(os.devnull):\n    pass\nderived = data"),
+        ),
+        start_label="Start from data",
+        active_name="derived",
+        script_inputs=(ScriptInput(name="data", label="Input"),),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False, provenance_spec=recorded_spec)
+
+        tool = _ManagedUnaryTool(data)
+        child_uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
+        tool.set_script_inputs(
+            tool.script_inputs,
+            primary_input="data",
+            state="stale",
+        )
+        trust_requests: list[ToolProvenanceSpec] = []
+        monkeypatch.setattr(
+            manager._lineage_controller,
+            "_prompt_trusted_script_replay",
+            lambda spec, **_kwargs: trust_requests.append(spec) or True,
+        )
+
+        assert manager._lineage_controller._refresh_source_chain_to_uid(child_uid)
+        assert trust_requests == []
+        assert tool.source_state == "fresh"
+
+
+def test_manager_reload_ignores_unreachable_unsafe_live_input_fallback(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    left = xr.DataArray([1.0, 2.0], dims="x")
+    right = xr.DataArray([10.0, 20.0], dims="x")
+    unsafe_fallback = script(
+        ScriptCodeOperation(
+            label="Create recorded right input",
+            code=("import os\nright = xr.DataArray([100.0, 200.0], dims='x')"),
+        ),
+        start_label="Create right input",
+        active_name="right",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (left, right):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        left_input = manager._lineage_controller._script_input_for_node(
+            manager._node_for_target(0)
+        ).model_copy(update={"name": "left"})
+        right_input = manager._lineage_controller._script_input_for_node(
+            manager._node_for_target(1)
+        ).model_copy(
+            update={
+                "name": "right",
+                "provenance_spec": unsafe_fallback.model_dump(mode="json"),
+            }
+        )
+        derived_spec = script(
+            ScriptCodeOperation(label="Add live inputs", code="result = left + right"),
+            start_label="Add live inputs",
+            seed_code="result = left",
+            active_name="result",
+            script_inputs=(left_input, right_input),
+        )
+        derived = itool(left + right, manager=False, execute=False)
+        assert isinstance(derived, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(
+            derived,
+            show=False,
+            provenance_spec=derived_spec,
+        )
+        trust_requests: list[ToolProvenanceSpec] = []
+        monkeypatch.setattr(
+            manager._lineage_controller,
+            "_prompt_trusted_script_replay",
+            lambda spec, **_kwargs: trust_requests.append(spec) or True,
+        )
+
+        derived_node = manager._node_for_target(2)
+        assert manager._lineage_controller._node_can_reload_script_inputs(derived_node)
+        updated_left = left + 100.0
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated_left)
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(derived_node.uid) == "changed",
+            timeout=5000,
+        )
+
+        assert derived_node.reload_source_data()
+        xr.testing.assert_identical(
+            derived_node.current_public_data().rename(None),
+            (updated_left + right).rename(None),
+        )
+        assert trust_requests == []
+
+
+def test_managed_input_recorded_fallback_tracks_nested_live_dependency(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        root_node = manager._node_for_target(0)
+
+        nested_input = manager._lineage_controller._script_input_for_node(
+            root_node
+        ).model_copy(update={"name": "source"})
+        fallback = script(
+            ScriptCodeOperation(
+                label="Increment source",
+                code="derived = source + 1",
+            ),
+            start_label="Start from source",
+            active_name="derived",
+            script_inputs=(nested_input,),
+        )
+
+        tool = _ManagedUnaryTool(data)
+        child_uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
+        tool.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    label="Missing derived input",
+                    node_uid="missing-node",
+                    data_role="source",
+                    provenance_spec=fallback,
+                ),
+            ),
+            primary_input="data",
+            auto_update=False,
+            state="stale",
+        )
+
+        assert {
+            ref.node_uid
+            for ref in manager._lineage_controller._dependency_refs_for_uid(child_uid)
+        } == {"missing-node"}
+        assert manager._child_node(child_uid).reload_source_data()
+        xr.testing.assert_identical(tool.tool_data, data + 1)
+
+        refreshed_input = tool.script_inputs[0]
+        assert refreshed_input.node_uid is None
+        refreshed_fallback = refreshed_input.parsed_provenance_spec()
+        assert refreshed_fallback is not None
+        assert refreshed_fallback.script_inputs[0].node_uid == root_node.uid
+        assert {
+            ref.node_uid
+            for ref in manager._lineage_controller._dependency_refs_for_uid(child_uid)
+        } == {root_node.uid}
+
+        updated = (data + 10).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+        qtbot.wait_until(lambda: tool.source_state == "stale", timeout=5000)
+
+
+def test_live_managed_input_fallback_includes_source_transform(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(6.0),
+        dims="x",
+        coords={"x": np.arange(6)},
+        name="data",
+    )
+    path = tmp_path / "transformed-input.h5"
+    data.to_netcdf(path, engine="h5netcdf")
+    source_spec = selection(IselOperation(kwargs={"x": slice(1, 5, 2)}))
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        itool(
+            data,
+            manager=True,
+            file_path=path,
+            load_func=(
+                xr.load_dataarray,
+                {"engine": "h5netcdf"},
+                FileDataSelection(kind="dataarray"),
+            ),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        root = manager._tool_graph.root_wrappers[0]
+        script_input = manager._lineage_controller._script_input_for_node(
+            root
+        ).model_copy(
+            update={
+                "name": "data",
+                "source_spec": source_spec.model_dump(mode="json"),
+            }
+        )
+
+        resolved = manager._lineage_controller._resolve_live_script_input_for_reload(
+            script_input
+        )
+        assert resolved is not None
+        live_data, refreshed_input = resolved
+        expected = source_spec.apply(data)
+        xr.testing.assert_equal(live_data, expected)
+
+        recorded_input = refreshed_input.model_copy(
+            update={"node_uid": None, "node_snapshot_token": None}
+        )
+        rebuilt, _refreshed = rebuild_script_inputs((recorded_input,))
+        xr.testing.assert_identical(rebuilt["data"], expected)
+
+
+def test_managed_input_auto_refresh_uses_fresh_live_script_source(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    other = xr.DataArray([10.0, 20.0], dims="x")
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data, other], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        assert (
+            manager._lineage_controller._show_multi_input_script_result(
+                data + other,
+                (0, 1),
+                operation_label="Add inputs",
+                operation_code="derived = data_0 + data_1",
+            )
+            == 2
+        )
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        tool = _ManagedUnaryTool(data + other)
+        tool._set_source_auto_update(True)
+        child_uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 2},
+            show=False,
+        )
+        binding_before = tool.script_inputs[0]
+        source = manager._tool_graph.root_wrappers[2]
+
+        updated = data + 100.0
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(source.uid) == "changed",
+            timeout=5000,
+        )
+
+        manager.get_imagetool(2).slicer_area.reload()
+        expected = updated + other
+        qtbot.wait_until(
+            lambda: tool.source_state == "fresh" and tool.tool_data.equals(expected),
+            timeout=5000,
+        )
+        xr.testing.assert_equal(tool.tool_data.rename(None), expected.rename(None))
+
+        binding_after = tool.script_inputs[0]
+        assert binding_after.node_snapshot_token == source.snapshot_token
+        assert binding_after.node_snapshot_token != binding_before.node_snapshot_token
+        fallback = binding_after.parsed_provenance_spec()
+        assert fallback is not None
+        assert fallback.script_inputs[0].node_snapshot_token == (
+            manager._tool_graph.root_wrappers[0].snapshot_token
+        )
+        assert manager.dependency_status_for_uid(child_uid) == "current"
+
+
+def test_managed_input_reload_refreshes_script_source_once(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    other = xr.DataArray([10.0, 20.0], dims="x")
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data, other], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        source_index = manager._lineage_controller._show_multi_input_script_result(
+            data + other,
+            (0, 1),
+            operation_label="Add inputs",
+            operation_code="derived = data_0 + data_1",
+        )
+        assert source_index == 2
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        consumer = _ManagedUnaryTool(data + other)
+        consumer_uid = manager.add_childtool(
+            consumer,
+            script_inputs={"data": source_index},
+            show=False,
+        )
+        consumer.set_script_inputs(
+            consumer.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+
+        updated = data + 100.0
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+        source = manager._node_for_target(source_index)
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(source.uid) == "changed",
+            timeout=5000,
+        )
+
+        assert manager._child_node(consumer_uid).reload_source_data()
+        qtbot.wait_until(
+            lambda: not manager._interaction_gate.pending_keys,
+            timeout=5000,
+        )
+        xr.testing.assert_equal(consumer.tool_data, updated + other)
+        assert consumer.update_calls == 1
+
+
+def test_managed_reload_resumes_after_deferred_script_result_input(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="data")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="weights")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        source = _DeferredManagedSumTool(data + weights)
+        source_uid = manager.add_childtool(
+            source,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        source.set_script_inputs(
+            source.script_inputs,
+            primary_input="data",
+            auto_update=False,
+        )
+        source_input = manager._lineage_controller._script_input_for_node(
+            manager._child_node(source_uid),
+            name="data",
+        )
+        source_input = source_input.model_copy(
+            update={
+                "provenance_spec": script(
+                    start_label="Create recorded fallback",
+                    seed_code="data = xr.DataArray([-1.0, -2.0], dims='x')",
+                    active_name="data",
+                ).model_dump(mode="json")
+            }
+        )
+        derived_spec = script(
+            ScriptCodeOperation(
+                label="Increment managed input",
+                code="derived = data + 1.0",
+            ),
+            start_label="Start from managed input",
+            active_name="derived",
+            script_inputs=(source_input,),
+        )
+        derived = itool(source.tool_data + 1.0, manager=False, execute=False)
+        assert isinstance(derived, erlab.interactive.imagetool.ImageTool)
+        derived_index = manager.add_imagetool(
+            derived,
+            show=False,
+            provenance_spec=derived_spec,
+        )
+        derived_node = manager._node_for_target(derived_index)
+        consumer = _ManagedUnaryTool(derived_node.current_public_data())
+        consumer_uid = manager.add_childtool(
+            consumer,
+            script_inputs={"data": derived_index},
+            show=False,
+        )
+        consumer.set_script_inputs(
+            consumer.script_inputs,
+            primary_input="data",
+            auto_update=False,
+        )
+
+        updated = (data + 100.0).rename("data")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+        qtbot.wait_until(lambda: source.source_state == "stale", timeout=5000)
+
+        assert not manager._child_node(consumer_uid).reload_source_data()
+        assert source.pending_inputs is not None
+        assert manager._dependency_tracker.source_refresh_queued(
+            source_uid,
+            derived_node.uid,
+        )
+        assert manager._dependency_tracker.source_refresh_queued(
+            derived_node.uid,
+            consumer_uid,
+        )
+
+        source.finish_deferred_update()
+
+        expected = updated + weights + 1.0
+        qtbot.wait_until(
+            lambda: (
+                consumer.source_state == "fresh" and consumer.tool_data.equals(expected)
+            ),
+            timeout=5000,
+        )
+        xr.testing.assert_identical(source.tool_data, updated + weights)
+        xr.testing.assert_identical(derived_node.current_public_data(), expected)
+        xr.testing.assert_identical(consumer.tool_data, expected)
+        assert consumer.update_calls == 1
+        assert derived_node.provenance_spec is not None
+        assert derived_node.provenance_spec.script_inputs[0].node_uid == source_uid
+        assert not manager._dependency_tracker.has_pending_source_refreshes()
+
+
+def test_managed_multi_input_reload_refreshes_all_file_sources_once(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="value")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="value")
+    paths = (tmp_path / "data.h5", tmp_path / "weights.h5")
+    for value, path in zip((data, weights), paths, strict=True):
+        value.to_netcdf(path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for index, (value, path) in enumerate(
+            zip((data, weights), paths, strict=True),
+            start=1,
+        ):
+            itool(
+                value,
+                manager=True,
+                file_path=path,
+                load_func=(
+                    xr.load_dataarray,
+                    {"engine": "h5netcdf"},
+                    FileDataSelection(kind="dataarray"),
+                ),
+            )
+            qtbot.wait_until(
+                lambda expected_count=index: manager.ntools == expected_count,
+                timeout=5000,
+            )
+
+        tool = _ReloadCountingManagedSumTool(data + weights)
+        child_uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        tool.set_script_inputs(
+            tool.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+
+        updated_data = data + 100.0
+        updated_weights = weights + 1000.0
+        for value, path in zip((updated_data, updated_weights), paths, strict=True):
+            value.to_netcdf(path, engine="h5netcdf")
+
+        assert manager._child_node(child_uid).reload_source_data()
+
+        xr.testing.assert_identical(fetch(0), updated_data)
+        xr.testing.assert_identical(fetch(1), updated_weights)
+        xr.testing.assert_equal(tool.tool_data, updated_data + updated_weights)
+        assert tool.update_calls == 1
+
+
+def test_managed_input_reload_uses_detached_child_file_source(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="value")
+    file_path = tmp_path / "detached-child.h5"
+    data.to_netcdf(file_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        itool(data, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        child = itool(
+            data,
+            manager=False,
+            execute=False,
+            file_path=file_path,
+            load_func=(
+                xr.load_dataarray,
+                {"engine": "h5netcdf"},
+                FileDataSelection(kind="dataarray"),
+            ),
+        )
+        assert isinstance(child, erlab.interactive.imagetool.ImageTool)
+        child_uid = manager.add_imagetool_child(child, 0, show=False)
+        child_node = manager._child_node(child_uid)
+        assert not child_node.has_source_binding
+
+        consumer = _ManagedUnaryTool(data)
+        consumer_uid = manager.add_childtool(
+            consumer,
+            script_inputs={"data": child_uid},
+            show=False,
+        )
+        updated = data + 100.0
+        updated.to_netcdf(file_path, engine="h5netcdf")
+
+        consumer_node = manager._child_node(consumer_uid)
+        assert consumer_node.reload_unavailable_reason() is None
+        assert consumer_node.reload_source_data()
+
+        xr.testing.assert_identical(fetch(child_uid), updated)
+        xr.testing.assert_identical(consumer.tool_data, updated)
+        assert consumer.update_calls == 1
+
+
+def test_selected_script_results_dedupe_nested_file_reload(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = xr.DataArray(
+        np.arange(12.0).reshape(6, 2),
+        dims=("x", "y"),
+        name="value",
+    )
+    source_path = tmp_path / "source.h5"
+    source.to_netcdf(source_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        itool(
+            source,
+            manager=True,
+            file_path=source_path,
+            load_func=(
+                xr.load_dataarray,
+                {"engine": "h5netcdf"},
+                FileDataSelection(kind="dataarray"),
+            ),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        child_uids: list[str] = []
+        derived_targets: list[int] = []
+        slices = (slice(0, 3), slice(3, 6))
+        for indexer in slices:
+            source_spec = selection(IselOperation(kwargs={"x": indexer}))
+            child_data = source_spec.apply(source)
+            child = itool(child_data, manager=False, execute=False)
+            assert isinstance(child, erlab.interactive.imagetool.ImageTool)
+            child_uid = manager.add_imagetool_child(
+                child,
+                0,
+                show=False,
+                source_spec=source_spec,
+                source_auto_update=False,
+            )
+            child_uids.append(child_uid)
+
+            script_input = manager._lineage_controller._script_input_for_node(
+                manager._child_node(child_uid)
+            )
+            derived = itool(child_data, manager=False, execute=False)
+            assert isinstance(derived, erlab.interactive.imagetool.ImageTool)
+            derived_targets.append(
+                manager.add_imagetool(
+                    derived,
+                    show=False,
+                    provenance_spec=script(
+                        ScriptCodeOperation(
+                            label="Copy child input",
+                            code=f"derived = {script_input.name}",
+                        ),
+                        start_label="Start from child input",
+                        active_name="derived",
+                        script_inputs=(script_input,),
+                    ),
+                )
+            )
+
+        root = manager._tool_graph.root_wrappers[0]
+        reload_source = root.slicer_area._reload
+        reload_calls = 0
+
+        def count_reload() -> bool:
+            nonlocal reload_calls
+            reload_calls += 1
+            return reload_source()
+
+        monkeypatch.setattr(root.slicer_area, "_reload", count_reload)
+        updated = source + 100.0
+        updated.to_netcdf(source_path, engine="h5netcdf")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+        qtbot.wait_until(
+            lambda: all(
+                manager._child_node(uid).source_state == "stale" for uid in child_uids
+            ),
+            timeout=5000,
+        )
+
+        manager.tree_view.selectionModel().clearSelection()
+        select_tools(manager, derived_targets)
+        manager.reload_selected()
+
+        assert reload_calls == 1
+        for target, indexer in zip(derived_targets, slices, strict=True):
+            xr.testing.assert_identical(fetch(target), updated.isel(x=indexer))
+
+
+def test_selected_managed_tools_dedupe_shared_file_input(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    inputs = (
+        xr.DataArray([1.0, 2.0], dims="x", name="value"),
+        xr.DataArray([10.0, 20.0], dims="x", name="value"),
+        xr.DataArray([100.0, 200.0], dims="x", name="value"),
+    )
+    paths = tuple(tmp_path / name for name in ("shared.h5", "left.h5", "right.h5"))
+    for value, path in zip(inputs, paths, strict=True):
+        value.to_netcdf(path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for index, (value, path) in enumerate(
+            zip(inputs, paths, strict=True),
+            start=1,
+        ):
+            itool(
+                value,
+                manager=True,
+                file_path=path,
+                load_func=(
+                    xr.load_dataarray,
+                    {"engine": "h5netcdf"},
+                    FileDataSelection(kind="dataarray"),
+                ),
+            )
+            qtbot.wait_until(
+                lambda expected_count=index: manager.ntools == expected_count,
+                timeout=5000,
+            )
+
+        first = _ReloadCountingManagedSumTool(inputs[0] + inputs[1])
+        first_uid = manager.add_childtool(
+            first,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        second = _ReloadCountingManagedSumTool(inputs[0] + inputs[2])
+        second_uid = manager.add_childtool(
+            second,
+            script_inputs={"data": 0, "weights": 2},
+            show=False,
+        )
+
+        reload_calls: list[int] = []
+        for root in manager._tool_graph.root_wrappers.values():
+            original_reload = root.slicer_area._reload
+
+            def track_reload(
+                *,
+                index: int = root.index,
+                reload_source: Callable[[], bool] = original_reload,
+            ) -> bool:
+                reload_calls.append(index)
+                return reload_source()
+
+            monkeypatch.setattr(root.slicer_area, "_reload", track_reload)
+
+        updated = tuple(value + 1000.0 for value in inputs)
+        for value, path in zip(updated, paths, strict=True):
+            value.to_netcdf(path, engine="h5netcdf")
+
+        manager.tree_view.selectionModel().clearSelection()
+        select_child_tool(manager, first_uid)
+        select_child_tool(manager, second_uid)
+        manager.reload_selected()
+
+        assert reload_calls.count(0) == 1
+        assert reload_calls.count(1) == 1
+        assert reload_calls.count(2) == 1
+        xr.testing.assert_equal(first.tool_data, updated[0] + updated[1])
+        xr.testing.assert_equal(second.tool_data, updated[0] + updated[2])
+        assert first.update_calls == 1
+        assert second.update_calls == 1
+
+
+def test_managed_multi_input_reload_rejects_mixed_file_and_raw_sources(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x", name="value")
+    weights = xr.DataArray([10.0, 20.0], dims="x", name="value")
+    file_path = tmp_path / "data.h5"
+    data.to_netcdf(file_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        itool(
+            data,
+            manager=True,
+            file_path=file_path,
+            load_func=(
+                xr.load_dataarray,
+                {"engine": "h5netcdf"},
+                FileDataSelection(kind="dataarray"),
+            ),
+        )
+        itool(weights, manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        tool = _ReloadCountingManagedSumTool(data + weights)
+        child_uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        child_node = manager._child_node(child_uid)
+
+        updated_data = data + 100.0
+        updated_data.to_netcdf(file_path, engine="h5netcdf")
+
+        assert child_node.reload_unavailable_reason() is not None
+        assert not child_node.can_reload_source_data()
+        assert not child_node.reload_source_data()
+        xr.testing.assert_identical(fetch(0), data)
+        xr.testing.assert_identical(tool.tool_data, data + weights)
+        assert tool.update_calls == 0
+
+
+def test_selected_upstream_reload_updates_managed_descendant_once(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    other = xr.DataArray([10.0, 20.0], dims="x")
+
+    with manager_context() as manager:
+        manager.show()
+        itool([data, other], manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        source_index = manager._lineage_controller._show_multi_input_script_result(
+            data + other,
+            (0, 1),
+            operation_label="Add inputs",
+            operation_code="derived = data_0 + data_1",
+        )
+        assert source_index == 2
+        qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
+
+        consumer = _ManagedUnaryTool(data + other)
+        consumer_uid = manager.add_childtool(
+            consumer,
+            script_inputs={"data": source_index},
+            show=False,
+        )
+        consumer.set_script_inputs(
+            consumer.script_inputs,
+            primary_input="data",
+            auto_update=True,
+        )
+        descendant = _ManagedUnaryTool(consumer.tool_data)
+        descendant_uid = manager.add_childtool(
+            descendant,
+            script_inputs={"data": consumer_uid},
+            show=False,
+        )
+
+        updated = data + 100.0
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, updated)
+        source = manager._node_for_target(source_index)
+        qtbot.wait_until(
+            lambda: manager.dependency_status_for_uid(source.uid) == "changed",
+            timeout=5000,
+        )
+
+        manager.tree_view.selectionModel().clearSelection()
+        select_tools(manager, [source_index])
+        select_child_tool(manager, descendant_uid)
+        manager.reload_selected()
+
+        expected = updated + other
+        qtbot.wait_until(
+            lambda: (
+                consumer.source_state == "fresh" and descendant.source_state == "fresh"
+            ),
+            timeout=5000,
+        )
+        xr.testing.assert_equal(consumer.tool_data, expected)
+        xr.testing.assert_equal(descendant.tool_data, expected)
+        assert consumer.update_calls == 1
+        assert descendant.update_calls == 1
+
+
+def test_managed_input_reload_cancellation_preserves_state(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    recorded_spec = script(
+        ScriptCodeOperation(
+            label="Evaluate recorded expression",
+            code=("import os\nwith open(os.devnull):\n    pass\nderived = data"),
+        ),
+        start_label="Start from data",
+        active_name="derived",
+        script_inputs=(ScriptInput(name="data", label="Input"),),
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False, provenance_spec=recorded_spec)
+
+        tool = _ManagedUnaryTool(data)
+        child_uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
+        tool.set_script_inputs(
+            tool.script_inputs,
+            primary_input="data",
+            state="stale",
+        )
+        monkeypatch.setattr(
+            manager._lineage_controller,
+            "_resolve_live_script_input_for_reload",
+            lambda *_args, **_kwargs: None,
+        )
+
+        def _cancel_trust(*_args, **_kwargs) -> bool:
+            raise manager_widgets._TrustedScriptReplayCancelled
+
+        monkeypatch.setattr(
+            manager._lineage_controller,
+            "_ensure_script_provenance_trusted",
+            _cancel_trust,
+        )
+
+        assert not manager._child_node(child_uid).reload_source_data()
+        assert tool.source_state == "stale"
+
+
+def test_duplicate_subtree_rebases_managed_input_dependencies(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    weights = xr.DataArray([3.0, 4.0], dims="x")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+
+        tool = _ManagedSumTool(data, weights)
+        original_uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+
+        original_parent = manager._node_for_target(0)
+        duplicated_index = manager.duplicate_imagetool(0)
+        duplicated_parent = manager._node_for_target(duplicated_index)
+        assert duplicated_parent.snapshot_token == original_parent.snapshot_token
+        assert (
+            duplicated_parent.source_snapshot_token
+            == original_parent.source_snapshot_token
+        )
+        assert len(duplicated_parent._childtool_indices) == 1
+        duplicated_uid = duplicated_parent._childtool_indices[0]
+        duplicated_tool = manager.get_childtool(duplicated_uid)
+        duplicated_inputs = {item.name: item for item in duplicated_tool.script_inputs}
+
+        assert duplicated_inputs["data"].node_uid == duplicated_parent.uid
+        assert (
+            duplicated_inputs["data"].node_snapshot_token
+            == duplicated_parent.snapshot_token
+        )
+        weights_node = manager._node_for_target(1)
+        assert duplicated_inputs["weights"].node_uid == weights_node.uid
+        assert (
+            duplicated_inputs["weights"].node_snapshot_token
+            == weights_node.snapshot_token
+        )
+        assert manager.dependency_status_for_uid(duplicated_uid) == "current"
+        assert duplicated_tool.source_state == "fresh"
+
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(0, data + 10.0)
+        qtbot.wait_until(lambda: tool.source_state == "stale", timeout=5000)
+
+        assert manager.dependency_status_for_uid(original_uid) == "changed"
+        assert manager.dependency_status_for_uid(duplicated_uid) == "current"
+        assert duplicated_tool.source_state == "fresh"
 
 
 def test_manager_goldtool_output_itool_stales_when_fit_results_change(
@@ -760,13 +3416,13 @@ def test_manager_goldtool_output_itool_stales_when_fit_results_change(
         itool(gold, link=False, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
+        child = GoldTool(gold.copy(deep=True), data_name="gold_input")
+        child.set_script_inputs((ScriptInput(name="data"),), primary_input="data")
         child_uid = manager.add_childtool(
-            GoldTool(gold.copy(deep=True), data_name="gold_input"),
-            0,
+            child,
+            script_inputs={"data": 0},
             show=False,
         )
-        child = manager.get_childtool(child_uid)
-        assert isinstance(child, GoldTool)
         configure_goldtool_child(child, fitted=True, spline=False)
         child.open_itool()
 
@@ -946,11 +3602,27 @@ def test_manager_metadata_uses_streamlined_child_derivation(
         select_child_tool(manager, child_uid)
         manager._update_info(uid=child_uid)
 
-        derivation = metadata_derivation_texts(manager)
-        assert derivation[0] == "Start from selected parent ImageTool data"
-        assert not any(line == "isel()" for line in derivation)
-        assert not any("Sort coordinates" in line for line in derivation)
-        assert any(line.startswith("transpose(") for line in derivation)
+        child_node = manager._child_node(child_uid)
+        displayed_spec = child_node.passive_displayed_provenance_spec
+        assert displayed_spec is not None
+        assert displayed_spec.kind == "script"
+        assert len(displayed_spec.script_inputs) == 1
+        assert displayed_spec.script_inputs[0].node_uid == parent_node.uid
+
+        start_item = manager.metadata_derivation_list.conceptual_item(0)
+        input_item = manager.metadata_derivation_list.conceptual_item(1)
+        assert start_item is not None
+        assert input_item is not None
+        start_row = start_item.data(manager_widgets._METADATA_DERIVATION_ROW_ROLE)
+        input_row = input_item.data(manager_widgets._METADATA_DERIVATION_ROW_ROLE)
+        assert isinstance(start_row, _ProvenanceDisplayRow)
+        assert isinstance(input_row, _ProvenanceDisplayRow)
+        assert start_row.replay_ref is not None
+        assert start_row.replay_ref.kind == "start"
+        assert input_row.replay_ref is not None
+        assert input_row.replay_ref.kind == "script_input"
+        assert input_row.replay_ref.script_input_index == 0
+        assert input_row.script_input_path == ()
 
         monkeypatch.setattr(
             type(parent_node),
@@ -1334,6 +4006,10 @@ def test_manager_manual_nested_refresh_resumes_after_deferred_parent(
             self._data = data
             self._status = _DeferredToolState()
             self.pending_data: xr.DataArray | None = None
+            self.set_script_inputs(
+                (ScriptInput(name="data", data_role="source"),),
+                primary_input="data",
+            )
 
         @property
         def tool_status(self) -> _DeferredToolState:
@@ -1347,9 +4023,9 @@ def test_manager_manual_nested_refresh_resumes_after_deferred_parent(
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> bool:
-            self.pending_data = new_data
-            self._source_refresh_deferred = self.has_source_binding
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            self.pending_data = inputs["data"]
+            self._defer_source_refresh()
             return False
 
         def finish_deferred_update(self) -> None:
@@ -1376,8 +4052,11 @@ def test_manager_manual_nested_refresh_resumes_after_deferred_parent(
         manager.add_imagetool(root_tool, show=False)
 
         parent_tool = _DeferredTool(root_data)
-        parent_uid = manager.add_childtool(parent_tool, 0, show=False)
-        parent_tool.set_source_binding(full_data(), auto_update=False)
+        parent_uid = manager.add_childtool(
+            parent_tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
 
         leaf_tool = itool(root_data.isel(y=slice(0, 2)), manager=False, execute=False)
         assert isinstance(leaf_tool, erlab.interactive.imagetool.ImageTool)
@@ -1399,7 +4078,9 @@ def test_manager_manual_nested_refresh_resumes_after_deferred_parent(
         qtbot.wait_until(lambda: parent_node.source_state == "stale", timeout=5000)
         qtbot.wait_until(lambda: leaf_node.source_state == "stale", timeout=5000)
 
-        assert manager._refresh_source_chain_to_uid(leaf_uid) is False
+        assert (
+            manager._lineage_controller._refresh_source_chain_to_uid(leaf_uid) is False
+        )
         assert parent_tool.pending_data is not None
         xr.testing.assert_identical(fetch(leaf_uid), root_data.isel(y=slice(0, 2)))
 
@@ -1722,17 +4403,24 @@ def test_manager_meshtool_output_child_qsel_copy_code_tracks_selected_output_id(
 def test_manager_fit2d_output_itools_use_distinct_output_ids(
     qtbot,
     monkeypatch,
-    exp_decay_model,
-    test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    t = np.linspace(0.0, 4.0, 25)
+    y = np.arange(3)
+    fit_input = xr.DataArray(
+        np.stack([((1.0 + 0.5 * index) * np.exp(-t / 2.0)) for index in y]),
+        dims=("y", "t"),
+        coords={"y": y, "t": t},
+        name="decay2d",
+    )
+
     with manager_context() as manager:
         manager.show()
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
 
-        itool(test_data, manager=True)
+        itool(fit_input, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         parent_tool = manager.get_imagetool(0)
         parent_tool.set_provenance_spec(
@@ -1746,7 +4434,8 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
             )
         )
 
-        child_uid, child = make_fit2d_child(manager, 0, exp_decay_model)
+        model = erlab.analysis.fit.models.PolynomialModel(degree=1)
+        child_uid, child = make_fit2d_child(manager, 0, model)
         monkeypatch.setattr(
             child,
             "_prompt_existing_output_imagetool",
@@ -1847,6 +4536,19 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
         assert includes_parent_offset(second_values_code)
         assert includes_parent_offset(stderr_code)
 
+        for code, active_name in (
+            (values_code, "parameter_values"),
+            (second_values_code, "parameter_values"),
+            (stderr_code, "parameter_stderr"),
+        ):
+            namespace = _exec_generated_code(
+                code,
+                {"data": fit_input.copy(deep=True)},
+            )
+            generated = namespace[active_name]
+            assert isinstance(generated, xr.DataArray)
+            assert generated.dims == ("y",)
+
         def selected_fit_output(code: str) -> tuple[str, str]:
             for call in (
                 node for node in ast.walk(ast.parse(code)) if isinstance(node, ast.Call)
@@ -1908,6 +4610,10 @@ def test_manager_output_refresh_updates_stale_parent_source(
             self._data = data
             self._status = _OutputToolState()
             self.refreshed_inputs: list[xr.DataArray] = []
+            self.set_script_inputs(
+                (ScriptInput(name="data", data_role="source"),),
+                primary_input="data",
+            )
 
         @property
         def tool_status(self) -> _OutputToolState:
@@ -1921,9 +4627,9 @@ def test_manager_output_refresh_updates_stale_parent_source(
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> bool:
-            self.refreshed_inputs.append(new_data)
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            self.refreshed_inputs.append(inputs["data"])
+            self._data = inputs["data"]
             return True
 
         def output_imagetool_data(
@@ -1958,8 +4664,11 @@ def test_manager_output_refresh_updates_stale_parent_source(
         manager.add_imagetool(root_tool, show=False)
 
         child = _OutputTool(data)
-        child_uid = manager.add_childtool(child, 0, show=False)
-        child.set_source_binding(full_data(), auto_update=False)
+        child_uid = manager.add_childtool(
+            child,
+            script_inputs={"data": 0},
+            show=False,
+        )
 
         initial_output = typing.cast("xr.DataArray", child.output_imagetool_data("out"))
         output_tool = itool(initial_output, manager=False, execute=False)
@@ -1984,7 +4693,9 @@ def test_manager_output_refresh_updates_stale_parent_source(
         qtbot.wait_until(lambda: output_node.source_state == "stale", timeout=5000)
         xr.testing.assert_identical(fetch(output_uid), initial_output)
 
-        assert manager._refresh_source_chain_to_uid(output_uid) is True
+        assert (
+            manager._lineage_controller._refresh_source_chain_to_uid(output_uid) is True
+        )
         assert child.refreshed_inputs
         assert child.source_state == "fresh"
         assert output_node.source_state == "fresh"
@@ -2555,7 +5266,7 @@ def test_manager_promote_child_imagetool_rehomes_subtree_and_detaches_provenance
         )
         xr.testing.assert_identical(fetch(child_uid), child_before)
         xr.testing.assert_identical(
-            manager._parent_source_data_for_uid(nested_uid),
+            manager._lineage_controller._parent_source_data_for_uid(nested_uid),
             manager.get_imagetool(promoted_index).slicer_area._data,
         )
 

--- a/tests/interactive/imagetool/manager/provenance/test_dependencies.py
+++ b/tests/interactive/imagetool/manager/provenance/test_dependencies.py
@@ -22,7 +22,6 @@ from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
-from erlab.interactive.imagetool._provenance._code import uses_default_replay_input
 from erlab.interactive.imagetool._provenance._execution import rebuild_script_inputs
 from erlab.interactive.imagetool._provenance._model import (
     DerivationEntry,
@@ -66,6 +65,7 @@ from tests.interactive.imagetool.manager.helpers import (
 )
 
 from ._common import (
+    _authorize_execution,
     _seed_fit2d_param_results,
     _set_selection_point,
     _set_selection_range,
@@ -2173,6 +2173,7 @@ def test_script_imagetool_self_cycle_is_not_reported_as_reloadable(
         reason = manager._lineage_controller._node_reload_unavailable_reason(node)
         assert reason is not None
         assert "cycle" in reason.lower()
+        assert node.slicer_area._reload_unavailable_reason() is not None
         assert not node.slicer_area.reloadable
         assert not node.reload_source_data()
         xr.testing.assert_identical(node.current_public_data(), data)
@@ -2196,6 +2197,7 @@ def test_script_imagetool_self_cycle_is_not_reported_as_reloadable(
         )
 
         assert manager._lineage_controller._node_reload_unavailable_reason(node) is None
+        assert node.slicer_area._reload_unavailable_reason() is None
         assert node.slicer_area.reloadable
         assert node.reload_source_data()
         xr.testing.assert_identical(node.current_public_data(), updated)
@@ -2409,7 +2411,7 @@ def test_managed_inputs_refresh_once_after_sibling_outputs_update(
         assert consumer.seen == [(1.0, 11.0)]
 
 
-def test_managed_input_reload_resolves_live_data_before_trust(
+def test_managed_input_reload_uses_live_data_without_code_authorization(
     qtbot,
     monkeypatch,
     manager_context: Callable[
@@ -2445,15 +2447,15 @@ def test_managed_input_reload_resolves_live_data_before_trust(
             primary_input="data",
             state="stale",
         )
-        trust_requests: list[ToolProvenanceSpec] = []
         monkeypatch.setattr(
             manager._lineage_controller,
-            "_prompt_trusted_script_replay",
-            lambda spec, **_kwargs: trust_requests.append(spec) or True,
+            "_authorize_provenance_execution",
+            lambda *_args, **_kwargs: pytest.fail(
+                "live managed input requested code authorization"
+            ),
         )
 
         assert manager._lineage_controller._refresh_source_chain_to_uid(child_uid)
-        assert trust_requests == []
         assert tool.source_state == "fresh"
 
 
@@ -2508,11 +2510,16 @@ def test_manager_reload_ignores_unreachable_unsafe_live_input_fallback(
             show=False,
             provenance_spec=derived_spec,
         )
-        trust_requests: list[ToolProvenanceSpec] = []
+        authorized_code: list[str] = []
+
+        def authorize(entries: tuple[typing.Any, ...], **_kwargs: typing.Any):
+            authorized_code.extend(entry.code for entry in entries)
+            return _authorize_execution(entries)
+
         monkeypatch.setattr(
             manager._lineage_controller,
-            "_prompt_trusted_script_replay",
-            lambda spec, **_kwargs: trust_requests.append(spec) or True,
+            "_authorize_provenance_execution",
+            authorize,
         )
 
         derived_node = manager._node_for_target(2)
@@ -2530,7 +2537,8 @@ def test_manager_reload_ignores_unreachable_unsafe_live_input_fallback(
             derived_node.current_public_data().rename(None),
             (updated_left + right).rename(None),
         )
-        assert trust_requests == []
+        assert authorized_code
+        assert not any("import os" in code for code in authorized_code)
 
 
 def test_managed_input_recorded_fallback_tracks_nested_live_dependency(
@@ -3576,6 +3584,13 @@ def test_manager_metadata_uses_streamlined_child_derivation(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         parent_tool = manager.get_imagetool(0)
+        parent_tool.set_provenance_spec(
+            script(
+                start_label="Start from source data",
+                seed_code="derived = source_data",
+                active_name="derived",
+            )
+        )
         parent_tool.slicer_area.images[0].open_in_dtool()
         qtbot.wait_until(
             lambda: len(manager._tool_graph.root_wrappers[0]._childtool_indices) == 1,
@@ -3632,7 +3647,7 @@ def test_manager_metadata_uses_streamlined_child_derivation(
         copied = copy_full_code_for_uid(monkeypatch, manager, child_uid)
         namespace = _exec_generated_code(
             copied,
-            {"data": parent_tool.slicer_area.data.copy(deep=True)},
+            {"source_data": parent_tool.slicer_area.data.copy(deep=True)},
         )
         result = namespace["result"]
         assert isinstance(result, xr.DataArray)
@@ -4338,6 +4353,13 @@ def test_manager_meshtool_output_child_qsel_copy_code_tracks_selected_output_id(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         parent_tool = manager.get_imagetool(0)
+        parent_tool.set_provenance_spec(
+            script(
+                start_label="Start from mesh data",
+                seed_code="derived = mesh_data",
+                active_name="derived",
+            )
+        )
         parent_tool.slicer_area.open_in_meshtool()
         qtbot.wait_until(
             lambda: len(manager._tool_graph.root_wrappers[0]._childtools) == 1,
@@ -4390,7 +4412,7 @@ def test_manager_meshtool_output_child_qsel_copy_code_tracks_selected_output_id(
         assert f"derived = {expected_name}.qsel(alpha=1, alpha_width=1)" in copied
         namespace = _exec_generated_code(
             copied,
-            {"data": parent_tool.slicer_area.data.copy(deep=True)},
+            {"mesh_data": parent_tool.slicer_area.data.copy(deep=True)},
         )
         generated = namespace["derived"]
         assert isinstance(generated, xr.DataArray)
@@ -4427,7 +4449,7 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
             script(
                 ScriptCodeOperation(
                     label="Prepare parent data",
-                    code="prepared_parent = data + 1",
+                    code="prepared_parent = decay_data + 1",
                 ),
                 start_label="Start from test data",
                 active_name="prepared_parent",
@@ -4525,7 +4547,7 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
             return any(
                 isinstance(node, ast.BinOp)
                 and isinstance(node.left, ast.Name)
-                and node.left.id == "data"
+                and node.left.id == "decay_data"
                 and isinstance(node.op, ast.Add)
                 and isinstance(node.right, ast.Constant)
                 and node.right.value == 1
@@ -4543,7 +4565,7 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
         ):
             namespace = _exec_generated_code(
                 code,
-                {"data": fit_input.copy(deep=True)},
+                {"decay_data": fit_input.copy(deep=True)},
             )
             generated = namespace[active_name]
             assert isinstance(generated, xr.DataArray)
@@ -4589,6 +4611,86 @@ def test_manager_fit2d_output_itools_use_distinct_output_ids(
             "modelfit_stderr",
             first_param_name,
         )
+
+
+def test_manager_file_backed_fit2d_parameter_full_code_is_self_contained(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    t = np.linspace(0.0, 4.0, 25)
+    y = np.arange(3)
+    fit_input = xr.DataArray(
+        np.stack([((1.0 + 0.5 * index) * np.exp(-t / 2.0)) for index in y]),
+        dims=("y", "t"),
+        coords={"y": y, "t": t},
+        name="decay2d",
+    )
+    source_path = tmp_path / "decay.h5"
+    workspace_path = tmp_path / "fit.itws"
+    fit_input.to_netcdf(source_path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        itool(
+            fit_input,
+            manager=True,
+            file_path=source_path,
+            load_func=(
+                xr.load_dataarray,
+                {"engine": "h5netcdf"},
+                FileDataSelection(kind="dataarray"),
+            ),
+        )
+        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+
+        model = erlab.analysis.fit.models.PolynomialModel(degree=1)
+        child_uid, child = make_fit2d_child(manager, 0, model)
+        child.timeout_spin.setValue(30.0)
+        child.nfev_spin.setValue(0)
+        child.y_index_spin.setValue(child.y_min_spin.value())
+        child._run_fit_2d("up")
+        qtbot.wait_until(
+            lambda: (
+                child._fit_thread is None
+                and child._fit_2d_total == 0
+                and not child._fit_2d_indices
+            ),
+            timeout=10000,
+        )
+
+        parameter_name = next(iter(child._params))
+        parameter_index = child.param_plot_combo.findText(parameter_name)
+        assert parameter_index >= 0
+        child.param_plot_combo.setCurrentIndex(parameter_index)
+        expected = child._param_plot_dataarray(parameter_name, stderr=False)
+        child.param_plot._show_parameter_values()
+
+        child_node = manager._child_node(child_uid)
+        qtbot.wait_until(lambda: len(child_node._childtool_indices) == 1, timeout=5000)
+        output_uid = child_node._childtool_indices[0]
+
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        assert output_uid in manager._tool_graph.nodes
+
+        copied = copy_full_code_for_uid(monkeypatch, manager, output_uid)
+        assert str(source_path) in copied
+        namespace = _exec_generated_code(copied, {})
+        generated = namespace["parameter_values"]
+        assert isinstance(generated, xr.DataArray)
+        xr.testing.assert_identical(generated, expected)
 
 
 def test_manager_output_refresh_updates_stale_parent_source(
@@ -4908,7 +5010,6 @@ def test_manager_open_in_new_window_nests_image_tool_children(
         )
         trigger_menu_action(menu, manager._metadata_copy_full_action)
         assert copied
-        assert not uses_default_replay_input(copied[-1])
         namespace = _exec_generated_code(copied[-1], {})
         result = namespace["result"]
         assert isinstance(result, xr.DataArray)

--- a/tests/interactive/imagetool/manager/provenance/test_dependencies.py
+++ b/tests/interactive/imagetool/manager/provenance/test_dependencies.py
@@ -3329,12 +3329,12 @@ def test_managed_input_reload_cancellation_preserves_state(
             lambda *_args, **_kwargs: None,
         )
 
-        def _cancel_trust(*_args, **_kwargs) -> bool:
-            raise manager_widgets._TrustedScriptReplayCancelled
+        def _cancel_trust(*_args, **_kwargs) -> None:
+            raise manager_widgets._TrustedProvenanceReplayCancelled
 
         monkeypatch.setattr(
             manager._lineage_controller,
-            "_ensure_script_provenance_trusted",
+            "_authorize_provenance_execution",
             _cancel_trust,
         )
 

--- a/tests/interactive/imagetool/manager/provenance/test_derivation_ui.py
+++ b/tests/interactive/imagetool/manager/provenance/test_derivation_ui.py
@@ -1596,6 +1596,11 @@ def test_manager_provenance_reorder_controller_tracks_dependencies_and_targets(
 
     manager = types.SimpleNamespace(
         _tool_graph=types.SimpleNamespace(nodes={"available": _Dependency()}),
+        _workspace_controller=types.SimpleNamespace(
+            issue_code_execution_capability=lambda entries, **_kwargs: (
+                _authorize_execution(entries)
+            ),
+        ),
         _extensions=types.SimpleNamespace(
             unavailable_reason_for_node=lambda _uid: None,
             capability_status=lambda *_args: "ready",
@@ -1613,9 +1618,6 @@ def test_manager_provenance_reorder_controller_tracks_dependencies_and_targets(
                     )
                 ),
             ),
-        ),
-        _authorize_provenance_execution=lambda entries, **_kwargs: _authorize_execution(
-            entries
         ),
     )
     manager._lineage_controller = manager_lineage._LineageController(

--- a/tests/interactive/imagetool/manager/provenance/test_derivation_ui.py
+++ b/tests/interactive/imagetool/manager/provenance/test_derivation_ui.py
@@ -12,6 +12,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
+import erlab.interactive.imagetool.manager._lineage as manager_lineage
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 from erlab.interactive.imagetool import itool
@@ -1616,6 +1617,9 @@ def test_manager_provenance_reorder_controller_tracks_dependencies_and_targets(
         _authorize_provenance_execution=lambda entries, **_kwargs: _authorize_execution(
             entries
         ),
+    )
+    manager._lineage_controller = manager_lineage._LineageController(
+        typing.cast("typing.Any", manager)
     )
     controller = _ProvenanceEditController(typing.cast("typing.Any", manager))
     spec = script(

--- a/tests/interactive/imagetool/manager/provenance/test_editor_foundations.py
+++ b/tests/interactive/imagetool/manager/provenance/test_editor_foundations.py
@@ -18,7 +18,6 @@ import erlab.interactive.imagetool.manager._details_panel as manager_details_pan
 import erlab.interactive.imagetool.manager._dialogs as manager_dialogs
 import erlab.interactive.imagetool.manager._extensions._dialogs as extension_dialogs
 import erlab.interactive.imagetool.manager._lineage as manager_lineage
-import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 from erlab.interactive.imagetool._load_source import (
@@ -1374,13 +1373,13 @@ def test_manager_selection_provenance_edit_restores_from_high_dimensional_source
             ),
         ),
     )
-    manager._script_input_can_reload = lambda *_args, **_kwargs: True
-    manager._rebuild_script_provenance = lambda *_args, **_kwargs: pytest.fail(
-        "selection edit should not rebuild script provenance"
-    )
-    manager._authorize_provenance_execution = lambda *_args, **_kwargs: False
-    manager._apply_provenance = lambda provenance, data, **_kwargs: provenance.apply(
-        data
+    manager._lineage_controller = types.SimpleNamespace(
+        _script_input_unavailable_reason=lambda *_args, **_kwargs: None,
+        _rebuild_script_provenance=lambda *_args, **_kwargs: pytest.fail(
+            "selection edit should not rebuild script provenance"
+        ),
+        _authorize_provenance_execution=lambda *_args, **_kwargs: None,
+        _apply_provenance=lambda provenance, data, **_kwargs: provenance.apply(data),
     )
     manager._update_info = lambda **_kwargs: None
     controller = provenance_edit_controller._ProvenanceEditController(
@@ -1543,7 +1542,6 @@ def test_manager_script_replay_uses_workspace_document_trust() -> None:
     assert len(trust_checks) == 1
     assert trust_checks[0] is entries
 
-
 def test_manager_script_replay_stops_when_workspace_code_is_untrusted() -> None:
     manager = types.SimpleNamespace(
         _workspace_controller=types.SimpleNamespace(
@@ -1656,37 +1654,6 @@ def test_manager_provenance_lightweight_helper_edges() -> None:
         is None
     )
 
-    forwarded: list[tuple[tuple[object, ...], str, bool]] = []
-    entries = (object(),)
-    capability = object()
-
-    def authorize_script_provenance_execution(
-        entries_arg: tuple[object, ...],
-        *,
-        reason: str,
-        raise_on_block: bool = True,
-    ) -> object:
-        forwarded.append((entries_arg, reason, raise_on_block))
-        return capability
-
-    manager = types.SimpleNamespace(
-        _lineage_controller=types.SimpleNamespace(
-            _authorize_provenance_execution=(authorize_script_provenance_execution)
-        )
-    )
-
-    assert (
-        manager_mainwindow.ImageToolManager._authorize_provenance_execution(
-            typing.cast("typing.Any", manager),
-            entries,
-            reason="reload this result",
-        )
-        is capability
-    )
-
-    assert forwarded == [(entries, "reload this result", True)]
-
-
 def test_manager_trust_required_script_can_reload_and_rebuilds_trusted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1705,13 +1672,16 @@ def test_manager_trust_required_script_can_reload_and_rebuilds_trusted(
                 )
             ),
         ),
-        _script_input_can_reload=lambda *_args, **_kwargs: True,
-        _resolve_live_script_input_for_reload=lambda *_args, **_kwargs: None,
     )
     controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
     capability = object()
     controller._authorize_provenance_execution = (  # type: ignore[method-assign]
         lambda _entries, *, reason, **_kwargs: ensured.append(reason) or capability
+    )
+    monkeypatch.setattr(
+        controller,
+        "_node_reload_unavailable_reason",
+        lambda *_args, **_kwargs: None,
     )
     node = types.SimpleNamespace(
         is_imagetool=True,

--- a/tests/interactive/imagetool/manager/provenance/test_editor_foundations.py
+++ b/tests/interactive/imagetool/manager/provenance/test_editor_foundations.py
@@ -1656,13 +1656,30 @@ def test_manager_provenance_lightweight_helper_edges() -> None:
 
 def test_manager_trust_required_script_can_reload_and_rebuilds_trusted(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
 ) -> None:
-    spec = _trust_required_script_spec()
+    original_spec = _trust_required_script_spec()
+    source_path = tmp_path / "source.h5"
+    source_path.touch()
+    spec = original_spec.model_copy(
+        update={
+            "script_inputs": (
+                original_spec.script_inputs[0].model_copy(
+                    update={
+                        "provenance_spec": _manager_replay_file_spec(
+                            source_path
+                        ).model_dump(mode="json")
+                    }
+                ),
+            )
+        }
+    )
     ensured: list[str] = []
     trusted_flags: list[bool] = []
     manager = types.SimpleNamespace(
         _extensions=types.SimpleNamespace(
             unavailable_reason_for_node=lambda _uid: None,
+            capability_status=lambda *_args, **_kwargs: None,
             replay_loader=lambda *_args, **_kwargs: pytest.fail(
                 "built-in provenance must not use extension loader execution"
             ),
@@ -1672,6 +1689,7 @@ def test_manager_trust_required_script_can_reload_and_rebuilds_trusted(
                 )
             ),
         ),
+        _tool_graph=types.SimpleNamespace(nodes={}),
     )
     controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
     capability = object()
@@ -1686,9 +1704,12 @@ def test_manager_trust_required_script_can_reload_and_rebuilds_trusted(
     node = types.SimpleNamespace(
         is_imagetool=True,
         imagetool=object(),
+        tool_window=None,
+        slicer_area=types.SimpleNamespace(_direct_reloadable=lambda: False),
         provenance_spec=spec,
         uid="node",
     )
+    manager._tool_graph.nodes[node.uid] = node
 
     def rebuild_script_provenance(
         spec_arg: ToolProvenanceSpec,

--- a/tests/interactive/imagetool/manager/provenance/test_editor_foundations.py
+++ b/tests/interactive/imagetool/manager/provenance/test_editor_foundations.py
@@ -1542,6 +1542,7 @@ def test_manager_script_replay_uses_workspace_document_trust() -> None:
     assert len(trust_checks) == 1
     assert trust_checks[0] is entries
 
+
 def test_manager_script_replay_stops_when_workspace_code_is_untrusted() -> None:
     manager = types.SimpleNamespace(
         _workspace_controller=types.SimpleNamespace(
@@ -1653,6 +1654,7 @@ def test_manager_provenance_lightweight_helper_edges() -> None:
         )
         is None
     )
+
 
 def test_manager_trust_required_script_can_reload_and_rebuilds_trusted(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/interactive/imagetool/manager/provenance/test_file_relinking.py
+++ b/tests/interactive/imagetool/manager/provenance/test_file_relinking.py
@@ -1104,7 +1104,7 @@ def test_manager_provenance_edit_controller_availability_branches() -> None:
 
     controller = _fake_edit_controller(
         _fake_edit_node(script_with_structured_step),
-        script_input_can_reload=lambda *_args, **_kwargs: False,
+        script_input_unavailable_reason=lambda *_args, **_kwargs: "Unavailable",
     )
     assert controller.can_edit_row(structured_row) == (True, "")
 
@@ -1146,7 +1146,7 @@ def test_manager_provenance_edit_controller_availability_branches() -> None:
     active_row = active_filter_spec.display_rows()[3]
     controller = _fake_edit_controller(
         _fake_edit_node(active_filter_spec, active_filter=active_filter),
-        script_input_can_reload=lambda *_args, **_kwargs: False,
+        script_input_unavailable_reason=lambda *_args, **_kwargs: "Unavailable",
     )
     assert controller.can_edit_row(active_row) == (True, "")
 
@@ -2618,7 +2618,7 @@ def test_manager_provenance_script_file_revert_reports_missing_source(
         _RecordingMessageDialog,
     )
     monkeypatch.setattr(
-        controller._manager,
+        controller._manager._lineage_controller,
         "_rebuild_script_provenance",
         raise_missing_rebuild,
     )

--- a/tests/interactive/imagetool/manager/provenance/test_file_relinking.py
+++ b/tests/interactive/imagetool/manager/provenance/test_file_relinking.py
@@ -1646,7 +1646,7 @@ def test_manager_provenance_file_edit_preserves_script_steps(
             return int(QtWidgets.QDialog.DialogCode.Accepted)
 
         def provenance_spec(self, **_kwargs: typing.Any) -> ToolProvenanceSpec:
-            return replacement.model_copy(update={"steps": script_spec.steps})
+            return replacement
 
         def selected_batch_peers(self):
             return ()

--- a/tests/interactive/imagetool/manager/provenance/test_restore_transforms.py
+++ b/tests/interactive/imagetool/manager/provenance/test_restore_transforms.py
@@ -10,7 +10,6 @@ from qtpy import QtCore, QtWidgets
 import erlab
 import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
 from erlab.interactive.imagetool import itool
-from erlab.interactive.imagetool._provenance._code import uses_default_replay_input
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     ToolProvenanceSpec,
@@ -508,7 +507,6 @@ def test_manager_transform_launch_modes_refresh_nested_and_detached(
             copied[-1],
             {"source_data": data.copy(deep=True)},
         )
-        assert not uses_default_replay_input(copied[-1])
         full_result = full_namespace["derived"]
         assert isinstance(full_result, xr.DataArray)
         xr.testing.assert_identical(

--- a/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
+++ b/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
@@ -19,7 +19,6 @@ from erlab.interactive._mesh import MeshTool
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool, ResolutionTool
 from erlab.interactive.imagetool import itool
-from erlab.interactive.imagetool._provenance._code import uses_default_replay_input
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     ScriptInput,
@@ -497,7 +496,6 @@ def test_manager_non_watched_full_code_prompts_for_source_variable(
 
         assert prompted == [node.uid]
         assert copied
-        assert not uses_default_replay_input(copied[-1])
         namespace = _exec_generated_code(
             copied[-1], {"source_data": test_data.copy(deep=True)}
         )
@@ -595,7 +593,6 @@ def test_manager_file_backed_full_code_uses_load_code(
         trigger_menu_action(menu, manager._metadata_copy_full_action)
 
         assert copied
-        assert not uses_default_replay_input(copied[-1])
         namespace = _exec_generated_code(copied[-1], {})
         xr.testing.assert_identical(namespace["derived"], test_data.qsel.mean("alpha"))
 

--- a/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
+++ b/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
@@ -20,7 +20,11 @@ from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool, ResolutionTool
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._provenance._code import uses_default_replay_input
-from erlab.interactive.imagetool._provenance._model import FileDataSelection, full_data
+from erlab.interactive.imagetool._provenance._model import (
+    FileDataSelection,
+    ScriptInput,
+    full_data,
+)
 from erlab.interactive.imagetool._provenance._operations import AverageOperation
 from erlab.interactive.imagetool.manager import fetch
 from erlab.interactive.imagetool.manager._server import _remove_idx, _show_idx
@@ -942,7 +946,15 @@ def test_manager_goldtool_child_side_panel(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         child = GoldTool(gold.copy(deep=True), data_name="gold_input")
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
+        child_uid = manager.add_childtool(
+            child,
+            script_inputs={"data": 0},
+            show=False,
+        )
         configure_goldtool_child(child, fitted=True, spline=True)
 
         manager.tree_view.clearSelection()
@@ -973,7 +985,15 @@ def test_manager_goldtool_child_side_panel_live_refresh(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         child = GoldTool(gold.copy(deep=True), data_name="gold_input")
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
+        child_uid = manager.add_childtool(
+            child,
+            script_inputs={"data": 0},
+            show=False,
+        )
         configure_goldtool_child(child, fitted=True, spline=False)
 
         manager.tree_view.clearSelection()
@@ -1004,9 +1024,14 @@ def test_manager_restool_child_side_panel(
         itool(gold, link=False, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
+        child = ResolutionTool(gold.copy(deep=True), data_name="gold_input")
+        child.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
         child_uid = manager.add_childtool(
-            ResolutionTool(gold.copy(deep=True), data_name="gold_input"),
-            0,
+            child,
+            script_inputs={"data": 0},
             show=False,
         )
 
@@ -1037,13 +1062,16 @@ def test_manager_restool_child_side_panel_live_refresh(
         itool(gold, link=False, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
+        child = ResolutionTool(gold.copy(deep=True), data_name="gold_input")
+        child.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
         child_uid = manager.add_childtool(
-            ResolutionTool(gold.copy(deep=True), data_name="gold_input"),
-            0,
+            child,
+            script_inputs={"data": 0},
             show=False,
         )
-        child = manager.get_childtool(child_uid)
-        assert isinstance(child, ResolutionTool)
 
         manager.tree_view.clearSelection()
         select_child_tool(manager, child_uid)
@@ -1076,9 +1104,14 @@ def test_manager_meshtool_child_side_panel(
         itool(test_data, link=False, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
+        child = MeshTool(test_data.copy(deep=True), data_name="mesh_input")
+        child.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
         child_uid = manager.add_childtool(
-            MeshTool(test_data.copy(deep=True), data_name="mesh_input"),
-            0,
+            child,
+            script_inputs={"data": 0},
             show=False,
         )
 
@@ -1109,13 +1142,16 @@ def test_manager_meshtool_child_side_panel_live_refresh(
         itool(test_data, link=False, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
+        child = MeshTool(test_data.copy(deep=True), data_name="mesh_input")
+        child.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
         child_uid = manager.add_childtool(
-            MeshTool(test_data.copy(deep=True), data_name="mesh_input"),
-            0,
+            child,
+            script_inputs={"data": 0},
             show=False,
         )
-        child = manager.get_childtool(child_uid)
-        assert isinstance(child, MeshTool)
 
         manager.tree_view.clearSelection()
         select_child_tool(manager, child_uid)
@@ -1375,9 +1411,8 @@ def test_manager_dependency_summary_coalesces_matching_input_name_and_label() ->
         data_role="displayed",
     )
     manager = types.SimpleNamespace(
-        _dependency_refs_for_uid=lambda _uid: (ref,),
+        _dependency_tracker=types.SimpleNamespace(refs_for_uid=lambda _uid: (ref,)),
         _tool_graph=types.SimpleNamespace(nodes={}),
-        _dependency_ref_has_recorded_file=lambda _spec, _ref: False,
     )
     controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
 

--- a/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
+++ b/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
@@ -815,6 +815,132 @@ def test_manager_watched_root_ftool_copy_code_1d_omits_duplicate_seed_and_noop_s
         _assert_modelfit_code_replays_source(copied[-1], "my_data", test_data)
 
 
+def test_manager_open_weighted_ftool_binds_replays_and_refreshes_inputs(
+    qtbot,
+    monkeypatch,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    x = np.linspace(-1.0, 1.0, 21)
+    data = xr.DataArray(
+        np.exp(-((x / 0.25) ** 2)),
+        dims=("x",),
+        coords={"x": x},
+        name="data",
+    )
+    uncertainty = xr.DataArray(
+        np.linspace(0.1, 0.2, x.size),
+        dims=("x",),
+        coords={"x": x},
+        name="uncertainty",
+    )
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager._data_ingress.receive_data(
+            [data], {}, watched_var=("data", "kernel-data")
+        )
+        manager._data_ingress.receive_data(
+            [uncertainty], {}, watched_var=("uncertainty", "kernel-uncertainty")
+        )
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+
+        data_node = manager._tool_graph.root_wrappers[0]
+        uncertainty_node = manager._tool_graph.root_wrappers[1]
+        child_uid = manager.open_weighted_ftool(data_node.uid, uncertainty_node.uid)
+
+        assert child_uid is not None
+        assert data_node._childtool_indices == [child_uid]
+        child = manager.get_childtool(child_uid)
+        assert isinstance(child, Fit1DTool)
+        assert [(item.name, item.node_uid) for item in child.script_inputs] == [
+            ("data", data_node.uid),
+            ("uncertainty", uncertainty_node.uid),
+        ]
+        copied = copy_full_code_for_uid(monkeypatch, manager, child_uid)
+        replayed = _exec_generated_code(
+            copied,
+            {
+                "data": data.copy(deep=True),
+                "uncertainty": uncertainty.copy(deep=True),
+            },
+        )["result"]
+        assert isinstance(replayed, xr.Dataset)
+        xr.testing.assert_identical(
+            replayed.modelfit_data, data.rename("modelfit_data")
+        )
+        xr.testing.assert_allclose(replayed.modelfit_weights, 1.0 / uncertainty)
+
+        manager._flush_idle_work(force=True)
+        qtbot.wait(0)
+        assert child.source_state == "fresh"
+
+        updates: list[dict[str, xr.DataArray]] = []
+        update_inputs = child.update_inputs
+
+        def _update_inputs(inputs: dict[str, xr.DataArray]) -> bool | None:
+            updates.append(dict(inputs))
+            return update_inputs(inputs)
+
+        monkeypatch.setattr(child, "update_inputs", _update_inputs)
+        child._set_source_auto_update(True)
+        updated_uncertainty = uncertainty * 2.0
+        manager._data_watched_update(
+            "uncertainty", "kernel-uncertainty", updated_uncertainty
+        )
+        manager._flush_idle_work(force=True)
+        qtbot.wait(0)
+
+        assert len(updates) == 1
+        assert set(updates[0]) == {"data", "uncertainty"}
+        xr.testing.assert_equal(updates[0]["data"], data)
+        xr.testing.assert_equal(updates[0]["uncertainty"], updated_uncertainty)
+        assert child.uncertainty is not None
+        xr.testing.assert_equal(child.uncertainty, updated_uncertainty)
+
+        manager.remove_imagetool(1)
+        qtbot.wait_until(lambda: child.source_state == "unavailable", timeout=5000)
+        assert data_node._childtool_indices == [child_uid]
+        assert child.uncertainty is not None
+
+
+def test_manager_open_weighted_ftool_rejects_invalid_uncertainty_input(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    uncertainty = xr.ones_like(test_data).rename("uncertainty")
+    invalid_uncertainty = uncertainty.isel(alpha=slice(1, None))
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        monkeypatch.setattr(
+            manager._actions_controller, "_show_operation_error", lambda *_: None
+        )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            show=False,
+        )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(
+                invalid_uncertainty, _in_manager=True
+            ),
+            show=False,
+        )
+
+        data_node = manager._tool_graph.root_wrappers[0]
+        invalid_node = manager._tool_graph.root_wrappers[1]
+        assert manager.open_weighted_ftool(data_node.uid, invalid_node.uid) is None
+        assert data_node._childtool_indices == []
+
+
 def test_manager_selecting_unfit_ftool_child_does_not_warn(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -4,7 +4,7 @@ import sys
 import types
 import typing
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 import numpy as np
 import pytest
@@ -29,13 +29,13 @@ from erlab.interactive.imagetool._provenance._model import (
     FileLoadSource,
     FileReplayCall,
     ScriptInput,
-    ScriptInputDependencyRef,
     compose_full_provenance,
     file_load,
     full_data,
     operation_group_range,
     script,
     selection,
+    to_replay_provenance_spec,
 )
 from erlab.interactive.imagetool._provenance._operations import (
     AverageOperation,
@@ -141,6 +141,26 @@ def test_manager_file_source_extension_status_reason(
 
     assert reason is not None
     assert expected in reason
+
+
+class _ScriptInputTreeTool(erlab.interactive.utils.ToolWindow):
+    tool_name = "dtool"
+
+    def __init__(self, data: xr.DataArray, *, tool_name: str = "dtool") -> None:
+        super().__init__()
+        self.tool_name = tool_name
+        self._data = data
+        self.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
+
+    @property
+    def tool_data(self) -> xr.DataArray:
+        return self._data
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self._data = inputs["data"]
 
 
 def test_manager_console(
@@ -270,9 +290,6 @@ def test_store_selected_supports_root_and_nested_child_imagetools(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    class _StoreTreeTool(erlab.interactive.utils.ToolWindow):
-        tool_name = "dtool"
-
     root_data = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
         dims=("x", "y"),
@@ -287,7 +304,11 @@ def test_store_selected_supports_root_and_nested_child_imagetools(
         manager.add_imagetool(root_tool, show=False)
         root_uid = manager._tool_graph.root_wrappers[0].uid
 
-        intermediate_uid = manager.add_childtool(_StoreTreeTool(), 0, show=False)
+        intermediate_uid = manager.add_childtool(
+            _ScriptInputTreeTool(root_data),
+            script_inputs={"data": 0},
+            show=False,
+        )
         child_tool = itool(child_data, manager=False, execute=False)
         assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
         child_uid = manager.add_imagetool_child(
@@ -866,6 +887,31 @@ def test_resolve_console_namespace_patches_before_lazy_import(monkeypatch) -> No
         "plt": "module:matplotlib.pyplot",
         "era": "module:erlab.analysis",
     }
+
+
+def test_tool_namespace_script_input_delegates_to_lineage() -> None:
+    expected = ScriptInput(name="canonical")
+    calls: list[tuple[object, str | None]] = []
+
+    class _Lineage:
+        def _script_input_for_node(
+            self, node: object, *, name: str | None = None
+        ) -> ScriptInput:
+            calls.append((node, name))
+            return expected
+
+    class _Manager:
+        _lineage_controller = _Lineage()
+
+    class _Wrapper:
+        manager = _Manager()
+        index = 4
+
+    wrapper = _Wrapper()
+    namespace = ToolNamespace(wrapper)  # type: ignore[arg-type]
+
+    assert namespace._script_input() is expected
+    assert calls == [(wrapper, "data_4")]
 
 
 def test_tool_namespace_get_data_item(
@@ -2054,9 +2100,6 @@ def test_manager_console_child_imagetool_access_tracks_provenance(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    class _ConsoleTreeTool(erlab.interactive.utils.ToolWindow):
-        tool_name = "dtool"
-
     data0 = xr.DataArray(
         np.arange(4.0).reshape(2, 2),
         dims=("x", "y"),
@@ -2078,8 +2121,12 @@ def test_manager_console_child_imagetool_access_tracks_provenance(
         itool([data0, data1], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
 
-        intermediate_tool = _ConsoleTreeTool()
-        intermediate_uid = manager.add_childtool(intermediate_tool, 0, show=False)
+        intermediate_tool = _ScriptInputTreeTool(data0)
+        intermediate_uid = manager.add_childtool(
+            intermediate_tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
         intermediate_node = manager._child_node(intermediate_uid)
         intermediate_node.name = "Derivative"
         child_tool = itool(child_data, manager=False, execute=False)
@@ -2246,9 +2293,6 @@ def test_manager_reload_script_input_uses_public_nested_1d_child_data(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    class _ConsoleTreeTool(erlab.interactive.utils.ToolWindow):
-        tool_name = "ftool"
-
     x = np.arange(3.0)
     eV = np.arange(5.0)
     data = xr.DataArray(
@@ -2274,8 +2318,12 @@ def test_manager_reload_script_input_uses_public_nested_1d_child_data(
         itool(data, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
-        intermediate_tool = _ConsoleTreeTool()
-        intermediate_uid = manager.add_childtool(intermediate_tool, 0, show=False)
+        intermediate_tool = _ScriptInputTreeTool(data, tool_name="ftool")
+        intermediate_uid = manager.add_childtool(
+            intermediate_tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
         manager._child_node(intermediate_uid).name = "Fit"
         child_tool = itool(shift, manager=False, execute=False)
         assert isinstance(child_tool, erlab.interactive.imagetool.ImageTool)
@@ -2314,7 +2362,7 @@ def test_manager_reload_script_input_uses_public_nested_1d_child_data(
 
         child_tool.slicer_area.replace_source_data(updated_shift)
 
-        rebuilt = manager._rebuild_script_provenance(
+        rebuilt = manager._lineage_controller._rebuild_script_provenance(
             spec,
             target_node_uid=manager._tool_graph.root_wrappers[shifted_index].uid,
         )
@@ -2919,10 +2967,9 @@ def test_manager_concat_can_replace_source_tool_and_preserve_children(
             None,
             manager._tool_graph.root_wrappers[1].snapshot_token,
         ]
-        assert (
-            replacement_provenance.script_inputs[0].parsed_provenance_spec()
-            == old_root_provenance
-        )
+        assert replacement_provenance.script_inputs[
+            0
+        ].parsed_provenance_spec() == to_replay_provenance_spec(old_root_provenance)
 
         dialog = manager._actions_controller._concat_dialog
         dialog._result_combo.setCurrentIndex(
@@ -3124,7 +3171,7 @@ def test_manager_displayed_script_inputs_track_and_reload_filters(
             operation,
             emit_edited=True,
         )
-        created_index = manager._show_multi_input_script_result(
+        created_index = manager._lineage_controller._show_multi_input_script_result(
             filtered0 + data1,
             (0, 1),
             operation_label="Add displayed ImageTools",
@@ -3177,7 +3224,7 @@ def test_manager_reload_script_inputs_replaces_compatible_and_preserves_cursor(
         itool([data0, data1], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data0 - data1,
                 (0, 1),
                 operation_label="Subtract inputs",
@@ -3269,7 +3316,7 @@ def test_manager_reload_script_inputs_normalizes_derived_1d_stack_dim(
         itool([data], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data.mean("y"),
                 (0,),
                 operation_label="Average input",
@@ -3292,7 +3339,7 @@ def test_manager_reload_script_inputs_normalizes_derived_1d_stack_dim(
         )
 
         monkeypatch.setattr(
-            manager,
+            manager._lineage_controller,
             "_prompt_incompatible_reload_commit",
             lambda _details: pytest.fail("compatible 1D reload prompted"),
         )
@@ -3341,7 +3388,7 @@ def test_manager_reload_script_derived_target_reports_runtime_error(
         itool(data, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data.copy(deep=True),
                 (0,),
                 operation_label="Runtime failure",
@@ -3351,13 +3398,15 @@ def test_manager_reload_script_derived_target_reports_runtime_error(
         )
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
 
-        assert not manager._reload_script_derived_target(1)
+        assert not manager._lineage_controller._reload_script_derived_target(1)
 
     assert len(critical_calls) == 1
     assert "ValueError" in str(critical_calls[0][1].get("detailed_text", ""))
 
 
-def test_manager_reload_script_derived_target_honors_trust_cancel() -> None:
+def test_manager_reload_script_derived_target_honors_trust_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     spec = script(
         ScriptCodeOperation(label="Copy", code="derived = data"),
         start_label="Run script",
@@ -3369,18 +3418,18 @@ def test_manager_reload_script_derived_target_honors_trust_cancel() -> None:
         raise manager_widgets._TrustedProvenanceReplayCancelled
 
     manager = types.SimpleNamespace(
+        _dependency_tracker=types.SimpleNamespace(),
         _node_for_target=lambda _target: node,
-        _rebuild_script_provenance=rebuild,
         _extensions=types.SimpleNamespace(
             execution=types.SimpleNamespace(
                 capture_replay_sources=lambda: contextlib.nullcontext(object())
             )
         ),
     )
+    controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
+    monkeypatch.setattr(controller, "_rebuild_script_provenance", rebuild)
 
-    assert not manager_lineage._LineageController(
-        typing.cast("typing.Any", manager)
-    )._reload_script_derived_target("node")
+    assert not controller._reload_script_derived_target("node")
 
 
 def test_manager_reload_script_derived_target_rejects_non_imagetool_result(
@@ -3402,15 +3451,29 @@ def test_manager_reload_script_derived_target_rejects_non_imagetool_result(
     )
     dialogs: list[str] = []
     manager = types.SimpleNamespace(
+        _dependency_tracker=types.SimpleNamespace(),
         _node_for_target=lambda _target: node,
-        _rebuild_script_provenance=lambda *_args, **_kwargs: result,
-        _reload_incompatibility_details=lambda *_args: "incompatible",
-        _prompt_incompatible_reload_commit=lambda _details: "new",
         _extensions=types.SimpleNamespace(
             execution=types.SimpleNamespace(
                 capture_replay_sources=lambda: contextlib.nullcontext(object())
             )
         ),
+    )
+    controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
+    monkeypatch.setattr(
+        controller,
+        "_rebuild_script_provenance",
+        lambda *_args, **_kwargs: result,
+    )
+    monkeypatch.setattr(
+        controller,
+        "_reload_incompatibility_details",
+        lambda *_args: "incompatible",
+    )
+    monkeypatch.setattr(
+        controller,
+        "_prompt_incompatible_reload_commit",
+        lambda _details: "new",
     )
     monkeypatch.setattr(erlab.interactive, "itool", lambda *_args, **_kwargs: object())
     monkeypatch.setattr(
@@ -3419,9 +3482,7 @@ def test_manager_reload_script_derived_target_rejects_non_imagetool_result(
         lambda _parent, _title, text, **_kwargs: dialogs.append(text),
     )
 
-    assert not manager_lineage._LineageController(
-        typing.cast("typing.Any", manager)
-    )._reload_script_derived_target("node")
+    assert not controller._reload_script_derived_target("node")
     assert dialogs == ["An error occurred while opening reloaded data."]
 
 
@@ -3445,7 +3506,7 @@ def test_manager_reload_script_inputs_normalizes_nonuniform_idx_dims(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         assert manager.get_imagetool(0).slicer_area.data.dims == ("x_idx", "y")
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data + 1.0,
                 (0,),
                 operation_label="Offset restored input",
@@ -3465,7 +3526,7 @@ def test_manager_reload_script_inputs_normalizes_nonuniform_idx_dims(
         )
 
         monkeypatch.setattr(
-            manager,
+            manager._lineage_controller,
             "_prompt_incompatible_reload_commit",
             lambda _details: pytest.fail("compatible nonuniform reload prompted"),
         )
@@ -3500,7 +3561,7 @@ def test_manager_reload_script_inputs_rebuilds_live_nested_input(
         itool([data0, data1], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data0 - data1,
                 (0, 1),
                 operation_label="Subtract inputs",
@@ -3510,7 +3571,7 @@ def test_manager_reload_script_inputs_rebuilds_live_nested_input(
         )
         qtbot.wait_until(lambda: manager.ntools == 3, timeout=5000)
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 (data0 - data1) + data0,
                 (2, 0),
                 operation_label="Add derived input",
@@ -3539,8 +3600,11 @@ def test_manager_reload_script_inputs_rebuilds_live_nested_input(
         assert manager.dependency_status_for_uid(final_uid) == "current"
         rebuilt_spec = manager._tool_graph.root_wrappers[3].provenance_spec
         assert rebuilt_spec is not None
-        assert rebuilt_spec.script_inputs[0].node_uid is None
-        nested_spec = rebuilt_spec.script_inputs[0].parsed_provenance_spec()
+        rebuilt_input = rebuilt_spec.script_inputs[0]
+        nested_wrapper = manager._tool_graph.root_wrappers[2]
+        assert rebuilt_input.node_uid == nested_wrapper.uid
+        assert rebuilt_input.node_snapshot_token == nested_wrapper.snapshot_token
+        nested_spec = rebuilt_input.parsed_provenance_spec()
         assert nested_spec is not None
         assert [source.node_uid for source in nested_spec.script_inputs] == [
             manager._tool_graph.root_wrappers[0].uid,
@@ -3567,7 +3631,7 @@ def test_manager_reload_script_inputs_after_workspace_roundtrip(
         itool([data0, data1], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data0 - data1,
                 (0, 1),
                 operation_label="Subtract inputs",
@@ -3647,7 +3711,7 @@ def test_manager_reload_script_inputs_incompatible_prompt_paths(
         itool([data0, data1], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data0 - data1,
                 (0, 1),
                 operation_label="Subtract inputs",
@@ -3664,14 +3728,18 @@ def test_manager_reload_script_inputs_incompatible_prompt_paths(
         select_tools(manager, [2])
 
         monkeypatch.setattr(
-            manager, "_prompt_incompatible_reload_commit", lambda _details: "cancel"
+            manager._lineage_controller,
+            "_prompt_incompatible_reload_commit",
+            lambda _details: "cancel",
         )
         manager.reload_selected()
         assert manager.ntools == 3
         xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, original)
 
         monkeypatch.setattr(
-            manager, "_prompt_incompatible_reload_commit", lambda _details: "new"
+            manager._lineage_controller,
+            "_prompt_incompatible_reload_commit",
+            lambda _details: "new",
         )
         manager.reload_selected()
         qtbot.wait_until(lambda: manager.ntools == 4, timeout=5000)
@@ -3681,7 +3749,9 @@ def test_manager_reload_script_inputs_incompatible_prompt_paths(
         manager.tree_view.deselect_all()
         select_tools(manager, [2])
         monkeypatch.setattr(
-            manager, "_prompt_incompatible_reload_commit", lambda _details: "replace"
+            manager._lineage_controller,
+            "_prompt_incompatible_reload_commit",
+            lambda _details: "replace",
         )
         manager.reload_selected()
         xr.testing.assert_identical(manager.get_imagetool(2).slicer_area.data, expected)
@@ -3727,7 +3797,7 @@ def test_manager_reload_script_inputs_uses_recorded_file_for_removed_parent(
             replay_source_data=None,
         )
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data0 - data1,
                 (0, 1),
                 operation_label="Subtract inputs",
@@ -3904,7 +3974,7 @@ def test_manager_reload_script_inputs_reuses_shared_recorded_file_prefix(
             replay_source_data=None,
         )
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 left_data - right_data,
                 (0, 1),
                 operation_label="Subtract inputs",
@@ -3929,11 +3999,11 @@ def test_manager_reload_script_inputs_reuses_shared_recorded_file_prefix(
         manager.remove_imagetool(1)
         manager.remove_imagetool(0)
         monkeypatch.setattr(
-            manager,
+            manager._lineage_controller,
             "_prompt_incompatible_reload_commit",
             lambda _details: "replace",
         )
-        assert manager._reload_script_derived_target(2)
+        assert manager._lineage_controller._reload_script_derived_target(2)
 
         xr.testing.assert_identical(
             manager.get_imagetool(2).slicer_area.data,
@@ -3971,7 +4041,7 @@ def test_manager_reload_script_inputs_missing_parent_without_source_noops(
         itool([data0, data1], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data0 - data1,
                 (0, 1),
                 operation_label="Subtract inputs",
@@ -4076,7 +4146,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         itool([data0, data1], manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
         assert (
-            manager._show_multi_input_script_result(
+            manager._lineage_controller._show_multi_input_script_result(
                 data0 - data1,
                 (0, 1),
                 operation_label="Subtract inputs",
@@ -4100,41 +4170,16 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         assert manager.dependency_status_badge_for_uid("missing") is None
         assert manager.dependency_status_tooltip_for_uid("missing") is None
         assert manager.dependency_input_summary_for_uid("missing") is None
-        assert not manager._missing_dependencies_have_recorded_file("missing")
-        assert manager._script_provenance_inputs_current(script_spec)
-        stale_input = script_spec.script_inputs[0].model_copy(
-            update={"node_snapshot_token": "stale"}
-        )
-        stale_spec = script_spec.model_copy(
-            update={"script_inputs": (stale_input, *script_spec.script_inputs[1:])}
-        )
-        missing_input = script_spec.script_inputs[0].model_copy(
-            update={"node_uid": "missing-parent"}
-        )
-        missing_spec = script_spec.model_copy(
-            update={"script_inputs": (missing_input, *script_spec.script_inputs[1:])}
-        )
-        assert not manager._script_provenance_inputs_current(stale_spec)
-        assert not manager._script_provenance_inputs_current(missing_spec)
 
         full_data_input = ScriptInput(
             name="full",
             label="Full data",
             provenance_spec=full_data().model_dump(mode="json"),
         )
-        assert not manager._script_input_can_reload(full_data_input)
-        assert manager._script_input_unavailable_reason(full_data_input) is not None
-        file_without_source_input = types.SimpleNamespace(
-            name="file_without_source",
-            node_uid=None,
-            label="File without source",
-            parsed_provenance_spec=lambda: file_spec.model_copy(
-                update={"file_load_source": None}
-            ),
-        )
-        assert not manager._script_input_can_reload(file_without_source_input)
         assert (
-            manager._script_input_unavailable_reason(file_without_source_input)
+            manager._lineage_controller._script_input_unavailable_reason(
+                full_data_input
+            )
             is not None
         )
         missing_file_input = ScriptInput(
@@ -4148,9 +4193,10 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
                 }
             ).model_dump(mode="json"),
         )
-        assert not manager._script_input_has_recorded_file(missing_file_input)
-        missing_file_reason = manager._script_input_unavailable_reason(
-            missing_file_input
+        missing_file_reason = (
+            manager._lineage_controller._script_input_unavailable_reason(
+                missing_file_input
+            )
         )
         assert missing_file_reason is not None
         assert str(tmp_path / "missing.nc") in missing_file_reason
@@ -4164,21 +4210,27 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             label="No replay call",
             parsed_provenance_spec=lambda: file_spec.model_copy(
                 update={
+                    "kind": "script",
                     "file_load_source": load_source.model_copy(
                         update={"replay_call": None}
-                    )
+                    ),
                 }
             ),
         )
-        assert not manager._script_input_can_reload(no_replay_call_input)
-        assert manager._script_input_unavailable_reason(no_replay_call_input)
+        assert manager._lineage_controller._script_input_unavailable_reason(
+            no_replay_call_input
+        )
         valid_file_input = ScriptInput(
             name="valid_file",
             label="Valid file",
             provenance_spec=file_spec.model_dump(mode="json"),
         )
-        assert manager._script_input_can_reload(valid_file_input)
-        assert manager._script_input_unavailable_reason(valid_file_input) is None
+        assert (
+            manager._lineage_controller._script_input_unavailable_reason(
+                valid_file_input
+            )
+            is None
+        )
 
         script_file_spec = script(
             start_label="Load recorded",
@@ -4191,9 +4243,12 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             label="Script-backed file",
             provenance_spec=script_file_spec.model_dump(mode="json"),
         )
-        assert manager._script_input_has_recorded_file(script_file_input)
-        assert manager._script_input_can_reload(script_file_input)
-        assert manager._script_input_unavailable_reason(script_file_input) is None
+        assert (
+            manager._lineage_controller._script_input_unavailable_reason(
+                script_file_input
+            )
+            is None
+        )
 
         missing_script_file = tmp_path / "missing-script.nc"
         missing_script_file_input = ScriptInput(
@@ -4207,10 +4262,10 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
                 }
             ).model_dump(mode="json"),
         )
-        assert not manager._script_input_has_recorded_file(missing_script_file_input)
-        assert not manager._script_input_can_reload(missing_script_file_input)
-        missing_script_reason = manager._script_input_unavailable_reason(
-            missing_script_file_input
+        missing_script_reason = (
+            manager._lineage_controller._script_input_unavailable_reason(
+                missing_script_file_input
+            )
         )
         assert missing_script_reason is not None
         assert str(missing_script_file) in missing_script_reason
@@ -4236,8 +4291,9 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
                 }
             ).model_dump(mode="json"),
         )
-        assert not manager._script_input_can_reload(missing_loader_input)
-        reason = manager._script_input_unavailable_reason(missing_loader_input)
+        reason = manager._lineage_controller._script_input_unavailable_reason(
+            missing_loader_input
+        )
         assert reason is not None
         assert missing_loader in reason
 
@@ -4251,9 +4307,10 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
                 script_inputs=(valid_file_input,),
             ).model_dump(mode="json"),
         )
-        assert not manager._script_input_can_reload(nonreplayable_script_input)
         assert (
-            manager._script_input_unavailable_reason(nonreplayable_script_input)
+            manager._lineage_controller._script_input_unavailable_reason(
+                nonreplayable_script_input
+            )
             is not None
         )
         nested_missing_input = ScriptInput(
@@ -4266,7 +4323,9 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
                 script_inputs=(missing_file_input,),
             ).model_dump(mode="json"),
         )
-        nested_reason = manager._script_input_unavailable_reason(nested_missing_input)
+        nested_reason = manager._lineage_controller._script_input_unavailable_reason(
+            nested_missing_input
+        )
         assert nested_reason is not None
         assert str(tmp_path / "missing.nc") in nested_reason
         nested_valid_input = ScriptInput(
@@ -4279,7 +4338,12 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
                 script_inputs=(valid_file_input,),
             ).model_dump(mode="json"),
         )
-        assert manager._script_input_unavailable_reason(nested_valid_input) is None
+        assert (
+            manager._lineage_controller._script_input_unavailable_reason(
+                nested_valid_input
+            )
+            is None
+        )
 
         file_marker = "file-marker"
         child_marker = "child-marker"
@@ -4297,23 +4361,10 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             active_name="derived",
             script_inputs=(file_input,),
         )
-        nested_input = ScriptInput(
-            name="nested",
-            label="Nested input",
-            provenance_spec=nested_spec.model_dump(mode="json"),
-        )
-        ref = ScriptInputDependencyRef(
-            name="file_input",
-            label="File input",
-            node_uid="missing-file-node",
-            node_snapshot_token=file_marker,
-        )
-        assert manager._script_input_has_recorded_file(file_input)
-        assert manager._script_input_has_recorded_file(nested_input)
-        assert manager._dependency_ref_has_recorded_file(nested_spec, ref)
-        assert not manager._dependency_ref_has_recorded_file(None, ref)
         derived_wrapper.set_displayed_provenance(nested_spec)
-        assert manager._missing_dependencies_have_recorded_file(derived_uid)
+        tooltip = manager.dependency_status_tooltip_for_uid(derived_uid)
+        assert tooltip is not None
+        assert "Recorded source files found" in tooltip
 
         fake_child = types.SimpleNamespace(
             uid="1 child-node",
@@ -4327,14 +4378,14 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             provenance_for_role=lambda _role: file_spec,
             type_badge_text="tool",
         )
-        script_input = manager._script_input_for_node(fake_child)
+        script_input = manager._lineage_controller._script_input_for_node(fake_child)
         assert script_input.name.startswith("data__1_child")
         assert script_input.label == "Child node"
         assert script_input.parsed_provenance_spec() == file_spec
 
         monkeypatch.setattr(manager_mainwindow.QtWidgets, "QMessageBox", FakeMessageBox)
         FakeMessageBox.instances.clear()
-        manager._show_dependency_reload_dialog(0)
+        manager._lineage_controller._show_dependency_reload_dialog(0)
         assert not FakeMessageBox.instances
 
         with monkeypatch.context() as patch:
@@ -4343,9 +4394,11 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
                 manager, "dependency_input_summary_for_uid", lambda _uid: None
             )
             patch.setattr(
-                manager, "_node_can_reload_script_inputs", lambda _node: False
+                manager._lineage_controller,
+                "_node_can_reload_script_inputs",
+                lambda _node: False,
             )
-            manager._show_dependency_reload_dialog(0)
+            manager._lineage_controller._show_dependency_reload_dialog(0)
         assert (
             FakeMessageBox.instances[-1].standard_buttons
             is FakeMessageBox.StandardButton.Close
@@ -4357,14 +4410,20 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             patch.setattr(
                 manager, "dependency_input_summary_for_uid", lambda _uid: "details"
             )
-            patch.setattr(manager, "_node_can_reload_script_inputs", lambda _node: True)
             patch.setattr(
-                manager, "_reload_script_derived_target", reload_targets.append
+                manager._lineage_controller,
+                "_node_can_reload_script_inputs",
+                lambda _node: True,
+            )
+            patch.setattr(
+                manager._lineage_controller,
+                "_reload_script_derived_target",
+                reload_targets.append,
             )
             FakeMessageBox.clicked_index = 0
-            manager._show_dependency_reload_dialog(0)
+            manager._lineage_controller._show_dependency_reload_dialog(0)
             FakeMessageBox.clicked_index = 1
-            manager._show_dependency_reload_dialog(0)
+            manager._lineage_controller._show_dependency_reload_dialog(0)
         assert reload_targets == [0]
 
         for clicked_index, expected in (
@@ -4374,9 +4433,14 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             (None, "cancel"),
         ):
             FakeMessageBox.clicked_index = clicked_index
-            assert manager._prompt_incompatible_reload_commit("details") == expected
+            assert (
+                manager._lineage_controller._prompt_incompatible_reload_commit(
+                    "details"
+                )
+                == expected
+            )
 
-        details = manager._reload_incompatibility_details(
+        details = manager._lineage_controller._reload_incompatibility_details(
             data0,
             data0.rename({"x": "energy"}).assign_coords(y=[10.0, 11.0]),
         )
@@ -4388,7 +4452,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
                 erlab.interactive, "itool", lambda *_args, **_kwargs: object()
             )
             assert (
-                manager._show_multi_input_script_result(
+                manager._lineage_controller._show_multi_input_script_result(
                     data0,
                     (0,),
                     operation_label="No tool",
@@ -4402,15 +4466,21 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             assert not manager._script_reload_from_slicer_area(object(), execute=False)
         with monkeypatch.context() as patch:
             patch.setattr(manager, "target_from_slicer_area", lambda _area: 0)
-            patch.setattr(manager, "_node_can_reload_script_inputs", lambda _node: True)
+            patch.setattr(
+                manager._lineage_controller,
+                "_node_can_reload_script_inputs",
+                lambda _node: True,
+            )
             assert manager._script_reload_from_slicer_area(object(), execute=False)
 
         lineage = manager._lineage_controller
         non_imagetool_node = types.SimpleNamespace(is_imagetool=False)
         assert lineage._node_reload_unavailable_reason(non_imagetool_node)
         closed_imagetool_node = types.SimpleNamespace(
+            uid="closed",
             is_imagetool=True,
             imagetool=None,
+            tool_window=None,
             pending_workspace_memory_payload=None,
         )
         assert lineage._node_reload_unavailable_reason(closed_imagetool_node)
@@ -4418,6 +4488,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             uid="pending-memory",
             is_imagetool=True,
             imagetool=None,
+            tool_window=None,
             pending_workspace_memory_payload=(
                 tmp_path / "workspace.itws",
                 "0/imagetool",
@@ -4430,6 +4501,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             uid="pending-file",
             is_imagetool=True,
             imagetool=None,
+            tool_window=None,
             pending_workspace_memory_payload=(
                 tmp_path / "workspace.itws",
                 "0/imagetool",
@@ -4441,6 +4513,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             uid="script-no-inputs",
             is_imagetool=True,
             imagetool=object(),
+            tool_window=None,
             slicer_area=types.SimpleNamespace(
                 _direct_reloadable=lambda: False,
                 _provenance_reloadable=lambda: False,
@@ -4457,6 +4530,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             uid="script-file-input",
             is_imagetool=True,
             imagetool=object(),
+            tool_window=None,
             slicer_area=script_no_inputs_node.slicer_area,
             provenance_spec=script(
                 ScriptCodeOperation(label="Use file", code="derived = valid_file"),
@@ -4468,23 +4542,34 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
         assert lineage._node_reload_unavailable_reason(script_file_input_node) is None
 
         with monkeypatch.context() as patch:
-            patch.setattr(manager, "_selected_reload_candidates", lambda: None)
-            assert manager._selected_reload_targets() is None
+            patch.setattr(
+                manager._lineage_controller,
+                "_selected_reload_candidates",
+                lambda: None,
+            )
             manager.reload_selected()
         with monkeypatch.context() as patch:
             patch.setattr(
-                manager,
+                manager._lineage_controller,
                 "_selected_reload_candidates",
                 lambda: ([0], {}, "blocked"),
             )
-            assert manager._selected_reload_targets() is None
+            assert manager._lineage_controller._selected_reload_candidates() == (
+                [0],
+                {},
+                "blocked",
+            )
         with monkeypatch.context() as patch:
             patch.setattr(
-                manager,
+                manager._lineage_controller,
                 "_selected_reload_candidates",
                 lambda: ([0], {}, None),
             )
-            assert manager._selected_reload_targets() == ([0], {})
+            assert manager._lineage_controller._selected_reload_candidates() == (
+                [0],
+                {},
+                None,
+            )
         with monkeypatch.context() as patch:
             patch.setattr(
                 manager,
@@ -4494,11 +4579,19 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
             assert manager._reload_unavailable_reason_for_target(0)
         with monkeypatch.context() as patch:
             patch.setattr(manager, "_node_for_target", lambda _target: object())
-            patch.setattr(manager, "_reload_target_for_child", lambda _uid: 0)
-            assert manager._reload_unavailable_reason_for_target("child") is None
-            patch.setattr(manager, "_reload_target_for_child", lambda _uid: None)
             patch.setattr(
-                manager,
+                manager._lineage_controller,
+                "_reload_target_for_child",
+                lambda _uid: 0,
+            )
+            assert manager._reload_unavailable_reason_for_target("child") is None
+            patch.setattr(
+                manager._lineage_controller,
+                "_reload_target_for_child",
+                lambda _uid: None,
+            )
+            patch.setattr(
+                manager._lineage_controller,
                 "_reload_unavailable_reason_for_child",
                 lambda _uid: "child reason",
             )
@@ -4520,10 +4613,7 @@ def test_manager_reload_helper_status_dialog_and_workspace_branches(
                 ),
             )
         )
-        assert manager._workspace_loaded_uid_map(
-            {old_parent_uid: 0, "missing": "missing"}
-        ) == {old_parent_uid: manager._tool_graph.root_wrappers[0].uid}
-        manager._rebase_loaded_workspace_dependency_refs(
+        manager._lineage_controller._rebase_loaded_workspace_dependency_refs(
             {old_parent_uid: 0, derived_wrapper.uid: 2, "missing": "missing"}
         )
         rebased_spec = derived_wrapper.provenance_spec
@@ -4625,7 +4715,7 @@ def test_manager_reload_raw_self_replacement_unavailable(
         manager.tree_view.deselect_all()
         select_tools(manager, [0])
         manager._update_actions()
-        assert not manager._node_can_reload_script_inputs(wrapper)
+        assert not manager._lineage_controller._node_can_reload_script_inputs(wrapper)
         assert manager.reload_action.isVisible()
         assert manager.reload_action.isEnabled()
 
@@ -4741,7 +4831,9 @@ def test_manager_reload_data_explains_non_replayable_script_provenance(
                 ),
                 start_label="Run opaque code",
                 active_name="derived",
-                script_inputs=(manager._script_input_for_node(wrapper),),
+                script_inputs=(
+                    manager._lineage_controller._script_input_for_node(wrapper),
+                ),
             ),
             replay_source_data=None,
         )

--- a/tests/interactive/imagetool/manager/test_dialogs.py
+++ b/tests/interactive/imagetool/manager/test_dialogs.py
@@ -38,6 +38,7 @@ from erlab.interactive.imagetool.manager._dialogs import (
     _NameFilterDialog,
     _NameMapEditorDialog,
     _text_to_loader_extension_value,
+    _WeightedFtoolDialog,
 )
 from erlab.interactive.imagetool.manager._spreadsheet_metadata import (
     _MAPPING_NAME_COLUMN,
@@ -138,6 +139,58 @@ def test_window_layout_minimum_size_validation(qtbot) -> None:
     assert window_layout.frame_rects_fit_windows(
         [window], [QtCore.QRect(0, 0, 100, 80)]
     )
+
+
+def test_weighted_ftool_dialog_assigns_distinct_targets(qtbot) -> None:
+    dialog = _WeightedFtoolDialog(None, [(3, "Data"), (7, "Uncertainty")])
+    qtbot.addWidget(dialog)
+
+    data_label = dialog.findChild(
+        QtWidgets.QLabel, "manager_weighted_ftool_data_target"
+    )
+    uncertainty_label = dialog.findChild(
+        QtWidgets.QLabel, "manager_weighted_ftool_uncertainty_target"
+    )
+    swap_button = dialog.findChild(
+        QtWidgets.QPushButton, "manager_weighted_ftool_swap_button"
+    )
+    button_box = dialog.findChild(
+        QtWidgets.QDialogButtonBox, "manager_weighted_ftool_button_box"
+    )
+    assert data_label is not None
+    assert uncertainty_label is not None
+    assert swap_button is not None
+    assert button_box is not None
+    assert (dialog.data_target, dialog.uncertainty_target) == (3, 7)
+
+    swap_button.click()
+    assert (dialog.data_target, dialog.uncertainty_target) == (7, 3)
+
+    button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok).click()
+    assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
+
+    cancel_dialog = _WeightedFtoolDialog(None, [(3, "Data"), (7, "Uncertainty")])
+    qtbot.addWidget(cancel_dialog)
+    cancel_button = cancel_dialog.findChild(
+        QtWidgets.QDialogButtonBox, "manager_weighted_ftool_button_box"
+    )
+    assert cancel_button is not None
+    cancel_button.button(QtWidgets.QDialogButtonBox.StandardButton.Cancel).click()
+    assert cancel_dialog.result() == QtWidgets.QDialog.DialogCode.Rejected
+
+
+@pytest.mark.parametrize(
+    "targets",
+    [[], [(1, "One")], [(1, "One"), (2, "Two"), (3, "Three")]],
+)
+def test_weighted_ftool_dialog_rejects_invalid_target_pairs(targets) -> None:
+    with pytest.raises(ValueError, match="exactly two"):
+        _WeightedFtoolDialog(None, targets)
+
+
+def test_weighted_ftool_dialog_rejects_duplicate_targets() -> None:
+    with pytest.raises(ValueError, match="must be distinct"):
+        _WeightedFtoolDialog(None, [(1, "A"), (1, "B")])
 
 
 def test_window_layout_dialog_uses_semantic_icon_controls(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/test_extensions.py
+++ b/tests/interactive/imagetool/manager/test_extensions.py
@@ -7624,8 +7624,22 @@ def test_workspace_script_remap_updates_node_provenance_owners(
             source_state="stale",
         )
         input_tool = _ExtensionInputTool(xr.DataArray([3.0]))
-        tool_uid = manager.add_childtool(input_tool, 0, show=False)
-        input_tool.set_input_provenance_spec(old_spec)
+        input_tool.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    source_spec=old_spec.model_dump(mode="json"),
+                    provenance_spec=old_spec.model_dump(mode="json"),
+                ),
+            ),
+            primary_input="data",
+        )
+        tool_uid = manager.add_childtool(
+            input_tool,
+            script_inputs={"data": child_uid},
+            show=False,
+        )
+        input_tool._pending_script_inputs = input_tool.script_inputs
         manager._workspace_state.mark_clean()
 
         manager._extensions._remap_workspace_script(
@@ -7639,13 +7653,34 @@ def test_workspace_script_remap_updates_node_provenance_owners(
         child_display = typing.cast(
             "ExtensionRoutineOperation", child.provenance_spec.operations[-1]
         )
+        tool_source_spec = input_tool.script_inputs[0].parsed_source_spec()
+        tool_input_spec = input_tool.script_inputs[0].parsed_provenance_spec()
+        pending_inputs = input_tool._pending_script_inputs
+        pending_tool_input_spec = (
+            None
+            if pending_inputs is None
+            else pending_inputs[0].parsed_provenance_spec()
+        )
+        if (
+            tool_source_spec is None
+            or tool_input_spec is None
+            or pending_tool_input_spec is None
+        ):
+            raise RuntimeError("ToolWindow input provenance was discarded")
+        tool_source = typing.cast(
+            "ExtensionRoutineOperation", tool_source_spec.operations[-1]
+        )
         tool_input = typing.cast(
-            "ExtensionRoutineOperation",
-            input_tool.input_provenance_spec.operations[-1],
+            "ExtensionRoutineOperation", tool_input_spec.operations[-1]
+        )
+        pending_tool_input = typing.cast(
+            "ExtensionRoutineOperation", pending_tool_input_spec.operations[-1]
         )
         assert child_source.script_name == "local_routines.py"
         assert child_display.script_name == "local_routines.py"
+        assert tool_source.script_name == "local_routines.py"
         assert tool_input.script_name == "local_routines.py"
+        assert pending_tool_input.script_name == "local_routines.py"
         assert {child_uid, tool_uid}.issubset(manager._workspace_state.dirty_state)
 
 
@@ -7724,12 +7759,16 @@ def test_workspace_script_remap_updates_pending_tool_provenance(
         parameters={},
     )
     old_spec = full_data(operation)
-    source_key = erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR
-    input_key = erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
-    attrs = {
-        source_key: json.dumps(old_spec.model_dump(mode="json")),
-        input_key: json.dumps(old_spec.model_dump(mode="json")),
-    }
+    attrs = erlab.interactive.utils.ToolWindow._saved_script_input_attrs(
+        (
+            ScriptInput(
+                name="data",
+                source_spec=old_spec.model_dump(mode="json"),
+                provenance_spec=old_spec.model_dump(mode="json"),
+            ),
+        ),
+        "data",
+    )
 
     with manager_context() as manager:
         manager.add_imagetool(
@@ -7745,12 +7784,6 @@ def test_workspace_script_remap_updates_pending_tool_provenance(
             name="Pending extension tool",
         )
         manager._register_child_node(node)
-        node.set_restored_source_binding_metadata(
-            old_spec,
-            None,
-            auto_update=False,
-            state="stale",
-        )
         node.set_pending_workspace_payload(
             "tool",
             tmp_path / "workspace.itws",
@@ -7766,12 +7799,16 @@ def test_workspace_script_remap_updates_pending_tool_provenance(
         pending_attrs = node.pending_workspace_payload_attrs
         if pending_attrs is None:
             raise RuntimeError("Pending ToolWindow attributes were discarded")
-        source_spec = ToolProvenanceSpec.model_validate(
-            json.loads(pending_attrs[source_key])
+        script_inputs, primary_input = (
+            erlab.interactive.utils.ToolWindow._saved_script_input_metadata(
+                pending_attrs
+            )
         )
-        input_spec = ToolProvenanceSpec.model_validate(
-            json.loads(pending_attrs[input_key])
-        )
+        assert primary_input == "data"
+        source_spec = script_inputs[0].parsed_source_spec()
+        input_spec = script_inputs[0].parsed_provenance_spec()
+        if source_spec is None or input_spec is None:
+            raise RuntimeError("Pending ToolWindow provenance was discarded")
         assert (
             typing.cast(
                 "ExtensionRoutineOperation", source_spec.operations[-1]

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -4480,9 +4480,21 @@ def test_manager_metadata_full_code_generated_only_when_copied(
 ) -> None:
     calls: list[str] = []
     copied: list[str] = []
+    graph = types.SimpleNamespace(required_input_keys=lambda _kind: ())
 
-    def fake_derivation_code(wrapper):
+    def fake_derivation_replay_graph(wrapper):
         calls.append(wrapper.uid)
+        return graph, "derived"
+
+    def fake_emit_replay_code(
+        received_graph,
+        *,
+        output_name: str,
+        input_name_overrides: dict[str, str],
+    ) -> str:
+        assert received_graph is graph
+        assert output_name == "derived"
+        assert input_name_overrides == {}
         return "derived = xr.DataArray([1.0])"
 
     monkeypatch.setattr(
@@ -4493,6 +4505,11 @@ def test_manager_metadata_full_code_generated_only_when_copied(
 
     with manager_context() as manager:
         manager.show()
+        monkeypatch.setattr(
+            manager,
+            "_prompt_replay_input_name",
+            lambda _node: pytest.fail("input-independent replay must not prompt"),
+        )
         itool(xr.DataArray([1.0], dims=("x",)), manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         wrapper = manager._tool_graph.root_wrappers[0]
@@ -4503,8 +4520,13 @@ def test_manager_metadata_full_code_generated_only_when_copied(
 
         monkeypatch.setattr(
             type(wrapper),
-            "derivation_code",
-            property(fake_derivation_code),
+            "_derivation_replay_graph",
+            fake_derivation_replay_graph,
+        )
+        monkeypatch.setattr(
+            manager_details_panel,
+            "emit_replay_code",
+            fake_emit_replay_code,
         )
         manager._set_metadata_node(wrapper)
 

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -113,7 +113,6 @@ from .helpers import (
     click_tree_view_pos,
     configure_goldtool_child,
     copy_full_code_for_uid,
-    metadata_derivation_texts,
     select_child_tool,
     select_tools,
     trigger_menu_action,
@@ -8346,6 +8345,13 @@ def test_manager_goldtool_output_itool_nests_under_tool(
 
         itool(gold, link=False, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        manager.get_imagetool(0).set_provenance_spec(
+            provenance_model.script(
+                start_label="Start from gold data",
+                seed_code="derived = gold_data",
+                active_name="derived",
+            )
+        )
 
         tool = GoldTool(gold.copy(deep=True), data_name="gold_input")
         tool.set_script_inputs(
@@ -8378,11 +8384,6 @@ def test_manager_goldtool_output_itool_nests_under_tool(
         manager.tree_view.clearSelection()
         select_child_tool(manager, output_uid)
         manager._update_info(uid=output_uid)
-        assert metadata_derivation_texts(manager) == [
-            "Start from current goldtool input data",
-            "Use data from ImageTool 0",
-            "Fit and correct current data with the polynomial edge model",
-        ]
         copied = copy_full_code_for_uid(monkeypatch, manager, output_uid)
         assert "era.gold.poly(" in copied
         assert "corrected = era.gold.correct_with_edge(" in copied
@@ -8404,6 +8405,13 @@ def test_manager_dtool_output_itool_nests_under_tool(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         parent_tool = manager.get_imagetool(0)
+        parent_tool.set_provenance_spec(
+            provenance_model.script(
+                start_label="Start from source data",
+                seed_code="derived = source_data",
+                active_name="derived",
+            )
+        )
         parent_tool.slicer_area.images[0].open_in_dtool()
         qtbot.wait_until(
             lambda: len(manager._tool_graph.root_wrappers[0]._childtools) == 1,
@@ -8442,7 +8450,7 @@ def test_manager_dtool_output_itool_nests_under_tool(
         copied = copy_full_code_for_uid(monkeypatch, manager, output_uid)
         namespace = _exec_generated_code(
             copied,
-            {"data": parent_tool.slicer_area.data.copy(deep=True)},
+            {"source_data": parent_tool.slicer_area.data.copy(deep=True)},
         )
         result = namespace["result"]
         assert isinstance(result, xr.DataArray)
@@ -8465,6 +8473,13 @@ def test_manager_ktool_output_itool_nests_under_tool(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         parent_tool = manager.get_imagetool(0)
+        parent_tool.set_provenance_spec(
+            provenance_model.script(
+                start_label="Start from angle data",
+                seed_code="derived = angle_data",
+                active_name="derived",
+            )
+        )
         parent_tool.slicer_area.open_in_ktool()
         qtbot.wait_until(
             lambda: len(manager._tool_graph.root_wrappers[0]._childtools) == 1,

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -298,7 +298,15 @@ def test_managed_window_actions_reveal_tree_and_figure_rows(
         second_uid = manager._tool_graph.root_wrappers[1].uid
 
         child_tool = erlab.interactive.utils.ToolWindow()
-        child_uid = manager.add_childtool(child_tool, 0, show=False)
+        child_tool.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
+        child_uid = manager.add_childtool(
+            child_tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
         figure_tool = FigureComposerTool(test_data)
         figure_uid = manager.add_figuretool(figure_tool, show=False)
         second_figure_uid = manager.add_figuretool(
@@ -396,8 +404,19 @@ def test_arrange_selected_windows_accepts_and_cancels(
         _add_batch_tools(qtbot, manager, test_data)
         first = erlab.interactive.utils.ToolWindow()
         second = erlab.interactive.utils.ToolWindow()
-        first_uid = manager.add_childtool(first, 0)
-        second_uid = manager.add_childtool(second, 0)
+        for tool in (first, second):
+            tool.set_script_inputs(
+                (ScriptInput(name="data", data_role="displayed"),),
+                primary_input="data",
+            )
+        first_uid = manager.add_childtool(
+            first,
+            script_inputs={"data": 0},
+        )
+        second_uid = manager.add_childtool(
+            second,
+            script_inputs={"data": 0},
+        )
         select_child_tool(manager, first_uid)
         select_child_tool(manager, second_uid)
         manager._update_actions()
@@ -472,7 +491,14 @@ def test_arrange_selected_windows_preserves_geometry_when_layout_does_not_fit(
             erlab.interactive.utils.ToolWindow(),
         ]
         for window in windows:
-            uid = manager.add_childtool(window, 0)
+            window.set_script_inputs(
+                (ScriptInput(name="data", data_role="displayed"),),
+                primary_input="data",
+            )
+            uid = manager.add_childtool(
+                window,
+                script_inputs={"data": 0},
+            )
             select_child_tool(manager, uid)
         original = [window.geometry() for window in windows]
 
@@ -517,7 +543,18 @@ def test_arrange_selected_windows_rolls_back_geometry_on_error(
             erlab.interactive.utils.ToolWindow(),
             erlab.interactive.utils.ToolWindow(),
         ]
-        uids = [manager.add_childtool(window, 0) for window in windows]
+        for window in windows:
+            window.set_script_inputs(
+                (ScriptInput(name="data", data_role="displayed"),),
+                primary_input="data",
+            )
+        uids = [
+            manager.add_childtool(
+                window,
+                script_inputs={"data": 0},
+            )
+            for window in windows
+        ]
         for uid in uids:
             select_child_tool(manager, uid)
         windows[0].setGeometry(80, 90, 320, 240)
@@ -3950,9 +3987,14 @@ def test_batch_action_updates_when_tool_child_subtree_removes_imagetool(
         manager.show()
         _add_batch_tools(qtbot, manager, _batch_data("scan0"))
 
+        tool = erlab.interactive.utils.ToolWindow()
+        tool.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
         tool_uid = manager.add_childtool(
-            erlab.interactive.utils.ToolWindow(),
-            0,
+            tool,
+            script_inputs={"data": 0},
             show=False,
         )
         child_tool = typing.cast(
@@ -6347,7 +6389,7 @@ def test_manager_childtool_source_updates(
         wrapper = manager._tool_graph.root_wrappers[0]
         uid, child = next(iter(wrapper._childtools.items()))
         assert isinstance(child, DerivativeTool)
-        assert child.source_spec is not None
+        assert child.script_inputs[0].source_spec is not None
 
         initial = test_data.transpose("eV", "alpha")
         xr.testing.assert_identical(child.tool_data, initial)
@@ -6392,14 +6434,18 @@ def test_manager_childtool_source_updates(
             dialog.update_button.click()  # type: ignore[attr-defined]
 
         refresh_calls: list[str] = []
-        original_refresh_chain = manager._refresh_source_chain_to_uid
+        original_refresh_chain = (
+            manager._lineage_controller._refresh_source_chain_to_uid
+        )
 
         def _track_refresh_chain(refresh_uid: str) -> bool:
             refresh_calls.append(refresh_uid)
             return original_refresh_chain(refresh_uid)
 
         monkeypatch.setattr(
-            manager, "_refresh_source_chain_to_uid", _track_refresh_chain
+            manager._lineage_controller,
+            "_refresh_source_chain_to_uid",
+            _track_refresh_chain,
         )
 
         click_child_status_badge(
@@ -7488,7 +7534,11 @@ def test_manager_reload_selected_child_tool_refreshes_from_file_parent(
         child_uid = manager._tool_graph.root_wrappers[0]._childtool_indices[0]
         child = manager.get_childtool(child_uid)
         assert isinstance(child, DerivativeTool)
-        child.set_source_binding(child.source_spec, auto_update=auto_update)
+        child.set_script_inputs(
+            child.script_inputs,
+            primary_input=child.primary_input,
+            auto_update=auto_update,
+        )
 
         updated = source.copy(deep=True)
         updated.data = np.asarray(updated.data) + 100.0
@@ -7944,7 +7994,7 @@ def test_manager_reload_mixed_child_selection_requires_all_children_eligible(
         xr.testing.assert_identical(fetch(eligible_uid), source.isel(x=slice(0, 2)))
 
 
-def test_manager_selected_reload_targets_handles_stale_selection(
+def test_manager_selected_reload_candidates_handle_stale_selection(
     monkeypatch,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -7967,9 +8017,15 @@ def test_manager_selected_reload_targets_handles_stale_selection(
             lambda _uid: (_ for _ in ()).throw(KeyError("missing")),
         )
 
-        assert manager._selected_reload_targets() is None
+        candidates = manager._lineage_controller._selected_reload_candidates()
+        assert candidates is not None
+        assert candidates[2] is not None
 
-        child_node = types.SimpleNamespace(has_source_binding=True)
+        child_node = types.SimpleNamespace(
+            has_source_binding=True,
+            tool_script_inputs=(),
+            is_imagetool=False,
+        )
         stale_selection.setattr(manager, "_child_node", lambda _uid: child_node)
         stale_selection.setattr(
             manager,
@@ -7977,7 +8033,9 @@ def test_manager_selected_reload_targets_handles_stale_selection(
             lambda _node: (_ for _ in ()).throw(KeyError("missing-parent")),
         )
 
-        assert manager._selected_reload_targets() is None
+        candidates = manager._lineage_controller._selected_reload_candidates()
+        assert candidates is not None
+        assert candidates[2] is not None
 
 
 def test_manager_reload_selected_skips_child_refresh_when_parent_reload_fails(
@@ -7988,16 +8046,25 @@ def test_manager_reload_selected_skips_child_refresh_when_parent_reload_fails(
 ) -> None:
     with manager_context() as manager, monkeypatch.context() as reload_failure:
         node = types.SimpleNamespace(
-            imagetool=object(),
-            slicer_area=types.SimpleNamespace(_reload=lambda: False),
+            uid="root",
+            tool_script_inputs=(),
+            is_imagetool=False,
+            imagetool=None,
+            provenance_spec=None,
+            reload_source_data=lambda: False,
+            tool_window=None,
         )
         refreshed: list[str] = []
         reload_failure.setattr(
-            manager, "_selected_reload_targets", lambda: ([0], {0: ["child"]})
+            manager._lineage_controller,
+            "_selected_reload_candidates",
+            lambda: ([0], {0: ["child"]}, None),
         )
         reload_failure.setattr(manager, "_node_for_target", lambda _target: node)
         reload_failure.setattr(
-            manager, "_refresh_source_chain_to_uid", refreshed.append
+            manager._lineage_controller,
+            "_refresh_source_chain_to_uid",
+            refreshed.append,
         )
         manager.reload_selected()
 
@@ -8028,7 +8095,9 @@ def test_manager_full_data_childtool_updates_follow_transposed_view(
             timeout=5000,
         )
 
-        child = next(iter(manager._tool_graph.root_wrappers[0]._childtools.values()))
+        child_uid, child = next(
+            iter(manager._tool_graph.root_wrappers[0]._childtools.items())
+        )
         xarray.testing.assert_identical(child.tool_data, parent_tool.slicer_area.data)
 
         replaced = test_data.copy(deep=True)
@@ -8038,17 +8107,29 @@ def test_manager_full_data_childtool_updates_follow_transposed_view(
             itool(replaced, manager=True, replace=0)
 
         qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
-        assert child._update_from_parent_source() is True
+        assert manager._lineage_controller._refresh_tool_inputs(
+            child_uid,
+            allow_recorded=False,
+        )
         xarray.testing.assert_identical(child.tool_data, parent_tool.slicer_area.data)
 
-        child.set_source_binding(child.source_spec, auto_update=True, state="fresh")
+        child.set_script_inputs(
+            child.script_inputs,
+            primary_input=child.primary_input,
+            auto_update=True,
+            state="fresh",
+        )
         replaced2 = replaced.copy(deep=True)
         replaced2.data = np.asarray(replaced2.data) + 5
 
         with qtbot.wait_signal(manager._sigDataReplaced):
             itool(replaced2, manager=True, replace=0)
 
-        qtbot.wait_until(lambda: child.source_state == "fresh", timeout=5000)
+        qtbot.wait_until(
+            lambda: child.tool_data.identical(parent_tool.slicer_area.data),
+            timeout=5000,
+        )
+        assert child.source_state == "fresh"
         xarray.testing.assert_identical(child.tool_data, parent_tool.slicer_area.data)
 
 
@@ -8176,9 +8257,14 @@ def test_manager_goldtool_output_itool_nests_under_tool(
         itool(gold, link=False, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
+        tool = GoldTool(gold.copy(deep=True), data_name="gold_input")
+        tool.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
         child_uid = manager.add_childtool(
-            GoldTool(gold.copy(deep=True), data_name="gold_input"),
-            0,
+            tool,
+            script_inputs={"data": 0},
             show=False,
         )
         child = manager.get_childtool(child_uid)
@@ -8204,6 +8290,7 @@ def test_manager_goldtool_output_itool_nests_under_tool(
         manager._update_info(uid=output_uid)
         assert metadata_derivation_texts(manager) == [
             "Start from current goldtool input data",
+            "Use data from ImageTool 0",
             "Fit and correct current data with the polynomial edge model",
         ]
         copied = copy_full_code_for_uid(monkeypatch, manager, output_uid)
@@ -8321,7 +8408,12 @@ def test_manager_ktool_output_itool_nests_under_tool(
         qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
         qtbot.wait_until(lambda: output_node.source_state == "stale", timeout=5000)
 
-        child.set_source_binding(child.source_spec, auto_update=True, state="fresh")
+        child.set_script_inputs(
+            child.script_inputs,
+            primary_input=child.primary_input,
+            auto_update=True,
+            state="fresh",
+        )
         output_node.set_output_binding(
             typing.cast("str", output_node.output_id),
             provenance_spec=output_node.provenance_spec,
@@ -8431,12 +8523,14 @@ def test_manager_ktool_output_itool_marks_stale_without_recomputing(
         assert call_count == 0
         xr.testing.assert_identical(fetch(output_uid), before)
         qtbot.wait_until(
-            lambda: metadata_updates == [child_uid],
+            lambda: (
+                bool(metadata_updates)
+                and not manager._details_refresh_queue.pending_uids
+                and not manager._details_refresh_queue.is_active()
+            ),
             timeout=2000,
         )
-        assert metadata_updates == [child_uid]
-        assert not manager._details_refresh_queue.pending_uids
-        assert not manager._details_refresh_queue.is_active()
+        assert set(metadata_updates) == {child_uid}
 
         state_changes: list[str] = []
         monkeypatch.setattr(
@@ -8480,7 +8574,12 @@ def test_manager_reused_output_child_keeps_stale_state(
         output_uid = child_node._childtool_indices[0]
         output_node = manager._child_node(output_uid)
 
-        child.set_source_binding(child.source_spec, auto_update=False, state="stale")
+        child.set_script_inputs(
+            child.script_inputs,
+            primary_input=child.primary_input,
+            auto_update=False,
+            state="stale",
+        )
         output_node.set_output_binding(
             typing.cast("str", output_node.output_id),
             provenance_spec=output_node.provenance_spec,
@@ -8538,7 +8637,12 @@ def test_manager_dtool_output_itool_refreshes_with_parent_updates(
         qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
         qtbot.wait_until(lambda: output_node.source_state == "stale", timeout=5000)
 
-        child.set_source_binding(child.source_spec, auto_update=True, state="fresh")
+        child.set_script_inputs(
+            child.script_inputs,
+            primary_input=child.primary_input,
+            auto_update=True,
+            state="fresh",
+        )
         output_node.set_output_binding(
             typing.cast("str", output_node.output_id),
             provenance_spec=output_node.provenance_spec,
@@ -8588,7 +8692,12 @@ def test_manager_output_itool_auto_update_can_be_disabled_from_auto_badge(
         output_uid = child_node._childtool_indices[0]
         output_node = manager._child_node(output_uid)
 
-        child.set_source_binding(child.source_spec, auto_update=True, state="fresh")
+        child.set_script_inputs(
+            child.script_inputs,
+            primary_input=child.primary_input,
+            auto_update=True,
+            state="fresh",
+        )
 
         replaced = test_data.copy(deep=True)
         replaced.data = np.asarray(replaced.data) * 2

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -3144,6 +3144,96 @@ def test_batch_operation_metadata_matches_launcher() -> None:
     assert RestoreNonuniformDimsOperation.batch_available
 
 
+def test_weighted_ftool_action_routes_assigned_targets(
+    qtbot,
+    monkeypatch,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        assert manager.weighted_ftool_action.objectName() == (
+            "manager_open_weighted_ftool_action"
+        )
+        assert manager.weighted_ftool_action in manager.edit_menu.actions()
+        assert manager.weighted_ftool_action in manager.tree_view._menu.actions()
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            show=False,
+        )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(
+                xr.ones_like(test_data), _in_manager=True
+            ),
+            show=False,
+        )
+
+        select_tools(manager, [0])
+        assert not manager.weighted_ftool_action.isEnabled()
+        select_tools(manager, [0, 1])
+        assert manager.weighted_ftool_action.isEnabled()
+
+        calls: list[tuple[int | str, int | str]] = []
+        monkeypatch.setattr(
+            manager._actions_controller,
+            "open_weighted_ftool",
+            lambda data, uncertainty: calls.append((data, uncertainty)) or None,
+        )
+
+        class _Dialog:
+            result = QtWidgets.QDialog.DialogCode.Accepted
+            data_target = 1
+            uncertainty_target = 0
+
+            def __init__(self, _parent, _targets) -> None:
+                pass
+
+            def exec(self) -> QtWidgets.QDialog.DialogCode:
+                return self.result
+
+        monkeypatch.setattr(manager_actions, "_WeightedFtoolDialog", _Dialog)
+        manager.weighted_ftool_action.trigger()
+        assert calls == [(1, 0)]
+
+        _Dialog.result = QtWidgets.QDialog.DialogCode.Rejected
+        manager.weighted_ftool_action.trigger()
+        assert calls == [(1, 0)]
+
+
+def test_open_weighted_ftool_rejects_invalid_targets(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            show=False,
+        )
+        data_node = manager._tool_graph.root_wrappers[0]
+
+        with pytest.raises(ValueError, match="must use different ImageTools"):
+            manager.open_weighted_ftool(data_node.uid, data_node.uid)
+
+        child = erlab.interactive.ftool(test_data, execute=False)
+        child.set_script_inputs((ScriptInput(name="data"),), primary_input="data")
+        child_uid = manager.add_childtool(
+            child,
+            script_inputs={"data": data_node.uid},
+            parent=data_node.uid,
+            show=False,
+        )
+        with pytest.raises(TypeError, match="inputs must be ImageTools"):
+            manager.open_weighted_ftool(data_node.uid, child_uid)
+
+
 def test_batch_dialog_defensive_paths_and_launch(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -6,7 +6,7 @@ import pathlib
 import tempfile
 import types
 import typing
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 import numpy as np
 import pydantic
@@ -98,7 +98,7 @@ def test_details_refresh_queue_ignores_superseded_idle_request(qtbot) -> None:
     qtbot.wait_until(lambda: direct_flushed == [{"direct-node"}])
 
 
-def test_dependency_tracker_uses_passive_tool_provenance() -> None:
+def test_dependency_tracker_uses_tool_script_inputs() -> None:
     source = script(
         start_label="Source",
         seed_code="source = data",
@@ -118,29 +118,14 @@ def test_dependency_tracker_uses_passive_tool_provenance() -> None:
         ),
     )
 
-    class _PassiveTool:
-        def current_provenance_spec(
-            self, *, flush_deferred_restore: bool = True
-        ) -> ToolProvenanceSpec:
-            assert flush_deferred_restore is False
-            return dependent
-
     class _PassiveNode:
+        is_imagetool = False
         provenance_revision = 0
+        tool_script_inputs = dependent.script_inputs
 
         @property
         def tool_window(self):
-            return _PassiveTool()
-
-        @property
-        def passive_displayed_provenance_spec(self):
-            return self.tool_window.current_provenance_spec(
-                flush_deferred_restore=False
-            )
-
-        @property
-        def displayed_provenance_spec(self):
-            pytest.fail("dependency tracking must not request flushing provenance")
+            pytest.fail("dependency tracking must not inspect the ToolWindow")
 
     graph = types.SimpleNamespace(nodes={"dependent-uid": _PassiveNode()})
     tracker = _ManagerDependencyTracker(typing.cast("_ManagerToolGraph", graph))
@@ -180,13 +165,17 @@ def test_dependency_tracker_indexes_dependents_and_caches_status() -> None:
         return snapshot[0]
 
     source_node = types.SimpleNamespace(
+        is_imagetool=True,
         tool_window=None,
+        tool_script_inputs=(),
         provenance_spec=None,
         provenance_revision=0,
         snapshot_token_for_role=_snapshot_token_for_role,
     )
     dependent_node = types.SimpleNamespace(
+        is_imagetool=True,
         tool_window=None,
+        tool_script_inputs=(),
         provenance_spec=dependent_spec,
         provenance_revision=0,
     )
@@ -229,6 +218,7 @@ def test_dependency_tracker_indexes_dependents_and_caches_status() -> None:
 
 def test_dependency_tracker_drops_missing_uid_from_pending_index() -> None:
     node = types.SimpleNamespace(
+        is_imagetool=True,
         tool_window=None,
         provenance_spec=None,
         provenance_revision=0,
@@ -261,7 +251,9 @@ def test_dependency_tracker_cache_follows_node_identity_and_revision(
         )
 
     node = types.SimpleNamespace(
+        is_imagetool=True,
         tool_window=None,
+        tool_script_inputs=(),
         provenance_spec=_dependent_spec("source-a"),
         provenance_revision=0,
     )
@@ -291,7 +283,9 @@ def test_dependency_tracker_cache_follows_node_identity_and_revision(
     assert ref_scans == 2
 
     replacement = types.SimpleNamespace(
+        is_imagetool=True,
         tool_window=None,
+        tool_script_inputs=(),
         provenance_spec=_dependent_spec("source-c"),
         provenance_revision=node.provenance_revision,
     )
@@ -326,22 +320,30 @@ def test_dependency_tracker_does_not_scan_all_nodes_for_dependents() -> None:
     nodes = _NoIterationDict(
         {
             "source-uid": types.SimpleNamespace(
+                is_imagetool=True,
                 tool_window=None,
+                tool_script_inputs=(),
                 provenance_spec=source_spec,
                 provenance_revision=0,
             ),
             "dependent-b": types.SimpleNamespace(
+                is_imagetool=True,
                 tool_window=None,
+                tool_script_inputs=(),
                 provenance_spec=dependent_spec,
                 provenance_revision=0,
             ),
             "unrelated": types.SimpleNamespace(
+                is_imagetool=True,
                 tool_window=None,
+                tool_script_inputs=(),
                 provenance_spec=None,
                 provenance_revision=0,
             ),
             "dependent-a": types.SimpleNamespace(
+                is_imagetool=True,
                 tool_window=None,
+                tool_script_inputs=(),
                 provenance_spec=dependent_spec,
                 provenance_revision=0,
             ),
@@ -558,12 +560,31 @@ class _InfoRefreshTool(erlab.interactive.utils.ToolWindow[_InfoRefreshToolState]
     StateModel = _InfoRefreshToolState
     tool_name = "info-refresh"
 
-    def __init__(self, data: xr.DataArray) -> None:
+    def __init__(
+        self,
+        data: xr.DataArray,
+        *,
+        source_spec: ToolProvenanceSpec | None = None,
+    ) -> None:
         super().__init__()
         self._data = data
         self._status = _InfoRefreshToolState()
         self._info_text = "initial child info"
         self.info_text_requests = 0
+        self.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    data_role="displayed",
+                    source_spec=(
+                        None
+                        if source_spec is None
+                        else source_spec.model_dump(mode="json")
+                    ),
+                ),
+            ),
+            primary_input="data",
+        )
 
     @property
     def tool_data(self) -> xr.DataArray:
@@ -585,6 +606,9 @@ class _InfoRefreshTool(erlab.interactive.utils.ToolWindow[_InfoRefreshToolState]
     def emit_info_text(self, text: str) -> None:
         self._info_text = text
         self.sigInfoChanged.emit()
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self._data = inputs["data"]
 
 
 def test_childtool_hover_preview_hides_missing_imageitem_pixmap(
@@ -1438,7 +1462,16 @@ def test_childtool_remove_after_tree_clear(
         test_data.qshow(manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
-        uid = manager.add_childtool(erlab.interactive.utils.ToolWindow(), 0, show=False)
+        tool = erlab.interactive.utils.ToolWindow()
+        tool.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
+        uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
         qtbot.wait_until(
             lambda: uid in manager._tool_graph.root_wrappers[0]._childtool_indices,
             timeout=5000,
@@ -1469,7 +1502,7 @@ def test_childtool_info_changed_debounces_manager_details_refresh(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         qtbot.wait_until(
             lambda: uid in manager._tool_graph.root_wrappers[0]._childtool_indices,
             timeout=5000,
@@ -1523,7 +1556,7 @@ def test_childtool_info_text_is_cached_until_info_changes(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         child_node = manager._child_node(uid)
         tool.info_text_requests = 0
         child_node._invalidate_info_text_cache()
@@ -1705,12 +1738,30 @@ def test_dependency_refresh_batches_contiguous_rows_by_parent(
         (test_data + 1).qshow(manager=True)
         qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
 
-        first_uid = manager.add_childtool(_InfoRefreshTool(test_data), 0, show=False)
-        second_uid = manager.add_childtool(_InfoRefreshTool(test_data), 0, show=False)
-        manager.add_childtool(_InfoRefreshTool(test_data), 0, show=False)
-        sparse_uid = manager.add_childtool(_InfoRefreshTool(test_data), 0, show=False)
+        first_uid = manager.add_childtool(
+            _InfoRefreshTool(test_data),
+            script_inputs={"data": 0},
+            show=False,
+        )
+        second_uid = manager.add_childtool(
+            _InfoRefreshTool(test_data),
+            script_inputs={"data": 0},
+            show=False,
+        )
+        manager.add_childtool(
+            _InfoRefreshTool(test_data),
+            script_inputs={"data": 0},
+            show=False,
+        )
+        sparse_uid = manager.add_childtool(
+            _InfoRefreshTool(test_data),
+            script_inputs={"data": 0},
+            show=False,
+        )
         other_parent_uid = manager.add_childtool(
-            _InfoRefreshTool(test_data), 1, show=False
+            _InfoRefreshTool(test_data),
+            script_inputs={"data": 1},
+            show=False,
         )
         qtbot.wait_until(
             lambda: (
@@ -1724,8 +1775,8 @@ def test_dependency_refresh_batches_contiguous_rows_by_parent(
             manager._tool_graph.root_wrappers[1].uid,
         ]
         monkeypatch.setattr(
-            manager,
-            "_dependency_dependent_uids",
+            manager._dependency_tracker,
+            "dependent_uids",
             lambda uid: (
                 [
                     *root_uids,
@@ -1926,7 +1977,9 @@ def test_managed_node_window_replacement_preserves_classification(
         assert isinstance(parent, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(parent, show=False)
         original_tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(original_tool, 0, show=False)
+        uid = manager.add_childtool(
+            original_tool, script_inputs={"data": 0}, show=False
+        )
         node = manager._child_node(uid)
         replacement_tool = _InfoRefreshTool(test_data)
         node.window = replacement_tool
@@ -1977,7 +2030,7 @@ def test_destroyed_managed_tool_releases_node_resources(
         manager.add_imagetool(parent, show=False)
         tool = _InfoRefreshTool(test_data)
         qtbot.addWidget(tool)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         node = manager._child_node(uid)
         reference_dataset = _ReferenceDataset()
         node._adopt_workspace_reference_datasets(
@@ -2027,7 +2080,7 @@ def test_tool_provenance_spec_is_cached_between_tool_signals(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         child_node = manager._child_node(uid)
         provenance = full_data()
         calls: list[bool] = []
@@ -2089,7 +2142,7 @@ def test_tool_provenance_revision_recovers_from_missed_signal(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         child_node = manager._child_node(uid)
         provenance = full_data()
         calls: list[bool] = []
@@ -2114,7 +2167,14 @@ def test_tool_provenance_revision_recovers_from_missed_signal(
         )
         tool.blockSignals(True)
         try:
-            tool.set_input_provenance_spec(provenance)
+            tool.set_script_inputs(
+                (
+                    tool.script_inputs[0].model_copy(
+                        update={"provenance_spec": provenance.model_dump(mode="json")}
+                    ),
+                ),
+                primary_input="data",
+            )
         finally:
             tool.blockSignals(False)
 
@@ -2124,9 +2184,8 @@ def test_tool_provenance_revision_recovers_from_missed_signal(
         assert calls == [False, False]
 
 
-def test_tool_provenance_change_reindexes_and_refreshes_dependency_metadata(
+def test_tool_input_change_reindexes_and_refreshes_dependency_metadata(
     qtbot,
-    monkeypatch,
     test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -2135,57 +2194,40 @@ def test_tool_provenance_change_reindexes_and_refreshes_dependency_metadata(
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         test_data.qshow(manager=True)
-        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        (test_data + 1).qshow(manager=True)
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
-        child_node = manager._child_node(uid)
-        source_node = manager._tool_graph.root_wrappers[0]
-        provenance = script(
-            start_label="Initial tool provenance",
-            seed_code="derived = 1",
-            active_name="derived",
-        )
-
-        def _current_provenance_spec(*, flush_deferred_restore: bool = True):
-            del flush_deferred_restore
-            return provenance
-
-        monkeypatch.setattr(
-            tool,
-            "current_provenance_spec",
-            _current_provenance_spec,
-        )
-        child_node._invalidate_tool_provenance_spec_cache()
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
+        first_source = manager._tool_graph.root_wrappers[0]
+        second_source = manager._tool_graph.root_wrappers[1]
         select_child_tool(manager, uid)
         manager._flush_idle_work(force=True)
         manager._flush_idle_work(force=True)
 
-        assert manager.dependency_status_for_uid(uid) is None
-        assert "Inputs" not in manager._metadata_detail_labels
+        assert manager.dependency_status_for_uid(uid) == "current"
+        assert uid in manager._dependency_tracker.dependent_uids(first_source.uid)
+        assert uid not in manager._dependency_tracker.dependent_uids(second_source.uid)
+        assert "Inputs" in manager._metadata_detail_labels
 
-        provenance = script(
-            ScriptCodeOperation(label="Use source", code="derived = source"),
-            start_label="Updated tool provenance",
-            active_name="derived",
-            script_inputs=(
-                ScriptInput(
-                    name="source",
-                    label="Source",
-                    node_uid=source_node.uid,
-                    node_snapshot_token=source_node.snapshot_token,
-                    provenance_spec=full_data(),
-                ),
-            ),
+        rebound_input = manager._lineage_controller._script_input_for_node(
+            second_source,
+            data_role="displayed",
+        ).model_copy(
+            update={
+                "name": "data",
+                "source_spec": tool.script_inputs[0].source_spec,
+            }
         )
-        tool._write_state()
+        tool.set_script_inputs((rebound_input,), primary_input="data")
 
         assert ("node-change", uid) in manager._interaction_gate.pending_keys
         manager._flush_idle_work(force=True)
         manager._details_refresh_queue.flush()
 
         assert manager.dependency_status_for_uid(uid) == "current"
-        assert uid in manager._dependency_dependent_uids(source_node.uid)
+        assert uid not in manager._dependency_tracker.dependent_uids(first_source.uid)
+        assert uid in manager._dependency_tracker.dependent_uids(second_source.uid)
         assert "Inputs" in manager._metadata_detail_labels
 
 
@@ -2248,7 +2290,7 @@ def test_manager_signals_do_not_restart_interaction_delay(
         )
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         child_node = manager._child_node(uid)
         child_node._handle_tool_info_changed()
         child_node._handle_tool_state_changed()
@@ -2316,7 +2358,7 @@ def test_tool_preview_refresh_uses_one_restartable_timer(
         test_data.qshow(manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         select_child_tool(manager, uid)
         requests: list[int] = []
         monkeypatch.setattr(
@@ -2347,9 +2389,8 @@ def test_copy_full_code_materializes_tool_provenance_on_demand(
         test_data.qshow(manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
-        tool = _InfoRefreshTool(test_data)
-        tool.set_source_binding(full_data(), auto_update=False)
-        uid = manager.add_childtool(tool, 0, show=False)
+        tool = _InfoRefreshTool(test_data, source_spec=full_data())
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         child_node = manager._child_node(uid)
         source_node = manager._tool_graph.root_wrappers[0]
         source_provenance = script(
@@ -2390,12 +2431,14 @@ def test_copy_full_code_materializes_tool_provenance_on_demand(
         )
         child_node._invalidate_tool_provenance_spec_cache()
 
-        select_child_tool(manager, uid)
-
-        assert manager._metadata_full_code_available
+        assert child_node.passive_displayed_provenance_spec is None
         assert calls == [False]
-        assert manager.dependency_status_for_uid(uid) is None
-        assert uid not in manager._dependency_dependent_uids(source_node.uid)
+        assert manager.dependency_status_for_uid(uid) == "current"
+        assert uid in manager._dependency_tracker.dependent_uids(source_node.uid)
+
+        select_child_tool(manager, uid)
+        assert manager._metadata_full_code_available
+        assert calls == [False, True]
 
         menu = manager._build_metadata_derivation_menu(include_row_actions=False)
         assert menu is not None
@@ -2403,9 +2446,9 @@ def test_copy_full_code_materializes_tool_provenance_on_demand(
         manager._metadata_copy_full_action.trigger()
         manager._flush_idle_work(force=True)
 
-        assert calls == [False, True]
+        assert calls == [False, True, True]
         assert manager.dependency_status_for_uid(uid) == "current"
-        assert uid in manager._dependency_dependent_uids(source_node.uid)
+        assert uid in manager._dependency_tracker.dependent_uids(source_node.uid)
         namespace: dict[str, object] = {}
         exec(copied[0], namespace)  # noqa: S102
         assert namespace["derived"] == 2
@@ -2425,7 +2468,7 @@ def test_full_tool_provenance_promotion_refreshes_cached_derivation(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         child_node = manager._child_node(uid)
         provenance = script(
             start_label="Deferred tool provenance",
@@ -2444,15 +2487,11 @@ def test_full_tool_provenance_promotion_refreshes_cached_derivation(
             _current_provenance_spec,
         )
         child_node._invalidate_tool_provenance_spec_cache()
-        select_child_tool(manager, uid)
 
         assert child_node.derivation_display_rows == ()
-        assert manager.metadata_derivation_list.topLevelItemCount() == 0
         assert calls == [False]
 
-        assert child_node.derivation_code
-        manager._flush_idle_work(force=True)
-        manager._details_refresh_queue.flush()
+        select_child_tool(manager, uid)
 
         assert calls == [False, True]
         assert child_node.derivation_display_rows
@@ -2472,9 +2511,8 @@ def test_repeated_stale_propagation_does_not_refresh_unchanged_child(
         test_data.qshow(manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
-        tool = _InfoRefreshTool(test_data)
-        tool.set_source_binding(full_data(), auto_update=False)
-        uid = manager.add_childtool(tool, 0, show=False)
+        tool = _InfoRefreshTool(test_data, source_spec=full_data())
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         root = manager._tool_graph.root_wrappers[0]
         refreshed_uids: list[str | None] = []
         info_changes: list[None] = []
@@ -2485,14 +2523,14 @@ def test_repeated_stale_propagation_does_not_refresh_unchanged_child(
             lambda target_uid=None: refreshed_uids.append(target_uid),
         )
 
-        manager._propagate_source_change_from_uid(root.uid, test_data)
+        manager._lineage_controller._propagate_source_state_from_uid(root.uid, "stale")
         assert tool.source_state == "stale"
         assert uid in refreshed_uids
         assert info_changes == [None]
 
         refreshed_uids.clear()
         info_changes.clear()
-        manager._propagate_source_change_from_uid(root.uid, test_data)
+        manager._lineage_controller._propagate_source_state_from_uid(root.uid, "stale")
         assert refreshed_uids == []
         assert info_changes == []
 
@@ -2511,7 +2549,7 @@ def test_childtool_state_changed_marks_dirty_without_details_refresh(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         qtbot.wait_until(
             lambda: uid in manager._tool_graph.root_wrappers[0]._childtool_indices,
             timeout=5000,
@@ -2766,7 +2804,7 @@ def test_childtool_data_changed_deduplicates_descendant_refresh(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         qtbot.wait_until(
             lambda: uid in manager._tool_graph.root_wrappers[0]._childtool_indices,
             timeout=5000,
@@ -2776,7 +2814,7 @@ def test_childtool_data_changed_deduplicates_descendant_refresh(
         propagated_uids: list[str] = []
         refreshed_uids: list[str | None] = []
         monkeypatch.setattr(
-            manager,
+            manager._lineage_controller,
             "_propagate_source_change_from_uid",
             lambda changed_uid: propagated_uids.append(changed_uid),
         )
@@ -2825,7 +2863,7 @@ def test_childtool_update_burst_rebuilds_selected_details_once(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         qtbot.wait_until(
             lambda: uid in manager._tool_graph.root_wrappers[0]._childtool_indices,
             timeout=5000,
@@ -2845,7 +2883,7 @@ def test_childtool_update_burst_rebuilds_selected_details_once(
 
         monkeypatch.setattr(manager, "_set_metadata_node", _record_metadata_rebuild)
         monkeypatch.setattr(
-            manager,
+            manager._lineage_controller,
             "_propagate_source_change_from_uid",
             lambda _uid: None,
         )
@@ -3308,7 +3346,7 @@ def test_childtool_info_changed_for_unselected_node_keeps_visible_details(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         qtbot.wait_until(
             lambda: uid in manager._tool_graph.root_wrappers[0]._childtool_indices,
             timeout=5000,
@@ -3341,7 +3379,7 @@ def test_childtool_repeated_info_changes_mark_state_dirty_once(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _InfoRefreshTool(test_data)
-        uid = manager.add_childtool(tool, 0, show=False)
+        uid = manager.add_childtool(tool, script_inputs={"data": 0}, show=False)
         qtbot.wait_until(
             lambda: uid in manager._tool_graph.root_wrappers[0]._childtool_indices,
             timeout=5000,
@@ -3516,7 +3554,16 @@ def test_remove_selected_calls_batch_remove(
         test_data.qshow(manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
-        uid = manager.add_childtool(erlab.interactive.utils.ToolWindow(), 0, show=False)
+        tool = erlab.interactive.utils.ToolWindow()
+        tool.set_script_inputs(
+            (ScriptInput(name="data", data_role="displayed"),),
+            primary_input="data",
+        )
+        uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
         qtbot.wait_until(
             lambda: uid in manager._tool_graph.root_wrappers[0]._childtool_indices,
             timeout=5000,

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -136,6 +136,34 @@ def test_dependency_tracker_uses_tool_script_inputs() -> None:
     assert refs[0].node_uid == "source-uid"
 
 
+def test_dependency_tracker_uses_model_owned_provenance_inputs() -> None:
+    dependent = script(
+        start_label="Dependent",
+        seed_code="derived = source",
+        active_name="derived",
+        script_inputs=(
+            ScriptInput(
+                name="source",
+                label="Source",
+                node_uid="source-uid",
+            ),
+        ),
+    )
+    node = types.SimpleNamespace(
+        is_imagetool=False,
+        provenance_revision=0,
+        tool_script_inputs=(),
+        provenance_spec=dependent,
+    )
+    graph = types.SimpleNamespace(nodes={"dependent-uid": node})
+    tracker = _ManagerDependencyTracker(typing.cast("_ManagerToolGraph", graph))
+
+    refs = tracker.refs_for_uid("dependent-uid")
+
+    assert len(refs) == 1
+    assert refs[0].node_uid == "source-uid"
+
+
 def test_dependency_tracker_indexes_dependents_and_caches_status() -> None:
     initial_snapshot = "snapshot-1"
     source_spec = script(

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -244,6 +244,24 @@ def test_dependency_tracker_indexes_dependents_and_caches_status() -> None:
     tracker._remove_reverse_refs("orphan-dependent")
 
 
+def test_dependency_tracker_discards_failed_refresh_chain() -> None:
+    graph = types.SimpleNamespace(nodes={})
+    tracker = _ManagerDependencyTracker(typing.cast("_ManagerToolGraph", graph))
+    tracker.queue_source_refresh("upstream", "failed")
+    tracker.queue_source_refresh("failed", "child")
+    tracker.queue_source_refresh("child", "grandchild")
+    tracker.queue_source_refresh("other-upstream", "grandchild")
+    tracker.queue_source_refresh("unrelated", "kept")
+
+    tracker.discard_source_refresh_chain("failed")
+
+    assert not tracker.source_refresh_queued("upstream", "failed")
+    assert not tracker.source_refresh_queued("failed", "child")
+    assert not tracker.source_refresh_queued("child", "grandchild")
+    assert not tracker.source_refresh_queued("other-upstream", "grandchild")
+    assert tracker.source_refresh_queued("unrelated", "kept")
+
+
 def test_dependency_tracker_drops_missing_uid_from_pending_index() -> None:
     node = types.SimpleNamespace(
         is_imagetool=True,

--- a/tests/interactive/imagetool/manager/test_warnings.py
+++ b/tests/interactive/imagetool/manager/test_warnings.py
@@ -20,7 +20,10 @@ from erlab.interactive.imagetool.manager import ImageToolManager
 from erlab.interactive.imagetool.manager._workspace import (
     _controller as workspace_controller,
 )
-from tests.interactive.imagetool.manager.workspace._support import _AddedTimeChildTool
+from tests.interactive.imagetool.manager.workspace._support import (
+    _AddedTimeChildTool,
+    add_source_childtool,
+)
 
 from .helpers import _UnserializableChildTool, select_child_tool
 
@@ -176,7 +179,8 @@ def test_manager_duplicate_unserializable_child_shows_error(
         itool(gold, link=False, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
-        child_uid = manager.add_childtool(
+        child_uid = add_source_childtool(
+            manager,
             _UnserializableChildTool(gold.copy(deep=True)),
             0,
             show=False,
@@ -206,12 +210,14 @@ def test_manager_duplicate_failure_rolls_back_partial_subtree(
         root = itool(gold, link=False, manager=False, execute=False)
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
-        serializable_uid = manager.add_childtool(
+        serializable_uid = add_source_childtool(
+            manager,
             _AddedTimeChildTool(gold.rename("serializable child")),
             0,
             show=False,
         )
-        manager.add_childtool(
+        add_source_childtool(
+            manager,
             _UnserializableChildTool(gold.copy(deep=True)),
             serializable_uid,
             show=False,
@@ -278,7 +284,8 @@ def test_manager_duplicate_mark_failure_restores_workspace_state(
         root = itool(gold, link=False, manager=False, execute=False)
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
-        manager.add_childtool(
+        add_source_childtool(
+            manager,
             _AddedTimeChildTool(gold.rename("child")),
             0,
             show=False,
@@ -329,7 +336,8 @@ def test_manager_duplicate_materialization_failure_is_not_reported_twice(
         root = itool(gold, link=False, manager=False, execute=False)
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
-        child_uid = manager.add_childtool(
+        child_uid = add_source_childtool(
+            manager,
             _UnserializableChildTool(gold.copy(deep=True)),
             0,
             show=False,
@@ -387,7 +395,8 @@ def test_manager_save_unserializable_child_shows_error(
         itool(gold, link=False, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
-        manager.add_childtool(
+        add_source_childtool(
+            manager,
             _UnserializableChildTool(gold.copy(deep=True)),
             0,
             show=False,

--- a/tests/interactive/imagetool/manager/test_wrapper.py
+++ b/tests/interactive/imagetool/manager/test_wrapper.py
@@ -1,7 +1,6 @@
 import contextlib
 import dataclasses
 import datetime
-import json
 import logging
 import pathlib
 import types
@@ -23,6 +22,7 @@ from erlab.interactive.imagetool._load_source import (
 )
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
+    ScriptInput,
     ToolProvenanceSpec,
     full_data,
 )
@@ -71,19 +71,17 @@ def test_wrapper_provenance_value_remap_requires_valid_specs() -> None:
             provenance, lambda _value: typing.cast("ToolProvenanceSpec", object())
         )
 
-    encoded = json.dumps(provenance.model_dump(mode="json"))
-    assert (
-        _ManagedWindowNode._pending_tool_provenance({"source": encoded}, "source")
-        == provenance
+    script_input = ScriptInput(
+        name="data",
+        source_spec=provenance.model_dump(mode="json"),
+        provenance_spec=provenance.model_dump(mode="json"),
     )
-    assert (
-        _ManagedWindowNode._pending_tool_provenance({"source": b"\xff"}, "source")
-        is None
+    remapped = _ManagedWindowNode._remap_script_input(
+        script_input,
+        lambda _value: ToolProvenanceSpec(kind="public_data"),
     )
-    assert _ManagedWindowNode._pending_tool_provenance({"source": 1}, "source") is None
-    assert (
-        _ManagedWindowNode._pending_tool_provenance({"source": "{"}, "source") is None
-    )
+    assert remapped.parsed_source_spec() == ToolProvenanceSpec(kind="public_data")
+    assert remapped.parsed_provenance_spec() == ToolProvenanceSpec(kind="public_data")
 
 
 def test_wrapper_materializes_source_binding_without_changing_provenance() -> None:
@@ -171,14 +169,27 @@ def test_wrapper_provenance_owner_remap_rolls_back_atomically(
         node.commit_provenance_owner_remap()
 
 
-def test_wrapper_applies_tool_owned_source_provenance() -> None:
+def test_wrapper_applies_tool_owned_script_inputs() -> None:
     changed: list[None] = []
+    previous = ScriptInput(name="data", source_spec=full_data().model_dump(mode="json"))
+    replacement = ScriptInput(
+        name="data",
+        source_spec=ToolProvenanceSpec(kind="public_data").model_dump(mode="json"),
+        provenance_spec=ToolProvenanceSpec(kind="public_data").model_dump(mode="json"),
+    )
 
     class _Tool:
-        source_spec = full_data()
-        input_provenance_spec = None
-        _source_spec = source_spec
-        _input_provenance_snapshot_from_parent = False
+        _script_inputs = (previous,)
+        _primary_input = "data"
+        _pending_script_inputs = (previous,)
+
+        @property
+        def script_inputs(self):
+            return self._script_inputs
+
+        @property
+        def primary_input(self):
+            return self._primary_input
 
         @staticmethod
         def _coalesce_provenance_changes():
@@ -206,9 +217,9 @@ def test_wrapper_applies_tool_owned_source_provenance() -> None:
         pending_payload_kind=None,
         node_source_spec=None,
         node_provenance_spec=None,
-        tool_source_spec=ToolProvenanceSpec(kind="public_data"),
-        tool_input_provenance_spec=None,
-        tool_input_from_parent=False,
+        tool_script_inputs=(replacement,),
+        tool_primary_input="data",
+        tool_pending_script_inputs=(replacement,),
         pending_payload_attrs=None,
     )
 
@@ -216,7 +227,9 @@ def test_wrapper_applies_tool_owned_source_provenance() -> None:
         typing.cast("_ManagedWindowNode", node), snapshot
     )
 
-    assert tool._source_spec == ToolProvenanceSpec(kind="public_data")
+    assert tool.script_inputs == (replacement,)
+    assert tool.primary_input == "data"
+    assert tool._pending_script_inputs == (replacement,)
     assert changed == [None]
 
 
@@ -634,7 +647,7 @@ def test_take_window_clears_and_reattach_restores_manager_execution_host(
         assert tool.slicer_area._in_manager
 
 
-def test_wrapper_source_data_replaced_uses_parent_fallback_and_skips_missing_child(
+def test_wrapper_source_data_replaced_uses_parent_fallback(
     qtbot,
     monkeypatch,
     test_data,
@@ -649,28 +662,22 @@ def test_wrapper_source_data_replaced_uses_parent_fallback_and_skips_missing_chi
         itool(test_data, manager=True)
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
-        parent_tool = manager.get_imagetool(0)
-        parent_tool.slicer_area.images[0].open_in_dtool()
-        qtbot.wait_until(
-            lambda: len(manager._tool_graph.root_wrappers[0]._childtools) == 1,
-            timeout=5000,
-        )
-
         wrapper = manager._tool_graph.root_wrappers[0]
-        _, child = next(iter(wrapper._childtools.items()))
         updated = test_data.copy(deep=True)
         updated.data = np.asarray(updated.data) * 7
-        handled: list[xr.DataArray] = []
+        propagated: list[tuple[str, xr.DataArray]] = []
 
         monkeypatch.setattr(
             wrapper.slicer_area, "_tool_source_parent_data", lambda: updated
         )
         monkeypatch.setattr(
-            child, "handle_parent_source_replaced", lambda data: handled.append(data)
+            manager._lineage_controller,
+            "_propagate_source_change_from_uid",
+            lambda uid, data: propagated.append((uid, data)),
         )
-        wrapper._childtool_indices.append("missing")
 
         wrapper._handle_source_data_replaced(object())
 
-        assert len(handled) == 1
-        xr.testing.assert_identical(handled[0], updated)
+        assert len(propagated) == 1
+        assert propagated[0][0] == wrapper.uid
+        xr.testing.assert_identical(propagated[0][1], updated)

--- a/tests/interactive/imagetool/manager/workspace/_support.py
+++ b/tests/interactive/imagetool/manager/workspace/_support.py
@@ -18,8 +18,27 @@ import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 from erlab.interactive.imagetool._provenance._model import (
     FileLoadSource,
     FileReplayCall,
+    ScriptInput,
     file_load,
 )
+
+
+def add_source_childtool(
+    manager: typing.Any,
+    tool: erlab.interactive.utils.ToolWindow,
+    source: int | str,
+    **kwargs: typing.Any,
+) -> str:
+    """Register a test ToolWindow that consumes durable displayed ImageTool data."""
+    tool.set_script_inputs(
+        (ScriptInput(name="data", data_role="displayed"),),
+        primary_input="data",
+    )
+    return manager.add_childtool(
+        tool,
+        script_inputs={"data": source},
+        **kwargs,
+    )
 
 
 class _AddedTimeChildState(pydantic.BaseModel):
@@ -33,6 +52,7 @@ class _AddedTimeChildTool(erlab.interactive.utils.ToolWindow[_AddedTimeChildStat
     def __init__(self, data: xr.DataArray) -> None:
         super().__init__()
         self._data = data
+        self._last_inputs: dict[str, xr.DataArray] = {}
         self._status = _AddedTimeChildState()
 
     @property
@@ -46,6 +66,21 @@ class _AddedTimeChildTool(erlab.interactive.utils.ToolWindow[_AddedTimeChildStat
     @tool_status.setter
     def tool_status(self, status: _AddedTimeChildState) -> None:
         self._status = status
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        primary = self.primary_input or "data"
+        self._last_inputs = dict(inputs)
+        self._data = inputs[primary]
+
+    def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
+        primary = self.primary_input or "data"
+        items = {imagetool_serialization.SAVED_TOOL_DATA_NAME: self._data}
+        items.update(
+            (name, value)
+            for name, value in self._last_inputs.items()
+            if name != primary
+        )
+        return items
 
 
 class _WorkspaceSweepToolState(pydantic.BaseModel):
@@ -100,8 +135,9 @@ class _WorkspaceSweepChildTool(
     def _primary_output_data(self) -> xr.DataArray:
         return self._data
 
-    def update_data(self, new_data: xr.DataArray) -> None:
-        self._data = new_data
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        primary = self.primary_input or "data"
+        self._data = inputs[primary]
 
     def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
         return {
@@ -113,6 +149,9 @@ class _WorkspaceSweepChildTool(
         self, data_items: Mapping[str, xr.DataArray], ds: xr.Dataset
     ) -> None:
         del ds
+        self._data = data_items[imagetool_serialization.SAVED_TOOL_DATA_NAME].rename(
+            self._data.name
+        )
         self._extra_data = data_items["auxiliary"]
 
 

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -47,7 +47,6 @@ from tests.interactive.imagetool.manager.helpers import (
     assert_fit_result_dataset_equivalent,
     assert_fit_result_list_equivalent,
     configure_goldtool_child,
-    copy_full_code_for_uid,
     make_fit2d_child,
     select_child_tool,
     select_tools,
@@ -59,6 +58,7 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _open_external_lazy_hdf5_imagetool_data,
     _request_workspace_save_and_wait,
     _request_workspace_save_as_and_wait,
+    add_source_childtool,
 )
 
 
@@ -435,7 +435,7 @@ def test_manager_duplicate_goldtool_child(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         child = GoldTool(gold.copy(deep=True), data_name="gold_input")
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
         configure_goldtool_child(child, fitted=True, spline=True)
         child.open_itool()
 
@@ -728,8 +728,7 @@ def test_manager_workspace_tool_data_reference_roundtrip(
         manager.add_imagetool(root, show=False)
 
         child = _AddedTimeChildTool(data.copy(deep=False))
-        child.set_source_binding(full_data())
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
 
         tree = manager._workspace_controller.saving._to_datatree()
         try:
@@ -741,7 +740,7 @@ def test_manager_workspace_tool_data_reference_roundtrip(
             )
             assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in references
             assert ds[erlab.interactive.utils._SAVED_TOOL_DATA_NAME].size == 0
-            with pytest.raises(ValueError, match="parent data is unavailable"):
+            with pytest.raises(ValueError, match="no manager-node resolver"):
                 erlab.interactive.utils.ToolWindow.from_dataset(ds)
 
             manager.remove_all_tools()
@@ -776,8 +775,7 @@ def test_manager_workspace_tool_data_reference_falls_back_on_shape_mismatch(
         manager.add_imagetool(root, show=False)
 
         child = DerivativeTool(child_data)
-        child.set_source_binding(full_data())
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
 
         tree = manager._workspace_controller.saving._to_datatree()
         try:
@@ -1117,7 +1115,7 @@ def test_manager_action_and_modelview_helper_branch_edges(
         assert shown == [wrapper.uid]
 
         child = _AddedTimeChildTool(data)
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
         removed.clear()
         with monkeypatch.context() as patch:
             patch.setattr(manager, "_find_watched_idx", lambda _uid: None)
@@ -2318,13 +2316,12 @@ def test_manager_workspace_roundtrip_goldtool_child(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         child = GoldTool(gold.copy(deep=True), data_name="gold_input")
-        child.set_source_binding(full_data())
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
         configure_goldtool_child(child, fitted=True, spline=True)
 
         expected_status = child.tool_status.model_copy(deep=True)
         expected_corrected = child.corrected.copy(deep=True)
-        expected_source_spec = child.source_spec
+        expected_script_inputs = child.script_inputs
         child.open_itool()
         child_node = manager._child_node(child_uid)
         qtbot.wait_until(lambda: len(child_node._childtool_indices) == 1, timeout=5000)
@@ -2350,7 +2347,7 @@ def test_manager_workspace_roundtrip_goldtool_child(
 
         loaded_child = manager.get_childtool(child_uid)
         assert isinstance(loaded_child, GoldTool)
-        assert loaded_child.source_spec == expected_source_spec
+        assert loaded_child.script_inputs == expected_script_inputs
         assert loaded_child.tool_status == expected_status
         xr.testing.assert_identical(loaded_child.corrected, expected_corrected)
         loaded_child_node = manager._child_node(child_uid)
@@ -2397,7 +2394,7 @@ def test_manager_workspace_roundtrip_dtool_child(
 
         expected_status = child.tool_status.model_copy(deep=True)
         expected_result = child.result.T.copy(deep=True)
-        expected_source_spec = child.source_spec
+        expected_script_inputs = child.script_inputs
         child.open_itool()
         child_node = manager._child_node(child_uid)
         qtbot.wait_until(lambda: len(child_node._childtool_indices) == 1, timeout=5000)
@@ -2423,7 +2420,7 @@ def test_manager_workspace_roundtrip_dtool_child(
 
         loaded_child = manager.get_childtool(child_uid)
         assert isinstance(loaded_child, DerivativeTool)
-        assert loaded_child.source_spec == expected_source_spec
+        assert loaded_child.script_inputs == expected_script_inputs
         assert loaded_child.tool_status == expected_status
         xr.testing.assert_identical(loaded_child.result.T, expected_result)
         loaded_child_node = manager._child_node(child_uid)
@@ -2444,9 +2441,7 @@ def test_manager_workspace_roundtrip_dtool_child(
 
 def test_manager_workspace_roundtrip_fit1d_child(
     qtbot,
-    monkeypatch,
     exp_decay_model,
-    test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -2455,19 +2450,21 @@ def test_manager_workspace_roundtrip_fit1d_child(
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         manager.show()
 
-        itool(test_data, link=False, manager=True)
-        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
-
         t = np.linspace(0.0, 4.0, 25)
         data = xr.DataArray(
             3.0 * np.exp(-t / 2.0), dims=("t",), coords={"t": t}, name="decay"
+        )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(data, _in_manager=True),
+            show=False,
+            provenance_spec=full_data().to_replay_spec(),
         )
         params = exp_decay_model.make_params(n0=2.0, tau=1.0)
         child = erlab.interactive.ftool(
             data, model=exp_decay_model, params=params, execute=False
         )
         assert isinstance(child, Fit1DTool)
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
 
         assert child._run_fit()
         qtbot.wait_until(lambda: child._last_result_ds is not None, timeout=10000)
@@ -2497,25 +2494,14 @@ def test_manager_workspace_roundtrip_fit1d_child(
         assert loaded_child.save_button.isEnabled()
         assert loaded_child.copy_button.isEnabled()
 
-        warnings: list[tuple[str, str]] = []
-        monkeypatch.setattr(
-            loaded_child,
-            "_show_warning",
-            lambda title, text: warnings.append((title, text)),
-        )
-        manager.tree_view.clearSelection()
-        select_child_tool(manager, child_uid)
-        manager._update_info(uid=child_uid)
-        copied = copy_full_code_for_uid(monkeypatch, manager, child_uid)
-        assert "modelfit" in copied
-        assert not warnings
+        restored_spec = manager._child_node(child_uid).displayed_provenance_spec
+        assert restored_spec is not None
+        assert restored_spec.script_inputs[0].parsed_provenance_spec() is not None
 
 
 def test_manager_workspace_roundtrip_fit2d_child(
     qtbot,
-    monkeypatch,
     exp_decay_model,
-    test_data,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
@@ -2524,8 +2510,19 @@ def test_manager_workspace_roundtrip_fit2d_child(
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         manager.show()
 
-        itool(test_data, link=False, manager=True)
-        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
+        t = np.linspace(0.0, 4.0, 25)
+        y = np.arange(3)
+        source_data = xr.DataArray(
+            np.stack([((1.0 + 0.5 * idx) * np.exp(-t / 2.0)) for idx in y], axis=0),
+            dims=("y", "t"),
+            coords={"y": y, "t": t},
+            name="decay2d",
+        )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(source_data, _in_manager=True),
+            show=False,
+            provenance_spec=full_data().to_replay_spec(),
+        )
 
         child_uid, child = make_fit2d_child(manager, 0, exp_decay_model)
         child.timeout_spin.setValue(30.0)
@@ -2563,24 +2560,14 @@ def test_manager_workspace_roundtrip_fit2d_child(
         assert loaded_child.copy_full_button.isEnabled()
         assert loaded_child.save_full_button.isEnabled()
 
-        warnings: list[tuple[str, str]] = []
-        monkeypatch.setattr(
-            loaded_child,
-            "_show_warning",
-            lambda title, text: warnings.append((title, text)),
-        )
-        manager.tree_view.clearSelection()
-        select_child_tool(manager, child_uid)
-        manager._update_info(uid=child_uid)
-        copied = copy_full_code_for_uid(monkeypatch, manager, child_uid)
-        assert "modelfit" in copied
-        assert not warnings
+        restored_spec = manager._child_node(child_uid).displayed_provenance_spec
+        assert restored_spec is not None
+        assert restored_spec.script_inputs[0].parsed_provenance_spec() is not None
 
 
 def test_manager_workspace_roundtrip_fit2d_child_with_spaced_axis(
     qtbot,
     exp_decay_model,
-    test_data,
     tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -2589,9 +2576,6 @@ def test_manager_workspace_roundtrip_fit2d_child_with_spaced_axis(
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         manager.show()
-
-        itool(test_data, link=False, manager=True)
-        qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         t = np.linspace(0.0, 4.0, 25)
         motor = np.arange(3.0)
@@ -2608,12 +2592,17 @@ def test_manager_workspace_roundtrip_fit2d_child_with_spaced_axis(
             },
             name="decay2d",
         )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(data, _in_manager=True),
+            show=False,
+            provenance_spec=full_data().to_replay_spec(),
+        )
         params = exp_decay_model.make_params(n0=1.0, tau=1.0)
         child = erlab.interactive.ftool(
             data, model=exp_decay_model, params=params, execute=False
         )
         assert isinstance(child, Fit2DTool)
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
         child.timeout_spin.setValue(30.0)
         child.nfev_spin.setValue(0)
         child.y_index_spin.setValue(child.y_min_spin.value())

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -2499,6 +2499,56 @@ def test_manager_workspace_roundtrip_fit1d_child(
         assert restored_spec.script_inputs[0].parsed_provenance_spec() is not None
 
 
+def test_manager_workspace_roundtrip_weighted_ftool_preserves_both_input_uids(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    uncertainty = xr.ones_like(test_data).rename("uncertainty")
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        manager.show()
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True),
+            show=False,
+            provenance_spec=full_data().to_replay_spec(),
+        )
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(uncertainty, _in_manager=True),
+            show=False,
+            provenance_spec=full_data().to_replay_spec(),
+        )
+
+        data_node = manager._tool_graph.root_wrappers[0]
+        uncertainty_node = manager._tool_graph.root_wrappers[1]
+        child_uid = manager.open_weighted_ftool(data_node.uid, uncertainty_node.uid)
+
+        assert child_uid is not None
+        tree = manager._workspace_controller.saving._to_datatree()
+        manager.remove_all_tools()
+        qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
+
+        for node in tree.values():
+            manager._workspace_controller.loading._load_workspace_node(
+                typing.cast("xr.DataTree", node)
+            )
+
+        qtbot.wait_until(lambda: manager.ntools == 2, timeout=5000)
+        loaded_child = manager.get_childtool(child_uid)
+        assert isinstance(loaded_child, (Fit1DTool, Fit2DTool))
+        assert [(item.name, item.node_uid) for item in loaded_child.script_inputs] == [
+            ("data", data_node.uid),
+            ("uncertainty", uncertainty_node.uid),
+        ]
+        assert loaded_child.source_state == "fresh"
+        assert loaded_child.uncertainty is not None
+        xr.testing.assert_identical(loaded_child.uncertainty, uncertainty)
+        assert manager._tool_graph.root_wrappers[0]._childtool_indices == [child_uid]
+
+
 def test_manager_workspace_roundtrip_fit2d_child(
     qtbot,
     exp_decay_model,

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -1868,8 +1868,15 @@ def test_pending_tool_reference_reads_owner_workspace(
             owner_node=owner_node,
         )
 
-        restored = resolver(reference)
-        assert restored is not None
+        restored = (
+            erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+                "data",
+                reference,
+                ds,
+                source_parent_data=None,
+                reference_resolver=resolver,
+            )
+        )
         xr.testing.assert_identical(restored, resolved.rename("transformed"))
         assert workspace_paths == [imported_path]
 

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -34,6 +34,7 @@ from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._load_source import _serialize_loader_kwargs
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
+    ScriptInput,
     ToolProvenanceSpec,
     compose_display_provenance,
     full_data,
@@ -66,6 +67,7 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _WorkspaceSweepChildTool,
     _WorkspaceSweepFigureTool,
     _WorkspaceSweepToolState,
+    add_source_childtool,
 )
 
 
@@ -1321,6 +1323,10 @@ def _workspace_sweep_node_snapshot(
         snapshot["imagetool_data_name"] = node.slicer_area._data.name
     else:
         tool = typing.cast("_WorkspaceSweepChildTool", node.tool_window)
+        snapshot["script_inputs"] = [
+            item.model_dump(mode="json") for item in tool.script_inputs
+        ]
+        snapshot["primary_input"] = tool.primary_input
         snapshot["tool_status"] = tool.tool_status.model_dump(mode="json")
         snapshot["tool_data_name"] = tool.tool_data.name
         snapshot["tool_display_name"] = tool._tool_display_name
@@ -1424,6 +1430,7 @@ def _workspace_sweep_h5_attr_payload(
         "tool_source_spec",
         "tool_source_binding",
         "tool_input_provenance_spec",
+        "tool_script_inputs",
         "tool_data_references",
     }
     node_path, _separator, _kind = payload_path.rpartition("/")
@@ -1488,7 +1495,8 @@ def test_manager_workspace_load_preserves_added_time(
             show=False,
             created_time=child_added,
         )
-        tool_uid = manager.add_childtool(
+        tool_uid = add_source_childtool(
+            manager,
             _AddedTimeChildTool(test_data),
             root_index,
             show=False,
@@ -1806,7 +1814,12 @@ def test_pending_tool_reference_reads_owner_workspace(
         loader = manager._workspace_controller.loading
         manager._workspace_state.path = tmp_path / "associated.itws"
         imported_path = tmp_path / "imported.itws"
-        reference = {"kind": "manager_node", "node_uid": "removed-source"}
+        source_spec = full_data(RenameOperation(name="transformed"))
+        reference = {
+            "kind": "manager_node",
+            "node_uid": "removed-source",
+            "source_spec": source_spec.model_dump(mode="json"),
+        }
         ds = xr.Dataset(
             attrs={
                 erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
@@ -1838,7 +1851,9 @@ def test_pending_tool_reference_reads_owner_workspace(
             owner_node=owner_node,
         )
 
-        assert resolver(reference) is resolved
+        restored = resolver(reference)
+        assert restored is not None
+        xr.testing.assert_identical(restored, resolved.rename("transformed"))
         assert workspace_paths == [imported_path]
 
 
@@ -2197,16 +2212,22 @@ def test_manager_workspace_roundtrip_restores_full_serializable_state(
             weights=[0.25, 0.5, 0.75],
             options={"snap": True, "labels": ["alpha", "beta"]},
         )
-        child_window.set_source_binding(
-            tool_source_spec,
-            source_binding=tool_binding,
+        child_window.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    data_role="source",
+                    source_spec=tool_source_spec,
+                    provenance_spec=root_provenance,
+                ),
+            ),
+            primary_input="data",
             auto_update=True,
             state="unavailable",
         )
-        child_window.set_input_provenance_spec(root_provenance)
         child_tool_uid = manager.add_childtool(
             child_window,
-            0,
+            script_inputs={"data": 0},
             show=False,
             uid="sweep-child-tool",
             snapshot_token=child_tool_marker,
@@ -2423,11 +2444,14 @@ def test_manager_workspace_roundtrip_restores_full_serializable_state(
         )
         assert tool_payload["tool_source_state"] == "unavailable"
         assert tool_payload["tool_source_auto_update"] is True
-        assert tool_payload["tool_source_spec"] == tool_source_spec.model_dump(
-            mode="json"
-        )
+        assert tool_payload["tool_script_inputs"] == [
+            item.model_dump(mode="json") for item in child_window.script_inputs
+        ]
+        assert tool_payload["tool_primary_input"] == "data"
+        assert "tool_source_spec" not in tool_payload
         assert "tool_source_binding" not in tool_payload
         assert "manager_node_provenance_spec" not in figure_payload
+        assert "tool_input_provenance_spec" not in tool_payload
         with h5py.File(fname, "r") as h5_file:
             tool_group = h5_file[
                 _current_workspace_payload_path(fname, "0/childtools/sweep-child-tool")
@@ -2988,8 +3012,7 @@ def test_manager_load_workspace_tool_dataset_materializes_reference(
         manager.add_imagetool(parent, show=False)
 
         child = _WorkspaceSweepChildTool(data.rename("child"))
-        child.set_source_binding(full_data())
-        manager.add_childtool(child, 0, show=False)
+        add_source_childtool(manager, child, 0, show=False)
         with child._save_tool_data_reference_context(manager._tool_graph.nodes):
             ds = child.to_dataset()
 
@@ -3040,7 +3063,7 @@ def test_manager_workspace_partially_loads_corrupted_child_with_warning(
         manager.add_imagetool(root, show=False)
 
         child = DerivativeTool(data)
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
 
         tree = manager._workspace_controller.saving._to_datatree()
         try:
@@ -3051,6 +3074,7 @@ def test_manager_workspace_partially_loads_corrupted_child_with_warning(
                 "xr.DataTree", tree[f"0/childtools/{child_uid}/tool"]
             ).to_dataset(inherit=False)
             child_ds = child_ds.copy(deep=True)
+            child_ds.attrs.pop(erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR, None)
             saved_data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
             child_ds[saved_data_name] = xr.DataArray(
                 np.arange(50.0).reshape(2, 5, 5),
@@ -3107,7 +3131,7 @@ def test_manager_workspace_roundtrips_child_plot_appearance(
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
         child = DerivativeTool(data)
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
         manager._workspace_controller._mark_workspace_clean()
 
         histogram = child.hists[0]
@@ -3810,8 +3834,8 @@ def test_manager_workspace_selected_import_uses_manifest_fast_path(
         root_a = itool(data, manager=False, execute=False)
         assert isinstance(root_a, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root_a, show=False)
-        child_uid = manager.add_childtool(
-            _WorkspaceSweepChildTool(data + 10), 0, show=False
+        child_uid = add_source_childtool(
+            manager, _WorkspaceSweepChildTool(data + 10), 0, show=False
         )
         root_b = itool(data + 1, manager=False, execute=False)
         assert isinstance(root_b, erlab.interactive.imagetool.ImageTool)

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -36,7 +36,7 @@ from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     ScriptInput,
     ToolProvenanceSpec,
-    compose_display_provenance,
+    compose_full_provenance,
     full_data,
     script,
 )
@@ -83,12 +83,12 @@ class _ManagedInputAuthorityTool(_AddedTimeChildTool):
     )
 
     def _copy_expression(
-        self, *, input_name: str | None, data: xr.DataArray | None
+        self, *, primary_input: str | None, data: xr.DataArray | None
     ) -> str | None:
         del data
-        if input_name is None:
+        if primary_input is None:
             return None
-        return f"{input_name}.rename('tool-result')"
+        return f"{primary_input}.rename('tool-result')"
 
 
 def _workspace_sweep_json(value: typing.Any) -> typing.Any:
@@ -1105,24 +1105,33 @@ def test_managed_tool_rebuilds_input_provenance_from_parent(
             provenance_spec=parent_provenance,
         )
         child = _ManagedInputAuthorityTool(source_spec.apply(data))
-        child.set_source_binding(source_spec)
-        child.set_input_provenance_spec(_injected_input_provenance())
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    data_role="displayed",
+                    source_spec=source_spec.model_dump(mode="json"),
+                    provenance_spec=_injected_input_provenance().model_dump(
+                        mode="json"
+                    ),
+                ),
+            ),
+            primary_input="data",
+        )
+        child_uid = manager.add_childtool(
+            child,
+            script_inputs={"data": 0},
+            show=False,
+        )
 
-        expected = compose_display_provenance(
+        expected = compose_full_provenance(
             manager._tool_graph.root_wrappers[0].displayed_provenance_spec,
             source_spec,
-            parent_data=data,
         )
-        assert child._effective_input_provenance_spec() == expected
+        assert child.script_inputs[0].parsed_provenance_spec() == expected
         current = child.current_provenance_spec()
         assert current is not None
         assert "attacker" not in current.display_code()
-
-        figure = _WorkspaceSweepFigureTool(data)
-        figure.set_input_provenance_spec(_injected_input_provenance())
-        figure_uid = manager.add_figuretool(figure, show=False)
-        assert figure._effective_input_provenance_spec() is None
 
         fname = tmp_path / "managed-input-authority.itws"
         manager._workspace_controller.saving._save_workspace_document(fname)
@@ -1135,11 +1144,6 @@ def test_managed_tool_rebuilds_input_provenance_from_parent(
                 erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
                 not in payload.attrs
             )
-        figure_path = f"figures/{figure_uid}"
-        figure_attrs = _current_workspace_payload_attrs(fname, figure_path)
-        assert (
-            erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR not in figure_attrs
-        )
 
 
 def test_legacy_tool_input_provenance_is_not_raw_copied(
@@ -1171,8 +1175,21 @@ def test_legacy_tool_input_provenance_is_not_raw_copied(
             provenance_spec=parent_provenance,
         )
         child = _ManagedInputAuthorityTool(source_spec.apply(data))
-        child.set_source_binding(source_spec)
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    data_role="displayed",
+                    source_spec=source_spec.model_dump(mode="json"),
+                ),
+            ),
+            primary_input="data",
+        )
+        child_uid = manager.add_childtool(
+            child,
+            script_inputs={"data": 0},
+            show=False,
+        )
         manager._workspace_controller.saving._save_workspace_document(fname)
 
     node_path = f"0/childtools/{child_uid}"
@@ -1206,12 +1223,12 @@ def test_legacy_tool_input_provenance_is_not_raw_copied(
 
         assert child_node.pending_workspace_tool_payload is None
         restored = typing.cast("_ManagedInputAuthorityTool", child_node.tool_window)
-        expected = compose_display_provenance(
+        restored_input = restored.script_inputs[0]
+        expected = compose_full_provenance(
             manager._tool_graph.root_wrappers[0].displayed_provenance_spec,
-            restored.source_spec,
-            parent_data=manager._tool_graph.root_wrappers[0].current_source_data(),
+            restored_input.parsed_source_spec(),
         )
-        assert restored._effective_input_provenance_spec() == expected
+        assert restored_input.parsed_provenance_spec() == expected
         current = restored.current_provenance_spec()
         assert current is not None
         assert "attacker" not in current.display_code()

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -1736,21 +1736,22 @@ def test_wrapper_pending_workspace_branch_helpers(
         original_tool = wrapper._imagetool
         wrapper._imagetool = None
         try:
-            monkeypatch.setattr(
-                wrapper,
-                "_load_source_details",
-                lambda: types.SimpleNamespace(load_code="data = 1"),
-            )
-            assert wrapper.load_source_code() == "data = 1"
-            assert wrapper.load_source_code(assign="renamed") == "renamed = 1"
-            with pytest.raises(ValueError, match="valid Python identifier"):
-                wrapper.load_source_code(assign="bad name")
-            monkeypatch.setattr(
-                wrapper,
-                "_load_source_details",
-                lambda: types.SimpleNamespace(load_code="data ="),
-            )
-            assert wrapper.load_source_code(assign="renamed") is None
+            with monkeypatch.context() as patch:
+                patch.setattr(
+                    wrapper,
+                    "_load_source_details",
+                    lambda: types.SimpleNamespace(load_code="data = 1"),
+                )
+                assert wrapper.load_source_code() == "data = 1"
+                assert wrapper.load_source_code(assign="renamed") == "renamed = 1"
+                with pytest.raises(ValueError, match="valid Python identifier"):
+                    wrapper.load_source_code(assign="bad name")
+                patch.setattr(
+                    wrapper,
+                    "_load_source_details",
+                    lambda: types.SimpleNamespace(load_code="data ="),
+                )
+                assert wrapper.load_source_code(assign="renamed") is None
         finally:
             wrapper._imagetool = original_tool
 

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -42,7 +42,6 @@ from erlab.interactive.imagetool._provenance._operations import (
     AverageOperation,
     BoxcarFilterOperation,
     GaussianFilterOperation,
-    ScriptCodeOperation,
     SortCoordOrderOperation,
     SqueezeOperation,
 )
@@ -72,7 +71,99 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _transaction_test_root_attrs,
     _WorkspaceManagerReferenceFigureTool,
     _WorkspaceSweepChildTool,
+    add_source_childtool,
 )
+
+
+def test_workspace_dependency_rebase_updates_tool_data_references() -> None:
+    saved_uid = "saved-source"
+    actual_uid = "actual-source"
+    script_input = ScriptInput(name="data", node_uid=saved_uid)
+    references = {
+        "<saved-tool-data>": {"kind": "manager_node", "node_uid": saved_uid},
+        "legacy": {"kind": "parent_source", "node_uid": saved_uid},
+    }
+
+    class _PendingNode:
+        tool_window = None
+        pending_workspace_payload_kind = "tool"
+        provenance_spec = None
+        tool_primary_input = "data"
+
+        def __init__(self) -> None:
+            self.attrs = {
+                erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR: json.dumps(
+                    [script_input.model_dump(mode="json")]
+                ),
+                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                    references
+                ),
+            }
+
+        @property
+        def pending_workspace_payload_attrs(self) -> dict[str, typing.Any]:
+            return dict(self.attrs)
+
+        @property
+        def tool_script_inputs(self) -> tuple[ScriptInput, ...]:
+            return tuple(
+                ScriptInput.model_validate(item)
+                for item in json.loads(
+                    self.attrs[erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR]
+                )
+            )
+
+        def update_pending_workspace_payload_attrs(
+            self, attrs: dict[str, typing.Any]
+        ) -> None:
+            self.attrs = dict(attrs)
+
+    class _LiveTool:
+        def __init__(self) -> None:
+            self.script_inputs = (script_input,)
+            self.primary_input = "data"
+            self.source_auto_update = False
+            self.source_state = "fresh"
+
+        def set_script_inputs(self, inputs, **_kwargs) -> None:
+            self.script_inputs = tuple(inputs)
+
+        def rebase_source_node_uids(self, _uid_map) -> None:
+            return
+
+    class _LiveNode:
+        pending_workspace_payload_kind = None
+        provenance_spec = None
+
+        def __init__(self) -> None:
+            self.tool_window = _LiveTool()
+            self._workspace_tool_data_references = references
+
+        def _set_workspace_tool_data_references(self, updated) -> None:
+            self._workspace_tool_data_references = updated
+
+    pending_node = _PendingNode()
+    live_node = _LiveNode()
+    nodes = {"pending": pending_node, "live": live_node}
+    manager = types.SimpleNamespace(_node_for_target=nodes.__getitem__)
+    controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
+
+    controller._rebase_node_dependency_refs(nodes, {saved_uid: actual_uid})
+
+    assert pending_node.tool_script_inputs[0].node_uid == actual_uid
+    assert (
+        pending_node.attrs[erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR] == "data"
+    )
+    pending_references = json.loads(
+        pending_node.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
+    )
+    assert pending_references["<saved-tool-data>"]["node_uid"] == actual_uid
+    assert pending_references["legacy"]["node_uid"] == saved_uid
+    assert live_node.tool_window.script_inputs[0].node_uid == actual_uid
+    assert (
+        live_node._workspace_tool_data_references["<saved-tool-data>"]["node_uid"]
+        == actual_uid
+    )
 
 
 def test_manager_workspace_restore_hidden_memory_link_group_keeps_payload_pending(
@@ -613,10 +704,9 @@ def test_manager_pending_memory_reload_unavailable_does_not_materialize(
         )
 
         select_tools(manager, [0])
-        reload_candidates = manager._selected_reload_candidates()
+        reload_candidates = manager._lineage_controller._selected_reload_candidates()
         assert reload_candidates is not None
         assert reload_candidates[2] is not None
-        assert manager._selected_reload_targets() is None
         manager._update_actions()
 
         assert manager.reload_action.isVisible()
@@ -674,9 +764,8 @@ def test_manager_pending_memory_file_source_reload_available_without_materializi
         )
 
         select_tools(manager, [0])
-        reload_candidates = manager._selected_reload_candidates()
+        reload_candidates = manager._lineage_controller._selected_reload_candidates()
         assert reload_candidates == ([0], {}, None)
-        assert manager._selected_reload_targets() == ([0], {})
         manager._update_actions()
 
         assert manager.reload_action.isVisible()
@@ -748,8 +837,11 @@ def test_manager_pending_memory_child_routes_reload_to_file_source_parent(
         )
 
         select_child_tool(manager, child_uid)
-        assert manager._selected_reload_candidates() == ([0], {0: [child_uid]}, None)
-        assert manager._selected_reload_targets() == ([0], {0: [child_uid]})
+        assert manager._lineage_controller._selected_reload_candidates() == (
+            [0],
+            {0: [child_uid]},
+            None,
+        )
         manager._update_actions()
 
         assert manager.reload_action.isVisible()
@@ -851,7 +943,7 @@ def test_manager_pending_memory_output_child_source_change_marks_stale(
         root.hide()
 
         tool_window = _WorkspaceSweepChildTool(data)
-        child_tool_uid = manager.add_childtool(tool_window, 0, show=False)
+        child_tool_uid = add_source_childtool(manager, tool_window, 0, show=False)
         output_data = tool_window.output_imagetool_data("workspace-sweep.primary")
         assert output_data is not None
         output_tool = itool(output_data, manager=False, execute=False)
@@ -1777,7 +1869,6 @@ def test_pending_workspace_reload_reason_branches(
         monkeypatch.setattr(
             manager_lineage, "has_file_load_source", lambda _spec: False
         )
-
         file_spec = types.SimpleNamespace(kind="file")
         monkeypatch.setattr(
             controller,
@@ -1787,6 +1878,7 @@ def test_pending_workspace_reload_reason_branches(
         assert (
             controller._pending_imagetool_reload_unavailable_reason(
                 types.SimpleNamespace(
+                    uid="pending",
                     provenance_spec=file_spec,
                     _load_source_details=lambda: None,
                 )
@@ -1794,77 +1886,32 @@ def test_pending_workspace_reload_reason_branches(
             == "missing file"
         )
 
-        opaque_script = script(
-            ScriptCodeOperation(label="Opaque", code=None, copyable=False),
-            start_label="Run script",
-            seed_code="derived = data",
-            active_name="derived",
-            script_inputs=(ScriptInput(name="data", label="Input"),),
-        )
-        opaque_reason = controller._pending_imagetool_reload_unavailable_reason(
-            types.SimpleNamespace(
-                provenance_spec=opaque_script,
-                uid="pending",
-                _load_source_details=lambda: None,
-            )
-        )
-        assert opaque_reason is not None
-
-        raw_script = script(
-            ScriptCodeOperation(
-                label="Transform",
-                code="derived = data + 1",
-            ),
-            start_label="Run script",
-            seed_code="derived = data",
-            active_name="derived",
-        )
-        raw_reason = controller._pending_imagetool_reload_unavailable_reason(
-            types.SimpleNamespace(
-                provenance_spec=raw_script,
-                uid="pending",
-                _load_source_details=lambda: None,
-            )
-        )
-        assert raw_reason is not None
-        assert "no recorded inputs" in raw_reason
-
-        script_input = object()
-        script_spec = types.SimpleNamespace(
-            kind="script",
-            script_inputs=(script_input,),
-        )
-        replayable = True
-        monkeypatch.setattr(
-            controller,
-            "_script_provenance_runnable",
-            lambda _spec: replayable,
-        )
+        script_spec = types.SimpleNamespace(kind="script", script_inputs=())
         monkeypatch.setattr(
             manager_lineage,
-            "provenance_code_trust_entries",
-            lambda *_args, **_kwargs: pytest.fail(
-                "passive reload status built code-trust entries"
+            "_replay_capability",
+            lambda _spec, **_kwargs: types.SimpleNamespace(
+                replayable=False,
+                requires_trust=True,
             ),
         )
-        unavailable_reason: str | None = None
-        monkeypatch.setattr(
-            manager,
-            "_script_input_unavailable_reason",
-            lambda *_args, **_kwargs: unavailable_reason,
-        )
-        unavailable_reason = "missing input"
-        assert (
-            controller._pending_imagetool_reload_unavailable_reason(
-                types.SimpleNamespace(
-                    provenance_spec=script_spec,
-                    uid="pending",
-                    _load_source_details=lambda: None,
-                )
+        trust_reason = controller._pending_imagetool_reload_unavailable_reason(
+            types.SimpleNamespace(
+                uid="pending",
+                provenance_spec=script_spec,
+                _load_source_details=lambda: None,
             )
-            == unavailable_reason
         )
-        unavailable_reason = None
+        assert trust_reason == "The recorded script steps cannot be reloaded."
+
+        monkeypatch.setattr(
+            manager_lineage,
+            "_replay_capability",
+            lambda _spec, **_kwargs: types.SimpleNamespace(
+                replayable=True,
+                requires_trust=True,
+            ),
+        )
         assert (
             controller._pending_imagetool_reload_unavailable_reason(
                 types.SimpleNamespace(
@@ -1876,20 +1923,10 @@ def test_pending_workspace_reload_reason_branches(
             is None
         )
 
-        replayable = False
-        replay_reason = controller._pending_imagetool_reload_unavailable_reason(
-            types.SimpleNamespace(
-                provenance_spec=script_spec,
-                uid="pending",
-                _load_source_details=lambda: None,
-            )
-        )
-        assert replay_reason is not None
-        assert "cannot be reloaded automatically" in replay_reason
-
         missing_path = tmp_path / "missing.h5"
         missing_reason = controller._pending_imagetool_reload_unavailable_reason(
             types.SimpleNamespace(
+                uid="pending",
                 provenance_spec=None,
                 _load_source_details=lambda: types.SimpleNamespace(
                     path=missing_path,
@@ -1898,13 +1935,13 @@ def test_pending_workspace_reload_reason_branches(
             )
         )
         assert missing_reason is not None
-        assert str(missing_path) in missing_reason
 
         existing_path = tmp_path / "scan.h5"
         existing_path.write_bytes(b"")
         assert (
             controller._pending_imagetool_reload_unavailable_reason(
                 types.SimpleNamespace(
+                    uid="pending",
                     provenance_spec=None,
                     _load_source_details=lambda: types.SimpleNamespace(
                         path=existing_path,
@@ -1916,6 +1953,7 @@ def test_pending_workspace_reload_reason_branches(
         )
         missing_loader_reason = controller._pending_imagetool_reload_unavailable_reason(
             types.SimpleNamespace(
+                uid="pending",
                 provenance_spec=None,
                 _load_source_details=lambda: types.SimpleNamespace(
                     path=existing_path,
@@ -1924,7 +1962,7 @@ def test_pending_workspace_reload_reason_branches(
             )
         )
         assert missing_loader_reason is not None
-        assert "loader information" in missing_loader_reason
+        assert missing_loader_reason != missing_reason
 
 
 def test_pending_workspace_provenance_edit_materialization_failures(
@@ -2390,7 +2428,7 @@ def test_hidden_workspace_toolwindows_restore_pending_until_shown(
 
         child = _AddedTimeChildTool(data.rename("child"))
         child._tool_display_name = "Hidden child"
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
         child.hide()
 
         figure = _WorkspaceManagerReferenceFigureTool(
@@ -2434,13 +2472,121 @@ def test_hidden_workspace_toolwindows_restore_pending_until_shown(
         assert figure_node.tool_window is None
         assert figure_uid in manager._figure_uids()
 
+        child_node._set_source_auto_update(True)
+        child_node._set_source_state("stale")
         child_node.show()
 
         assert constructed == ["Hidden child"]
         assert child_node.pending_workspace_tool_payload is None
         assert child_node.tool_window is not None
         assert child_node.type_badge_text == _AddedTimeChildTool.tool_name
+        assert child_node.tool_window.source_auto_update
+        assert child_node.tool_window.source_state == "stale"
         assert root_node.pending_workspace_memory_payload is not None
+
+
+def test_pending_workspace_toolwindow_restores_named_input_dependencies(
+    qtbot,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        np.arange(4.0), dims="x", coords={"x": np.arange(4)}, name="data"
+    )
+    weights = xr.DataArray(
+        np.arange(4.0) + 1.0,
+        dims="x",
+        coords={"x": np.arange(4)},
+        name="weights",
+    )
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        for value in (data, weights):
+            root = itool(value, manager=False, execute=False)
+            assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(root, show=False)
+            root.hide()
+
+        child = _AddedTimeChildTool(data)
+        child.set_script_inputs(
+            (
+                ScriptInput(name="data", data_role="source"),
+                ScriptInput(name="weights", data_role="source"),
+            ),
+            primary_input="data",
+        )
+        child.update_inputs({"data": data, "weights": weights})
+        child_uid = manager.add_childtool(
+            child,
+            script_inputs={"data": 0, "weights": 1},
+            show=False,
+        )
+        child.hide()
+
+        workspace = tmp_path / "pending-named-input-tool.itws"
+        manager._workspace_controller.saving._save_workspace_document(workspace)
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+
+        child_node = manager._child_node(child_uid)
+        assert child_node.tool_window is None
+        assert tuple(item.name for item in child_node.tool_script_inputs) == (
+            "data",
+            "weights",
+        )
+        assert {
+            ref.name
+            for ref in manager._lineage_controller._dependency_refs_for_uid(child_uid)
+        } == {
+            "data",
+            "weights",
+        }
+
+        updated_weights = (weights * 3.0).rename("weights")
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            replace_data(1, updated_weights)
+        qtbot.wait_until(lambda: child_node.source_state == "stale", timeout=5000)
+        assert child_node.tool_window is None
+
+        child_node.show()
+        restored = child_node.tool_window
+        assert isinstance(restored, _AddedTimeChildTool)
+        assert restored.source_state == "stale"
+        assert restored.primary_input == "data"
+
+        assert manager._lineage_controller._refresh_tool_inputs(
+            child_uid,
+            allow_recorded=False,
+        )
+        assert restored.source_state == "fresh"
+        xr.testing.assert_identical(restored.tool_data, data)
+        xr.testing.assert_identical(restored._last_inputs["weights"], updated_weights)
+
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        child_node = manager._child_node(child_uid)
+        assert child_node.tool_window is None
+        manager.remove_imagetool(1)
+        qtbot.wait_until(lambda: child_node.source_state == "unavailable", timeout=5000)
+        assert child_node.tool_window is None
+
+        child_node.show()
+        restored = child_node.tool_window
+        assert isinstance(restored, _AddedTimeChildTool)
+        assert restored.source_state == "unavailable"
 
 
 def test_pending_toolwindow_reference_availability_rejects_unsupported_kind(
@@ -2457,7 +2603,9 @@ def test_pending_toolwindow_reference_availability_rejects_unsupported_kind(
         manager.add_imagetool(root, show=False)
         root_uid = manager._tool_graph.root_wrappers[0].uid
 
-        child_uid = manager.add_childtool(_AddedTimeChildTool(data), 0, show=False)
+        child_uid = add_source_childtool(
+            manager, _AddedTimeChildTool(data), 0, show=False
+        )
         child_node = manager._child_node(child_uid)
         child_node.set_pending_workspace_payload(
             "tool",
@@ -2470,7 +2618,7 @@ def test_pending_toolwindow_reference_availability_rejects_unsupported_kind(
             },
         )
         saver = manager._workspace_controller.saving
-        assert saver._pending_workspace_tool_references_available(child_node)
+        assert saver._pending_workspace_tool_reference_status(child_node)[0]
 
         child_node.update_pending_workspace_payload_attrs(
             {
@@ -2480,9 +2628,9 @@ def test_pending_toolwindow_reference_availability_rejects_unsupported_kind(
             }
         )
         assert not (
-            manager._workspace_controller.saving._pending_workspace_tool_references_available(
+            manager._workspace_controller.saving._pending_workspace_tool_reference_status(
                 child_node
-            )
+            )[0]
         )
 
         child_node.update_pending_workspace_payload_attrs(
@@ -2493,9 +2641,9 @@ def test_pending_toolwindow_reference_availability_rejects_unsupported_kind(
             }
         )
         assert not (
-            manager._workspace_controller.saving._pending_workspace_tool_references_available(
+            manager._workspace_controller.saving._pending_workspace_tool_reference_status(
                 child_node
-            )
+            )[0]
         )
 
 
@@ -2691,7 +2839,7 @@ def test_manager_reload_selected_materializes_hidden_memory_payload(
             _reload,
         )
         monkeypatch.setattr(
-            manager,
+            manager._lineage_controller,
             "_selected_reload_candidates",
             lambda: ([0], {}, None),
         )
@@ -2818,12 +2966,12 @@ def test_manager_workspace_child_tool_reference_materializes_only_child_data(
         root = itool(data, manager=False, execute=False)
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
+        root_node = manager._tool_graph.root_wrappers[0]
         root.hide()
 
         child_data = data.copy(deep=True).rename("child")
         child = _WorkspaceSweepChildTool(child_data)
-        child.set_source_binding(full_data())
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
 
         fname = tmp_path / "pending-parent-child-reference.itws"
         manager._workspace_controller.saving._save_workspace_document(fname)
@@ -2832,9 +2980,11 @@ def test_manager_workspace_child_tool_reference_materializes_only_child_data(
                 "tool_data_references"
             ]
         )
-        assert references[imagetool_serialization.SAVED_TOOL_DATA_NAME] == {
-            "kind": "parent_source"
-        }
+        reference = references[imagetool_serialization.SAVED_TOOL_DATA_NAME]
+        assert reference["kind"] == "manager_node"
+        assert reference["node_uid"] == root_node.uid
+        assert reference["node_snapshot_token"] == root_node.snapshot_token
+        assert reference["data_role"] == "displayed"
 
         pending_payloads = manager._workspace_controller.loading.pending
         original_materialize = pending_payloads._materialize_pending_workspace_payload
@@ -2996,9 +3146,13 @@ def test_manager_workspace_embedded_child_tool_keeps_parent_payload_pending(
         root.hide()
 
         child_data = (data + 10.0).rename("embedded")
-        child_uid = manager.add_childtool(
-            _WorkspaceSweepChildTool(child_data), 0, show=False
+        child_uid = add_source_childtool(
+            manager,
+            _WorkspaceSweepChildTool(child_data),
+            0,
+            show=False,
         )
+        manager._child_node(child_uid)._set_source_state("stale")
 
         fname = tmp_path / "pending-parent-embedded-child.itws"
         manager._workspace_controller.saving._save_workspace_document(fname)
@@ -3030,6 +3184,7 @@ def test_manager_workspace_embedded_child_tool_keeps_parent_payload_pending(
         assert wrapper.pending_workspace_memory_payload is not None
         loaded_child = manager.get_childtool(child_uid)
         assert isinstance(loaded_child, _WorkspaceSweepChildTool)
+        assert loaded_child.source_state == "stale"
         assert loaded_child.tool_data.name == child_data.name
         assert loaded_child.tool_data.dims == child_data.dims
         np.testing.assert_array_equal(loaded_child.tool_data.values, child_data.values)

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -1889,27 +1889,25 @@ def test_pending_workspace_reload_reason_branches(
         script_spec = types.SimpleNamespace(kind="script", script_inputs=())
         monkeypatch.setattr(
             manager_lineage,
-            "_replay_capability",
+            "_script_replay_validation",
             lambda _spec, **_kwargs: types.SimpleNamespace(
-                replayable=False,
-                requires_trust=True,
+                permissive_replayable=False,
             ),
         )
-        trust_reason = controller._pending_imagetool_reload_unavailable_reason(
+        replay_reason = controller._pending_imagetool_reload_unavailable_reason(
             types.SimpleNamespace(
                 uid="pending",
                 provenance_spec=script_spec,
                 _load_source_details=lambda: None,
             )
         )
-        assert trust_reason == "The recorded script steps cannot be reloaded."
+        assert replay_reason == "The recorded script steps cannot be reloaded."
 
         monkeypatch.setattr(
             manager_lineage,
-            "_replay_capability",
+            "_script_replay_validation",
             lambda _spec, **_kwargs: types.SimpleNamespace(
-                replayable=True,
-                requires_trust=True,
+                permissive_replayable=True,
             ),
         )
         assert (

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -48,7 +48,6 @@ if typing.TYPE_CHECKING:
         _controller as workspace_controller,
     )
 
-from erlab.interactive.imagetool._provenance._code import uses_default_replay_input
 from tests.interactive.imagetool.manager.workspace._support import (
     _AddedTimeChildTool,
     _compute_first_value,
@@ -1102,7 +1101,6 @@ def test_manager_pending_memory_file_source_full_code_uses_saved_load_code(
         trigger_menu_action(menu, manager._metadata_copy_full_action)
 
         assert copied
-        assert not uses_default_replay_input(copied[-1])
         namespace = _exec_generated_code(copied[-1], {})
         xr.testing.assert_identical(
             namespace["derived"].rename(None),

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -20,11 +20,18 @@ import erlab.interactive.imagetool.manager._workspace._pending as workspace_pend
 import erlab.interactive.imagetool.viewer_linking as imagetool_viewer_linking
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
-from erlab.interactive.imagetool._provenance._model import FileDataSelection, full_data
+from erlab.interactive.imagetool._provenance._model import (
+    FileDataSelection,
+    compose_display_provenance,
+    compose_full_provenance,
+    full_data,
+    parse_script_inputs,
+)
 from erlab.interactive.imagetool._provenance._operations import (
     AssignAttrsOperation,
     AverageOperation,
     ImageToolSelectionSourceBinding,
+    IselOperation,
 )
 from tests.interactive.imagetool.manager.helpers import (
     _exec_generated_code,
@@ -51,8 +58,10 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _open_external_lazy_hdf5_imagetool_data,
     _request_workspace_save_and_wait,
     _request_workspace_save_as_and_wait,
+    _workspace_test_file_spec,
     _WorkspaceManagerReferenceFigureTool,
     _WorkspaceSweepFigureTool,
+    add_source_childtool,
 )
 
 
@@ -1182,7 +1191,7 @@ def test_generation_save_copies_pending_tools_without_construction(
 
         child = _AddedTimeChildTool(data.rename("child"))
         child._tool_display_name = "Pending child"
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
         child.hide()
 
         figure = _WorkspaceManagerReferenceFigureTool(
@@ -1360,7 +1369,7 @@ def test_hidden_toolwindow_with_missing_saved_class_is_skipped(
         manager.add_imagetool(root, show=False)
 
         child = _AddedTimeChildTool(data)
-        child_uid = manager.add_childtool(child, 0, show=False)
+        child_uid = add_source_childtool(manager, child, 0, show=False)
         child.hide()
 
         fname = tmp_path / "missing-hidden-tool-class.itws"
@@ -1398,7 +1407,7 @@ def test_hidden_toolwindow_with_missing_saved_class_is_skipped(
         assert isinstance(skipped[0][1], TypeError)
 
 
-def test_pending_toolwindow_source_metadata_decodes_saved_state(
+def test_pending_toolwindow_legacy_binding_is_materialized_by_saved_input_decoder(
     qtbot,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
@@ -1406,6 +1415,13 @@ def test_pending_toolwindow_source_metadata_decodes_saved_state(
 ) -> None:
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(
+            np.arange(6.0).reshape(2, 3), dims=("x", "y"), name="source"
+        )
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        root_node = manager._tool_graph.root_wrappers[0]
         binding = ImageToolSelectionSourceBinding(
             selection_mode="isel",
             selection_indexers={"x": 0},
@@ -1420,24 +1436,166 @@ def test_pending_toolwindow_source_metadata_decodes_saved_state(
             erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR: True,
         }
 
-        source_spec, source_binding, auto_update, state = (
-            manager._workspace_controller.loading.pending._workspace_tool_source_metadata(
-                attrs
+        loader = manager._workspace_controller.loading
+        deferred = loader._workspace_tool_dataset_with_canonical_inputs(
+            xr.Dataset(attrs=attrs),
+            parent_target=0,
+        )
+        script_inputs = parse_script_inputs(
+            deferred.attrs[erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR]
+        )
+        assert len(script_inputs) == 1
+        assert script_inputs[0].data_role == "displayed"
+        assert script_inputs[0].node_uid == root_node.uid
+        assert script_inputs[0].node_snapshot_token == root_node.snapshot_token
+        assert script_inputs[0].source_spec is None
+        assert erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR in deferred.attrs
+
+        assert bool(
+            deferred.attrs.get(erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR)
+        )
+        assert loader._workspace_tool_source_state_from_attrs(deferred.attrs) == "stale"
+
+        source_parent_data, _resolver = loader._workspace_tool_restore_references(
+            deferred,
+            parent_target=0,
+        )
+        materialized_inputs, primary_input = (
+            erlab.interactive.utils.ToolWindow._saved_script_input_metadata(
+                deferred.attrs,
+                source_parent_data=source_parent_data,
             )
         )
+        assert primary_input == "data"
+        assert materialized_inputs[0].data_role == "displayed"
+        assert materialized_inputs[0].node_uid == root_node.uid
+        assert materialized_inputs[0].node_snapshot_token == root_node.snapshot_token
+        source_spec = materialized_inputs[0].parsed_source_spec()
+        assert source_spec is not None
+        xr.testing.assert_identical(source_spec.apply(data), data.isel(x=0))
 
-        assert source_spec is None
-        assert source_binding == binding
-        assert auto_update is True
-        assert state == "stale"
+        invalid_attrs = dict(deferred.attrs)
+        invalid_attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = "not-valid"
+        assert loader._workspace_tool_source_state_from_attrs(invalid_attrs) == "fresh"
 
-        attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = "not-valid"
-        *_, state = (
-            manager._workspace_controller.loading.pending._workspace_tool_source_metadata(
-                attrs
-            )
+
+def test_legacy_toolwindow_reload_applies_source_spec_once(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source_path = tmp_path / "legacy-toolwindow-source.nc"
+    data = xr.DataArray(np.arange(5.0), dims="x", name="source")
+    data.to_netcdf(source_path)
+    parent_provenance = _workspace_test_file_spec(source_path)
+    source_spec = full_data(IselOperation(kwargs={"x": slice(1, None)}))
+    resolved = source_spec.apply(data)
+    legacy_input_provenance = compose_display_provenance(
+        parent_provenance,
+        source_spec,
+        parent_data=data,
+    )
+    assert legacy_input_provenance is not None
+
+    legacy_tool = _AddedTimeChildTool(resolved)
+    qtbot.addWidget(legacy_tool)
+    legacy_ds = legacy_tool.to_dataset()
+    legacy_ds.attrs[erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR] = json.dumps(
+        source_spec.model_dump(mode="json")
+    )
+    legacy_ds.attrs[erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
+        json.dumps(legacy_input_provenance.model_dump(mode="json"))
+    )
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(
+            root,
+            show=False,
+            provenance_spec=parent_provenance,
         )
-        assert state == "fresh"
+
+        child_uid = manager._workspace_controller.loading._load_workspace_tool_dataset(
+            legacy_ds,
+            parent_target=0,
+        )
+        assert isinstance(child_uid, str)
+        child = manager._child_node(child_uid)
+        assert child.tool_window is not None
+        script_input = child.tool_window.script_inputs[0]
+        fallback = script_input.parsed_provenance_spec()
+        assert fallback == compose_full_provenance(parent_provenance, source_spec)
+
+        monkeypatch.setattr(
+            manager._lineage_controller,
+            "_ensure_script_provenance_trusted",
+            lambda *_args, **_kwargs: False,
+        )
+        child.tool_window.set_script_inputs(
+            (script_input.model_copy(update={"node_uid": "removed-parent"}),),
+            primary_input=child.tool_window.primary_input,
+            auto_update=child.tool_window.source_auto_update,
+            state="stale",
+        )
+        assert manager._lineage_controller._refresh_tool_inputs(
+            child_uid,
+            allow_recorded=True,
+        )
+
+        xr.testing.assert_identical(child.tool_window.tool_data, resolved)
+
+
+def test_legacy_toolwindow_input_provenance_binds_live_parent(
+    qtbot,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(np.arange(5.0), dims="x", name="source")
+    input_provenance = full_data().to_replay_spec()
+    legacy_tool = _AddedTimeChildTool(data)
+    qtbot.addWidget(legacy_tool)
+    legacy_ds = legacy_tool.to_dataset()
+    legacy_ds.attrs[erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
+        json.dumps(input_provenance.model_dump(mode="json"))
+    )
+    legacy_ds.attrs[erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR] = True
+    legacy_ds.attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = "fresh"
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = itool(data, manager=False, execute=False)
+        assert isinstance(root, erlab.interactive.imagetool.ImageTool)
+        manager.add_imagetool(root, show=False)
+        root_node = manager._node_for_target(0)
+
+        child_uid = manager._workspace_controller.loading._load_workspace_tool_dataset(
+            legacy_ds,
+            parent_target=0,
+        )
+        child = manager._child_node(child_uid)
+        assert child.tool_window is not None
+        script_input = child.tool_window.script_inputs[0]
+        assert script_input.node_uid == root_node.uid
+        assert script_input.node_snapshot_token == root_node.snapshot_token
+        assert script_input.parsed_provenance_spec() == input_provenance
+
+        updated = data + 10.0
+        with qtbot.wait_signal(manager._sigDataReplaced):
+            erlab.interactive.imagetool.manager.replace_data(0, updated)
+        qtbot.wait_until(
+            lambda: (
+                child.tool_window is not None
+                and child.tool_window.tool_data.identical(updated)
+            ),
+            timeout=5000,
+        )
+        assert child.tool_window.source_state == "fresh"
 
 
 def test_manager_duplicate_pending_memory_uses_saved_payload(
@@ -1499,8 +1657,8 @@ def test_manager_duplicate_pending_child_tool_uses_saved_payload(
         child_data = (data + 10.0).rename("child")
         child = _AddedTimeChildTool(child_data)
         child.tool_status = child.StateModel(value=7)
-        child_uid = manager.add_childtool(
-            child, 0, show=False, note="pending child note"
+        child_uid = add_source_childtool(
+            manager, child, 0, show=False, note="pending child note"
         )
         child.hide()
 
@@ -1559,7 +1717,7 @@ def test_manager_duplicate_pending_mixed_subtree_is_complete(
         tool_data = (data + 20.0).rename("tool child")
         tool_child = _AddedTimeChildTool(tool_data)
         tool_child.tool_status = tool_child.StateModel(value=9)
-        tool_uid = manager.add_childtool(tool_child, 0, show=False)
+        tool_uid = add_source_childtool(manager, tool_child, 0, show=False)
 
         for window in (root, image_child, tool_child):
             window.hide()
@@ -1805,7 +1963,7 @@ def test_manager_save_as_rebinds_external_lazy_tool_data(
         ).to_netcdf(external_path, engine="h5netcdf", invalid_netcdf=True)
         external = _open_external_lazy_hdf5_imagetool_data(external_path)
         try:
-            loaded_figure.update_data(external + 0.0)
+            loaded_figure.update_inputs({"data": external + 0.0})
             manager._workspace_controller._mark_node_data_dirty(figure_uid)
             monkeypatch.setattr(
                 manager._workspace_controller,

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -1533,8 +1533,10 @@ def test_legacy_toolwindow_reload_applies_source_spec_once(
 
         monkeypatch.setattr(
             manager._lineage_controller,
-            "_ensure_script_provenance_trusted",
-            lambda *_args, **_kwargs: False,
+            "_authorize_provenance_execution",
+            lambda *_args, **_kwargs: pytest.fail(
+                "file fallback must not request code authorization"
+            ),
         )
         child.tool_window.set_script_inputs(
             (script_input.model_copy(update={"node_uid": "removed-parent"}),),

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -32,9 +32,10 @@ from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
-from erlab.interactive.imagetool._provenance._model import full_data
+from erlab.interactive.imagetool._provenance._model import ScriptInput, full_data
 from erlab.interactive.imagetool._provenance._operations import (
     ImageToolSelectionSourceBinding,
+    IselOperation,
 )
 from erlab.interactive.imagetool.manager import ImageToolManager
 from erlab.interactive.imagetool.manager._extensions._models import (
@@ -64,6 +65,7 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _request_workspace_save_as_and_wait,
     _rich_workspace_attr_value,
     _write_transaction_test_workspace,
+    add_source_childtool,
 )
 
 
@@ -96,7 +98,8 @@ def test_manager_workspace_saves_added_time_for_all_node_kinds(
             show=False,
             created_time=child_added,
         )
-        tool_uid = manager.add_childtool(
+        tool_uid = add_source_childtool(
+            manager,
             _AddedTimeChildTool(test_data),
             root_index,
             show=False,
@@ -156,13 +159,17 @@ def test_manager_workspace_restores_hidden_ktool_angle_scales(
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         root = itool(data, manager=False, execute=False)
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
-        manager.add_imagetool(root, show=False)
+        manager.add_imagetool(
+            root,
+            show=False,
+            provenance_spec=full_data().to_replay_spec(),
+        )
 
         kspace_tool = KspaceTool(data, data_name="scan", options_model=options_model)
         kspace_tool._angle_scale_spins["alpha"].setValue(1.25)
         kspace_tool._angle_scale_spins["beta"].setValue(0.75)
         expected = kspace_tool._converted_output()
-        tool_uid = manager.add_childtool(kspace_tool, 0, show=False)
+        tool_uid = add_source_childtool(manager, kspace_tool, 0, show=False)
 
         workspace_path = tmp_path / "hidden-ktool-scales.itws"
         manager._workspace_controller.saving._save_workspace_document(workspace_path)
@@ -1805,25 +1812,25 @@ def test_workspace_gc_worker_reports_contention_and_errors() -> None:
     assert "cleanup failed" in results[0][1]
 
 
-def test_pending_workspace_tool_attrs_update_source_metadata() -> None:
+def test_pending_workspace_tool_attrs_update_script_inputs() -> None:
     saver = workspace_saving._WorkspaceSaver.__new__(workspace_saving._WorkspaceSaver)
     pending_base = {
         "tool_display_name": "old",
         "tool_title": "prefix old",
         erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR: "stale",
         erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR: "legacy",
+        erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR: "data",
     }
     saver._pending_workspace_node_attrs = types.MethodType(
         lambda _self, _node, _attrs, *, kind: dict(pending_base),
         saver,
     )
-    model = types.SimpleNamespace(model_dump=lambda **_kwargs: {"value": 1})
+    script_input = ScriptInput(name="data", node_uid="source", source_spec=full_data())
     node = types.SimpleNamespace(
         pending_workspace_payload_attrs={},
         name="new",
-        source_spec=model,
-        source_binding=None,
-        has_source_binding=True,
+        tool_script_inputs=(script_input,),
+        tool_primary_input="data",
         source_state="valid",
         source_auto_update=True,
     )
@@ -1831,22 +1838,42 @@ def test_pending_workspace_tool_attrs_update_source_metadata() -> None:
     attrs = saver._pending_workspace_tool_attrs(node)
 
     assert attrs["tool_title"] == "prefix new"
-    assert erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR in attrs
+    assert json.loads(attrs[erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR]) == [
+        script_input.model_dump(mode="json")
+    ]
+    assert attrs[erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR] == "data"
+    assert erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR not in attrs
     assert erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR not in attrs
     assert attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] == "valid"
     assert attrs[erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR] is True
     assert erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
 
+    pending_base.clear()
+    pending_base.update(
+        {
+            erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR: json.dumps(
+                full_data().model_dump(mode="json")
+            ),
+            erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                {
+                    erlab.interactive.utils._SAVED_TOOL_DATA_NAME: {
+                        "kind": "parent_source"
+                    }
+                }
+            ),
+        }
+    )
+    attrs = saver._pending_workspace_tool_attrs(node)
+    assert erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR in attrs
+
     node.name = "plain"
-    node.source_spec = None
-    node.source_binding = model
-    node.has_source_binding = False
+    node.tool_script_inputs = ()
     pending_base.clear()
     attrs = saver._pending_workspace_tool_attrs(node)
 
     assert attrs["tool_title"] == "plain"
-    assert erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR not in attrs
-    assert erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR in attrs
+    assert erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR not in attrs
+    assert erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR not in attrs
     assert erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR not in attrs
     assert erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR not in attrs
 
@@ -1874,6 +1901,33 @@ def test_workspace_reference_uid_detection_and_invalid_reader_path() -> None:
     )
     saver._close_workspace_idle_readers("workspace.itws")
     assert closed == ["closed"]
+
+
+def test_manager_node_reference_validation_applies_source_spec(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(np.arange(4.0), dims="x", name="source")
+    with manager_context() as manager:
+        manager.add_imagetool(
+            erlab.interactive.imagetool.ImageTool(data, _in_manager=True),
+            show=False,
+        )
+        node = manager._tool_graph.root_wrappers[0]
+        source_spec = full_data(IselOperation(kwargs={"x": slice(1, None)}))
+        reference = {
+            "kind": "manager_node",
+            "node_uid": node.uid,
+            "node_snapshot_token": node.snapshot_token,
+            "source_spec": source_spec.model_dump(mode="json"),
+        }
+
+        controller = manager._workspace_controller
+        assert controller._tool_data_reference_matches_current_data(
+            reference, data.isel(x=slice(1, None))
+        )
+        assert not controller._tool_data_reference_matches_current_data(reference, data)
 
 
 def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
@@ -1987,7 +2041,7 @@ def test_pending_workspace_unavailable_reference_uids(
         parent_uid=parent_uid,
     )
 
-    assert saver._pending_workspace_tool_unavailable_reference_uids(node) == expected
+    assert saver._pending_workspace_tool_reference_status(node)[1] == expected
 
 
 def test_serialize_workspace_node_error_without_optional_metadata() -> None:
@@ -5376,7 +5430,7 @@ def test_manager_workspace_dirty_marker_not_saved_in_titles(
         manager.add_imagetool(root, show=False)
         root_uid = manager._tool_graph.root_wrappers[0].uid
         tool = DerivativeTool(data)
-        tool_uid = manager.add_childtool(tool, 0, show=False)
+        tool_uid = add_source_childtool(manager, tool, 0, show=False)
 
         root.setWindowTitle("stale root title[*]")
         manager._tool_graph.root_wrappers[0].update_title()
@@ -5617,7 +5671,7 @@ def test_manager_workspace_child_save_shortcuts_use_background_save(
         child_save[0].activated.emit()
 
         tool = DerivativeTool(data)
-        manager.add_childtool(tool, 0, show=False)
+        add_source_childtool(manager, tool, 0, show=False)
         tool_save = [
             shortcut
             for shortcut in tool.findChildren(QtWidgets.QShortcut)

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -1916,18 +1916,41 @@ def test_manager_node_reference_validation_applies_source_spec(
         )
         node = manager._tool_graph.root_wrappers[0]
         source_spec = full_data(IselOperation(kwargs={"x": slice(1, None)}))
+        owner_tool = _AddedTimeChildTool(data.isel(x=slice(1, None)))
+        owner_tool.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    source_spec=source_spec.model_dump(mode="json"),
+                ),
+            ),
+            primary_input="data",
+        )
+        owner_uid = manager.add_childtool(
+            owner_tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
+        owner_node = manager._child_node(owner_uid)
         reference = {
             "kind": "manager_node",
             "node_uid": node.uid,
             "node_snapshot_token": node.snapshot_token,
+            "input_name": "data",
             "source_spec": source_spec.model_dump(mode="json"),
         }
 
         controller = manager._workspace_controller
         assert controller._tool_data_reference_matches_current_data(
-            reference, data.isel(x=slice(1, None))
+            reference,
+            data.isel(x=slice(1, None)),
+            owner_node=owner_node,
         )
-        assert not controller._tool_data_reference_matches_current_data(reference, data)
+        assert not controller._tool_data_reference_matches_current_data(
+            reference,
+            data,
+            owner_node=owner_node,
+        )
 
 
 def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_trust.py
+++ b/tests/interactive/imagetool/manager/workspace/test_trust.py
@@ -67,6 +67,7 @@ from erlab.interactive.utils import ToolWindow
 from tests.interactive.imagetool.manager.workspace._support import (
     _current_workspace_payload_attrs,
     _current_workspace_payload_path,
+    add_source_childtool,
 )
 
 if typing.TYPE_CHECKING:
@@ -506,12 +507,19 @@ def test_signed_workspace_rejects_payload_metadata_added_outside_manifest(
     reset_saved_code_trust(domain="erlab.workspace")
     workspace_path = tmp_path / "injected-pending-payload.itws"
     data = xr.DataArray(np.arange(5.0), dims="x", name="data")
+    monkeypatch.setattr(
+        QtWidgets.QDialog,
+        "exec",
+        lambda dialog: pytest.fail(
+            f"Unexpected dialog: {type(dialog).__name__} {dialog.windowTitle()!r}"
+        ),
+    )
 
     with manager_context() as manager:
         manager.add_imagetool(ImageTool(data), show=False)
         fit_tool = Fit1DTool(data)
         qtbot.addWidget(fit_tool)
-        fit_uid = manager.add_childtool(fit_tool, 0, show=False)
+        fit_uid = add_source_childtool(manager, fit_tool, 0, show=False)
         fit_tool.hide()
 
         manager._workspace_controller.saving._save_workspace_document(workspace_path)
@@ -580,7 +588,7 @@ def test_signed_workspace_materializes_unchanged_fit_payload(
         qtbot.addWidget(fit_tool)
         fit_tool._serialized_fit_result_blob = np.arange(8, dtype=np.uint8)
         fit_tool._pending_persisted_fit_is_current = False
-        fit_uid = manager.add_childtool(fit_tool, 0, show=False)
+        fit_uid = add_source_childtool(manager, fit_tool, 0, show=False)
         fit_tool.hide()
 
         manager._workspace_controller.saving._save_workspace_document(workspace_path)
@@ -617,8 +625,22 @@ def test_signed_workspace_materializes_child_parent_source_code(
         manager.add_imagetool(ImageTool(parent_data), show=False)
         child = _TrustProbeTool(child_data)
         qtbot.addWidget(child)
-        child.set_source_binding(source_spec)
-        child_uid = manager.add_childtool(child, 0, show=True)
+        child.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    data_role="displayed",
+                    source_spec=source_spec.model_dump(mode="json"),
+                ),
+            ),
+            primary_input="data",
+        )
+        parent_uid = manager._node_for_target(0).uid
+        child_uid = manager.add_childtool(
+            child,
+            script_inputs={"data": 0},
+            show=True,
+        )
 
         manager._workspace_controller.saving._save_workspace_document(workspace_path)
         references = json.loads(
@@ -626,9 +648,12 @@ def test_signed_workspace_materializes_child_parent_source_code(
                 workspace_path, f"0/childtools/{child_uid}"
             )["tool_data_references"]
         )
-        assert references[interactive_utils._SAVED_TOOL_DATA_NAME] == {
-            "kind": "parent_source"
-        }
+        reference = references[interactive_utils._SAVED_TOOL_DATA_NAME]
+        assert reference["kind"] == "manager_node"
+        assert reference["input_name"] == "data"
+        assert reference["node_uid"] == parent_uid
+        assert reference["data_role"] == "displayed"
+        assert reference["source_spec"] == source_spec.model_dump(mode="json")
         assert _trust_uses_saved_signature(manager._workspace_state.code_trust)
 
     with manager_context() as manager:
@@ -640,7 +665,7 @@ def test_signed_workspace_materializes_child_parent_source_code(
         assert manager._workspace_state.code_trust == signed
         assert node.tool_window is not None
         assert node.tool_window._document_trust == signed
-        assert node.tool_window.source_spec == source_spec
+        assert node.tool_window.script_inputs[0].parsed_source_spec() == source_spec
         assert node.tool_window.tool_data.dims == ("y",)
 
 
@@ -1293,7 +1318,7 @@ def test_workspace_host_routes_materialized_tool_trust_to_one_state(
 
         tool = _TrustProbeTool(data)
         qtbot.addWidget(tool)
-        manager.add_childtool(tool, 0, show=False)
+        add_source_childtool(manager, tool, 0, show=False)
 
         assert not document_trust_has_trusted_lineage(tool._current_document_trust())
 
@@ -1882,7 +1907,7 @@ def test_workspace_host_retains_tool_payload_verification_failure(
         tool.set_document_trust(untrusted_document_trust(), notify=False)
 
         manager._workspace_state.code_trust = trusted_location_document_trust()
-        manager.add_childtool(tool, 0, show=False)
+        add_source_childtool(manager, tool, 0, show=False)
 
         assert not document_trust_is_trusted(manager._workspace_state.code_trust)
         assert not document_trust_is_trusted(tool._current_document_trust())

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -30,6 +30,10 @@ import erlab.interactive.imagetool.manager._server as imagetool_manager_server
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 import erlab.interactive.imagetool.viewer_linking as imagetool_viewer_linking
 import erlab.interactive.imagetool.viewer_state as imagetool_viewer_state
+from erlab.interactive._code_trust import (
+    issue_complete_execution_capability,
+    new_document_trust,
+)
 from erlab.interactive._figurecomposer import (
     FigureDataSelectionState,
     FigureOperationKind,
@@ -4688,6 +4692,7 @@ def test_itool_reload_unavailable_reason_metadata_branches(
             ScriptCodeOperation(label="Use input", code="derived = data"),
             start_label="Run script",
             active_name="derived",
+            script_inputs=(ScriptInput(name="data"),),
         )
     )
     assert win.slicer_area._provenance_reload_unavailable_reason() is not None
@@ -5355,8 +5360,12 @@ def test_standalone_transformed_tool_input_records_resolved_fallback(qtbot) -> N
     provenance_child = add_child()
     fallback = provenance_child.script_inputs[0].parsed_provenance_spec()
     assert fallback == compose_full_provenance(parent_provenance, source_spec)
+
+    def authorize(entries):
+        return issue_complete_execution_capability(new_document_trust(), entries)[1]
+
     xarray.testing.assert_identical(
-        replay_script_provenance(fallback, {}),
+        replay_script_provenance(fallback, {}, authorize=authorize),
         resolved,
     )
 

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -51,14 +51,20 @@ from erlab.interactive.imagetool._figurecomposer_adapter import (
     build_figure_composer_operation,
 )
 from erlab.interactive.imagetool._load_source import _register_local_callable_loader
-from erlab.interactive.imagetool._provenance._execution import replay_file_provenance
+from erlab.interactive.imagetool._provenance._execution import (
+    replay_file_provenance,
+    replay_script_provenance,
+)
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     FileLoadSource,
     FileReplayCall,
     ReplayStage,
+    ScriptInput,
     ToolProvenanceOperation,
     ToolProvenanceSpec,
+    compose_display_provenance,
+    compose_full_provenance,
     file_load,
     full_data,
     script,
@@ -5289,13 +5295,72 @@ def test_itool_child_tool_source_specs_and_non_source_updates(qtbot) -> None:
     win.slicer_area.open_in_meshtool()
     qtbot.wait_until(lambda: len(win.slicer_area._associated_tools) == 1, timeout=5000)
     child = next(iter(win.slicer_area._associated_tools.values()))
-    assert child.source_spec == full_data()
+    assert child.script_inputs[0].data_role == "displayed"
+    assert child.script_inputs[0].parsed_source_spec() == full_data()
     assert child.source_state == "fresh"
 
     new_data = data.copy(deep=True)
     new_data.data = np.asarray(new_data.data) * 2
     win.slicer_area.set_data(new_data)
     assert child.source_state == "fresh"
+
+
+def test_standalone_transformed_tool_input_records_resolved_fallback(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(24.0).reshape((3, 4, 2)),
+        dims=("alpha", "eV", "beta"),
+        name="source",
+    )
+    source_spec = selection(IselOperation(kwargs={"beta": 0}))
+    resolved = source_spec.apply(data)
+    parent = itool(data, manager=False, execute=False)
+    assert isinstance(parent, ImageTool)
+    qtbot.addWidget(parent)
+
+    def add_child() -> DerivativeTool:
+        child = dtool(resolved, execute=False)
+        qtbot.addWidget(child)
+        child.set_script_inputs(
+            (
+                ScriptInput(
+                    name="data",
+                    source_spec=source_spec.model_dump(mode="json"),
+                ),
+            ),
+            primary_input="data",
+        )
+        parent.slicer_area.add_tool_window(child, transfer_to_manager=False)
+        return child
+
+    memory_child = add_child()
+    assert memory_child.script_inputs[0].parsed_provenance_spec() is None
+    namespace = _exec_generated_code(
+        memory_child.copy_code(),
+        {"data": data.copy(deep=True)},
+    )
+    xarray.testing.assert_identical(namespace["result"], memory_child.result)
+
+    parent_provenance = script(
+        ScriptCodeOperation(
+            label="Create parent input",
+            code=(
+                "source = xr.DataArray(np.arange(24.0).reshape((3, 4, 2)), "
+                "dims=('alpha', 'eV', 'beta'), name='source')"
+            ),
+        ),
+        start_label="Create parent input",
+        active_name="source",
+    )
+    parent.set_provenance_spec(parent_provenance)
+    provenance_child = add_child()
+    fallback = provenance_child.script_inputs[0].parsed_provenance_spec()
+    assert fallback == compose_full_provenance(parent_provenance, source_spec)
+    xarray.testing.assert_identical(
+        replay_script_provenance(fallback, {}),
+        resolved,
+    )
+
+    parent.close()
 
 
 def test_child_tool_from_gaussian_filtered_itool_keeps_display_provenance(
@@ -5318,12 +5383,37 @@ def test_child_tool_from_gaussian_filtered_itool_keeps_display_provenance(
     child = next(iter(win.slicer_area._associated_tools.values()))
 
     xarray.testing.assert_identical(child.tool_data, expected)
-    assert child.input_provenance_spec is not None
-    display_code = child.input_provenance_spec.display_code()
+    input_provenance = child.script_inputs[0].parsed_provenance_spec()
+    assert input_provenance is not None
+    display_code = input_provenance.display_code()
     assert display_code is not None
     assert "gaussian_filter" in display_code
     namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
     xarray.testing.assert_identical(namespace["derived"], expected)
+
+    win.close()
+
+
+def test_standalone_child_tool_refreshes_from_displayed_filter(qtbot) -> None:
+    data = xr.DataArray(
+        np.arange(25).reshape((5, 5)).astype(float),
+        dims=["alpha", "eV"],
+        coords={"alpha": np.arange(5, dtype=float), "eV": np.arange(5, dtype=float)},
+    )
+    operation = GaussianFilterOperation(sigma={"alpha": 1.0})
+    expected = operation.apply(data)
+
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    win.slicer_area.open_in_meshtool()
+    qtbot.wait_until(lambda: len(win.slicer_area._associated_tools) == 1, timeout=5000)
+    child = next(iter(win.slicer_area._associated_tools.values()))
+
+    win.slicer_area.apply_filter_operation(operation, emit_edited=True)
+
+    assert child.source_state == "stale"
+    assert child._update_from_input_source()
+    xr.testing.assert_identical(child.tool_data, expected)
 
     win.close()
 
@@ -5500,7 +5590,24 @@ def test_child_tool_copy_code_streamlines_noop_source_steps(qtbot) -> None:
         execute=False,
     )
     qtbot.addWidget(derivative)
-    derivative.set_source_binding(image.make_tool_source_spec(transpose=True))
+    source_spec = image.make_tool_source_spec(transpose=True)
+    input_provenance = compose_display_provenance(
+        None,
+        source_spec,
+        parent_data=win.slicer_area.data,
+    )
+    assert input_provenance is not None
+    derivative.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                data_role="source",
+                source_spec=source_spec.model_dump(mode="json"),
+                provenance_spec=input_provenance.model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+    )
 
     derivative_code = derivative.copy_code()
     assert ".isel()" not in derivative_code
@@ -5513,8 +5620,24 @@ def test_child_tool_copy_code_streamlines_noop_source_steps(qtbot) -> None:
         execute=False,
     )
     qtbot.addWidget(squeezed_child)
-    squeezed_child.set_source_parent_fetcher(lambda: _TEST_DATA["2D"].copy())
-    squeezed_child.set_source_binding(selection(SqueezeOperation()))
+    source_spec = selection(SqueezeOperation())
+    input_provenance = compose_display_provenance(
+        None,
+        source_spec,
+        parent_data=_TEST_DATA["2D"],
+    )
+    assert input_provenance is not None
+    squeezed_child.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                data_role="source",
+                source_spec=source_spec.model_dump(mode="json"),
+                provenance_spec=input_provenance.model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+    )
 
     squeezed_code = squeezed_child.copy_code()
     assert ".isel()" not in squeezed_code
@@ -5539,7 +5662,24 @@ def test_child_tool_copy_code_keeps_meaningful_parent_selection(qtbot) -> None:
         execute=False,
     )
     qtbot.addWidget(child)
-    child.set_source_binding(image.make_tool_source_spec(transpose=True))
+    source_spec = image.make_tool_source_spec(transpose=True)
+    input_provenance = compose_display_provenance(
+        None,
+        source_spec,
+        parent_data=win.slicer_area.data,
+    )
+    assert input_provenance is not None
+    child.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                data_role="source",
+                source_spec=source_spec.model_dump(mode="json"),
+                provenance_spec=input_provenance.model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+    )
 
     code = child.copy_code()
     assert "sort_coord_order" not in code
@@ -8878,7 +9018,7 @@ def test_itool_open_in_ktool_sets_full_data_source_binding(qtbot, monkeypatch) -
 
     win.slicer_area.open_in_ktool()
 
-    assert child.source_spec == full_data()
+    assert child.script_inputs[0].parsed_source_spec() == full_data()
     assert child.source_state == "fresh"
 
     win.close()
@@ -8972,8 +9112,9 @@ def test_itool_open_in_ftool_sets_squeezed_source_spec(qtbot, monkeypatch) -> No
     image = win.slicer_area.images[0]
     image.open_in_ftool()
 
-    assert child.source_spec == image.make_tool_source_spec(squeeze=True)
-    assert child.source_binding is None
+    assert child.script_inputs[0].parsed_source_spec() == image.make_tool_source_spec(
+        squeeze=True
+    )
     assert child.source_state == "fresh"
 
     win.close()
@@ -8991,10 +9132,10 @@ def test_profile_open_in_ftool_omits_noop_squeeze_source_binding(
     profile = win.slicer_area.profiles[0]
     profile.open_in_ftool()
 
-    assert child.source_spec is not None
+    source_spec = child.script_inputs[0].parsed_source_spec()
+    assert source_spec is not None
     assert not any(
-        isinstance(operation, SqueezeOperation)
-        for operation in child.source_spec.operations
+        isinstance(operation, SqueezeOperation) for operation in source_spec.operations
     )
 
     child.close()
@@ -12279,10 +12420,15 @@ def test_itool_full_data_child_updates_follow_transposed_view(qtbot) -> None:
         win.slicer_area.replace_source_data(replaced)
 
     qtbot.wait_until(lambda: child.source_state == "stale", timeout=5000)
-    assert child._update_from_parent_source() is True
+    assert child._update_from_input_source() is True
     xarray.testing.assert_identical(child.tool_data, win.slicer_area.data)
 
-    child.set_source_binding(child.source_spec, auto_update=True, state="fresh")
+    child.set_script_inputs(
+        child.script_inputs,
+        primary_input=child.primary_input,
+        auto_update=True,
+        state="fresh",
+    )
     replaced2 = replaced.copy(deep=True)
     replaced2.data = np.asarray(replaced2.data) + 5
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -8831,6 +8831,17 @@ def test_model_fit_operation_replays_fixed_and_expression_parameters() -> None:
     )
     xr.testing.assert_identical(namespace["derived"], expected)
 
+    stderr_operation = operation.model_copy(
+        update={"parameter": "c0", "output": "stderr"}
+    )
+    stderr = stderr_operation.apply(data)
+    assert stderr.name == "c0_stderr"
+    assert np.isnan(stderr.item())
+
+    stderr_code = f"derived = {stderr_operation.expression_code('data')}"
+    stderr_namespace = _exec_generated_code(stderr_code, {"data": data})
+    xr.testing.assert_identical(stderr_namespace["derived"], stderr)
+
 
 @pytest.mark.parametrize(
     ("parameter", "message"),

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -119,6 +119,7 @@ from erlab.interactive.imagetool._provenance._model import (
     restamp_operation_groups,
     script,
     script_input_dependency_refs,
+    script_inputs_dependency_refs,
     selection,
     stamp_operation_group,
     strip_operation_groups,
@@ -1339,6 +1340,34 @@ def test_operation_replay_code_passes_source_context() -> None:
     xr.testing.assert_identical(
         namespace["result"],
         operation._apply_schema_v2(child, parent_data=parent),
+    )
+
+
+def test_external_input_bypasses_trust_required_recorded_fallback() -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    fallback = script(
+        ScriptCodeOperation(
+            label="Trusted fallback",
+            code="import os\nright = xr.DataArray([0.0], dims='x')",
+        ),
+        start_label="Build fallback",
+        active_name="right",
+    )
+    spec = script(
+        ScriptCodeOperation(label="Use input", code="result = right"),
+        start_label="Use external input",
+        active_name="result",
+        script_inputs=(ScriptInput(name="right", provenance_spec=fallback),),
+    )
+
+    assert script_provenance_replayable(spec, external_input_names={"right"})
+    assert not script_provenance_requires_trust(
+        spec,
+        external_input_names={"right"},
+    )
+    xr.testing.assert_identical(
+        replay_script_provenance(spec, {"right": data}),
+        data,
     )
 
 
@@ -6406,6 +6435,10 @@ def test_script_input_dependency_refs_recurse_and_rebase() -> None:
             ),
         ),
     )
+
+    assert [
+        ref.node_uid for ref in script_inputs_dependency_refs(spec.script_inputs)
+    ] == ["old-extra"]
 
     refs = script_input_dependency_refs(spec)
     assert [

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -62,6 +62,7 @@ from erlab.interactive.imagetool._provenance._execution import (
     replay_file_provenance,
     replay_script_provenance,
     script_provenance_replayable,
+    script_provenance_requires_trust,
 )
 from erlab.interactive.imagetool._provenance._graph import ReplayGraph, ReplayGraphError
 from erlab.interactive.imagetool._provenance._model import (
@@ -8839,7 +8840,10 @@ def test_model_fit_operation_replays_fixed_and_expression_parameters() -> None:
     assert np.isnan(stderr.item())
 
     stderr_code = f"derived = {stderr_operation.expression_code('data')}"
-    stderr_namespace = _exec_generated_code(stderr_code, {"data": data})
+    stderr_namespace = _exec_generated_code(
+        stderr_code,
+        {"data": data, "era": erlab.analysis},
+    )
     xr.testing.assert_identical(stderr_namespace["derived"], stderr)
 
 

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -49,8 +49,6 @@ from erlab.interactive.imagetool._provenance._code import (
     _statement_store_count,
     _validate_active_name,
     _validate_script_replay_code,
-    rebase_default_replay_input,
-    uses_default_replay_input,
 )
 from erlab.interactive.imagetool._provenance._execution import (
     _load_file_source_data,
@@ -3293,56 +3291,6 @@ def test_tool_provenance_validation_helpers_and_error_branches() -> None:
         {"data": 3, "other": 10},
     )
     assert invalidated_namespace["result"] == 4
-    rebased = rebase_default_replay_input(
-        "derived = data\nscale = 2\nresult = derived + scale",
-        "source_data",
-    )
-    rebased_namespace = _exec_generated_code(rebased, {"source_data": 3})
-    assert rebased_namespace["result"] == 5
-    assert rebased_namespace["derived"] == 3
-    assert uses_default_replay_input("result = data + 1")
-    assert not uses_default_replay_input("result = source_data + 1")
-    helper_code = (
-        "def normalize(data):\n"
-        "    return data / data.max()\n"
-        "\n"
-        "derived = normalize(data_0)"
-    )
-    assert not uses_default_replay_input(helper_code)
-    assert rebase_default_replay_input(helper_code, "source_data") == helper_code
-    mixed_helper_code = (
-        "def normalize(data):\n"
-        "    return data / data.max()\n"
-        "\n"
-        "derived = normalize(data)"
-    )
-    rebased_helper_code = rebase_default_replay_input(mixed_helper_code, "source_data")
-    assert "def normalize(data):\n    return data / data.max()" in rebased_helper_code
-    assert "derived = normalize(source_data)" in rebased_helper_code
-    free_input_helper_code = (
-        "def transform():\n    return data + 1\n\nderived = transform()"
-    )
-    assert uses_default_replay_input(free_input_helper_code)
-    rebased_free_helper_code = rebase_default_replay_input(
-        free_input_helper_code,
-        "source_data",
-    )
-    assert not uses_default_replay_input(rebased_free_helper_code)
-    free_helper_namespace = {"source_data": 3}
-    exec(  # noqa: S102
-        rebased_free_helper_code,
-        free_helper_namespace,
-        free_helper_namespace,
-    )
-    assert free_helper_namespace["derived"] == 4
-    same_line_lambdas = (
-        "first = lambda: data + 1; second = lambda: data + 2\n"
-        "derived = first() + second()"
-    )
-    rebased_lambdas = rebase_default_replay_input(same_line_lambdas, "source_data")
-    lambda_namespace = {"source_data": 1}
-    exec(rebased_lambdas, lambda_namespace, lambda_namespace)  # noqa: S102
-    assert lambda_namespace["derived"] == 5
     replaced_helper_code = _replace_code_identifiers(
         "def normalize(data):\n    return data / data.max()\n\nderived = data",
         {"data": "source_data", "derived": "result"},
@@ -3404,67 +3352,6 @@ def test_tool_provenance_validation_helpers_and_error_branches() -> None:
         )
     with pytest.raises(TypeError, match="Script and file provenance use"):
         script(start_label="Start", active_name="derived")._display_operations()
-
-
-def test_rebase_default_replay_input_respects_lexical_scopes() -> None:
-    helper_code = (
-        "from __future__ import annotations\n\n"
-        "def transform(source):\n"
-        "    return data + source\n\n"
-        "derived = transform(1)"
-    )
-    rebased = rebase_default_replay_input(helper_code, "source")
-    namespace = {"source": 10}
-    exec(rebased, namespace, namespace)  # noqa: S102
-    assert namespace["derived"] == 11
-    assert not uses_default_replay_input(rebased)
-
-    if sys.version_info >= (3, 12):
-        class_comprehension = (
-            "class Container:\n"
-            "    data = 1\n"
-            "    values = [data for _ in range(1)]\n"
-            "    functions = [lambda: data for _ in range(1)]\n"
-            "derived = (Container.values, Container.functions[0]())"
-        )
-        rebased_comprehension = rebase_default_replay_input(
-            class_comprehension,
-            "source",
-        )
-        namespace = {"source": 10}
-        exec(rebased_comprehension, namespace, namespace)  # noqa: S102
-        assert namespace["derived"] == ([10], 10)
-
-        generic_code = (
-            "def transform[T](value: T) -> T:\n"
-            "    return data\n"
-            "\n"
-            "class Container[T]:\n"
-            "    value = data\n"
-            "\n"
-            "derived = transform(Container.value)"
-        )
-        rebased_generic = rebase_default_replay_input(generic_code, "source")
-        namespace = {"source": 10}
-        exec(rebased_generic, namespace, namespace)  # noqa: S102
-        assert namespace["derived"] == 10
-
-        type_alias_code = "type Payload[T] = tuple[T, type(data)]"
-        rebased_type_alias = rebase_default_replay_input(type_alias_code, "source")
-        namespace = {"source": 10}
-        exec(rebased_type_alias, namespace, namespace)  # noqa: S102
-        assert typing.get_args(namespace["Payload"].__value__)[1] is int
-        assert not uses_default_replay_input(rebased_type_alias)
-
-    if sys.version_info >= (3, 14):
-        annotation_code = (
-            "def transform(value: (lambda: data)()):\n"
-            "    return value\n"
-            "\n"
-            "derived = transform(1)"
-        )
-        rebased_annotation = rebase_default_replay_input(annotation_code, "source")
-        assert not uses_default_replay_input(rebased_annotation)
 
 
 def test_select_coord_operation_round_trips_and_applies() -> None:
@@ -6555,25 +6442,6 @@ class Child(Base, metaclass=data_5):
     assert "source_data" in _replace_code_identifiers(
         code,
         {"data_0": "source_data"},
-    )
-    rebased = rebase_default_replay_input(
-        """
-def normalize(value=data) -> data:
-    return value
-
-lambda_value = lambda value=data: value
-
-class Child(data):
-    pass
-
-derived = data
-""",
-        "source_data",
-    )
-    assert "source_data" in rebased
-    assert (
-        rebase_default_replay_input("derived = data", "not valid python(")
-        == "derived = data"
     )
     assert _simplify_display_code("derived =") == "derived ="
     assert _simplify_display_code("") == ""

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -62,7 +62,6 @@ from erlab.interactive.imagetool._provenance._execution import (
     replay_file_provenance,
     replay_script_provenance,
     script_provenance_replayable,
-    script_provenance_requires_trust,
 )
 from erlab.interactive.imagetool._provenance._graph import ReplayGraph, ReplayGraphError
 from erlab.interactive.imagetool._provenance._model import (
@@ -1362,12 +1361,12 @@ def test_external_input_bypasses_trust_required_recorded_fallback() -> None:
     )
 
     assert script_provenance_replayable(spec, external_input_names={"right"})
-    assert not script_provenance_requires_trust(
-        spec,
-        external_input_names={"right"},
-    )
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"right": data}),
+        replay_script_provenance(
+            spec,
+            {"right": data},
+            authorize=_authorize_execution,
+        ),
         data,
     )
 
@@ -8835,7 +8834,7 @@ def test_model_fit_operation_replays_fixed_and_expression_parameters() -> None:
     stderr_operation = operation.model_copy(
         update={"parameter": "c0", "output": "stderr"}
     )
-    stderr = stderr_operation.apply(data)
+    stderr = stderr_operation.apply(data, authorization=authorization)
     assert stderr.name == "c0_stderr"
     assert np.isnan(stderr.item())
 

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -15,7 +15,7 @@ import erlab
 import erlab.extensions._api as extension_api
 from erlab.interactive._code_trust import issue_execution_capability, new_document_trust
 from erlab.interactive.imagetool._load_source import _register_local_callable_loader
-from erlab.interactive.imagetool._provenance import _graph
+from erlab.interactive.imagetool._provenance import _execution, _graph
 from erlab.interactive.imagetool._provenance._code import (
     _SCRIPT_REPLAY_ALLOWED_BUILTINS,
     _code_uses_name,
@@ -24,11 +24,12 @@ from erlab.interactive.imagetool._provenance._code import (
     _replace_code_identifiers,
 )
 from erlab.interactive.imagetool._provenance._execution import (
-    _script_provenance_validates,
     execute_replay_graph,
+    rebuild_script_inputs,
     rebuild_script_provenance,
     replay_script_provenance,
     script_provenance_replayable,
+    script_provenance_requires_trust,
 )
 from erlab.interactive.imagetool._provenance._graph import (
     ReplayGraph,
@@ -88,6 +89,7 @@ from erlab.interactive.imagetool._provenance._operations import (
     SelOperation,
     SortCoordOrderOperation,
     SqueezeOperation,
+    TransposeOperation,
 )
 from erlab.interactive.imagetool._provenance._trust import (
     provenance_replay_graph_code_trust_entries,
@@ -528,26 +530,20 @@ class Child(Base, metaclass=data_5):
         external_input_spec,
         external_input_names={"data"},
     )
-    assert not _script_provenance_validates(
+    assert not script_provenance_requires_trust(
         script(
             start_label="Run script",
             seed_code="derived =",
             active_name="derived",
         ),
-        strict_replay_code=False,
     )
-    assert not _script_provenance_validates(
+    assert not script_provenance_requires_trust(
         script(
             ScriptCodeOperation(label="Broken", code="derived ="),
             start_label="Run script",
             seed_code="derived = 0",
             active_name="derived",
         ),
-        strict_replay_code=False,
-    )
-    assert not _script_provenance_validates(
-        None,
-        strict_replay_code=True,
     )
     assert _single_assignment_output_name("derived: xr.DataArray = data") == "derived"
     assert _single_assignment_output_name("derived =") is None
@@ -938,6 +934,499 @@ def test_script_input_parsing_does_not_affect_model_equality() -> None:
     assert without_provenance.parsed_provenance_spec() is None
 
 
+def test_rebuild_script_inputs_controls_recorded_fallback(
+    tmp_path: pathlib.Path,
+) -> None:
+    data = xr.DataArray(np.arange(6.0).reshape(2, 3), dims=("x", "y"))
+    path = tmp_path / "recorded-input.nc"
+    data.to_netcdf(path)
+    source_spec = selection(TransposeOperation(dims=("y", "x")))
+    fallback = compose_full_provenance(_file_spec(path), source_spec)
+    assert fallback is not None
+    script_input = ScriptInput(
+        name="data",
+        label="Closed input",
+        node_uid="missing-node",
+        source_spec=source_spec,
+        provenance_spec=fallback,
+    )
+    expected = source_spec.apply(data)
+
+    with pytest.raises(ReplayGraphError, match="not available in this Manager"):
+        rebuild_script_inputs(
+            (script_input,),
+            live_input_resolver=lambda _input: None,
+            allow_recorded=False,
+        )
+
+    resolved, refreshed = rebuild_script_inputs(
+        (script_input,),
+        live_input_resolver=lambda _input: None,
+        recorded_input_authorizer=lambda *_args: pytest.fail(
+            "file fallback must not request script authorization"
+        ),
+        allow_recorded=True,
+    )
+
+    xr.testing.assert_identical(resolved["data"], expected)
+    assert refreshed[0].node_uid is None
+
+    fallback_spec = script(
+        start_label="Copy transformed input",
+        seed_code="derived = data",
+        active_name="derived",
+        script_inputs=(script_input,),
+    )
+    xr.testing.assert_identical(
+        execute_replay_graph(compile_replay_graph(fallback_spec)),
+        expected,
+    )
+    code = emit_replay_code(
+        compile_replay_graph(fallback_spec, display=True),
+        output_name="derived",
+    )
+    xr.testing.assert_identical(_exec_generated_code(code)["derived"], expected)
+
+    external_spec = fallback_spec.model_copy(
+        update={
+            "script_inputs": (
+                script_input.model_copy(update={"provenance_spec": None}),
+            )
+        }
+    )
+    external_code = emit_replay_code(
+        compile_replay_graph(external_spec, display=True),
+        output_name="derived",
+    )
+    xr.testing.assert_identical(
+        _exec_generated_code(external_code, {"data": data})["derived"],
+        expected,
+    )
+
+    resolved, refreshed = rebuild_script_inputs(
+        (script_input,),
+        live_input_resolver=lambda item: (expected, item),
+        recorded_input_authorizer=lambda *_args: pytest.fail(
+            "live input must not authorize recorded provenance"
+        ),
+    )
+    xr.testing.assert_identical(resolved["data"], expected)
+    assert refreshed == (script_input,)
+
+    with pytest.raises(ReplayGraphError, match="Duplicate named provenance input"):
+        rebuild_script_inputs(
+            (script_input, script_input),
+            live_input_resolver=lambda _item: pytest.fail(
+                "duplicate names must fail before resolution"
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("left_uid", "left_role", "right_uid", "right_role"),
+    [
+        ("shared-node", "source", "shared-node", "displayed"),
+        ("left-node", "displayed", "right-node", "displayed"),
+    ],
+    ids=("data-role", "node-uid"),
+)
+def test_rebuild_script_provenance_cache_separates_live_inputs(
+    left_uid,
+    left_role,
+    right_uid,
+    right_role,
+) -> None:
+    source = xr.DataArray([[1.0, 3.0], [5.0, 7.0]], dims=("x", "y"))
+    displayed = xr.DataArray([[10.0, 30.0], [50.0, 70.0]], dims=("x", "y"))
+    data_by_ref = {
+        (left_uid, left_role): source,
+        (right_uid, right_role): displayed,
+    }
+
+    def nested(node_uid, data_role):
+        return script(
+            AverageOperation(dims=("x",)),
+            start_label="Average input",
+            active_name="data_0",
+            script_inputs=(
+                ScriptInput(
+                    name="data_0",
+                    label=data_role,
+                    node_uid=node_uid,
+                    node_snapshot_token=f"{left_uid}:{right_uid}:snapshot",
+                    data_role=data_role,
+                ),
+            ),
+        )
+
+    spec = script(
+        ScriptCodeOperation(label="Add", code="derived = left + right"),
+        start_label="Add inputs",
+        active_name="derived",
+        script_inputs=(
+            ScriptInput(
+                name="left",
+                label="Source data",
+                provenance_spec=nested(left_uid, left_role),
+            ),
+            ScriptInput(
+                name="right",
+                label="Displayed data",
+                provenance_spec=nested(right_uid, right_role),
+            ),
+        ),
+    )
+
+    def resolve_live(script_input):
+        data = data_by_ref.get((script_input.node_uid, script_input.data_role))
+        return None if data is None else (data, script_input)
+
+    result, _ = rebuild_script_provenance(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+
+    xr.testing.assert_identical(result, source.mean("x") + displayed.mean("x"))
+
+
+def test_rebuild_cache_separates_live_input_source_transforms() -> None:
+    source = xr.DataArray(np.arange(12.0).reshape(3, 4), dims=("x", "y"))
+    snapshot_token = f"snapshot-{id(source)}"
+
+    def nested(start: int) -> ToolProvenanceSpec:
+        source_spec = selection(IselOperation(kwargs={"x": slice(start, start + 2)}))
+        return script(
+            AverageOperation(dims=("y",)),
+            start_label="Average selected input",
+            active_name="data",
+            script_inputs=(
+                ScriptInput(
+                    name="data",
+                    node_uid="shared-node",
+                    node_snapshot_token=snapshot_token,
+                    source_spec=source_spec,
+                ),
+            ),
+        )
+
+    spec = script(
+        ScriptCodeOperation(
+            label="Stack selected inputs",
+            code="result = xr.concat([left, right], dim='branch')",
+        ),
+        start_label="Stack selected inputs",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(name="left", provenance_spec=nested(0)),
+            ScriptInput(name="right", provenance_spec=nested(1)),
+        ),
+    )
+
+    def resolve_live(script_input: ScriptInput):
+        if script_input.node_uid != "shared-node":
+            return None
+        source_spec = script_input.parsed_source_spec()
+        if source_spec is None:
+            return source, script_input
+        return source_spec.apply(source), script_input
+
+    result, _ = rebuild_script_provenance(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+
+    expected = xr.concat(
+        [
+            source.isel(x=slice(0, 2)).mean("y"),
+            source.isel(x=slice(1, 3)).mean("y"),
+        ],
+        dim="branch",
+    )
+    xr.testing.assert_identical(result, expected)
+
+
+def test_replay_cache_uses_resolved_live_input_snapshot() -> None:
+    source = xr.DataArray([[1.0, 3.0], [5.0, 7.0]], dims=("x", "y"))
+    displayed = xr.DataArray([[10.0, 30.0], [50.0, 70.0]], dims=("x", "y"))
+    live_input = ScriptInput(
+        name="data_0",
+        label="Live input",
+        node_uid="shared-node",
+    )
+    spec = script(
+        AverageOperation(dims=("x",)),
+        start_label="Average input",
+        active_name="data_0",
+        script_inputs=(live_input,),
+    )
+    replay_cache: dict[str, xr.DataArray] = {}
+
+    def execute_with(data):
+        resolved_input = live_input.model_copy(
+            update={"node_snapshot_token": str(id(data))}
+        )
+        graph = compile_replay_graph(
+            spec,
+            live_input_resolver=lambda _item: (data, resolved_input),
+        )
+        return execute_replay_graph(graph, cache=replay_cache)
+
+    xr.testing.assert_identical(execute_with(source), source.mean("x"))
+    xr.testing.assert_identical(execute_with(displayed), displayed.mean("x"))
+
+
+def test_replay_cache_separates_anonymous_external_inputs() -> None:
+    source = xr.DataArray([[1.0, 3.0], [5.0, 7.0]], dims=("x", "y"))
+    displayed = xr.DataArray([[10.0, 30.0], [50.0, 70.0]], dims=("x", "y"))
+    replay_cache: dict[str, xr.DataArray] = {}
+
+    for script_inputs in ((), (ScriptInput(name="data"),)):
+        spec = script(
+            AverageOperation(dims=("x",)),
+            start_label="Average input",
+            seed_code="result = data",
+            active_name="result",
+            script_inputs=script_inputs,
+        )
+        for data in (source, displayed):
+            graph = compile_replay_graph(spec, external_inputs={"data": data})
+            xr.testing.assert_identical(
+                execute_replay_graph(graph, cache=replay_cache),
+                data.mean("x"),
+            )
+
+
+def test_display_graph_uses_external_placeholders_for_unrecorded_inputs() -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    weights = xr.DataArray([3.0, 4.0], dims="x")
+    spec = script(
+        ScriptCodeOperation(
+            label="Apply weights",
+            code="result = data * weights",
+        ),
+        start_label="Use external inputs",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(
+                name="data",
+                label="ImageTool 0",
+                node_uid="data-node",
+            ),
+            ScriptInput(
+                name="weights",
+                label="ImageTool 1",
+                node_uid="weights-node",
+            ),
+        ),
+    )
+
+    with pytest.raises(ReplayGraphError, match="recorded source provenance"):
+        compile_replay_graph(spec)
+
+    code = emit_replay_code(
+        compile_replay_graph(spec, display=True),
+        output_name="result",
+    )
+    namespace = _exec_generated_code(
+        code,
+        {
+            "data": data.copy(deep=True),
+            "weights": weights.copy(deep=True),
+        },
+    )
+    xr.testing.assert_identical(namespace["result"], data * weights)
+
+
+def test_display_graph_reuses_placeholder_for_same_live_input() -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    snapshot_token = f"snapshot-{id(data)}"
+    shared_input = {
+        "label": "ImageTool 0",
+        "node_uid": "shared-node",
+        "node_snapshot_token": snapshot_token,
+    }
+    spec = script(
+        ScriptCodeOperation(
+            label="Add shared input",
+            code="result = left + right",
+        ),
+        start_label="Use one external input twice",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(name="left", **shared_input),
+            ScriptInput(name="right", **shared_input),
+        ),
+    )
+
+    code = emit_replay_code(
+        compile_replay_graph(spec, display=True),
+        output_name="result",
+    )
+    namespace = _exec_generated_code(code, {"left": data.copy(deep=True)})
+    xr.testing.assert_identical(namespace["result"], data + data)
+
+
+def test_display_graph_rejects_reserved_external_input_name() -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    spec = script(
+        start_label="Copy external input",
+        seed_code="result = xr",
+        active_name="result",
+        script_inputs=(ScriptInput(name="xr"),),
+    )
+
+    xr.testing.assert_identical(
+        replay_script_provenance(spec, {"xr": data}),
+        data,
+    )
+    with pytest.raises(ReplayGraphError, match="conflicts with a replay global"):
+        compile_replay_graph(spec, display=True)
+    assert spec.display_code() is None
+
+
+def test_display_graph_does_not_mutate_external_input() -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    original = data.copy(deep=True)
+    spec = script(
+        ScriptCodeOperation(
+            label="Increment input",
+            code="data[:] = data + 1.0\nresult = data",
+        ),
+        start_label="Use external input",
+        active_name="result",
+        script_inputs=(ScriptInput(name="data"),),
+    )
+
+    code = emit_replay_code(
+        compile_replay_graph(spec, display=True),
+        output_name="result",
+    )
+    namespace = _exec_generated_code(code, {"data": data})
+
+    xr.testing.assert_identical(namespace["result"], original + 1.0)
+    xr.testing.assert_identical(data, original)
+
+
+def test_rebuild_cache_separates_detached_recorded_inputs(
+    tmp_path: pathlib.Path,
+) -> None:
+    source = xr.DataArray([[1.0, 3.0], [5.0, 7.0]], dims=("x", "y"))
+    displayed = xr.DataArray([[10.0, 30.0], [50.0, 70.0]], dims=("x", "y"))
+    source_path = tmp_path / "source.nc"
+    displayed_path = tmp_path / "displayed.nc"
+    source.to_netcdf(source_path)
+    displayed.to_netcdf(displayed_path)
+
+    def nested(path):
+        return script(
+            AverageOperation(dims=("x",)),
+            start_label="Average input",
+            active_name="data_0",
+            script_inputs=(
+                ScriptInput(
+                    name="data_0",
+                    label="Recorded input",
+                    provenance_spec=_file_spec(path),
+                ),
+            ),
+        )
+
+    replay_cache: dict[str, xr.DataArray] = {}
+    source_result, _ = rebuild_script_provenance(
+        nested(source_path),
+        live_input_resolver=lambda item: (source, item),
+        cache=replay_cache,
+    )
+    displayed_result, _ = rebuild_script_provenance(
+        nested(displayed_path),
+        live_input_resolver=lambda item: (displayed, item),
+        cache=replay_cache,
+    )
+
+    xr.testing.assert_identical(source_result, source.mean("x"))
+    xr.testing.assert_identical(displayed_result, displayed.mean("x"))
+
+
+def test_rebuild_executes_nested_script_once(monkeypatch) -> None:
+    calls = 0
+
+    def counted_random():
+        nonlocal calls
+        calls += 1
+        return float(calls)
+
+    monkeypatch.setattr(np.random, "random", counted_random)
+    nested = script(
+        ScriptCodeOperation(
+            label="Create data",
+            code=(
+                "derived = xr.DataArray("
+                "[np.random.random(), np.random.random()], dims=('x',))"
+            ),
+        ),
+        start_label="Create input",
+        active_name="derived",
+    )
+    spec = script(
+        ScriptCodeOperation(label="Copy", code="derived = data"),
+        start_label="Copy input",
+        active_name="derived",
+        script_inputs=(
+            ScriptInput(
+                name="data",
+                label="Nested input",
+                provenance_spec=nested,
+            ),
+        ),
+    )
+
+    result, _ = rebuild_script_provenance(spec, trusted_user_code=True)
+
+    assert calls == 2
+    xr.testing.assert_identical(
+        result,
+        xr.DataArray([1.0, 2.0], dims=("x",)),
+    )
+
+
+def test_rebuild_validates_all_inputs_before_nested_execution(
+    tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    calls = 0
+
+    def counted_random():
+        nonlocal calls
+        calls += 1
+        return 1.0
+
+    monkeypatch.setattr(np.random, "random", counted_random)
+    nested = script(
+        ScriptCodeOperation(
+            label="Create data",
+            code=("left = xr.DataArray([np.random.random(), 2.0], dims=('x',))"),
+        ),
+        start_label="Create left input",
+        active_name="left",
+    )
+    path = tmp_path / "source.nc"
+    xr.DataArray([10.0, 20.0], dims="x").to_netcdf(path)
+    invalid_file = _file_spec(path).model_copy(update={"seed_code": "right ="})
+    spec = script(
+        ScriptCodeOperation(label="Add inputs", code="result = left + right"),
+        start_label="Add inputs",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(name="left", provenance_spec=nested),
+            ScriptInput(name="right", provenance_spec=invalid_file),
+        ),
+    )
+
+    with pytest.raises(ReplayGraphError, match="not valid Python"):
+        rebuild_script_provenance(spec, trusted_user_code=True)
+
+    assert calls == 0
+
+
 def test_replay_graph_file_script_input_and_rebuild_edges(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -1001,7 +1490,7 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
         active_name="derived",
         script_inputs=(ScriptInput(name="data_0", label="Closed input"),),
     )
-    with pytest.raises(ReplayGraphError, match="not open"):
+    with pytest.raises(ReplayGraphError, match="recorded source"):
         rebuild_script_provenance(missing_spec)
 
     live_calls = 0
@@ -1146,7 +1635,7 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
         active_name="derived",
         script_inputs=(unsupported_input,),
     )
-    with pytest.raises(ReplayGraphError, match="cannot be replayed"):
+    with pytest.raises(ReplayGraphError, match="non-replayable"):
         rebuild_script_provenance(unsupported_spec)
 
     full_data_spec = script(
@@ -1161,7 +1650,7 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
             ),
         ),
     )
-    with pytest.raises(ReplayGraphError, match="reloadable"):
+    with pytest.raises(ReplayGraphError, match="not self-contained"):
         rebuild_script_provenance(full_data_spec)
 
 
@@ -4301,6 +4790,511 @@ def test_replay_graph_trusted_user_code_replays_nested_scripts(
 
     assert rebuilt.kind == "script"
     xr.testing.assert_identical(result, (source + 1) * 2)
+
+
+def test_live_inputs_bypass_unreachable_unsafe_fallback() -> None:
+    left = xr.DataArray([1.0, 2.0], dims="x")
+    right = xr.DataArray([10.0, 20.0], dims="x")
+    unsafe_right_spec = script(
+        ScriptCodeOperation(
+            label="Create right input",
+            code="import os\nright = xr.DataArray([100.0, 200.0], dims='x')",
+        ),
+        start_label="Create right input",
+        active_name="right",
+    )
+    spec = script(
+        ScriptCodeOperation(label="Add inputs", code="result = left + right"),
+        start_label="Add inputs",
+        seed_code="result = left",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(name="left", label="Left input"),
+            ScriptInput(
+                name="right",
+                label="Right input",
+                provenance_spec=unsafe_right_spec,
+            ),
+        ),
+    )
+    left_input, right_input = spec.script_inputs
+
+    def resolve_live(script_input: ScriptInput):
+        if script_input is left_input:
+            return left, script_input
+        if script_input is right_input:
+            return right, script_input
+        return None
+
+    assert script_provenance_replayable(spec)
+    assert script_provenance_requires_trust(spec)
+    assert script_provenance_replayable(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+    assert not script_provenance_requires_trust(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+
+    result, _rebuilt_spec = rebuild_script_provenance(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+
+    xr.testing.assert_identical(result, left + right)
+
+
+@pytest.mark.parametrize("right_fallback", [None, full_data()])
+def test_replay_rejects_unresolved_recorded_input(
+    right_fallback: ToolProvenanceSpec | None,
+) -> None:
+    left = xr.DataArray([1.0, 2.0], dims="x")
+    spec = script(
+        ScriptCodeOperation(label="Add inputs", code="result = left + right"),
+        start_label="Add inputs",
+        seed_code="result = left",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(name="left"),
+            ScriptInput(name="right", provenance_spec=right_fallback),
+        ),
+    )
+
+    assert script_provenance_replayable(
+        spec,
+        external_input_names={"left"},
+    )
+    with pytest.raises(ReplayGraphError):
+        rebuild_script_provenance(
+            spec,
+            live_input_resolver=lambda item: (
+                (left, item) if item.name == "left" else None
+            ),
+        )
+
+
+def test_live_input_resolution_uses_exact_input_across_nested_scopes() -> None:
+    live_shared = xr.DataArray([1.0, 2.0], dims="x")
+    recorded_shared = script(
+        ScriptCodeOperation(
+            label="Create nested input",
+            code=(
+                "import os\n"
+                "shared = xr.DataArray([10.0, 20.0], dims='x') "
+                "+ int(os.path.exists(os.devnull))"
+            ),
+        ),
+        start_label="Create nested input",
+        active_name="shared",
+    )
+    nested_spec = script(
+        ScriptCodeOperation(label="Copy nested input", code="nested = shared"),
+        start_label="Copy nested input",
+        active_name="nested",
+        script_inputs=(
+            ScriptInput(
+                name="shared",
+                label="Nested shared input",
+                provenance_spec=recorded_shared,
+            ),
+        ),
+    )
+    spec = script(
+        ScriptCodeOperation(
+            label="Add inputs",
+            code="derived = shared + nested",
+        ),
+        start_label="Add inputs",
+        active_name="derived",
+        script_inputs=(
+            ScriptInput(name="shared", label="Live shared input"),
+            ScriptInput(
+                name="nested",
+                label="Nested input",
+                provenance_spec=nested_spec,
+            ),
+        ),
+    )
+    outer_shared_input = spec.script_inputs[0]
+
+    def resolve_live(script_input: ScriptInput):
+        if script_input is outer_shared_input:
+            return live_shared, script_input
+        return None
+
+    assert script_provenance_requires_trust(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+
+    result, _rebuilt_spec = rebuild_script_provenance(
+        spec,
+        live_input_resolver=resolve_live,
+        trusted_user_code=True,
+    )
+
+    xr.testing.assert_identical(
+        result,
+        live_shared + xr.DataArray([11.0, 21.0], dims="x"),
+    )
+
+
+def test_rebuild_nested_live_inputs_uses_first_resolution() -> None:
+    left = xr.DataArray([1.0, 2.0], dims="x")
+    right = xr.DataArray([10.0, 20.0], dims="x")
+    nested = script(
+        ScriptCodeOperation(label="Add inputs", code="result = left + right"),
+        start_label="Add nested inputs",
+        seed_code="result = left",
+        active_name="result",
+        script_inputs=(ScriptInput(name="left"), ScriptInput(name="right")),
+    )
+    spec = script(
+        start_label="Copy nested result",
+        seed_code="result = nested",
+        active_name="result",
+        script_inputs=(ScriptInput(name="nested", provenance_spec=nested),),
+    )
+    calls: dict[str, int] = {}
+
+    def resolve_live(script_input: ScriptInput):
+        calls[script_input.name] = calls.get(script_input.name, 0) + 1
+        if script_input.name == "nested":
+            return None
+        if calls[script_input.name] > 1:
+            return None
+        data = left if script_input.name == "left" else right
+        return data, script_input
+
+    result, _rebuilt = rebuild_script_provenance(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+
+    xr.testing.assert_identical(result, left + right)
+    assert calls == {"nested": 1, "left": 1, "right": 1}
+
+
+def test_live_input_bypasses_invalid_recorded_fallback() -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    live_input = ScriptInput(
+        name="data",
+        node_uid="live-data",
+        provenance_spec={"kind": "invalid"},
+    )
+    spec = script(
+        start_label="Copy live data",
+        seed_code="result = data",
+        active_name="result",
+        script_inputs=(live_input,),
+    )
+
+    def resolve_live(script_input: ScriptInput):
+        return (data, script_input) if script_input is live_input else None
+
+    assert script_provenance_replayable(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+    result, _rebuilt_spec = rebuild_script_provenance(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+
+    xr.testing.assert_identical(result, data)
+
+
+def test_external_input_bypasses_invalid_recorded_fallback() -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    spec = script(
+        start_label="Copy external data",
+        seed_code="result = data",
+        active_name="result",
+        script_inputs=(ScriptInput(name="data", provenance_spec={"kind": "invalid"}),),
+    )
+
+    assert script_provenance_replayable(
+        spec,
+        external_input_names={"data"},
+    )
+    xr.testing.assert_identical(
+        replay_script_provenance(spec, {"data": data}),
+        data,
+    )
+
+
+def test_nested_trust_rejection_precedes_any_input_load(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    loaded = xr.DataArray([1.0, 2.0], dims="x")
+    load_calls: list[str] = []
+
+    def load_dataarray(path: str) -> xr.DataArray:
+        load_calls.append(path)
+        return loaded
+
+    monkeypatch.setattr(xr, "load_dataarray", load_dataarray)
+    source_path = tmp_path / "unused.nc"
+    source_path.touch()
+    unsafe_fallback = script(
+        ScriptCodeOperation(
+            label="Use trusted code",
+            code="import os\nblocked = int(os.path.exists(os.devnull))",
+        ),
+        start_label="Run trusted code",
+        active_name="blocked",
+    )
+    nested_fallback = script(
+        start_label="Copy blocked input",
+        seed_code="blocked = child",
+        active_name="blocked",
+        script_inputs=(ScriptInput(name="child", provenance_spec=unsafe_fallback),),
+    )
+
+    with pytest.raises(ReplayGraphError, match="recorded operation"):
+        rebuild_script_inputs(
+            (
+                ScriptInput(
+                    name="loaded",
+                    provenance_spec=_file_spec(source_path),
+                ),
+                ScriptInput(name="blocked", provenance_spec=nested_fallback),
+            )
+        )
+
+    assert load_calls == []
+
+
+def test_invalid_later_fallback_precedes_any_input_load(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    loaded = xr.DataArray([1.0, 2.0], dims="x")
+    load_calls: list[str] = []
+
+    def load_dataarray(path: str) -> xr.DataArray:
+        load_calls.append(path)
+        return loaded
+
+    monkeypatch.setattr(xr, "load_dataarray", load_dataarray)
+    source_path = tmp_path / "unused.nc"
+    source_path.touch()
+    file_spec = _file_spec(source_path)
+    invalid_file = file_spec.model_copy(update={"seed_code": "child ="})
+    invalid_fallback = script(
+        start_label="Copy invalid input",
+        seed_code="result = child",
+        active_name="result",
+        script_inputs=(ScriptInput(name="child", provenance_spec=invalid_file),),
+    )
+
+    with pytest.raises(ReplayGraphError, match="not valid Python"):
+        rebuild_script_inputs(
+            (
+                ScriptInput(name="loaded", provenance_spec=file_spec),
+                ScriptInput(name="invalid", provenance_spec=invalid_fallback),
+            )
+        )
+
+    assert load_calls == []
+
+
+def test_missing_later_callable_precedes_any_file_load(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    source_path = tmp_path / "source.nc"
+    source_path.touch()
+    loaded = xr.DataArray([1.0, 2.0], dims="x")
+    load_calls: list[str] = []
+
+    def load_dataarray(path: str) -> xr.DataArray:
+        load_calls.append(path)
+        return loaded
+
+    monkeypatch.setattr(xr, "load_dataarray", load_dataarray)
+    file_spec = _file_spec(source_path)
+    load_source = file_spec.file_load_source
+    assert load_source is not None
+    replay_call = load_source.replay_call
+    assert replay_call is not None
+    missing_callable_spec = file_spec.model_copy(
+        update={
+            "file_load_source": load_source.model_copy(
+                update={
+                    "replay_call": replay_call.model_copy(
+                        update={
+                            "kind": "callable",
+                            "target": "definitely_missing_replay_loader.load",
+                        }
+                    )
+                }
+            )
+        }
+    )
+
+    with pytest.raises(ReplayGraphError, match="loader is not available"):
+        rebuild_script_inputs(
+            (
+                ScriptInput(name="first", provenance_spec=file_spec),
+                ScriptInput(name="second", provenance_spec=missing_callable_spec),
+            )
+        )
+
+    assert load_calls == []
+
+
+def test_live_input_classification_enforces_rebuild_depth_limit() -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    spec = script(
+        ScriptCodeOperation(label="Add inputs", code="result = left + right"),
+        start_label="Add live inputs",
+        seed_code="result = left",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(name="left", node_uid="left"),
+            ScriptInput(name="right", node_uid="right"),
+        ),
+    )
+    for level in range(21):
+        spec = script(
+            start_label=f"Copy nested input {level}",
+            seed_code="result = child",
+            active_name="result",
+            script_inputs=(ScriptInput(name="child", provenance_spec=spec),),
+        )
+
+    def resolve_live(script_input: ScriptInput):
+        if script_input.node_uid in {"left", "right"}:
+            return data, script_input
+        return None
+
+    assert not script_provenance_replayable(
+        spec,
+        live_input_resolver=resolve_live,
+    )
+    with pytest.raises(ReplayGraphError, match="maximum reload depth"):
+        rebuild_script_provenance(
+            spec,
+            live_input_resolver=resolve_live,
+        )
+
+
+def test_rebuild_preflight_work_scales_linearly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    depth = 12
+    spec = script(
+        start_label="Create leaf input",
+        seed_code="result = xr.DataArray([1.0, 2.0], dims='x')",
+        active_name="result",
+    )
+    for level in range(1, depth):
+        spec = script(
+            start_label=f"Copy nested input {level}",
+            seed_code="result = child",
+            active_name="result",
+            script_inputs=(ScriptInput(name="child", provenance_spec=spec),),
+        )
+
+    capability_calls = 0
+    compile_calls = 0
+    analyze = _execution._analyze_replay_capability
+    compile_graph = _execution.compile_replay_graph
+
+    def counted_analyze(*args, **kwargs):
+        nonlocal capability_calls
+        capability_calls += 1
+        return analyze(*args, **kwargs)
+
+    def counted_compile(*args, **kwargs):
+        nonlocal compile_calls
+        compile_calls += 1
+        return compile_graph(*args, **kwargs)
+
+    monkeypatch.setattr(_execution, "_analyze_replay_capability", counted_analyze)
+    monkeypatch.setattr(_execution, "compile_replay_graph", counted_compile)
+
+    result, _rebuilt = rebuild_script_provenance(spec)
+
+    xr.testing.assert_identical(result, xr.DataArray([1.0, 2.0], dims="x"))
+    assert capability_calls <= 2 * depth
+    assert compile_calls <= 2 * depth
+
+
+def test_external_input_name_does_not_leak_into_nested_fallback(
+    tmp_path: pathlib.Path,
+) -> None:
+    outer_left = xr.DataArray([1.0, 2.0], dims="x")
+    inner_left = xr.DataArray([100.0, 200.0], dims="x")
+    inner_left_path = tmp_path / "inner-left.nc"
+    inner_left.to_netcdf(inner_left_path)
+    right_spec = script(
+        ScriptCodeOperation(label="Offset input", code="right = left + 10.0"),
+        start_label="Create right",
+        active_name="right",
+        script_inputs=(
+            ScriptInput(name="left", provenance_spec=_file_spec(inner_left_path)),
+        ),
+    )
+    spec = script(
+        ScriptCodeOperation(label="Add inputs", code="result = left + right"),
+        start_label="Add inputs",
+        seed_code="result = left",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(name="left"),
+            ScriptInput(name="right", provenance_spec=right_spec),
+        ),
+    )
+    expected = outer_left + inner_left + 10.0
+
+    assert script_provenance_replayable(
+        spec,
+        external_input_names={"left"},
+    )
+    xr.testing.assert_identical(
+        replay_script_provenance(spec, {"left": outer_left}),
+        expected,
+    )
+    code = typing.cast("str", spec.display_code())
+    xr.testing.assert_identical(
+        _exec_generated_code(code, {"left": outer_left})["result"],
+        expected,
+    )
+
+
+def test_display_graph_rejects_nested_store_over_external_input() -> None:
+    left = xr.DataArray([1.0, 2.0], dims="x")
+    right = xr.DataArray([10.0, 20.0], dims="x")
+    right_spec = script(
+        ScriptCodeOperation(
+            label="Create right",
+            code="left = xr.DataArray([10.0, 20.0], dims='x')\nright = left",
+        ),
+        start_label="Create right",
+        active_name="right",
+    )
+    spec = script(
+        ScriptCodeOperation(label="Add inputs", code="result = left + right"),
+        start_label="Add inputs",
+        seed_code="result = left",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(name="left"),
+            ScriptInput(name="right", provenance_spec=right_spec),
+        ),
+    )
+
+    xr.testing.assert_identical(
+        replay_script_provenance(spec, {"left": left}),
+        left + right,
+    )
+    with pytest.raises(ReplayGraphError, match="provenance name 'left'"):
+        emit_replay_code(compile_replay_graph(spec, display=True))
+    assert spec.display_code() is None
 
 
 @pytest.mark.parametrize(

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -1223,6 +1223,81 @@ def test_display_graph_uses_external_placeholders_for_unrecorded_inputs() -> Non
     xr.testing.assert_identical(namespace["result"], data * weights)
 
 
+def test_display_graph_reports_and_renames_required_caller_input() -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    spec = script(
+        ScriptCodeOperation(
+            label="Offset source",
+            code=(
+                "def offset(source_data):\n"
+                "    return data + source_data\n\n"
+                "result = offset(1)"
+            ),
+        ),
+        start_label="Use caller data",
+        active_name="result",
+    )
+
+    graph = compile_replay_graph(spec, display=True)
+    (source_key,) = graph.required_input_keys("data")
+    code = emit_replay_code(
+        graph,
+        output_name="result",
+        input_name_overrides={source_key: "source_data"},
+    )
+
+    assert graph.required_input_keys() == (source_key,)
+    xr.testing.assert_identical(
+        _exec_generated_code(code, {"source_data": data})["result"],
+        data + 1,
+    )
+
+
+def test_display_graph_validates_input_name_overrides() -> None:
+    spec = script(
+        ScriptCodeOperation(label="Combine sources", code="result = left + right"),
+        start_label="Use caller data",
+        active_name="result",
+    )
+    graph = compile_replay_graph(spec, display=True)
+    left_key, right_key = graph.required_input_keys()
+
+    with pytest.raises(ReplayGraphError, match="unknown key"):
+        emit_replay_code(graph, input_name_overrides={"missing": "source"})
+    with pytest.raises(ReplayGraphError, match="valid Python identifier"):
+        emit_replay_code(graph, input_name_overrides={left_key: "not valid"})
+    with pytest.raises(ReplayGraphError, match="distinct names"):
+        emit_replay_code(
+            graph,
+            input_name_overrides={left_key: "source", right_key: "source"},
+        )
+    with pytest.raises(ReplayGraphError, match="cannot use the requested name"):
+        emit_replay_code(graph, input_name_overrides={left_key: "np"})
+
+
+def test_display_graph_reports_no_input_for_nested_file_provenance() -> None:
+    spec = script(
+        ScriptCodeOperation(label="Offset source", code="result = data + 1"),
+        start_label="Use recorded input",
+        active_name="result",
+        script_inputs=(
+            ScriptInput(
+                name="data",
+                label="File source",
+                provenance_spec=_file_spec("scan.h5"),
+            ),
+        ),
+    )
+
+    graph = compile_replay_graph(spec, display=True)
+
+    assert graph.required_input_keys() == ()
+    assert "load_dataarray('scan.h5')" in emit_replay_code(
+        graph,
+        output_name="result",
+    )
+
+
 def test_display_graph_reuses_placeholder_for_same_live_input() -> None:
     data = xr.DataArray([1.0, 2.0], dims="x")
     snapshot_token = f"snapshot-{id(data)}"
@@ -5150,22 +5225,14 @@ def test_rebuild_preflight_work_scales_linearly(
             script_inputs=(ScriptInput(name="child", provenance_spec=spec),),
         )
 
-    capability_calls = 0
     compile_calls = 0
-    analyze = _execution._analyze_replay_capability
     compile_graph = _execution.compile_replay_graph
-
-    def counted_analyze(*args, **kwargs):
-        nonlocal capability_calls
-        capability_calls += 1
-        return analyze(*args, **kwargs)
 
     def counted_compile(*args, **kwargs):
         nonlocal compile_calls
         compile_calls += 1
         return compile_graph(*args, **kwargs)
 
-    monkeypatch.setattr(_execution, "_analyze_replay_capability", counted_analyze)
     monkeypatch.setattr(_execution, "compile_replay_graph", counted_compile)
 
     result, _rebuilt = rebuild_script_provenance(
@@ -5174,7 +5241,6 @@ def test_rebuild_preflight_work_scales_linearly(
     )
 
     xr.testing.assert_identical(result, xr.DataArray([1.0, 2.0], dims="x"))
-    assert capability_calls <= 2 * depth
     assert compile_calls <= 2 * depth
 
 

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -29,7 +29,6 @@ from erlab.interactive.imagetool._provenance._execution import (
     rebuild_script_provenance,
     replay_script_provenance,
     script_provenance_replayable,
-    script_provenance_requires_trust,
 )
 from erlab.interactive.imagetool._provenance._graph import (
     ReplayGraph,
@@ -530,21 +529,6 @@ class Child(Base, metaclass=data_5):
         external_input_spec,
         external_input_names={"data"},
     )
-    assert not script_provenance_requires_trust(
-        script(
-            start_label="Run script",
-            seed_code="derived =",
-            active_name="derived",
-        ),
-    )
-    assert not script_provenance_requires_trust(
-        script(
-            ScriptCodeOperation(label="Broken", code="derived ="),
-            start_label="Run script",
-            seed_code="derived = 0",
-            active_name="derived",
-        ),
-    )
     assert _single_assignment_output_name("derived: xr.DataArray = data") == "derived"
     assert _single_assignment_output_name("derived =") is None
     assert _single_assignment_output_name("obj.value = data") is None
@@ -962,7 +946,7 @@ def test_rebuild_script_inputs_controls_recorded_fallback(
     resolved, refreshed = rebuild_script_inputs(
         (script_input,),
         live_input_resolver=lambda _input: None,
-        recorded_input_authorizer=lambda *_args: pytest.fail(
+        authorize=lambda *_args: pytest.fail(
             "file fallback must not request script authorization"
         ),
         allow_recorded=True,
@@ -1006,7 +990,7 @@ def test_rebuild_script_inputs_controls_recorded_fallback(
     resolved, refreshed = rebuild_script_inputs(
         (script_input,),
         live_input_resolver=lambda item: (expected, item),
-        recorded_input_authorizer=lambda *_args: pytest.fail(
+        authorize=lambda *_args: pytest.fail(
             "live input must not authorize recorded provenance"
         ),
     )
@@ -1084,6 +1068,7 @@ def test_rebuild_script_provenance_cache_separates_live_inputs(
     result, _ = rebuild_script_provenance(
         spec,
         live_input_resolver=resolve_live,
+        authorize=_authorize_execution,
     )
 
     xr.testing.assert_identical(result, source.mean("x") + displayed.mean("x"))
@@ -1133,6 +1118,7 @@ def test_rebuild_cache_separates_live_input_source_transforms() -> None:
     result, _ = rebuild_script_provenance(
         spec,
         live_input_resolver=resolve_live,
+        authorize=_authorize_execution,
     )
 
     expected = xr.concat(
@@ -1276,7 +1262,11 @@ def test_display_graph_rejects_reserved_external_input_name() -> None:
     )
 
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"xr": data}),
+        replay_script_provenance(
+            spec,
+            {"xr": data},
+            authorize=_authorize_execution,
+        ),
         data,
     )
     with pytest.raises(ReplayGraphError, match="conflicts with a replay global"):
@@ -1380,7 +1370,7 @@ def test_rebuild_executes_nested_script_once(monkeypatch) -> None:
         ),
     )
 
-    result, _ = rebuild_script_provenance(spec, trusted_user_code=True)
+    result, _ = rebuild_script_provenance(spec, authorize=_authorize_execution)
 
     assert calls == 2
     xr.testing.assert_identical(
@@ -1389,9 +1379,7 @@ def test_rebuild_executes_nested_script_once(monkeypatch) -> None:
     )
 
 
-def test_rebuild_validates_all_inputs_before_nested_execution(
-    tmp_path: pathlib.Path, monkeypatch
-) -> None:
+def test_rebuild_validates_all_inputs_before_nested_execution(monkeypatch) -> None:
     calls = 0
 
     def counted_random():
@@ -1408,21 +1396,23 @@ def test_rebuild_validates_all_inputs_before_nested_execution(
         start_label="Create left input",
         active_name="left",
     )
-    path = tmp_path / "source.nc"
-    xr.DataArray([10.0, 20.0], dims="x").to_netcdf(path)
-    invalid_file = _file_spec(path).model_copy(update={"seed_code": "right ="})
+    invalid_script = script(
+        start_label="Create right input",
+        seed_code="right =",
+        active_name="right",
+    )
     spec = script(
         ScriptCodeOperation(label="Add inputs", code="result = left + right"),
         start_label="Add inputs",
         active_name="result",
         script_inputs=(
             ScriptInput(name="left", provenance_spec=nested),
-            ScriptInput(name="right", provenance_spec=invalid_file),
+            ScriptInput(name="right", provenance_spec=invalid_script),
         ),
     )
 
     with pytest.raises(ReplayGraphError, match="not valid Python"):
-        rebuild_script_provenance(spec, trusted_user_code=True)
+        rebuild_script_provenance(spec, authorize=_authorize_execution)
 
     assert calls == 0
 
@@ -1592,17 +1582,20 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
     assert rebuilt_displayed.script_inputs[0].data_role == "displayed"
 
     miss_calls = 0
-    duplicate_file_input = ScriptInput(
-        name="data_0",
+    shared_file_input = ScriptInput(
+        name="left",
         label="Closed file input",
         node_uid="same-uid",
         provenance_spec=file_spec,
     )
-    duplicate_file_spec = script(
-        ScriptCodeOperation(label="Copy", code="derived = data_0"),
+    shared_file_spec = script(
+        ScriptCodeOperation(label="Add", code="derived = left + right"),
         start_label="Run script",
         active_name="derived",
-        script_inputs=(duplicate_file_input, duplicate_file_input),
+        script_inputs=(
+            shared_file_input,
+            shared_file_input.model_copy(update={"name": "right"}),
+        ),
     )
 
     def miss_live(_script_input):
@@ -1611,11 +1604,11 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
         return
 
     rebuilt_from_miss, _rebuilt_from_miss_spec = rebuild_script_provenance(
-        duplicate_file_spec,
+        shared_file_spec,
         live_input_resolver=miss_live,
         authorize=_authorize_execution,
     )
-    xr.testing.assert_identical(rebuilt_from_miss, data)
+    xr.testing.assert_identical(rebuilt_from_miss, data * 2.0)
     assert miss_calls == 2
 
     unsupported_nested = script(
@@ -4827,12 +4820,9 @@ def test_live_inputs_bypass_unreachable_unsafe_fallback() -> None:
         return None
 
     assert script_provenance_replayable(spec)
-    assert script_provenance_requires_trust(spec)
+    assert not script_provenance_replayable(unsafe_right_spec)
+    assert script_provenance_replayable(unsafe_right_spec, allow_code=True)
     assert script_provenance_replayable(
-        spec,
-        live_input_resolver=resolve_live,
-    )
-    assert not script_provenance_requires_trust(
         spec,
         live_input_resolver=resolve_live,
     )
@@ -4840,6 +4830,7 @@ def test_live_inputs_bypass_unreachable_unsafe_fallback() -> None:
     result, _rebuilt_spec = rebuild_script_provenance(
         spec,
         live_input_resolver=resolve_live,
+        authorize=_authorize_execution,
     )
 
     xr.testing.assert_identical(result, left + right)
@@ -4923,15 +4914,13 @@ def test_live_input_resolution_uses_exact_input_across_nested_scopes() -> None:
             return live_shared, script_input
         return None
 
-    assert script_provenance_requires_trust(
-        spec,
-        live_input_resolver=resolve_live,
-    )
+    assert not script_provenance_replayable(recorded_shared)
+    assert script_provenance_replayable(recorded_shared, allow_code=True)
 
     result, _rebuilt_spec = rebuild_script_provenance(
         spec,
         live_input_resolver=resolve_live,
-        trusted_user_code=True,
+        authorize=_authorize_execution,
     )
 
     xr.testing.assert_identical(
@@ -4970,6 +4959,7 @@ def test_rebuild_nested_live_inputs_uses_first_resolution() -> None:
     result, _rebuilt = rebuild_script_provenance(
         spec,
         live_input_resolver=resolve_live,
+        authorize=_authorize_execution,
     )
 
     xr.testing.assert_identical(result, left + right)
@@ -5000,6 +4990,7 @@ def test_live_input_bypasses_invalid_recorded_fallback() -> None:
     result, _rebuilt_spec = rebuild_script_provenance(
         spec,
         live_input_resolver=resolve_live,
+        authorize=_authorize_execution,
     )
 
     xr.testing.assert_identical(result, data)
@@ -5019,52 +5010,13 @@ def test_external_input_bypasses_invalid_recorded_fallback() -> None:
         external_input_names={"data"},
     )
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"data": data}),
+        replay_script_provenance(
+            spec,
+            {"data": data},
+            authorize=_authorize_execution,
+        ),
         data,
     )
-
-
-def test_nested_trust_rejection_precedes_any_input_load(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: pathlib.Path,
-) -> None:
-    loaded = xr.DataArray([1.0, 2.0], dims="x")
-    load_calls: list[str] = []
-
-    def load_dataarray(path: str) -> xr.DataArray:
-        load_calls.append(path)
-        return loaded
-
-    monkeypatch.setattr(xr, "load_dataarray", load_dataarray)
-    source_path = tmp_path / "unused.nc"
-    source_path.touch()
-    unsafe_fallback = script(
-        ScriptCodeOperation(
-            label="Use trusted code",
-            code="import os\nblocked = int(os.path.exists(os.devnull))",
-        ),
-        start_label="Run trusted code",
-        active_name="blocked",
-    )
-    nested_fallback = script(
-        start_label="Copy blocked input",
-        seed_code="blocked = child",
-        active_name="blocked",
-        script_inputs=(ScriptInput(name="child", provenance_spec=unsafe_fallback),),
-    )
-
-    with pytest.raises(ReplayGraphError, match="recorded operation"):
-        rebuild_script_inputs(
-            (
-                ScriptInput(
-                    name="loaded",
-                    provenance_spec=_file_spec(source_path),
-                ),
-                ScriptInput(name="blocked", provenance_spec=nested_fallback),
-            )
-        )
-
-    assert load_calls == []
 
 
 def test_invalid_later_fallback_precedes_any_input_load(
@@ -5074,20 +5026,19 @@ def test_invalid_later_fallback_precedes_any_input_load(
     loaded = xr.DataArray([1.0, 2.0], dims="x")
     load_calls: list[str] = []
 
-    def load_dataarray(path: str) -> xr.DataArray:
-        load_calls.append(path)
+    def load_file_source(load_source, **_kwargs) -> xr.DataArray:
+        load_calls.append(load_source.path)
         return loaded
 
-    monkeypatch.setattr(xr, "load_dataarray", load_dataarray)
+    monkeypatch.setattr(_execution, "_load_file_source_data", load_file_source)
     source_path = tmp_path / "unused.nc"
     source_path.touch()
     file_spec = _file_spec(source_path)
-    invalid_file = file_spec.model_copy(update={"seed_code": "child ="})
     invalid_fallback = script(
+        ScriptCodeOperation(label="Invalid code", code="result ="),
         start_label="Copy invalid input",
-        seed_code="result = child",
         active_name="result",
-        script_inputs=(ScriptInput(name="child", provenance_spec=invalid_file),),
+        script_inputs=(ScriptInput(name="child", provenance_spec=file_spec),),
     )
 
     with pytest.raises(ReplayGraphError, match="not valid Python"):
@@ -5110,11 +5061,11 @@ def test_missing_later_callable_precedes_any_file_load(
     loaded = xr.DataArray([1.0, 2.0], dims="x")
     load_calls: list[str] = []
 
-    def load_dataarray(path: str) -> xr.DataArray:
-        load_calls.append(path)
+    def load_file_source(load_source, **_kwargs) -> xr.DataArray:
+        load_calls.append(load_source.path)
         return loaded
 
-    monkeypatch.setattr(xr, "load_dataarray", load_dataarray)
+    monkeypatch.setattr(_execution, "_load_file_source_data", load_file_source)
     file_spec = _file_spec(source_path)
     load_source = file_spec.file_load_source
     assert load_source is not None
@@ -5217,7 +5168,10 @@ def test_rebuild_preflight_work_scales_linearly(
     monkeypatch.setattr(_execution, "_analyze_replay_capability", counted_analyze)
     monkeypatch.setattr(_execution, "compile_replay_graph", counted_compile)
 
-    result, _rebuilt = rebuild_script_provenance(spec)
+    result, _rebuilt = rebuild_script_provenance(
+        spec,
+        authorize=_authorize_execution,
+    )
 
     xr.testing.assert_identical(result, xr.DataArray([1.0, 2.0], dims="x"))
     assert capability_calls <= 2 * depth
@@ -5256,7 +5210,11 @@ def test_external_input_name_does_not_leak_into_nested_fallback(
         external_input_names={"left"},
     )
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"left": outer_left}),
+        replay_script_provenance(
+            spec,
+            {"left": outer_left},
+            authorize=_authorize_execution,
+        ),
         expected,
     )
     code = typing.cast("str", spec.display_code())
@@ -5289,7 +5247,11 @@ def test_display_graph_rejects_nested_store_over_external_input() -> None:
     )
 
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"left": left}),
+        replay_script_provenance(
+            spec,
+            {"left": left},
+            authorize=_authorize_execution,
+        ),
         left + right,
     )
     with pytest.raises(ReplayGraphError, match="provenance name 'left'"):

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -66,7 +66,9 @@ from erlab.interactive.imagetool._provenance._model import (
     compose_full_provenance,
     file_load,
     full_data,
+    parse_script_inputs,
     public_data,
+    rebase_script_inputs_node_uids,
     script,
     selection,
 )
@@ -918,6 +920,24 @@ def test_script_input_parsing_does_not_affect_model_equality() -> None:
     assert without_provenance.parsed_provenance_spec() is None
 
 
+def test_script_input_parsing_validates_boundary_values() -> None:
+    with pytest.raises(TypeError, match="source spec must be"):
+        ScriptInput(name="data", source_spec=object())
+    with pytest.raises(TypeError, match="must be a live ToolProvenanceSpec"):
+        ScriptInput(
+            name="data",
+            source_spec=script(start_label="Use data", active_name="data"),
+        )
+
+    assert parse_script_inputs(None) == ()
+    for invalid in ('"data"', 1):
+        with pytest.raises(TypeError, match="must be a sequence"):
+            parse_script_inputs(invalid)
+
+    script_inputs = (ScriptInput(name="data", node_uid="source"),)
+    assert rebase_script_inputs_node_uids(script_inputs, {}) == script_inputs
+
+
 def test_rebuild_script_inputs_controls_recorded_fallback(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -1004,6 +1024,21 @@ def test_rebuild_script_inputs_controls_recorded_fallback(
                 "duplicate names must fail before resolution"
             ),
         )
+
+    for recorded_spec, message in (
+        (None, "does not contain recorded source provenance"),
+        (full_data(), "does not contain reloadable script or file provenance"),
+    ):
+        with pytest.raises(ReplayGraphError, match=message):
+            rebuild_script_inputs(
+                (
+                    ScriptInput(
+                        name="detached",
+                        label="Detached input",
+                        provenance_spec=recorded_spec,
+                    ),
+                )
+            )
 
 
 @pytest.mark.parametrize(
@@ -1273,6 +1308,56 @@ def test_display_graph_validates_input_name_overrides() -> None:
         )
     with pytest.raises(ReplayGraphError, match="cannot use the requested name"):
         emit_replay_code(graph, input_name_overrides={left_key: "np"})
+
+
+def test_display_graph_disambiguates_and_overrides_external_input_names() -> None:
+    graph = ReplayGraph(display=True)
+    script_code = "def add_values():\n    return left + right\n\nresult = add_values()"
+    caller_key = graph.add_node(
+        "caller",
+        "caller_input",
+        payload={"name": "source"},
+    )
+    external_key = graph.add_node(
+        "external",
+        "external_input",
+        payload={"name": "source"},
+    )
+    graph.output_key = graph.add_node(
+        "script",
+        "script",
+        parents=(caller_key, external_key),
+        cacheable=False,
+        payload={
+            "active_name": "result",
+            "bindings": (("left", caller_key), ("right", external_key)),
+            "codes": (script_code,),
+            "document_codes": (script_code,),
+            "external_names": ((),),
+            "hoist_imports": (False,),
+            "uses_implicit_framework_imports": (False,),
+        },
+    )
+    source = xr.DataArray([1.0, 2.0], dims="x")
+    other = xr.DataArray([3.0, 4.0], dims="x")
+
+    code = emit_replay_code(graph, output_name="result")
+    namespace = _exec_generated_code(
+        code,
+        {"source": source, "source_2": other},
+    )
+    xr.testing.assert_identical(namespace["result"], source + other)
+
+    overridden_code = emit_replay_code(
+        graph,
+        output_name="result",
+        input_name_overrides={external_key: "weights"},
+    )
+    overridden = _exec_generated_code(
+        overridden_code,
+        {"source": source, "weights": other},
+    )
+    xr.testing.assert_identical(overridden["result"], source + other)
 
 
 def test_display_graph_reports_no_input_for_nested_file_provenance() -> None:
@@ -5127,6 +5212,53 @@ def test_invalid_later_fallback_precedes_any_input_load(
     assert load_calls == []
 
 
+def test_rebuild_script_inputs_rejects_unavailable_file_sources_before_loading(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "source.nc"
+    path.touch()
+    base_spec = _file_spec(path)
+    load_source = base_spec.file_load_source
+    assert load_source is not None
+
+    extension_unavailable = base_spec.model_copy(
+        update={
+            "file_load_source": load_source.model_copy(
+                update={
+                    "replay_call": FileReplayCall(
+                        kind="extension_loader",
+                        target="missing_loader.py",
+                        source_hash="a" * 64,
+                        capability_id="load_data",
+                        selection=FileDataSelection(kind="dataarray"),
+                    )
+                }
+            )
+        }
+    )
+    monkeypatch.setattr(
+        _execution,
+        "_registered_script_capability_status",
+        lambda *_args: "disabled",
+    )
+    monkeypatch.setattr(
+        _execution,
+        "_load_file_source_data",
+        lambda *_args, **_kwargs: pytest.fail(
+            "unavailable sources must fail before loading"
+        ),
+    )
+
+    for spec, message in (
+        (_file_spec(tmp_path / "missing.nc"), "source file is not available"),
+        (_erlab_file_spec(path, "missing-loader"), "loader is not available"),
+        (extension_unavailable, "extension loader is not available"),
+    ):
+        with pytest.raises(ReplayGraphError, match=message):
+            rebuild_script_inputs((ScriptInput(name="source", provenance_spec=spec),))
+
+
 def test_missing_later_callable_precedes_any_file_load(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pathlib.Path,
@@ -5323,6 +5455,34 @@ def test_display_graph_rejects_nested_store_over_external_input() -> None:
     with pytest.raises(ReplayGraphError, match="provenance name 'left'"):
         emit_replay_code(compile_replay_graph(spec, display=True))
     assert spec.display_code() is None
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        (
+            "from math import *\nresult = left",
+            "opaque namespace import",
+        ),
+        (
+            "np = left\nresult = left",
+            "overwrite replay global 'np'",
+        ),
+    ],
+)
+def test_display_graph_rejects_unsafe_multi_input_namespace_changes(
+    code: str,
+    message: str,
+) -> None:
+    spec = script(
+        ScriptCodeOperation(label="Use input", code=code),
+        start_label="Use input",
+        active_name="result",
+        script_inputs=(ScriptInput(name="left"),),
+    )
+
+    with pytest.raises(ReplayGraphError, match=message):
+        emit_replay_code(compile_replay_graph(spec, display=True))
 
 
 @pytest.mark.parametrize(

--- a/tests/interactive/test_derivative.py
+++ b/tests/interactive/test_derivative.py
@@ -2,7 +2,7 @@ import ast
 import json
 import tempfile
 import typing
-from types import SimpleNamespace
+from collections.abc import Mapping
 
 import numpy as np
 import pyqtgraph as pg
@@ -117,8 +117,14 @@ def test_dtool(qtbot, interpmode, smoothmode, nsmooth, method_idx) -> None:
         win.curv_factor_spin.setValue(40)
 
     check_generated_code(win)
-    win.set_source_binding(
-        full_data(),
+    script_input = ScriptInput(
+        name="data",
+        source_spec=full_data().model_dump(mode="json"),
+        provenance_spec=full_data().to_replay_spec().model_dump(mode="json"),
+    )
+    win.set_script_inputs(
+        (script_input,),
+        primary_input="data",
         auto_update=True,
         state="stale",
     )
@@ -134,7 +140,8 @@ def test_dtool(qtbot, interpmode, smoothmode, nsmooth, method_idx) -> None:
 
         assert win.tool_status == win_restored.tool_status
         assert str(win_restored.info_text) == str(win.info_text)
-        assert win_restored.source_spec == win.source_spec
+        assert win_restored.script_inputs == win.script_inputs
+        assert win_restored.primary_input == "data"
         assert win_restored.source_auto_update is True
         assert win_restored.source_state == "stale"
         check_generated_code(win_restored)
@@ -249,7 +256,7 @@ def test_dtool_smoothing_copy_code_uses_readable_steps(qtbot) -> None:
     xr.testing.assert_identical(win.result, namespace["result"])
 
     spec = script(
-        *win._copy_provenance(input_name="data"),
+        *win._copy_provenance(primary_input="data"),
         start_label="Compute derivative output",
         seed_code="derived = data",
         active_name="result",
@@ -401,17 +408,23 @@ def test_dtool_deferred_restore_delays_result_recompute(qtbot, monkeypatch) -> N
     assert calls == [restored]
 
 
-def test_dtool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> None:
+def test_dtool_copy_code_replays_script_input_provenance(qtbot) -> None:
     data = xr.DataArray(
         np.arange(49).reshape((7, 7)), dims=["x", "y"], name="data"
     ).astype(np.float64)
     source = selection(IselOperation(kwargs={"y": slice(1, 6)}))
-    parent_provenance = selection(IselOperation(kwargs={"x": slice(0, 2)}))
     source_data = source.apply(data)
     win: DerivativeTool = dtool(source_data, execute=False)
     qtbot.addWidget(win)
-    win.set_source_binding(source)
-    win.set_input_provenance_parent_fetcher(lambda: parent_provenance)
+    win.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                provenance_spec=source.to_replay_spec().model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+    )
 
     code = win.copy_code()
 
@@ -423,7 +436,7 @@ def test_dtool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> No
     xr.testing.assert_identical(win.result, result)
 
 
-def test_dtool_update_data_preserves_state(qtbot) -> None:
+def test_dtool_update_inputs_preserves_state(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
     ).astype(np.float64)
@@ -446,7 +459,7 @@ def test_dtool_update_data_preserves_state(qtbot) -> None:
     win.curv_factor_spin.setValue(12.0)
 
     status = win.tool_status
-    win.update_data(new_data)
+    win.update_inputs({"data": new_data})
 
     assert win.tool_status == status
     xr.testing.assert_identical(win.tool_data, new_data)
@@ -523,15 +536,21 @@ def test_dtool_output_imagetool_provenance_transposes_result(qtbot) -> None:
     xr.testing.assert_identical(result, win.result.T)
 
 
-def test_dtool_source_update_marks_unavailable_for_incompatible_data(qtbot) -> None:
+def test_dtool_input_update_marks_unavailable_for_incompatible_data(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
     ).astype(np.float64)
     win: DerivativeTool = dtool(data, execute=False)
     qtbot.addWidget(win)
 
-    win.set_source_binding(
-        selection(TransposeOperation()),
+    source_spec = selection(TransposeOperation())
+    script_input = ScriptInput(
+        name="data",
+        source_spec=source_spec.model_dump(mode="json"),
+    )
+    win.set_script_inputs(
+        (script_input,),
+        primary_input="data",
         auto_update=True,
     )
 
@@ -541,13 +560,16 @@ def test_dtool_source_update_marks_unavailable_for_incompatible_data(qtbot) -> N
         coords={"x": np.arange(5), "y": np.arange(5), "z": np.arange(5)},
         name="data",
     )
-    win.handle_parent_source_replaced(parent_data)
+    win._set_input_resolver(
+        lambda: ({"data": source_spec.apply(parent_data)}, (script_input,))
+    )
+    win.handle_input_sources_replaced()
 
     assert win.source_state == "unavailable"
     xr.testing.assert_identical(win.tool_data, data)
 
 
-def test_dtool_full_data_source_update_marks_unavailable_for_incompatible_data(
+def test_dtool_full_data_input_update_marks_unavailable_for_incompatible_data(
     qtbot,
 ) -> None:
     data = xr.DataArray(
@@ -556,27 +578,38 @@ def test_dtool_full_data_source_update_marks_unavailable_for_incompatible_data(
     win: DerivativeTool = dtool(data, execute=False)
     qtbot.addWidget(win)
 
-    win.set_source_binding(
-        full_data(),
+    script_input = ScriptInput(
+        name="data",
+        source_spec=full_data().model_dump(mode="json"),
+    )
+    win.set_script_inputs(
+        (script_input,),
+        primary_input="data",
         auto_update=False,
     )
 
     parent_data = xr.DataArray(np.arange(5), dims=("x",), name="data")
-    win.handle_parent_source_replaced(parent_data)
+    win._set_input_resolver(lambda: ({"data": parent_data}, (script_input,)))
+    win.handle_input_sources_replaced()
 
     assert win.source_state == "unavailable"
     xr.testing.assert_identical(win.tool_data, data)
 
 
-def test_dtool_restored_source_binding_without_parent_stays_stale(qtbot) -> None:
+def test_dtool_restored_script_input_without_resolver_stays_stale(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
     ).astype(np.float64)
     win: DerivativeTool = dtool(data, execute=False)
     qtbot.addWidget(win)
 
-    win.set_source_binding(
-        full_data(),
+    script_input = ScriptInput(
+        name="data",
+        source_spec=full_data().model_dump(mode="json"),
+    )
+    win.set_script_inputs(
+        (script_input,),
+        primary_input="data",
         auto_update=True,
         state="stale",
     )
@@ -590,11 +623,11 @@ def test_dtool_restored_source_binding_without_parent_stays_stale(qtbot) -> None
         assert isinstance(win_restored, DerivativeTool)
         assert win_restored.source_state == "stale"
 
-        assert win_restored._update_from_parent_source() is False
+        assert win_restored._update_from_input_source() is False
         assert win_restored.source_state == "stale"
 
 
-def test_dtool_source_update_with_temporarily_missing_parent_stays_stale(qtbot) -> None:
+def test_dtool_input_update_recovers_after_resolver_becomes_available(qtbot) -> None:
     data = xr.DataArray(
         np.arange(25).reshape((5, 5)), dims=["x", "y"], name="data"
     ).astype(np.float64)
@@ -604,27 +637,32 @@ def test_dtool_source_update_with_temporarily_missing_parent_stays_stale(qtbot) 
     win: DerivativeTool = dtool(data, execute=False)
     qtbot.addWidget(win)
 
-    win.set_source_binding(
-        full_data(),
+    script_input = ScriptInput(
+        name="data",
+        source_spec=full_data().model_dump(mode="json"),
+    )
+    win.set_script_inputs(
+        (script_input,),
+        primary_input="data",
         auto_update=True,
         state="stale",
     )
 
     available = False
 
-    def fetcher() -> xr.DataArray:
+    def resolver() -> tuple[dict[str, xr.DataArray], tuple[ScriptInput, ...]]:
         if not available:
             raise LookupError("Parent tool is temporarily unavailable")
-        return updated
+        return {"data": updated}, (script_input,)
 
-    win.set_source_parent_fetcher(fetcher)
+    win._set_input_resolver(resolver)
 
-    assert win._update_from_parent_source() is False
-    assert win.source_state == "stale"
+    assert win._update_from_input_source() is False
+    assert win.source_state == "unavailable"
 
     available = True
 
-    assert win._update_from_parent_source() is True
+    assert win._update_from_input_source() is True
     assert win.source_state == "fresh"
     xr.testing.assert_identical(win.tool_data, updated)
 
@@ -764,7 +802,7 @@ def test_tool_provenance_roundtrip_and_resolve_selection() -> None:
         )
 
 
-def test_tool_window_source_binding_helpers_and_failure_paths(qtbot) -> None:
+def test_tool_window_script_input_helpers_and_failure_paths(qtbot) -> None:
     class _DummyState(BaseModel):
         value: int = 0
 
@@ -786,6 +824,7 @@ def test_tool_window_source_binding_helpers_and_failure_paths(qtbot) -> None:
             self._value = 0
             self.fail_validate = False
             self.fail_update = False
+            self.validate_calls = 0
 
         @property
         def tool_status(self) -> _DummyState:
@@ -799,24 +838,27 @@ def test_tool_window_source_binding_helpers_and_failure_paths(qtbot) -> None:
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
+        def validate_update_inputs(
+            self, inputs: Mapping[str, xr.DataArray]
+        ) -> Mapping[str, xr.DataArray]:
+            self.validate_calls += 1
             if self.fail_validate:
                 raise ValueError("invalid update")
-            return super().validate_update_data(new_data)
+            return super().validate_update_inputs(inputs)
 
-        def update_data(self, new_data: xr.DataArray) -> None:
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
             if self.fail_update:
                 raise RuntimeError("update failed")
-            self._data = new_data
+            self._data = inputs["data"]
 
         def _dummy_expression(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             del data
-            return f"{input_name or 'data'}.mean()"
+            return f"{primary_input or 'data'}.mean()"
 
     data = xr.DataArray(np.arange(9).reshape((3, 3)), dims=("x", "y"), name="data")
     updated = xr.DataArray(
@@ -838,16 +880,26 @@ def test_tool_window_source_binding_helpers_and_failure_paths(qtbot) -> None:
     tool.setCentralWidget(replacement)
     assert tool.centralWidget() is replacement
 
-    spec = selection(IselOperation(kwargs={"x": slice(0, 2)}))
-    tool.set_source_binding(spec, auto_update=True, state="stale")
-    assert tool.has_source_binding is True
+    source_spec = selection(IselOperation(kwargs={"x": slice(0, 2)}))
+    script_input = ScriptInput(
+        name="data",
+        source_spec=source_spec.model_dump(mode="json"),
+        provenance_spec=source_spec.to_replay_spec().model_dump(mode="json"),
+    )
+    tool.set_script_inputs(
+        (script_input,),
+        primary_input="data",
+        auto_update=True,
+        state="stale",
+    )
+    assert tool.script_inputs
     assert tool.source_status_text == "Update Available"
     assert "Automatic updates are enabled." in tool._source_status_button.toolTip()
-    copied_spec = tool.source_spec
-    assert copied_spec is not None
+    copied_input = tool.script_inputs[0]
     with pytest.raises(ValidationError, match="Instance is frozen"):
-        copied_spec.kind = "changed"
-    assert tool.source_spec == spec
+        copied_input.name = "changed"
+    assert tool.script_inputs == (script_input,)
+    assert tool.primary_input == "data"
 
     tool._set_source_state("unavailable")
     assert tool.source_status_text == "Update Unavailable"
@@ -862,73 +914,49 @@ def test_tool_window_source_binding_helpers_and_failure_paths(qtbot) -> None:
     assert tool.source_status_text == ""
     assert tool._source_status_bar.isHidden()
 
-    tool.set_source_binding(None, auto_update=True, state="stale")
-    assert tool.source_spec is None
-    assert tool.has_source_binding is False
-    assert tool.source_status_text == ""
-    assert tool._source_status_bar.isHidden()
+    with pytest.raises(ValueError, match="fixed"):
+        tool.set_script_inputs((), primary_input=None)
 
-    with pytest.raises(RuntimeError, match="not bound to an ImageTool source"):
-        tool._resolve_source_data(updated)
-
-    tool._set_source_state("fresh")
-    tool.handle_parent_source_replaced(updated)
-    assert tool.source_state == "fresh"
-
-    with pytest.raises(TypeError, match="ToolProvenanceSpec or None"):
-        tool.set_source_binding(
-            {"kind": "selection", "operations": [{"op": "invalid"}]}
-        )
-    tool.set_source_parent_fetcher(lambda: updated)
-    assert tool._update_from_parent_source() is False
-    assert tool.source_state == "unavailable"
-
-    tool.set_source_binding(full_data(), auto_update=True)
+    tool._set_input_resolver(lambda: ({"data": updated}, (script_input,)))
     tool.fail_validate = True
-    assert tool._update_from_parent_source() is False
+    assert tool._update_from_input_source() is False
     assert tool.source_state == "unavailable"
     tool.fail_validate = False
 
     tool.fail_update = True
-    assert tool._update_from_parent_source() is False
+    assert tool._update_from_input_source() is False
     assert tool.source_state == "unavailable"
     tool.fail_update = False
 
-    assert tool._update_from_parent_source() is True
+    assert tool._update_from_input_source() is True
     assert tool.source_state == "fresh"
     xr.testing.assert_identical(tool.tool_data, updated)
 
-    tool.set_source_binding(full_data(), auto_update=False)
-    tool.handle_parent_source_replaced(updated * 2)
+    tool._set_source_auto_update(False)
+    tool._set_input_resolver(lambda: ({"data": updated * 2}, (script_input,)))
+    tool.handle_input_sources_replaced()
     assert tool.source_state == "stale"
 
-    tool.set_source_binding(full_data(), auto_update=True)
+    tool._set_source_auto_update(True)
+    tool._set_input_resolver(lambda: ({"data": updated}, (script_input,)))
+    validate_calls = tool.validate_calls
     tool.fail_validate = True
-    tool.handle_parent_source_replaced(updated)
+    tool.handle_input_sources_replaced()
+    assert tool.validate_calls == validate_calls + 1
     assert tool.source_state == "unavailable"
     tool.fail_validate = False
 
     tool.fail_update = True
-    tool.handle_parent_source_replaced(updated)
+    tool.handle_input_sources_replaced()
     assert tool.source_state == "unavailable"
     tool.fail_update = False
 
-    bad_parent = SimpleNamespace(
-        kspace=SimpleNamespace(
-            _valid_offset_keys=(),
-            momentum_axes=(),
-            configuration=0,
-            _has_hv=False,
-        )
-    )
-    tool.set_source_binding(full_data(), auto_update=True)
-    tool.handle_parent_source_replaced(bad_parent)
+    tool._set_input_resolver(lambda: ({"wrong": updated}, (script_input,)))
+    tool.handle_input_sources_replaced()
     assert tool.source_state == "unavailable"
 
 
-def test_tool_copy_code_uses_current_tool_input_without_parent_provenance(
-    qtbot,
-) -> None:
+def test_tool_copy_code_uses_current_script_input(qtbot) -> None:
     class _DummyState(BaseModel):
         value: int = 0
 
@@ -963,14 +991,14 @@ def test_tool_copy_code_uses_current_tool_input_without_parent_provenance(
         def _dummy_expression(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             del data
-            return f"{input_name or 'data'}.mean()"
+            return f"{primary_input or 'data'}.mean()"
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
     data = xr.DataArray(np.arange(9).reshape((3, 3)), dims=("x", "y"), name="data")
     parent = erlab.interactive.itool(data, execute=False, manager=False)
@@ -980,18 +1008,34 @@ def test_tool_copy_code_uses_current_tool_input_without_parent_provenance(
 
     tool = _DummyTool(data.isel(x=slice(0, 2)))
     qtbot.addWidget(tool)
-    tool.set_source_binding(full_data())
+    tool.set_script_inputs(
+        (ScriptInput(name="data"),),
+        primary_input="data",
+    )
     parent.slicer_area.add_tool_window(tool, transfer_to_manager=False)
 
     code = tool.copy_code()
-    assert ".isel(" not in code
+    assert ".isel(" in code
     namespace = _exec_generated_code(
         code,
-        {"data": tool.tool_data.copy(deep=True)},
+        {"data": data.copy(deep=True)},
     )
     result = namespace["result"]
     assert isinstance(result, xr.DataArray)
     xr.testing.assert_identical(result, data.isel(x=slice(0, 2)).mean())
+
+    multi_input_tool = _DummyTool(data)
+    qtbot.addWidget(multi_input_tool)
+    multi_input_tool.set_script_inputs(
+        (ScriptInput(name="data"), ScriptInput(name="right")),
+        primary_input="data",
+    )
+    with pytest.raises(ValueError, match="must declare one input"):
+        parent.slicer_area.add_tool_window(
+            multi_input_tool,
+            transfer_to_manager=False,
+        )
+    assert multi_input_tool._input_resolver is None
 
 
 def test_tool_input_provenance_snapshot_tracks_applied_refreshes(qtbot) -> None:
@@ -1029,28 +1073,33 @@ def test_tool_input_provenance_snapshot_tracks_applied_refreshes(qtbot) -> None:
         def _dummy_expression(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             del data
-            return f"{input_name or 'data'}.mean()"
+            return f"{primary_input or 'data'}.mean()"
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
     data = xr.DataArray(np.arange(16).reshape((4, 4)), dims=("x", "y"), name="data")
     parent_provenance = {"spec": selection(IselOperation(kwargs={"x": slice(0, 2)}))}
 
     tool = _DummyTool(data.isel(x=slice(0, 2)))
     qtbot.addWidget(tool)
-    tool.set_source_binding(full_data())
-    tool.set_input_provenance_parent_fetcher(lambda: parent_provenance["spec"])
+    script_input = ScriptInput(
+        name="data",
+        provenance_spec=parent_provenance["spec"]
+        .to_replay_spec()
+        .model_dump(mode="json"),
+    )
+    tool.set_script_inputs((script_input,), primary_input="data")
 
     initial_code = tool.copy_code()
-    assert ".isel(" not in initial_code
+    assert ".isel(" in initial_code
     initial_namespace = _exec_generated_code(
         initial_code,
-        {"data": tool.tool_data.copy(deep=True)},
+        {"data": data.copy(deep=True)},
     )
     initial_result = initial_namespace["result"]
     assert isinstance(initial_result, xr.DataArray)
@@ -1058,30 +1107,41 @@ def test_tool_input_provenance_snapshot_tracks_applied_refreshes(qtbot) -> None:
 
     parent_provenance["spec"] = selection(IselOperation(kwargs={"y": slice(0, 2)}))
     stale_code = tool.copy_code()
-    assert ".isel(" not in stale_code
+    assert "x=slice" in stale_code
+    assert "y=slice" not in stale_code
     stale_namespace = _exec_generated_code(
         stale_code,
-        {"data": tool.tool_data.copy(deep=True)},
+        {"data": data.copy(deep=True)},
     )
     stale_result = stale_namespace["result"]
     assert isinstance(stale_result, xr.DataArray)
     xr.testing.assert_identical(stale_result, data.isel(x=slice(0, 2)).mean())
 
-    tool._data = data.isel(y=slice(0, 2))
-    tool.finalize_source_refresh()
+    refreshed_input = script_input.model_copy(
+        update={
+            "provenance_spec": parent_provenance["spec"]
+            .to_replay_spec()
+            .model_dump(mode="json")
+        }
+    )
+    assert tool._apply_inputs(
+        {"data": data.isel(y=slice(0, 2))},
+        (refreshed_input,),
+    )
 
     refreshed_code = tool.copy_code()
-    assert ".isel(" not in refreshed_code
+    assert "x=slice" not in refreshed_code
+    assert "y=slice" in refreshed_code
     refreshed_namespace = _exec_generated_code(
         refreshed_code,
-        {"data": tool.tool_data.copy(deep=True)},
+        {"data": data.copy(deep=True)},
     )
     refreshed_result = refreshed_namespace["result"]
     assert isinstance(refreshed_result, xr.DataArray)
     xr.testing.assert_identical(refreshed_result, data.isel(y=slice(0, 2)).mean())
 
 
-def test_tool_input_provenance_resyncs_when_parent_fetcher_arrives_late(qtbot) -> None:
+def test_tool_input_provenance_resyncs_when_resolver_refreshes_input(qtbot) -> None:
     class _DummyState(BaseModel):
         value: int = 0
 
@@ -1116,21 +1176,25 @@ def test_tool_input_provenance_resyncs_when_parent_fetcher_arrives_late(qtbot) -
         def _dummy_expression(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             del data
-            return f"{input_name or 'data'}.mean()"
+            return f"{primary_input or 'data'}.mean()"
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
     data = xr.DataArray(np.arange(16).reshape((4, 4)), dims=("x", "y"), name="data")
 
     tool = _DummyTool(data)
     qtbot.addWidget(tool)
-    tool.set_source_binding(selection(SqueezeOperation()))
-    tool.set_input_provenance_parent_fetcher(lambda: None)
+    input_provenance = selection(SqueezeOperation()).to_replay_spec()
+    script_input = ScriptInput(
+        name="data",
+        provenance_spec=input_provenance.model_dump(mode="json"),
+    )
+    tool.set_script_inputs((script_input,), primary_input="data")
 
     early_code = tool.copy_code()
     early_namespace = _exec_generated_code(early_code, {"data": data.copy(deep=True)})
@@ -1139,7 +1203,11 @@ def test_tool_input_provenance_resyncs_when_parent_fetcher_arrives_late(qtbot) -
     xr.testing.assert_identical(early_result, data.mean())
     assert ".squeeze()" in early_code
 
-    tool.set_source_parent_fetcher(lambda: data)
+    refreshed_input = script_input.model_copy(
+        update={"provenance_spec": full_data().to_replay_spec().model_dump(mode="json")}
+    )
+    tool._set_input_resolver(lambda: ({"data": data}, (refreshed_input,)))
+    assert tool._update_from_input_source()
 
     refreshed_code = tool.copy_code()
     refreshed_namespace = _exec_generated_code(

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -877,6 +877,7 @@ def test_goldtool_abort_fit_task_disconnects_late_worker_signals(qtbot, gold) ->
         lambda _center, _stderr: late_calls.append("finished")
     )
     task.signals.sigFailed.connect(lambda _message: late_calls.append("failed"))
+    win._source_refresh_deferred = True
 
     win._abort_fit_task()
     task.signals.sigIterated.emit(1)
@@ -887,6 +888,11 @@ def test_goldtool_abort_fit_task_disconnects_late_worker_signals(qtbot, gold) ->
 
     assert win._fit_task is None
     assert late_calls == []
+    assert not win._source_refresh_deferred
+
+    win._source_refresh_deferred = True
+    win._abort_fit_task()
+    assert not win._source_refresh_deferred
 
 
 def test_edge_fit_task_aborted_before_run_skips_fit(gold, monkeypatch) -> None:
@@ -1081,18 +1087,23 @@ def test_goldtool_late_task_results_do_not_update_while_closing(qtbot, gold) -> 
     assert not hasattr(win, "edge_center")
 
 
-def test_goldtool_perform_edge_fit_ignores_closing_updates(qtbot, gold) -> None:
+def test_goldtool_perform_edge_fit_ignores_closing_updates(
+    qtbot, gold, monkeypatch
+) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
 
     class _ThreadPoolDouble:
         def __init__(self) -> None:
             self.started_tasks: list[EdgeFitTask] = []
+            self.raise_on_start = False
 
         def activeThreadCount(self) -> int:
             return 0
 
         def start(self, task: EdgeFitTask) -> None:
+            if self.raise_on_start:
+                raise RuntimeError("start failed")
             self.started_tasks.append(task)
 
     threadpool = _ThreadPoolDouble()
@@ -1103,6 +1114,18 @@ def test_goldtool_perform_edge_fit_ignores_closing_updates(qtbot, gold) -> None:
     assert threadpool.started_tasks == [win._fit_task]
 
     win._abort_fit_task()
+    failures: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        erlab.interactive.utils.MessageDialog,
+        "critical",
+        lambda *args, **kwargs: failures.append((args, kwargs)),
+    )
+    threadpool.raise_on_start = True
+    win.perform_edge_fit()
+
+    assert win._fit_task is None
+    assert len(failures) == 1
+
     win._fit_closing = True
     win.perform_edge_fit()
 
@@ -1245,11 +1268,13 @@ def test_goldtool_handle_fit_failed_ignores_stale_and_closing_tasks(
     assert critical_calls == []
 
     win._fit_closing = False
+    win._source_refresh_deferred = True
     win._handle_fit_failed("current failure", task=current_task)
 
     assert win._fit_task is None
     assert disconnected == [current_task]
     assert len(critical_calls) == 1
+    assert not win._source_refresh_deferred
 
     win._handle_fit_failed("taskless failure")
 
@@ -2491,8 +2516,9 @@ def test_restool_start_fit_worker_returns_false_when_thread_exists(qtbot) -> Non
     win._fit_thread = None
 
 
-def test_restool_start_fit_worker_sets_signature_when_missing(
-    qtbot, monkeypatch
+@pytest.mark.parametrize("start_fails", [False, True], ids=["started", "start-error"])
+def test_restool_start_fit_worker_handles_thread_start(
+    qtbot, monkeypatch, start_fails: bool
 ) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
@@ -2512,6 +2538,8 @@ def test_restool_start_fit_worker_sets_signature_when_missing(
             self.sigErrored = _DummySignal()
             self.sigCancelled = _DummySignal()
             self.started = False
+            self.deleted = False
+            created.append(self)
 
         def cancel(self) -> None:
             return
@@ -2523,18 +2551,34 @@ def test_restool_start_fit_worker_sets_signature_when_missing(
             return True
 
         def start(self) -> None:
+            if start_fails:
+                raise RuntimeError("start failed")
             self.started = True
 
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    created: list[_DummyThread] = []
     monkeypatch.setattr("erlab.interactive.fermiedge.ResolutionFitThread", _DummyThread)
     monkeypatch.setattr(win, "_current_fit_signature", lambda: ("sig",))
+    failures: list[str] = []
+    monkeypatch.setattr(win, "_fit_failed", failures.append)
     win._fit_thread = None
     win._fit_signature_current = None
     win._fit_cancel_requested = True
 
-    assert win._start_fit_worker()
-    assert isinstance(win._fit_thread, _DummyThread)
+    assert win._start_fit_worker() is not start_fails
     assert win._fit_cancel_requested is False
+    assert len(created) == 1
+    if start_fails:
+        assert win._fit_thread is None
+        assert created[0].deleted
+        assert failures == ["Fit failed to start"]
+        return
+
+    assert isinstance(win._fit_thread, _DummyThread)
     assert win._fit_thread.started
+    assert failures == []
     win._fit_thread = None
 
 

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -172,7 +172,7 @@ def test_goldtool_adaptive_toggle_is_persisted_and_forwarded(
     assert adaptive_check.isChecked()
     assert step_edge_check.isChecked()
 
-    win.data_name = "era"
+    win.data_name = "gold_data"
     provenance = win.current_provenance_spec()
     assert provenance is not None
     replay_kwargs: dict[str, typing.Any] = {}
@@ -185,7 +185,7 @@ def test_goldtool_adaptive_toggle_is_persisted_and_forwarded(
         return xr.Dataset()
 
     monkeypatch.setattr(erlab.analysis.gold, "poly", capture_poly)
-    namespace = {"era": gold}
+    namespace = {"era": erlab.analysis, "gold_data": gold}
     exec(provenance.display_code(), namespace, namespace)  # noqa: S102
     assert isinstance(replay_args[0], xr.DataArray)
     assert replay_kwargs["adaptive"] is True

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -24,7 +24,7 @@ from erlab.interactive.fermiedge import (
     goldtool,
     restool,
 )
-from erlab.interactive.imagetool._provenance._model import full_data
+from erlab.interactive.imagetool._provenance._model import ScriptInput
 from erlab.io.exampledata import generate_gold_edge
 
 
@@ -584,7 +584,7 @@ def test_goldtool_close_skips_deferred_fit_snapshot(qtbot, gold, monkeypatch) ->
     assert not restored._flush_restore_work(key=GoldTool._PERSISTED_FIT_SNAPSHOT_KEY)
 
 
-def test_goldtool_deferred_restore_update_data_refits_pending_fit(
+def test_goldtool_deferred_restore_update_inputs_refits_pending_fit(
     qtbot, gold, monkeypatch
 ) -> None:
     win: GoldTool = goldtool(gold, execute=False, data_name="gold_input")
@@ -601,16 +601,22 @@ def test_goldtool_deferred_restore_update_data_refits_pending_fit(
     assert restored._pending_persisted_fit_snapshot is not None
 
     called: list[bool] = []
-    monkeypatch.setattr(restored, "perform_edge_fit", lambda: called.append(True))
+
+    def start_fit() -> None:
+        called.append(True)
+        restored._fit_task = typing.cast("EdgeFitTask", object())
+
+    monkeypatch.setattr(restored, "perform_edge_fit", start_fit)
     new_gold = gold.copy(deep=True)
     new_gold.data = np.asarray(new_gold.data) * 1.02
 
-    assert restored.update_data(new_gold) is False
+    assert restored.update_inputs({"data": new_gold}) is False
 
     assert called == [True]
     assert restored._pending_persisted_fit_snapshot is None
     assert not hasattr(restored, "edge_center")
     xr.testing.assert_identical(restored.data, new_gold)
+    restored._fit_task = None
 
 
 @pytest.mark.parametrize("defer_restore_work", [False, True])
@@ -656,15 +662,24 @@ def test_goldtool_handles_missing_cpu_count(qtbot, gold, monkeypatch) -> None:
     assert cpu_widget.maximum() == 1
 
 
-def test_goldtool_cancel_background_work_stops_pending_update(qtbot, gold) -> None:
+def test_goldtool_cancel_background_work_aborts_fit_task(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
 
-    win._pending_update_timer.start(1000)
+    class _DummyTask:
+        def __init__(self) -> None:
+            self.aborted = False
+            self.signals = EdgeFitSignals()
 
-    assert win._pending_update_timer.isActive()
+        def abort_fit(self) -> None:
+            self.aborted = True
+
+    task = _DummyTask()
+    win._fit_task = task
+
     assert win._cancel_background_work(timeout_ms=0)
-    assert not win._pending_update_timer.isActive()
+    assert task.aborted
+    assert win._fit_task is None
 
 
 def test_goldtool_duplicate_roundtrip(qtbot, gold) -> None:
@@ -734,7 +749,23 @@ def test_goldtool_roi_limits_descending_coords(qtbot, gold) -> None:
     assert y1 == pytest.approx(-0.5)
 
 
-def test_goldtool_update_data_invalidates_fit_and_can_refit(
+def test_goldtool_update_inputs_preserves_constructor_data_corr(qtbot, gold) -> None:
+    corrected = gold.copy(deep=True)
+    corrected.data = np.asarray(corrected.data) * 1.02
+    win: GoldTool = goldtool(gold, data_corr=corrected, execute=False)
+    qtbot.addWidget(win)
+
+    updated = gold.copy(deep=True)
+    updated.data = np.asarray(updated.data) * 1.05
+    validated = win.validate_update_inputs({"data": updated})
+
+    assert tuple(validated) == ("data",)
+    assert win.update_inputs(validated)
+    xr.testing.assert_identical(win.data, updated)
+    xr.testing.assert_identical(win.data_corr, corrected)
+
+
+def test_goldtool_update_inputs_invalidates_fit_and_can_refit(
     qtbot, gold, monkeypatch
 ) -> None:
     win: GoldTool = goldtool(gold, execute=False)
@@ -757,7 +788,7 @@ def test_goldtool_update_data_invalidates_fit_and_can_refit(
 
     new_gold = gold.copy(deep=True)
     new_gold.data = np.asarray(new_gold.data) * 1.05
-    win.update_data(new_gold)
+    win.update_inputs({"data": new_gold})
 
     assert win.params_edge.values["T (K)"] == pytest.approx(45.0)
     assert win.params_poly.values["Degree"] == 3
@@ -772,12 +803,12 @@ def test_goldtool_update_data_invalidates_fit_and_can_refit(
 
     newer_gold = new_gold.copy(deep=True)
     newer_gold.data = np.asarray(newer_gold.data) * 1.02
-    win.update_data(newer_gold)
+    win.update_inputs({"data": newer_gold})
 
     assert called == [True]
 
 
-def test_goldtool_update_data_ignores_late_results_from_aborted_task(
+def test_goldtool_apply_inputs_ignores_late_results_from_aborted_task(
     qtbot, gold, monkeypatch
 ) -> None:
     win: GoldTool = goldtool(gold, execute=False)
@@ -799,7 +830,9 @@ def test_goldtool_update_data_ignores_late_results_from_aborted_task(
 
     new_gold = gold.copy(deep=True)
     new_gold.data = np.asarray(new_gold.data) * 1.01
-    win.update_data(new_gold)
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs((script_input,), primary_input="data")
+    win._apply_inputs({"data": new_gold}, (script_input,))
 
     assert stale_task.aborted is True
     assert win._fit_task is None
@@ -1048,16 +1081,9 @@ def test_goldtool_late_task_results_do_not_update_while_closing(qtbot, gold) -> 
     assert not hasattr(win, "edge_center")
 
 
-def test_goldtool_perform_edge_fit_ignores_pending_or_closing_updates(
-    qtbot, gold
-) -> None:
+def test_goldtool_perform_edge_fit_ignores_closing_updates(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
-
-    win._pending_update_request = object()  # type: ignore[assignment]
-    win.perform_edge_fit()
-
-    assert win._fit_task is None
 
     class _ThreadPoolDouble:
         def __init__(self) -> None:
@@ -1070,7 +1096,6 @@ def test_goldtool_perform_edge_fit_ignores_pending_or_closing_updates(
             self.started_tasks.append(task)
 
     threadpool = _ThreadPoolDouble()
-    win._pending_update_request = None
     win._fit_closing = False
     win._threadpool = threadpool  # type: ignore[assignment]
     win.perform_edge_fit()
@@ -1231,7 +1256,7 @@ def test_goldtool_handle_fit_failed_ignores_stale_and_closing_tasks(
     assert len(critical_calls) == 2
 
 
-def test_goldtool_update_data_defers_until_fit_worker_drains(
+def test_goldtool_apply_inputs_stops_fit_worker_before_update(
     qtbot, gold, monkeypatch
 ) -> None:
     win: GoldTool = goldtool(gold, execute=False)
@@ -1248,76 +1273,33 @@ def test_goldtool_update_data_defers_until_fit_worker_drains(
     stale_task = _DummyTask()
     win._fit_task = stale_task
 
-    active_counts = iter((1, 0))
+    wait_timeouts: list[int] = []
     monkeypatch.setattr(
-        win._threadpool,
-        "activeThreadCount",
-        lambda: next(active_counts, 0),
+        type(win),
+        "_wait_for_threadpool",
+        staticmethod(
+            lambda _threadpool, *, timeout_ms: wait_timeouts.append(timeout_ms) or True
+        ),
     )
 
     new_gold = gold.copy(deep=True)
     new_gold.data = np.asarray(new_gold.data) * 1.02
-    win.update_data(new_gold)
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs((script_input,), primary_input="data")
 
+    assert win._apply_inputs({"data": new_gold}, (script_input,))
     assert stale_task.aborted is True
-    assert win._pending_update_request is not None
-    xr.testing.assert_identical(win.data, gold)
-
-    win._pending_update_timer.stop()
-    win._flush_pending_update()
-
-    assert win._pending_update_request is None
-    xr.testing.assert_identical(win.data, new_gold)
-
-
-def test_goldtool_auto_source_update_stays_stale_until_deferred_refresh_applies(
-    qtbot, gold, monkeypatch
-) -> None:
-    win: GoldTool = goldtool(gold, execute=False)
-    qtbot.addWidget(win)
-    win.set_source_binding(
-        full_data(),
-        auto_update=True,
-    )
-
-    class _DummyTask:
-        def __init__(self) -> None:
-            self.aborted = False
-            self.signals = EdgeFitSignals()
-
-        def abort_fit(self) -> None:
-            self.aborted = True
-
-    stale_task = _DummyTask()
-    win._fit_task = stale_task
-
-    active_counts = iter((1, 0))
-    monkeypatch.setattr(
-        win._threadpool,
-        "activeThreadCount",
-        lambda: next(active_counts, 0),
-    )
-
-    new_gold = gold.copy(deep=True)
-    new_gold.data = np.asarray(new_gold.data) * 1.02
-    win.handle_parent_source_replaced(new_gold)
-
-    assert stale_task.aborted is True
-    assert win.source_state == "stale"
-    xr.testing.assert_identical(win.data, gold)
-
-    win._pending_update_timer.stop()
-    win._flush_pending_update()
-
-    assert win.source_state == "fresh"
+    assert wait_timeouts == [win.BACKGROUND_TASK_TIMEOUT_MS]
     xr.testing.assert_identical(win.data, new_gold)
 
 
 def test_goldtool_auto_source_update_emits_one_data_change(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
-    win.set_source_binding(
-        full_data(),
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs(
+        (script_input,),
+        primary_input="data",
         auto_update=True,
     )
 
@@ -1326,7 +1308,7 @@ def test_goldtool_auto_source_update_emits_one_data_change(qtbot, gold) -> None:
 
     new_gold = gold.copy(deep=True)
     new_gold.data = np.asarray(new_gold.data) * 1.02
-    win.handle_parent_source_replaced(new_gold)
+    assert win._apply_inputs({"data": new_gold}, (script_input,))
 
     assert win.source_state == "fresh"
     assert emissions == [True]
@@ -1339,17 +1321,24 @@ def test_goldtool_auto_source_update_with_refit_stays_stale_until_fit_finishes(
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
     _configure_goldtool_state(win, fitted=True)
-    win.set_source_binding(
-        full_data(),
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs(
+        (script_input,),
+        primary_input="data",
         auto_update=True,
     )
 
     fit_started: list[bool] = []
-    monkeypatch.setattr(win, "perform_edge_fit", lambda: fit_started.append(True))
+
+    def start_fit() -> None:
+        fit_started.append(True)
+        win._fit_task = typing.cast("EdgeFitTask", object())
+
+    monkeypatch.setattr(win, "perform_edge_fit", start_fit)
 
     new_gold = gold.copy(deep=True)
     new_gold.data = np.asarray(new_gold.data) * 1.02
-    win.handle_parent_source_replaced(new_gold)
+    assert not win._apply_inputs({"data": new_gold}, (script_input,))
 
     assert fit_started == [True]
     assert win.source_state == "stale"
@@ -1387,14 +1376,14 @@ def test_goldtool_close_event_ignored_if_threadpool_does_not_quiesce(
     win.close()
 
 
-def test_goldtool_update_data_clamps_roi_to_non_empty_bounds(qtbot, gold) -> None:
+def test_goldtool_update_inputs_clamps_roi_to_non_empty_bounds(qtbot, gold) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
 
     win.params_roi.modify_roi(x0=-12.0, x1=-8.0, y0=-0.45, y1=-0.3)
     narrowed = gold.sel(alpha=slice(-2.5, 2.5), eV=slice(-0.1, 0.05))
 
-    win.update_data(narrowed)
+    win.update_inputs({"data": narrowed})
 
     x0, y0, x1, y1 = win.params_roi.roi_limits
     xmin, ymin, xmax, ymax = win.params_roi.max_bounds
@@ -1410,17 +1399,21 @@ def test_goldtool_update_data_clamps_roi_to_non_empty_bounds(qtbot, gold) -> Non
     assert selected.sizes["eV"] > 0
 
 
-def test_goldtool_validate_update_data_transposes_and_rejects_invalid(
+def test_goldtool_validate_update_inputs_transposes_and_rejects_invalid(
     qtbot, gold
 ) -> None:
     win: GoldTool = goldtool(gold, execute=False)
     qtbot.addWidget(win)
 
-    transposed = win.validate_update_data(gold.transpose(*reversed(gold.dims)))
+    transposed = win.validate_update_inputs(
+        {"data": gold.transpose(*reversed(gold.dims))}
+    )["data"]
     assert transposed.dims[0] == "eV"
 
     with pytest.raises(ValueError, match="2D DataArray with an `eV` dimension"):
-        win.validate_update_data(xr.DataArray(np.arange(5), dims=("alpha",)))
+        win.validate_update_inputs(
+            {"data": xr.DataArray(np.arange(5), dims=("alpha",))}
+        )
 
 
 def test_goldtool_undo_redo_state_change(qtbot, gold) -> None:
@@ -1624,7 +1617,9 @@ def test_restool_loads_legacy_saved_state_without_source_update_flag(qtbot) -> N
         assert win_restored.refit_on_source_update_check.isChecked() is False
 
 
-def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -> None:
+def test_restool_update_inputs_invalidates_fit_and_can_refit(
+    qtbot, monkeypatch
+) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
     )
@@ -1656,7 +1651,7 @@ def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -
     status = win.tool_status
     new_gold = gold.copy(deep=True)
     new_gold.data = np.asarray(new_gold.data) * 1.03
-    win.update_data(new_gold)
+    win.update_inputs({"data": new_gold})
 
     expected = status.model_copy(
         update={"results": ("No fit results", "—", "—", "—", "—")}
@@ -1673,14 +1668,14 @@ def test_restool_update_data_invalidates_fit_and_can_refit(qtbot, monkeypatch) -
     win.refit_on_source_update_check.setChecked(True)
     newer_gold = new_gold.copy(deep=True)
     newer_gold.data = np.asarray(newer_gold.data) * 1.01
-    win.update_data(newer_gold)
+    win.update_inputs({"data": newer_gold})
 
     xr.testing.assert_identical(
         fit_inputs[0], newer_gold.sel({win.y_dim: slice(*win.y_range)}).mean(win.y_dim)
     )
 
 
-def test_restool_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
+def test_restool_apply_inputs_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
     )
@@ -1713,7 +1708,9 @@ def test_restool_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> N
     updated = gold.copy(deep=True)
     updated.data = np.asarray(updated.data) * 1.01
 
-    assert win.update_data(updated) is False
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs((script_input,), primary_input="data")
+    assert win._apply_inputs({"data": updated}, (script_input,)) is False
     assert stuck_thread.cancel_called
     assert stuck_thread.interrupted
     assert stuck_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
@@ -1721,7 +1718,7 @@ def test_restool_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> N
     win._fit_thread = None
 
 
-def test_restool_update_data_auto_refit_after_waiting_cancelled_thread(
+def test_restool_apply_inputs_auto_refit_after_waiting_cancelled_thread(
     qtbot, monkeypatch
 ) -> None:
     gold = generate_gold_edge(
@@ -1767,7 +1764,9 @@ def test_restool_update_data_auto_refit_after_waiting_cancelled_thread(
     updated = gold.copy(deep=True)
     updated.data = np.asarray(updated.data) * 1.01
 
-    assert win.update_data(updated) is False
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs((script_input,), primary_input="data")
+    assert win._apply_inputs({"data": updated}, (script_input,)) is False
     assert started == [True]
     assert old_thread.cancel_called
     assert old_thread.interrupted
@@ -1807,18 +1806,22 @@ def test_restool_queue_fit_action_ignores_stale_thread(qtbot) -> None:
     assert win._pending_fit_action is None
 
 
-def test_restool_validate_update_data_transposes_and_rejects_invalid(qtbot) -> None:
+def test_restool_validate_update_inputs_transposes_and_rejects_invalid(qtbot) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
     )
     win = restool(gold, execute=False)
     qtbot.addWidget(win)
 
-    transposed = win.validate_update_data(gold.transpose(*reversed(gold.dims)))
+    transposed = win.validate_update_inputs(
+        {"data": gold.transpose(*reversed(gold.dims))}
+    )["data"]
     assert transposed.dims[-1] == "eV"
 
     with pytest.raises(ValueError, match="2D and have an 'eV' dimension"):
-        win.validate_update_data(xr.DataArray(np.arange(5), dims=("alpha",)))
+        win.validate_update_inputs(
+            {"data": xr.DataArray(np.arange(5), dims=("alpha",))}
+        )
 
 
 def test_restool_fit_thread_loads_result_before_emit(monkeypatch) -> None:
@@ -2298,7 +2301,9 @@ def test_restool_queue_fit_action_runs_immediately_when_no_thread(qtbot) -> None
     assert win._pending_fit_action is None
 
 
-def test_restool_finalize_fit_thread_drops_actions_while_closing(qtbot) -> None:
+def test_restool_finalize_fit_thread_drops_actions_while_closing(
+    qtbot, monkeypatch
+) -> None:
     gold = generate_gold_edge(
         edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
     )
@@ -2318,11 +2323,145 @@ def test_restool_finalize_fit_thread_drops_actions_while_closing(qtbot) -> None:
     win._pending_fit_action = lambda: called.append("action")
     win._fit_queued = True
     win._fit_closing = True
+    source_refreshes: list[bool] = []
+    monkeypatch.setattr(
+        win, "finalize_source_refresh", lambda: source_refreshes.append(True)
+    )
 
     win._finalize_fit_thread(thread)  # type: ignore[arg-type]
 
     assert called == []
+    assert source_refreshes == []
     assert win._fit_thread is None
+    assert not win._fit_queued
+    assert thread.deleted
+
+
+@pytest.mark.parametrize("outcome", ["success", "timeout", "error"])
+def test_restool_stale_fit_terminal_finalizes_deferred_source_refresh(
+    qtbot, monkeypatch, outcome: str
+) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _ThreadPlaceholder:
+        def __init__(self) -> None:
+            self.deleted = False
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    thread = _ThreadPlaceholder()
+    win._fit_thread = thread  # type: ignore[assignment]
+    win._fit_signature_current = ("current",)
+    win._source_refresh_deferred = True
+    finalized: list[bool] = []
+
+    def _finalize_source_refresh() -> None:
+        finalized.append(True)
+        win._source_refresh_deferred = False
+
+    monkeypatch.setattr(win, "finalize_source_refresh", _finalize_source_refresh)
+    actions = {
+        "success": lambda: win._handle_fit_success(xr.Dataset(), 0.1, ("stale",)),
+        "timeout": lambda: win._handle_fit_timeout(0.1, ("stale",)),
+        "error": lambda: win._handle_fit_error("boom", ("stale",)),
+    }
+    win._pending_fit_action = actions[outcome]
+
+    win._finalize_fit_thread(thread)  # type: ignore[arg-type]
+
+    assert finalized == [True]
+    assert win._result_ds is None
+    assert thread.deleted
+
+
+def test_restool_fit_action_exception_finalizes_deferred_source_refresh(
+    qtbot, monkeypatch
+) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _ThreadPlaceholder:
+        def __init__(self) -> None:
+            self.deleted = False
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    thread = _ThreadPlaceholder()
+    win._fit_thread = thread  # type: ignore[assignment]
+    win._fit_signature_displayed = ("stale",)
+    win._result_ds = xr.Dataset()
+    win.live_check.setChecked(True)
+    win._source_refresh_deferred = True
+    finalized: list[bool] = []
+
+    def _finalize_source_refresh() -> None:
+        finalized.append(True)
+        win._source_refresh_deferred = False
+
+    def _raise() -> None:
+        raise RuntimeError("broken fit result")
+
+    monkeypatch.setattr(win, "finalize_source_refresh", _finalize_source_refresh)
+    win._pending_fit_action = _raise
+
+    win._finalize_fit_thread(thread)  # type: ignore[arg-type]
+
+    assert finalized == [True]
+    assert win._result_ds is None
+    assert win._fit_signature_displayed is None
+    assert not win.live_check.isChecked()
+    assert thread.deleted
+
+
+@pytest.mark.parametrize(("restart_started", "finalize_count"), [(False, 1), (True, 0)])
+def test_restool_deferred_source_refresh_follows_queued_restart(
+    qtbot, monkeypatch, restart_started: bool, finalize_count: int
+) -> None:
+    gold = generate_gold_edge(
+        edge_coeffs=(0.0, 0.0, 0.0), background_coeffs=(5.0, 0.0, -2e-3), seed=1
+    )
+    win = restool(gold, execute=False)
+    qtbot.addWidget(win)
+
+    class _ThreadPlaceholder:
+        def __init__(self) -> None:
+            self.deleted = False
+
+        def deleteLater(self) -> None:
+            self.deleted = True
+
+    thread = _ThreadPlaceholder()
+    win._fit_thread = thread  # type: ignore[assignment]
+    win._fit_queued = True
+    win._source_refresh_deferred = True
+    finalized: list[bool] = []
+    starts: list[bool] = []
+
+    def _finalize_source_refresh() -> None:
+        finalized.append(True)
+        win._source_refresh_deferred = False
+
+    def _start_fit_worker() -> bool:
+        starts.append(True)
+        return restart_started
+
+    monkeypatch.setattr(win, "finalize_source_refresh", _finalize_source_refresh)
+    monkeypatch.setattr(win, "_start_fit_worker", _start_fit_worker)
+
+    win._finalize_fit_thread(thread)  # type: ignore[arg-type]
+
+    assert starts == [True]
+    assert len(finalized) == finalize_count
+    assert win._source_refresh_deferred is restart_started
     assert not win._fit_queued
     assert thread.deleted
 

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -1634,6 +1634,17 @@ def test_fit1d_validate_update_inputs_invalid_input_keeps_existing_ui(qtbot) -> 
     with pytest.raises(ValueError, match="1D DataArray"):
         win.validate_update_inputs({"data": bad_data})
 
+    uncertainty = xr.full_like(data, 0.2)
+    validated = win.validate_update_inputs({"data": data, "uncertainty": uncertainty})
+    xr.testing.assert_identical(validated["data"], data)
+    xr.testing.assert_identical(validated["uncertainty"], uncertainty)
+
+    win._set_direct_weights(xr.ones_like(data))
+    with pytest.raises(ValueError, match="align exactly"):
+        win.validate_update_inputs(
+            {"data": data.assign_coords(x=np.asarray(data.x) + 1.0)}
+        )
+
     assert win.centralWidget() is old_central
     assert old_central is not None
     assert old_central.parent() is not None
@@ -1809,7 +1820,10 @@ def test_fit1d_refit_start_failure_commits_published_input(qtbot, monkeypatch) -
     xr.testing.assert_identical(win.tool_data, updated)
 
 
-def test_fit1d_async_refit_failure_commits_published_input(qtbot, monkeypatch) -> None:
+@pytest.mark.parametrize("terminal", ["error", "timeout"])
+def test_fit1d_async_refit_terminal_commits_published_input(
+    qtbot, monkeypatch, terminal: str
+) -> None:
     data = _make_1d_data()
     updated = data * 1.1
     win = erlab.interactive.ftool(data, execute=False)
@@ -1826,7 +1840,10 @@ def test_fit1d_async_refit_failure_commits_published_input(qtbot, monkeypatch) -
 
     assert win._apply_inputs({"data": updated}, (refreshed_binding,)) is False
     assert win._source_refresh_deferred is True
-    win._fit_errored("fit failed")
+    if terminal == "error":
+        win._fit_errored("fit failed")
+    else:
+        win._fit_timed_out(fit1d.time.perf_counter())
 
     assert win.source_state == "fresh"
     assert win.script_inputs == (refreshed_binding,)

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -244,6 +244,342 @@ def test_fit1d_copy_code_executes_with_notebook_aliases(qtbot) -> None:
     assert isinstance(namespace["result"], xr.Dataset)
 
 
+def test_fit1d_uncertainty_defaults_and_error_bars(qtbot) -> None:
+    data = _make_1d_data()
+    uncertainty = xr.full_like(data, 0.2).rename("sigma")
+
+    unweighted = erlab.interactive.ftool(data, execute=False)
+    weighted = erlab.interactive.ftool(
+        data,
+        uncertainty=uncertainty,
+        uncertainty_name="sigma",
+        execute=False,
+    )
+    overridden = erlab.interactive.ftool(
+        data,
+        uncertainty=uncertainty,
+        scale_covar=True,
+        execute=False,
+    )
+    for win in (unweighted, weighted, overridden):
+        qtbot.addWidget(win)
+
+    assert unweighted.scale_covar_check.objectName() == "ftoolScaleCovarCheck"
+    assert unweighted.scale_covar_check.isChecked()
+    assert unweighted.current_provenance_spec() is not None
+    assert not unweighted.normalize_residuals_check.isEnabled()
+    assert not weighted.scale_covar_check.isChecked()
+    assert weighted.normalize_residuals_check.objectName() == (
+        "ftoolNormalizeResidualsCheck"
+    )
+    assert weighted.normalize_residuals_check.isChecked()
+    assert overridden.scale_covar_check.isChecked()
+    assert weighted.current_provenance_spec() is None
+    np.testing.assert_allclose(weighted.data_errorbar.opts["top"], uncertainty)
+    np.testing.assert_allclose(weighted.data_errorbar.opts["bottom"], uncertainty)
+
+    xvals = weighted._x_values()
+    residuals = weighted._normalized_data_values() - weighted._model_eval_values(xvals)
+    np.testing.assert_allclose(weighted._last_residual, residuals / uncertainty)
+    weighted.normalize_residuals_check.setChecked(False)
+    np.testing.assert_allclose(weighted._last_residual, residuals)
+
+    weighted.scale_covar_check.setChecked(True)
+    assert weighted.tool_status.scale_covar
+
+    weighted._set_fit_running(True, multi=False)
+    assert not weighted.scale_covar_check.isEnabled()
+    weighted._set_fit_running(False, multi=False)
+    assert weighted.scale_covar_check.isEnabled()
+
+
+def test_fit1d_uncertainty_validation(qtbot) -> None:
+    data = _make_1d_data()
+    misaligned = xr.DataArray(
+        np.ones(data.size),
+        dims=("x",),
+        coords={"x": np.arange(data.size)},
+    )
+    extra_dim = xr.DataArray(np.ones(data.size), dims=("other",))
+
+    with pytest.raises(TypeError, match=r"xarray\.DataArray"):
+        erlab.interactive.ftool(  # type: ignore[arg-type]
+            data, uncertainty=np.ones(data.size), execute=False
+        )
+    with pytest.raises(ValueError, match="align exactly"):
+        erlab.interactive.ftool(data, uncertainty=misaligned, execute=False)
+    with pytest.raises(ValueError, match="subset"):
+        erlab.interactive.ftool(data, uncertainty=extra_dim, execute=False)
+    with pytest.raises(TypeError, match="real numeric"):
+        erlab.interactive.ftool(
+            data,
+            uncertainty=xr.full_like(data, "invalid", dtype=object),
+            execute=False,
+        )
+    with pytest.raises(TypeError, match="real numeric"):
+        erlab.interactive.ftool(
+            data,
+            uncertainty=xr.DataArray(
+                np.ones(data.size, dtype=complex),
+                dims=data.dims,
+                coords=data.coords,
+            ),
+            execute=False,
+        )
+
+    for invalid_value in (0.0, -0.1, np.nan, np.inf):
+        with pytest.raises(ValueError, match="finite and strictly positive"):
+            erlab.interactive.ftool(
+                data,
+                uncertainty=xr.full_like(data, invalid_value),
+                execute=False,
+            )
+
+    data_with_nan = data.copy()
+    data_with_nan[0] = np.nan
+    uncertainty_with_nan = xr.full_like(data, 0.2)
+    uncertainty_with_nan[0] = np.nan
+    win = erlab.interactive.ftool(
+        data_with_nan,
+        uncertainty=uncertainty_with_nan,
+        execute=False,
+    )
+    qtbot.addWidget(win)
+
+
+def test_fit1d_direct_weights_validation() -> None:
+    data = _make_1d_data()
+
+    assert fit1d._validate_weights_input(data, None) is None
+    scalar = xr.DataArray(2.0)
+    assert fit1d._validate_weights_input(data, scalar) is scalar
+    zero = xr.DataArray(0.0)
+    assert fit1d._validate_weights_input(data, zero) is zero
+    xr.testing.assert_identical(
+        fit1d._broadcast_weights(data, scalar), xr.full_like(data, 2.0).rename(None)
+    )
+
+    with pytest.raises(TypeError, match=r"xarray\.DataArray"):
+        fit1d._validate_weights_input(data, np.ones(data.size))
+    with pytest.raises(TypeError, match="real numeric"):
+        fit1d._validate_weights_input(data, xr.full_like(data, "invalid", dtype=object))
+    with pytest.raises(TypeError, match="real numeric"):
+        fit1d._validate_weights_input(data, xr.full_like(data, 1.0, dtype=complex))
+    with pytest.raises(ValueError, match="unexpected dimensions"):
+        fit1d._validate_weights_input(
+            data, xr.DataArray(np.ones((data.size, 2)), dims=("x", "extra"))
+        )
+    with pytest.raises(ValueError, match="align exactly"):
+        fit1d._validate_weights_input(
+            data,
+            xr.DataArray(
+                np.ones(data.size),
+                dims="x",
+                coords={"x": data.x + 1.0},
+            ),
+        )
+    for invalid_value in (-1.0, np.nan, np.inf):
+        with pytest.raises(ValueError, match="finite and nonnegative"):
+            fit1d._validate_weights_input(data, xr.full_like(data, invalid_value))
+
+
+def test_fit1d_rejects_ambiguous_internal_weighting(qtbot) -> None:
+    data = _make_1d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+
+    weighting = xr.ones_like(data)
+    with pytest.raises(ValueError, match="Only one"):
+        win._reset_fit_state(
+            data,
+            win._model,
+            win._params,
+            uncertainty=weighting,
+            direct_weights=weighting,
+            data_name="data",
+            model_name="model",
+        )
+
+    tiny_weights = xr.full_like(data, np.nextafter(0.0, 1.0))
+    win._set_direct_weights(tiny_weights)
+    xr.testing.assert_identical(win._fit_weights(), tiny_weights)
+    assert np.isnan(win.data_errorbar.opts["top"]).all()
+
+
+def test_fit1d_scalar_uncertainty_broadcasts(qtbot, exp_decay_model) -> None:
+    t = np.linspace(0.0, 4.0, 25)
+    data = xr.DataArray(
+        3.0 * np.exp(-t / 2.0), dims=("t",), coords={"t": t}, name="decay"
+    )
+    uncertainty = xr.DataArray(0.2, name="sigma")
+    win = erlab.interactive.ftool(
+        data,
+        model=exp_decay_model,
+        params=exp_decay_model.make_params(n0=2.0, tau=1.0),
+        uncertainty=uncertainty,
+        data_name="decay",
+        model_name="model",
+        uncertainty_name="xr.DataArray(0.2)",
+        execute=False,
+    )
+    qtbot.addWidget(win)
+
+    np.testing.assert_allclose(win.data_errorbar.opts["top"], 0.2)
+    weights = win._fit_weights()
+    assert weights is not None
+    xr.testing.assert_allclose(weights, xr.full_like(data, 5.0))
+
+    prelude = win._copy_prelude()
+    assert "input_uncertainty" not in prelude
+    namespace = {
+        "decay": data,
+        "model": exp_decay_model,
+        "xr": xr,
+    }
+    exec(  # noqa: S102
+        f"{prelude}\nreplayed = {win._fit_expression()}",
+        namespace,
+    )
+    replayed_result = namespace["replayed"].modelfit_results.compute().item()
+    np.testing.assert_allclose(replayed_result.weights, 5.0)
+
+
+def test_fit1d_generated_uncertainty_name_does_not_shadow_data(
+    qtbot, exp_decay_model
+) -> None:
+    t = np.linspace(0.0, 4.0, 25)
+    fit_uncertainty = xr.DataArray(
+        3.0 * np.exp(-t / 2.0),
+        dims=("t",),
+        coords={"t": t},
+        name="fit_uncertainty",
+    )
+    sigma = xr.DataArray(0.2)
+    win = erlab.interactive.ftool(
+        fit_uncertainty,
+        model=exp_decay_model,
+        params=exp_decay_model.make_params(n0=2.0, tau=1.0),
+        uncertainty=sigma,
+        data_name="fit_uncertainty",
+        model_name="model",
+        uncertainty_name="sigma.copy()",
+        execute=False,
+    )
+    qtbot.addWidget(win)
+
+    namespace = {
+        "fit_uncertainty": fit_uncertainty,
+        "model": exp_decay_model,
+        "sigma": sigma,
+    }
+    exec(  # noqa: S102
+        f"{win._copy_prelude()}\nreplayed = {win._fit_expression()}",
+        namespace,
+    )
+    replayed = namespace["replayed"]
+    xr.testing.assert_identical(
+        replayed.modelfit_data,
+        fit_uncertainty.rename("modelfit_data"),
+    )
+    np.testing.assert_allclose(
+        replayed.modelfit_results.compute().item().weights,
+        5.0,
+    )
+
+
+def test_fit1d_weighted_fit_and_generated_code(qtbot, exp_decay_model) -> None:
+    t = np.linspace(0.0, 4.0, 25)
+    data = xr.DataArray(
+        3.0 * np.exp(-t / 2.0), dims=("t",), coords={"t": t}, name="decay"
+    )
+    uncertainty = xr.DataArray(
+        np.linspace(0.1, 0.2, t.size),
+        dims=("t",),
+        coords={"t": t},
+        name="sigma",
+    )
+    params = exp_decay_model.make_params(n0=2.0, tau=1.0)
+    win = erlab.interactive.ftool(
+        data,
+        model=exp_decay_model,
+        params=params,
+        uncertainty=uncertainty,
+        data_name="decay",
+        model_name="model",
+        uncertainty_name="sigma",
+        execute=False,
+    )
+    qtbot.addWidget(win)
+    win.normalize_check.setChecked(True)
+    win.domain_min_spin.setValue(0.5)
+    win.domain_max_spin.setValue(3.5)
+    win.nfev_spin.setValue(0)
+
+    fit_uncertainty = win._fit_uncertainty()
+    assert fit_uncertainty is not None
+    expected_uncertainty = uncertainty.sel(t=slice(0.5, 3.5)) / abs(
+        data.sel(t=slice(0.5, 3.5)).mean()
+    )
+    xr.testing.assert_allclose(fit_uncertainty, expected_uncertainty)
+
+    assert win._run_fit()
+    qtbot.waitUntil(lambda: win._last_result_ds is not None, timeout=10000)
+    assert win._last_result_ds is not None
+    result = win._last_result_ds.modelfit_results.compute().item()
+    np.testing.assert_allclose(result.weights, 1.0 / expected_uncertainty.values)
+    assert result.scale_covar is False
+
+    win.scale_covar_check.setChecked(True)
+    assert win._run_fit()
+    qtbot.waitUntil(lambda: not win._fit_running(), timeout=10000)
+    assert win._last_result_ds is not None
+    assert win._last_result_ds.modelfit_results.compute().item().scale_covar is True
+    win.scale_covar_check.setChecked(False)
+
+    namespace = {
+        "decay": data,
+        "model": exp_decay_model,
+        "sigma": uncertainty,
+    }
+    exec(  # noqa: S102
+        f"{win._copy_prelude()}\nreplayed = {win._fit_expression()}",
+        namespace,
+    )
+    replayed_result = namespace["replayed"].modelfit_results.compute().item()
+    np.testing.assert_allclose(
+        replayed_result.weights, 1.0 / expected_uncertainty.values
+    )
+    assert replayed_result.scale_covar is False
+
+    win._run_fit_multiple(1)
+    qtbot.waitUntil(lambda: not win._fit_running(), timeout=10000)
+    assert win._last_result_ds is not None
+    multi_result = win._last_result_ds.modelfit_results.compute().item()
+    np.testing.assert_allclose(
+        multi_result.weights,
+        1.0 / expected_uncertainty.values,
+    )
+
+
+def test_fit1d_uncertainty_persistence_roundtrip(qtbot) -> None:
+    data = _make_1d_data()
+    uncertainty = xr.full_like(data, 0.2).rename("sigma")
+    win = erlab.interactive.ftool(
+        data,
+        uncertainty=uncertainty,
+        uncertainty_name="sigma",
+        execute=False,
+    )
+    qtbot.addWidget(win)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit1DTool)
+    xr.testing.assert_identical(restored.uncertainty, uncertainty)
+    assert restored.tool_status.uncertainty_name == "sigma"
+    assert restored.scale_covar_check.isChecked() is False
+
+
 def test_fit1d_tool_status_without_saved_params_uses_model_defaults(
     qtbot, exp_decay_model
 ) -> None:
@@ -814,6 +1150,7 @@ def test_fit1d_open_saved_fit_dataset(qtbot, exp_decay_model) -> None:
         data, model=exp_decay_model, params=params, execute=False
     )
     qtbot.addWidget(win)
+    win.scale_covar_check.setChecked(False)
 
     assert win._run_fit()
     qtbot.waitUntil(lambda: win._last_result_ds is not None, timeout=10000)
@@ -828,6 +1165,222 @@ def test_fit1d_open_saved_fit_dataset(qtbot, exp_decay_model) -> None:
     assert win_restored.save_button.isEnabled()
     assert win_restored.copy_button.isEnabled()
     assert isinstance(win_restored._model, type(exp_decay_model))
+    assert not win_restored.scale_covar_check.isChecked()
+
+    overridden = erlab.interactive.ftool(fit_ds, scale_covar=True, execute=False)
+    qtbot.addWidget(overridden)
+    assert overridden.scale_covar_check.isChecked()
+    assert not overridden._fit_is_current
+    assert not overridden.save_button.isEnabled()
+    assert not overridden.copy_button.isEnabled()
+
+    supplied_uncertainty = erlab.interactive.ftool(
+        fit_ds,
+        uncertainty=xr.full_like(data, 0.2),
+        execute=False,
+    )
+    qtbot.addWidget(supplied_uncertainty)
+    assert not supplied_uncertainty._fit_is_current
+    assert not supplied_uncertainty.save_button.isEnabled()
+    assert not supplied_uncertainty.copy_button.isEnabled()
+
+    scaled_fit_ds = data.xlm.modelfit(
+        "t",
+        model=exp_decay_model,
+        params=params,
+        scale_covar=True,
+    ).load()
+    scaled_with_uncertainty = erlab.interactive.ftool(
+        scaled_fit_ds,
+        uncertainty=xr.full_like(data, 0.2),
+        execute=False,
+    )
+    qtbot.addWidget(scaled_with_uncertainty)
+    assert not scaled_with_uncertainty.scale_covar_check.isChecked()
+    assert not scaled_with_uncertainty._fit_is_current
+
+    weights = xr.DataArray(
+        np.linspace(0.3, 2.7, data.size), dims="t", coords={"t": data.t}
+    )
+    assert not np.array_equal(weights, 1.0 / (1.0 / weights))
+    weighted_fit_ds = data.xlm.modelfit(
+        "t",
+        model=exp_decay_model,
+        params=params,
+        weights=weights,
+        scale_covar=False,
+    ).load()
+    weighted_restored = erlab.interactive.ftool(weighted_fit_ds, execute=False)
+    qtbot.addWidget(weighted_restored)
+    xr.testing.assert_identical(
+        weighted_restored._direct_weights, weighted_fit_ds.modelfit_weights
+    )
+    np.testing.assert_array_equal(weighted_restored._fit_weights(), weights)
+    assert weighted_restored.uncertainty is not None
+    xr.testing.assert_allclose(weighted_restored.uncertainty, 1.0 / weights)
+    np.testing.assert_allclose(
+        weighted_restored.data_errorbar.opts["top"], 1.0 / weights
+    )
+    assert weighted_restored._fit_is_current
+    assert weighted_restored.save_button.isEnabled()
+    assert weighted_restored.copy_button.isEnabled()
+
+    namespace = {"weighted_fit_ds": weighted_fit_ds, "model": exp_decay_model}
+    exec(  # noqa: S102
+        f"{weighted_restored._copy_prelude()}\n"
+        f"replayed = {weighted_restored._fit_expression()}",
+        namespace,
+    )
+    np.testing.assert_array_equal(
+        namespace["replayed"].modelfit_results.compute().item().weights,
+        weights,
+    )
+
+    workspace_restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        weighted_restored.to_dataset()
+    )
+    qtbot.addWidget(workspace_restored)
+    assert isinstance(workspace_restored, Fit1DTool)
+    xr.testing.assert_identical(
+        workspace_restored._direct_weights, weighted_fit_ds.modelfit_weights
+    )
+    np.testing.assert_array_equal(workspace_restored._fit_weights(), weights)
+
+    weighted_restored.domain_min_spin.setValue(0.5)
+    weighted_restored.domain_max_spin.setValue(3.5)
+    cropped_data = weighted_restored._fit_data_raw()
+    np.testing.assert_array_equal(
+        weighted_restored._fit_weights(),
+        weights.sel(t=cropped_data.t),
+    )
+
+    weighted_restored._direct_weights_name = "fit_weights"
+    collision_namespace = {
+        "weighted_fit_ds": weighted_fit_ds,
+        "model": exp_decay_model,
+        "fit_weights": weights,
+    }
+    exec(  # noqa: S102
+        f"{weighted_restored._copy_prelude()}\n"
+        f"replayed = {weighted_restored._fit_expression()}",
+        collision_namespace,
+    )
+    np.testing.assert_array_equal(
+        collision_namespace["replayed"].modelfit_results.compute().item().weights,
+        weights.sel(t=cropped_data.t),
+    )
+    assert workspace_restored._fit_is_current
+    updated_data = data * 1.01
+    assert workspace_restored.update_data(updated_data)
+    xr.testing.assert_identical(
+        workspace_restored._direct_weights, weighted_fit_ds.modelfit_weights
+    )
+    np.testing.assert_array_equal(workspace_restored._fit_weights(), weights)
+
+    legacy_weighted = erlab.interactive.ftool(
+        weighted_fit_ds.drop_vars("modelfit_weights"), execute=False
+    )
+    qtbot.addWidget(legacy_weighted)
+    assert legacy_weighted.uncertainty is None
+    assert legacy_weighted.scale_covar_check.isChecked()
+    assert not legacy_weighted._fit_is_current
+    assert not legacy_weighted.save_button.isEnabled()
+    assert not legacy_weighted.copy_button.isEnabled()
+
+    invalid_weighted_ds = weighted_fit_ds.copy()
+    invalid_weighted_ds["modelfit_weights"] = -weights
+    invalid_weighted = erlab.interactive.ftool(invalid_weighted_ds, execute=False)
+    qtbot.addWidget(invalid_weighted)
+    assert invalid_weighted.uncertainty is None
+    assert not invalid_weighted._fit_is_current
+
+    zero_weights = weights.copy()
+    zero_weights[5] = 0.0
+    zero_weighted_ds = data.xlm.modelfit(
+        "t",
+        model=exp_decay_model,
+        params=params,
+        weights=zero_weights,
+        scale_covar=False,
+    ).load()
+    zero_weighted = erlab.interactive.ftool(zero_weighted_ds, execute=False)
+    qtbot.addWidget(zero_weighted)
+    xr.testing.assert_identical(
+        zero_weighted._direct_weights, zero_weighted_ds.modelfit_weights
+    )
+    np.testing.assert_array_equal(zero_weighted._fit_weights(), zero_weights)
+    assert zero_weighted._fit_is_current
+    assert np.isnan(zero_weighted.data_errorbar.opts["top"][5])
+    np.testing.assert_allclose(
+        np.delete(zero_weighted.data_errorbar.opts["top"], 5),
+        np.delete(1.0 / zero_weights.where(zero_weights != 0).values, 5),
+    )
+
+    scalar_weights = xr.DataArray(0.3)
+    scalar_fit_ds = data.xlm.modelfit(
+        "t",
+        model=exp_decay_model,
+        params=params,
+        weights=scalar_weights,
+        scale_covar=False,
+    ).load()
+    scalar_restored = erlab.interactive.ftool(scalar_fit_ds, execute=False)
+    qtbot.addWidget(scalar_restored)
+    xr.testing.assert_identical(
+        scalar_restored._direct_weights, scalar_fit_ds.modelfit_weights
+    )
+    xr.testing.assert_identical(
+        scalar_restored._fit_weights(), scalar_fit_ds.modelfit_weights
+    )
+    np.testing.assert_allclose(
+        scalar_restored.data_errorbar.opts["top"], 1.0 / scalar_weights
+    )
+    scalar_namespace = {
+        "scalar_fit_ds": scalar_fit_ds,
+        "model": exp_decay_model,
+    }
+    exec(  # noqa: S102
+        f"{scalar_restored._copy_prelude()}\n"
+        f"replayed = {scalar_restored._fit_expression()}",
+        scalar_namespace,
+    )
+    xr.testing.assert_identical(
+        scalar_namespace["replayed"].modelfit_weights,
+        scalar_fit_ds.modelfit_weights,
+    )
+    scalar_restored.normalize_check.setChecked(True)
+    norm = scalar_restored._fit_normalization_factor()
+    assert norm is not None
+    norm = abs(norm)
+    xr.testing.assert_identical(
+        scalar_restored._fit_weights(), scalar_fit_ds.modelfit_weights * norm
+    )
+    np.testing.assert_allclose(
+        scalar_restored._normalized_direct_weights_values(),
+        np.full(data.size, scalar_weights.item() * norm),
+    )
+    np.testing.assert_allclose(
+        scalar_restored.data_errorbar.opts["top"],
+        np.full(data.size, 1.0 / scalar_weights.item() / norm),
+    )
+    scalar_namespace = {
+        "scalar_fit_ds": scalar_fit_ds,
+        "model": exp_decay_model,
+    }
+    exec(  # noqa: S102
+        f"{scalar_restored._copy_prelude()}\n"
+        f"replayed = {scalar_restored._fit_expression()}",
+        scalar_namespace,
+    )
+    np.testing.assert_allclose(
+        scalar_namespace["replayed"].modelfit_results.compute().item().weights,
+        np.full(data.size, scalar_weights.item() * norm),
+    )
+    assert scalar_namespace["replayed"].modelfit_weights.dims == ()
+    xr.testing.assert_allclose(
+        scalar_namespace["replayed"].modelfit_weights,
+        scalar_fit_ds.modelfit_weights * norm,
+    )
 
 
 def test_fit1d_persistence_roundtrip_preserves_fit_result(
@@ -2751,6 +3304,62 @@ def test_fit1d_start_worker_start_exception_resets_buttons(qtbot, monkeypatch) -
     assert win._fit_cancel_requested is False
     assert win.fit_button.isEnabled()
     assert not win.cancel_fit_button.isEnabled()
+
+
+def test_fit1d_workers_use_one_scale_covar_snapshot(qtbot, monkeypatch) -> None:
+    win = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(win)
+
+    captured: list[bool] = []
+
+    class _Signal:
+        def connect(self, _callback) -> None:
+            return None
+
+    class _Worker:
+        def __init__(self, *_args, scale_covar: bool, **_kwargs) -> None:
+            captured.append(scale_covar)
+            self.finished = _Signal()
+            self.sigFinished = _Signal()
+            self.sigTimedOut = _Signal()
+            self.sigErrored = _Signal()
+            self.sigCancelled = _Signal()
+
+        def setServiceLevel(self, _level) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def deleteLater(self) -> None:
+            return None
+
+    monkeypatch.setattr(fit1d, "_FitWorker", _Worker)
+    callbacks = {
+        "on_success": lambda _result: None,
+        "on_timeout": lambda: None,
+        "on_error": lambda _message: None,
+    }
+
+    win.scale_covar_check.setChecked(False)
+    assert win._start_fit_worker(win._fit_data(), win._params, multi=True, **callbacks)
+    first_worker = win._fit_thread
+    assert not win.scale_covar_check.isEnabled()
+
+    win.scale_covar_check.setChecked(True)
+    win._fit_thread = None
+    assert win._start_fit_worker(win._fit_data(), win._params, multi=True, **callbacks)
+    second_worker = win._fit_thread
+
+    assert captured == [False, False]
+    for worker in (first_worker, second_worker):
+        if worker is not None:
+            worker.deleteLater()
+    win._fit_thread = None
+    win._fit_is_current = True
+    win._set_fit_running(False, multi=True)
+    assert win.scale_covar_check.isEnabled()
+    assert not win._fit_is_current
 
 
 def test_fit1d_run_fit_preparation_error_resets_buttons(qtbot, monkeypatch) -> None:

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -573,7 +573,10 @@ def test_fit1d_uncertainty_persistence_roundtrip(qtbot) -> None:
     )
     qtbot.addWidget(win)
 
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        win.to_dataset(),
+        _code_trust=new_document_trust(),
+    )
     qtbot.addWidget(restored)
     assert isinstance(restored, Fit1DTool)
     xr.testing.assert_identical(restored.uncertainty, uncertainty)

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -1304,7 +1304,7 @@ def test_fit1d_open_saved_fit_dataset(qtbot, exp_decay_model) -> None:
     )
 
     workspace_restored = erlab.interactive.utils.ToolWindow.from_dataset(
-        weighted_restored.to_dataset()
+        weighted_restored.to_dataset(), _code_trust=new_document_trust()
     )
     qtbot.addWidget(workspace_restored)
     assert isinstance(workspace_restored, Fit1DTool)
@@ -5033,7 +5033,7 @@ def test_fit1d_source_replacement_discards_pending_result_retry(qtbot) -> None:
     assert tool._pending_persisted_fit_is_current is True
     assert tool._last_result_ds is None
 
-    assert tool.update_data(data + 1.0)
+    assert tool.update_inputs({"data": data + 1.0})
     tool.set_document_trust(new_document_trust())
 
     assert tool._serialized_fit_result_blob is None

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -32,6 +32,7 @@ from erlab.interactive._fit_code_trust import (
     lmfit_parameter_expression_entries,
     lmfit_result_code_entry,
 )
+from erlab.interactive.imagetool._provenance._model import ScriptInput
 from tests._qt_helpers import signal_receiver_count
 
 
@@ -578,6 +579,69 @@ def test_fit1d_uncertainty_persistence_roundtrip(qtbot) -> None:
     xr.testing.assert_identical(restored.uncertainty, uncertainty)
     assert restored.tool_status.uncertainty_name == "sigma"
     assert restored.scale_covar_check.isChecked() is False
+
+
+def test_fit1d_managed_uncertainty_uses_named_persistence_input(qtbot) -> None:
+    data = _make_1d_data()
+    uncertainty = xr.full_like(data, 0.2).rename("sigma")
+    win = erlab.interactive.ftool(data, uncertainty=uncertainty, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+    bindings = (ScriptInput(name="data"), ScriptInput(name="uncertainty"))
+    win.set_script_inputs(bindings, primary_input="data", state="stale")
+
+    items = win._persistence_data_items()
+    assert "uncertainty" in items
+    assert fit1d._PERSISTED_UNCERTAINTY_VAR not in items
+    xr.testing.assert_identical(items["uncertainty"], uncertainty)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit1DTool)
+    assert restored.script_inputs == bindings
+    xr.testing.assert_identical(restored.uncertainty, uncertainty)
+
+    replacement_data = data + 1.0
+    replacement_uncertainty = uncertainty + 0.1
+    win._replace_persistence_data_items(
+        {
+            erlab.interactive.utils._SAVED_TOOL_DATA_NAME: replacement_data,
+            "uncertainty": replacement_uncertainty,
+        },
+        xr.Dataset(),
+    )
+    xr.testing.assert_identical(win.tool_data, replacement_data)
+    xr.testing.assert_identical(win.uncertainty, replacement_uncertainty)
+    assert win.script_inputs == bindings
+    assert win.source_state == "stale"
+
+
+def test_fit1d_legacy_uncertainty_and_direct_weights_persistence(qtbot) -> None:
+    data = _make_1d_data()
+    uncertainty = xr.full_like(data, 0.2).rename("sigma")
+    legacy = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(legacy)
+    assert isinstance(legacy, Fit1DTool)
+    legacy._restore_persistence_data_items(
+        {fit1d._PERSISTED_UNCERTAINTY_VAR: uncertainty}, xr.Dataset()
+    )
+    xr.testing.assert_identical(legacy.uncertainty, uncertainty)
+
+    weights = xr.full_like(data, 2.0).rename("weights")
+    weighted = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(weighted)
+    assert isinstance(weighted, Fit1DTool)
+    weighted._set_direct_weights(weights)
+    items = weighted._persistence_data_items()
+    assert fit1d._PERSISTED_WEIGHTS_VAR in items
+    assert "uncertainty" not in items
+    xr.testing.assert_identical(items[fit1d._PERSISTED_WEIGHTS_VAR], weights)
+
+    restored = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit1DTool)
+    restored._restore_persistence_data_items(items, xr.Dataset())
+    xr.testing.assert_identical(restored._direct_weights, weights)
 
 
 def test_fit1d_tool_status_without_saved_params_uses_model_defaults(
@@ -1271,7 +1335,7 @@ def test_fit1d_open_saved_fit_dataset(qtbot, exp_decay_model) -> None:
     )
     assert workspace_restored._fit_is_current
     updated_data = data * 1.01
-    assert workspace_restored.update_data(updated_data)
+    assert workspace_restored.update_inputs({"data": updated_data})
     xr.testing.assert_identical(
         workspace_restored._direct_weights, weighted_fit_ds.modelfit_weights
     )
@@ -1510,7 +1574,7 @@ def test_fit1d_persisted_result_digest_blocks_swapped_payload(
     assert not document_trust_has_trusted_lineage(duplicate._document_trust)
 
 
-def test_fit1d_update_data_preserves_state_and_refit(
+def test_fit1d_update_inputs_preserves_state_and_refit(
     qtbot, exp_decay_model, monkeypatch
 ):
     data = _make_1d_data()
@@ -1539,7 +1603,7 @@ def test_fit1d_update_data_preserves_state_and_refit(
         coords=data.coords,
         name=data.name,
     )
-    win.update_data(new_data)
+    win.update_inputs({"data": new_data})
 
     assert win.tool_status == status
     xr.testing.assert_identical(win.tool_data, new_data)
@@ -1550,12 +1614,12 @@ def test_fit1d_update_data_preserves_state_and_refit(
     win.refit_on_source_update_check.setChecked(True)
     newer_data = new_data.copy(deep=True)
     newer_data.data = np.asarray(newer_data.data) * 1.1
-    win.update_data(newer_data)
+    win.update_inputs({"data": newer_data})
 
     assert called == [True]
 
 
-def test_fit1d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
+def test_fit1d_validate_update_inputs_invalid_input_keeps_existing_ui(qtbot) -> None:
     data = _make_1d_data()
     win = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win)
@@ -1565,7 +1629,7 @@ def test_fit1d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     bad_data = xr.DataArray(np.arange(6).reshape((2, 3)), dims=("y", "x"))
 
     with pytest.raises(ValueError, match="1D DataArray"):
-        win.update_data(bad_data)
+        win.validate_update_inputs({"data": bad_data})
 
     assert win.centralWidget() is old_central
     assert old_central is not None
@@ -1573,7 +1637,7 @@ def test_fit1d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     xr.testing.assert_identical(win.tool_data, data)
 
 
-def test_fit1d_update_data_drops_missing_coord_backed_param_bindings(qtbot) -> None:
+def test_fit1d_update_inputs_drops_missing_coord_backed_param_bindings(qtbot) -> None:
     data = _make_1d_data().assign_coords(offset=1.25)
     win = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win)
@@ -1592,7 +1656,7 @@ def test_fit1d_update_data_drops_missing_coord_backed_param_bindings(qtbot) -> N
     assert not (win.param_model.flags(value_index) & QtCore.Qt.ItemFlag.ItemIsEditable)
 
     new_data = data.drop_vars("offset")
-    win.update_data(new_data)
+    win.update_inputs({"data": new_data})
 
     assert param_name not in win._params_from_coord
     value_index = win.param_model.index(0, 1)
@@ -1600,7 +1664,7 @@ def test_fit1d_update_data_drops_missing_coord_backed_param_bindings(qtbot) -> N
     assert win.param_mode_combo.currentText() == "Manual"
 
 
-def test_fit1d_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
+def test_fit1d_apply_inputs_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
     data = _make_1d_data()
     win = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win)
@@ -1636,7 +1700,9 @@ def test_fit1d_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> Non
         name=data.name,
     )
 
-    assert win.update_data(new_data) is False
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs((script_input,), primary_input="data")
+    assert win._apply_inputs({"data": new_data}, (script_input,)) is False
     assert stuck_thread.cancel_called
     assert stuck_thread.interrupted
     assert stuck_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
@@ -1646,7 +1712,7 @@ def test_fit1d_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> Non
     xr.testing.assert_identical(win.tool_data, data)
 
 
-def test_fit1d_update_data_keeps_fit_finished_receivers_constant(qtbot) -> None:
+def test_fit1d_update_inputs_keeps_fit_finished_receivers_constant(qtbot) -> None:
     data = _make_1d_data()
     win = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win)
@@ -1656,14 +1722,14 @@ def test_fit1d_update_data_keeps_fit_finished_receivers_constant(qtbot) -> None:
     for scale in (1.1, 1.2, 1.3):
         updated = data.copy(deep=True)
         updated.data = np.asarray(data.data) * scale
-        win.update_data(updated)
+        win.update_inputs({"data": updated})
         assert (
             signal_receiver_count(win, win.sigFitFinished, "sigFitFinished")
             == initial_receivers
         )
 
 
-def test_fit1d_update_data_auto_refit_after_waiting_cancelled_thread(
+def test_fit1d_apply_inputs_auto_refit_after_waiting_cancelled_thread(
     qtbot, monkeypatch
 ) -> None:
     data = _make_1d_data()
@@ -1708,12 +1774,62 @@ def test_fit1d_update_data_auto_refit_after_waiting_cancelled_thread(
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) * 1.1
 
-    assert win.update_data(updated) is False
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs((script_input,), primary_input="data")
+    assert win._apply_inputs({"data": updated}, (script_input,)) is False
     assert started == [True]
     assert old_thread.cancel_called
     assert old_thread.interrupted
     assert old_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
     assert old_thread.deleted is True
+
+
+def test_fit1d_refit_start_failure_commits_published_input(qtbot, monkeypatch) -> None:
+    data = _make_1d_data()
+    updated = data * 1.1
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+    win._last_result_ds = xr.Dataset()
+    win.refit_on_source_update_check.setChecked(True)
+    monkeypatch.setattr(win, "_run_fit", lambda: False)
+    old_snapshot = "old"
+    old_binding = ScriptInput(name="data", node_snapshot_token=old_snapshot)
+    refreshed_binding = old_binding.model_copy(update={"node_snapshot_token": "new"})
+    win.set_script_inputs((old_binding,), primary_input="data")
+
+    assert win._apply_inputs({"data": updated}, (refreshed_binding,)) is True
+
+    assert win.source_state == "fresh"
+    assert win.script_inputs == (refreshed_binding,)
+    assert win._pending_script_inputs is None
+    xr.testing.assert_identical(win.tool_data, updated)
+
+
+def test_fit1d_async_refit_failure_commits_published_input(qtbot, monkeypatch) -> None:
+    data = _make_1d_data()
+    updated = data * 1.1
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit1DTool)
+    win._last_result_ds = xr.Dataset()
+    win.refit_on_source_update_check.setChecked(True)
+    monkeypatch.setattr(win, "_run_fit", lambda: True)
+    monkeypatch.setattr(win, "_show_error", lambda *_args, **_kwargs: None)
+    old_snapshot = "old"
+    old_binding = ScriptInput(name="data", node_snapshot_token=old_snapshot)
+    refreshed_binding = old_binding.model_copy(update={"node_snapshot_token": "new"})
+    win.set_script_inputs((old_binding,), primary_input="data")
+
+    assert win._apply_inputs({"data": updated}, (refreshed_binding,)) is False
+    assert win._source_refresh_deferred is True
+    win._fit_errored("fit failed")
+
+    assert win.source_state == "fresh"
+    assert win.script_inputs == (refreshed_binding,)
+    assert win._pending_script_inputs is None
+    assert win._source_refresh_deferred is False
+    xr.testing.assert_identical(win.tool_data, updated)
 
 
 def test_fit1d_queue_fit_action_ignores_stale_thread(qtbot) -> None:

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -140,6 +140,89 @@ def _trust_allows_local_code_edit(trust) -> bool:
     return issue_execution_capability(trust, (entry,))[1] is not None
 
 
+def test_fit_dataset_scale_covar_requires_one_common_value(monkeypatch) -> None:
+    model = lmfit.models.LinearModel()
+
+    class _Result:
+        def __init__(self, scale_covar: bool, *, weighted: bool = False) -> None:
+            self.model = model
+            self.scale_covar = scale_covar
+            self.weights = np.ones(2) if weighted else None
+
+    common = xr.Dataset(
+        {
+            "modelfit_results": xr.DataArray(
+                [_Result(False), _Result(False)], dims=("fit",)
+            )
+        }
+    )
+    mixed = common.copy()
+    mixed["modelfit_results"] = xr.DataArray(
+        [_Result(False), _Result(True)], dims=("fit",)
+    )
+    missing = xr.Dataset(
+        {"modelfit_results": xr.DataArray([_Result(False), object()], dims=("fit",))}
+    )
+    weighted = xr.Dataset(
+        {
+            "modelfit_results": xr.DataArray(
+                [_Result(False, weighted=True), _Result(False, weighted=True)],
+                dims=("fit",),
+            )
+        }
+    )
+    mixed_weighted = xr.Dataset(
+        {
+            "modelfit_results": xr.DataArray(
+                [_Result(False), _Result(False, weighted=True)],
+                dims=("fit",),
+            )
+        }
+    )
+
+    assert fit2d_module._fit_dataset_settings(common) == (False, False)
+    assert fit2d_module._fit_dataset_settings(weighted) == (False, True)
+    assert fit2d_module._fit_dataset_settings(mixed_weighted) == (False, None)
+    assert fit2d_module._fit_dataset_scale_covar(common) is False
+    assert fit2d_module._fit_dataset_scale_covar(mixed) is None
+    assert fit2d_module._fit_dataset_scale_covar(missing) is None
+    assert fit2d_module._fit_dataset_scale_covar(xr.Dataset()) is None
+
+    original_compute = xr.DataArray.compute
+
+    def _raise_compute(self, **kwargs):
+        if self.name == "modelfit_results":
+            raise RuntimeError("cannot load result")
+        return original_compute(self, **kwargs)
+
+    monkeypatch.setattr(xr.DataArray, "compute", _raise_compute)
+    assert fit2d_module._fit_dataset_scale_covar(common) is None
+
+
+def test_ftool_uncertainty_name_fallback(qtbot, monkeypatch) -> None:
+    data = _make_1d_data()
+    uncertainty = xr.full_like(data, 0.2)
+
+    def _raise_argname(*_args, **_kwargs):
+        raise RuntimeError("name unavailable")
+
+    monkeypatch.setattr(fit2d_module.varname, "argname", _raise_argname)
+    win = erlab.interactive.ftool(data, uncertainty=uncertainty, execute=False)
+    qtbot.addWidget(win)
+
+    assert win.tool_status.uncertainty_name == "uncertainty"
+
+    model = lmfit.models.LinearModel()
+    fit_ds = data.xlm.modelfit("x", model=model, params=model.make_params()).load()
+    restored = erlab.interactive.ftool(fit_ds, execute=False)
+    qtbot.addWidget(restored)
+    assert restored.tool_status.data_name == "(fit_result)['modelfit_data']"
+
+    named = erlab.interactive.ftool(fit_ds, data_name="saved_fit", execute=False)
+    qtbot.addWidget(named)
+    assert named.tool_status.data_name == "(saved_fit)['modelfit_data']"
+
+
 def _assert_fit_result_dataset_equivalent(
     actual: xr.Dataset,
     expected: xr.Dataset,
@@ -271,6 +354,8 @@ def _seed_fit2d_param_results(win: Fit2DTool, params_list) -> None:
         win._fit_result_with_range(_fit_result_dataset(params))
         for params in params_list
     ]
+    win._fit_is_current = True
+    win._update_full_fit_saveable()
     win._update_param_plot_options()
 
 
@@ -768,6 +853,115 @@ def test_fit2d_run_fit(qtbot, exp_decay_model, monkeypatch) -> None:
     code = win._copy_code_full()
     assert "modelfit" in code
     assert ".isel(" in code
+
+
+def test_fit2d_weighted_fit_broadcasts_uncertainty(
+    qtbot, exp_decay_model, monkeypatch
+) -> None:
+    t = np.linspace(0.0, 4.0, 25)
+    y = np.arange(3)
+    data = xr.DataArray(
+        np.stack([((1.0 + 0.5 * idx) * np.exp(-t / 2.0)) for idx in y]),
+        dims=("y", "t"),
+        coords={"y": y, "t": t},
+        name="decay2d",
+    )
+    uncertainty = xr.DataArray(
+        np.linspace(0.1, 0.2, t.size),
+        dims=("t",),
+        coords={"t": t},
+        name="sigma",
+    )
+    params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+    win = erlab.interactive.ftool(
+        data,
+        model=exp_decay_model,
+        params=params,
+        uncertainty=uncertainty,
+        data_name="decay2d",
+        model_name="model",
+        uncertainty_name="sigma.copy()",
+        execute=False,
+    )
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+    warnings, errors = _configure_fit2d_for_tests(win, monkeypatch)
+
+    assert win.uncertainty is uncertainty
+    assert not win.scale_covar_check.isChecked()
+    np.testing.assert_allclose(win.data_errorbar.opts["top"], uncertainty)
+
+    win.y_index_spin.setValue(win.y_min_spin.value())
+    win.nfev_spin.setValue(0)
+    win._run_fit_2d("up")
+    qtbot.waitUntil(
+        lambda: all(ds is not None for ds in win._result_ds_full), timeout=10000
+    )
+
+    for result_ds in win._result_ds_full:
+        assert result_ds is not None
+        result = result_ds.modelfit_results.compute().item()
+        np.testing.assert_allclose(result.weights, 1.0 / uncertainty.values)
+        assert result.scale_covar is False
+    assert not warnings
+    assert not errors
+
+    unnormalized_namespace = {
+        "decay2d": data,
+        "model": exp_decay_model,
+        "sigma": uncertainty,
+        "xr": xr,
+    }
+    exec(win._copy_code_full(), unnormalized_namespace)  # noqa: S102
+    unnormalized_replay = unnormalized_namespace["result"]
+    for result in unnormalized_replay.modelfit_results.compute().values:
+        np.testing.assert_allclose(result.weights, 1.0 / uncertainty.values)
+
+    win.normalize_check.setChecked(True)
+    namespace = dict(unnormalized_namespace)
+    code = win._copy_code_full()
+    assert "input_uncertainty" not in code
+    exec(code, namespace)  # noqa: S102
+    replayed = namespace["result"]
+    for idx, result in enumerate(replayed.modelfit_results.compute().values):
+        np.testing.assert_allclose(
+            result.weights,
+            abs(data.isel(y=idx).mean().item()) / uncertainty.values,
+        )
+        assert result.scale_covar is False
+
+    slice_namespace = {
+        "decay2d": data,
+        "model": exp_decay_model,
+        "sigma": uncertainty,
+    }
+    exec(win.copy_code_1d(), slice_namespace)  # noqa: S102
+    replayed_slice = slice_namespace["result"]
+    slice_result = replayed_slice.modelfit_results.compute().item()
+    assert any(
+        np.allclose(
+            slice_result.weights,
+            abs(data.isel(y=idx).mean().item()) / uncertainty.values,
+        )
+        for idx in range(data.sizes["y"])
+    )
+
+    assert win.current_provenance_spec() is None
+    assert win.detached_output_imagetool_provenance(data) is None
+    assert win._parameter_model_fit_operation("n0", stderr=False) is None
+    values_output_id = Fit2DTool._parameter_output_id(
+        Fit2DTool.Output.PARAMETER_VALUES,
+        "n0",
+    )
+    values = win.output_imagetool_data(values_output_id)
+    assert values is not None
+    assert win.output_imagetool_provenance(values_output_id, values) is None
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit2DTool)
+    xr.testing.assert_identical(restored.uncertainty, uncertainty)
+    assert restored.scale_covar_check.isChecked() is False
 
 
 def test_fit2d_full_provenance_handles_spaced_fit_axis(qtbot) -> None:
@@ -1576,6 +1770,7 @@ def test_fit2d_open_saved_fit_dataset(qtbot, exp_decay_model, monkeypatch) -> No
     assert isinstance(win, Fit2DTool)
     warnings, errors = _configure_fit2d_for_tests(win, monkeypatch)
 
+    win.scale_covar_check.setChecked(False)
     win.y_index_spin.setValue(win.y_min_spin.value())
     win.nfev_spin.setValue(0)
     win._run_fit_2d("up")
@@ -1605,6 +1800,303 @@ def test_fit2d_open_saved_fit_dataset(qtbot, exp_decay_model, monkeypatch) -> No
     assert win_restored.save_button.isEnabled()
     assert win_restored.copy_full_button.isEnabled()
     assert win_restored.save_full_button.isEnabled()
+    assert not win_restored.scale_covar_check.isChecked()
+
+
+def test_fit2d_open_weighted_saved_fit_dataset(
+    qtbot, exp_decay_model, monkeypatch
+) -> None:
+    t = np.linspace(0.0, 4.0, 25)
+    y = np.arange(3)
+    data = xr.DataArray(
+        np.stack([((1.0 + 0.5 * idx) * np.exp(-t / 2.0)) for idx in y], axis=0),
+        dims=("y", "t"),
+        coords={"y": y, "t": t},
+        name="decay2d",
+    )
+    weights = xr.DataArray(np.linspace(0.3, 2.7, t.size), dims="t", coords={"t": t})
+    assert not np.array_equal(weights, 1.0 / (1.0 / weights))
+    params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+    weighted_fit_ds = data.xlm.modelfit(
+        "t",
+        model=exp_decay_model,
+        params=params,
+        weights=weights,
+        scale_covar=False,
+    ).load()
+
+    win = erlab.interactive.ftool(weighted_fit_ds, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+    xr.testing.assert_identical(
+        win._direct_weights_full, weighted_fit_ds.modelfit_weights
+    )
+    np.testing.assert_array_equal(win._fit_weights(), weights)
+    assert win.uncertainty is not None
+    xr.testing.assert_allclose(win.uncertainty, 1.0 / weights)
+    np.testing.assert_allclose(win.data_errorbar.opts["top"], 1.0 / weights)
+    assert win._fit_is_current
+    assert win.copy_full_button.isEnabled()
+    assert win.save_full_button.isEnabled()
+
+    namespace = {
+        "weighted_fit_ds": weighted_fit_ds,
+        "model": exp_decay_model,
+        "xr": xr,
+    }
+    exec(win._copy_code_full(), namespace)  # noqa: S102
+    xr.testing.assert_identical(
+        namespace["result"].modelfit_weights,
+        weighted_fit_ds.modelfit_weights,
+    )
+    for result in namespace["result"].modelfit_results.compute().values:
+        np.testing.assert_array_equal(result.weights, weights)
+
+    workspace_restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        win.to_dataset()
+    )
+    qtbot.addWidget(workspace_restored)
+    assert isinstance(workspace_restored, Fit2DTool)
+    xr.testing.assert_identical(
+        workspace_restored._direct_weights_full,
+        weighted_fit_ds.modelfit_weights,
+    )
+    np.testing.assert_array_equal(workspace_restored._fit_weights(), weights)
+
+    win.normalize_check.setChecked(True)
+    normalized_namespace = {
+        "weighted_fit_ds": weighted_fit_ds,
+        "model": exp_decay_model,
+        "xr": xr,
+    }
+    exec(win._copy_code_full(), normalized_namespace)  # noqa: S102
+    for idx, result in enumerate(
+        normalized_namespace["result"].modelfit_results.compute().values
+    ):
+        norm = abs(data.isel(y=idx).mean("t").item())
+        np.testing.assert_allclose(result.weights, weights * norm)
+    expected_normalized_weights = (weights * abs(data.mean("t"))).rename(
+        "modelfit_weights"
+    )
+    xr.testing.assert_identical(
+        normalized_namespace["result"].modelfit_weights,
+        expected_normalized_weights,
+    )
+    assert workspace_restored._fit_is_current
+    updated_data = data * 1.01
+    assert workspace_restored.update_data(updated_data)
+    xr.testing.assert_identical(
+        workspace_restored._direct_weights_full,
+        weighted_fit_ds.modelfit_weights,
+    )
+    np.testing.assert_array_equal(workspace_restored._fit_weights(), weights)
+
+    y_weights = xr.DataArray([0.5, 0.7, 0.9], dims="y", coords={"y": y})
+    y_weighted_fit_ds = data.xlm.modelfit(
+        "t",
+        model=exp_decay_model,
+        params=params,
+        weights=y_weights,
+        scale_covar=False,
+    ).load()
+    y_weighted = erlab.interactive.ftool(y_weighted_fit_ds, execute=False)
+    qtbot.addWidget(y_weighted)
+    assert isinstance(y_weighted, Fit2DTool)
+    xr.testing.assert_identical(
+        y_weighted._direct_weights_full,
+        y_weighted_fit_ds.modelfit_weights,
+    )
+    xr.testing.assert_equal(y_weighted._fit_weights(), y_weights.isel(y=1))
+    y_weighted.y_min_spin.setValue(1)
+    y_weighted.y_max_spin.setValue(2)
+    y_weighted_namespace = {
+        "y_weighted_fit_ds": y_weighted_fit_ds,
+        "model": exp_decay_model,
+        "xr": xr,
+    }
+    exec(y_weighted._copy_code_full(), y_weighted_namespace)  # noqa: S102
+    xr.testing.assert_identical(
+        y_weighted_namespace["result"].modelfit_weights,
+        y_weighted_fit_ds.modelfit_weights.isel(y=slice(1, 3)),
+    )
+
+    crop_x = np.linspace(-1.0, 1.0, 9)
+    crop_data = xr.DataArray(
+        np.stack((2.0 * crop_x + 1.0, 3.0 * crop_x - 1.0)),
+        dims=("y", "x"),
+        coords={"y": [0, 1], "x": crop_x},
+    )
+    crop_weights = xr.DataArray(
+        np.linspace(0.5, 1.5, crop_x.size), dims="x", coords={"x": crop_x}
+    )
+    crop_model = lmfit.models.LinearModel()
+    crop_params = crop_model.make_params(slope=1.0, intercept=0.0)
+    cropped = erlab.interactive.ftool(
+        crop_data,
+        model=crop_model,
+        params=crop_params,
+        data_name="crop_data",
+        model_name="crop_model",
+        execute=False,
+    )
+    qtbot.addWidget(cropped)
+    assert isinstance(cropped, Fit2DTool)
+    monkeypatch.setattr(
+        cropped,
+        "_show_warning",
+        lambda title, text: pytest.fail(f"{title}: {text}"),
+    )
+    cropped._set_direct_weights(crop_weights, weights_name="crop_weights")
+    direct_weight_lines: list[str] = []
+    direct_weight_name = cropped._full_copy_fit_direct_weights_name(
+        "crop_data", "crop_model", lines=direct_weight_lines
+    )
+    assert direct_weight_name is not None
+    direct_weight_namespace = {"crop_weights": crop_weights}
+    exec("\n".join(direct_weight_lines), direct_weight_namespace)  # noqa: S102
+    xr.testing.assert_identical(
+        direct_weight_namespace[direct_weight_name], crop_weights
+    )
+    _fit_slices_with_ranges(cropped, [(-0.5, 0.5), (-0.5, 0.5)])
+    cropped_namespace = {
+        "crop_data": crop_data,
+        "crop_model": crop_model,
+        "crop_weights": crop_weights,
+        "xr": xr,
+    }
+    exec(cropped._copy_code_full(), cropped_namespace)  # noqa: S102
+    xr.testing.assert_identical(
+        cropped_namespace["result"].modelfit_weights,
+        crop_weights.sel(x=slice(-0.5, 0.5)).rename("modelfit_weights"),
+    )
+
+    legacy = erlab.interactive.ftool(
+        weighted_fit_ds.drop_vars("modelfit_weights"), execute=False
+    )
+    qtbot.addWidget(legacy)
+    assert isinstance(legacy, Fit2DTool)
+    assert legacy.uncertainty is None
+    assert legacy.scale_covar_check.isChecked()
+    assert not legacy._fit_is_current
+    assert not legacy.copy_full_button.isEnabled()
+    assert not legacy.save_full_button.isEnabled()
+
+
+@pytest.mark.parametrize(
+    ("weight_kind", "normalize"),
+    [
+        pytest.param("scalar", False, id="scalar"),
+        pytest.param("fit", False, id="fit-dimension"),
+        pytest.param("slice", False, id="slice-dimension"),
+        pytest.param("full", False, id="two-dimensional"),
+        pytest.param("fit", True, id="normalized-fit-dimension"),
+    ],
+)
+def test_fit2d_save_full_preserves_direct_weight_dimensions(
+    qtbot, monkeypatch, weight_kind, normalize
+) -> None:
+    x = np.linspace(-1.0, 1.0, 9)
+    y = np.array([10.0, 20.0])
+    data = xr.DataArray(
+        np.stack((2.0 * x, 3.0 * x + 2.0)),
+        dims=("y", "x"),
+        coords={"y": y, "x": x},
+    )
+    fit_weights = xr.DataArray(np.linspace(0.5, 1.5, x.size), dims="x", coords={"x": x})
+    match weight_kind:
+        case "scalar":
+            weights = xr.DataArray(0.5)
+        case "fit":
+            weights = fit_weights
+        case "slice":
+            weights = xr.DataArray([0.5, 0.8], dims="y", coords={"y": y})
+        case "full":
+            weights = xr.DataArray(
+                np.outer([0.5, 0.8], fit_weights.values),
+                dims=("y", "x"),
+                coords={"y": y, "x": x},
+            )
+        case _:
+            raise ValueError(f"Unexpected weight kind: {weight_kind}")
+
+    model = lmfit.models.LinearModel()
+    fit_ds = data.xlm.modelfit(
+        "x",
+        model=model,
+        params=model.make_params(slope=1.0, intercept=0.0),
+        weights=weights,
+        scale_covar=False,
+    ).load()
+    win = erlab.interactive.ftool(fit_ds, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+    warnings, errors = _configure_fit2d_for_tests(win, monkeypatch)
+
+    if normalize:
+        win.normalize_check.setChecked(True)
+        win.domain_min_spin.setValue(-0.5)
+        win.domain_max_spin.setValue(0.5)
+        win.y_index_spin.setValue(win.y_min_spin.value())
+        win.nfev_spin.setValue(0)
+        win._run_fit_2d("up")
+        qtbot.waitUntil(lambda: not win._fit_2d_sequence_active(), timeout=10000)
+
+    saved_fits: list[xr.Dataset] = []
+
+    @contextlib.contextmanager
+    def _wait_stub(_parent, _message):
+        yield None
+
+    monkeypatch.setattr(erlab.interactive.utils, "wait_dialog", _wait_stub)
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "save_fit_ui",
+        lambda fit_result, *, parent: saved_fits.append(fit_result),
+    )
+    win._save_fit_full()
+
+    assert len(saved_fits) == 1
+    saved_weights = saved_fits[0].modelfit_weights
+    if normalize:
+        fit_data = data.sel(x=slice(-0.5, 0.5))
+        normalization = abs(fit_data.mean("x"))
+        normalization = normalization.where(~np.isclose(normalization, 0.0), 1.0)
+        expected = (fit_weights.sel(x=fit_data.x) * normalization).rename(
+            "modelfit_weights"
+        )
+        assert saved_weights.dims == expected.dims == ("x", "y")
+        np.testing.assert_allclose(saved_weights.values, expected.values)
+    else:
+        expected = fit_ds.modelfit_weights
+        assert saved_weights.dims == expected.dims
+        np.testing.assert_array_equal(saved_weights.values, expected.values)
+    for dim in expected.dims:
+        np.testing.assert_array_equal(
+            saved_weights.coords[dim].values, expected.coords[dim].values
+        )
+    reopened = erlab.interactive.ftool(saved_fits[0], execute=False)
+    qtbot.addWidget(reopened)
+    assert isinstance(reopened, Fit2DTool)
+    assert reopened._fit_is_current
+    xr.testing.assert_identical(reopened._direct_weights_full, saved_weights)
+    assert not warnings
+    assert not errors
+
+
+def test_fit2d_rejects_ambiguous_internal_weighting(qtbot) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    weighting = xr.ones_like(data)
+    with pytest.raises(ValueError, match="Only one"):
+        win._init_full_data_state(
+            data,
+            uncertainty=weighting,
+            direct_weights=weighting,
+            data_name="data",
+        )
 
 
 def test_fit2d_persistence_roundtrip_preserves_fit_results(
@@ -2271,6 +2763,26 @@ def test_fit2d_mixed_slice_ranges_copy_and_output_provenance(
     )
     xr.testing.assert_allclose(replayed, values)
 
+    direct_weights = xr.DataArray(
+        np.linspace(0.5, 1.5, x.size), dims="x", coords={"x": x}
+    )
+    win._set_direct_weights(direct_weights, weights_name="direct_weights")
+    namespace = {
+        "source_spectrum": data,
+        "direct_weights": direct_weights,
+        "era": erlab.analysis,
+        "xr": xr,
+    }
+    exec(win._copy_code_full(), namespace)  # noqa: S102
+    xr.testing.assert_identical(
+        namespace["result"].modelfit_weights,
+        direct_weights.rename("modelfit_weights"),
+    )
+    xr.testing.assert_identical(
+        win._direct_weights_for_full_fit_results(fit_ranges),
+        direct_weights.rename("modelfit_weights"),
+    )
+
 
 @pytest.mark.parametrize("descending", [False, True])
 def test_fit2d_mixed_slice_ranges_persistence_roundtrip(
@@ -2739,6 +3251,15 @@ def test_fit2d_parameter_output_provenance_uses_distinct_active_names(qtbot) -> 
     assert bound_values_code is not None
     assert "param='p0_center'" in bound_values_code
     assert "param='p0_width'" not in bound_values_code
+
+    win._set_uncertainty(xr.ones_like(win._data_full))
+    assert win.output_imagetool_provenance(values_output_id, values) is None
+    win._set_uncertainty(None)
+
+    win.scale_covar_check.setChecked(False)
+    win.scale_covar_check.setChecked(True)
+    assert not win._fit_is_current
+    assert win.output_imagetool_provenance(values_output_id, values) is None
 
     malformed_id = f"{Fit2DTool.Output.PARAMETER_VALUES.value}:"
     missing_id = Fit2DTool._parameter_output_id(

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -5040,7 +5040,7 @@ def test_fit2d_source_replacement_discards_pending_result_retry(qtbot) -> None:
     assert tool._pending_persisted_fit_is_current is True
     assert all(result is None for result in tool._result_ds_full)
 
-    assert tool.update_data(data + 1.0)
+    assert tool.update_inputs({"data": data + 1.0})
     tool.set_document_trust(new_document_trust())
 
     assert tool._serialized_fit_result_blob is None

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -1193,6 +1193,17 @@ def test_fit2d_validate_update_inputs_invalid_input_keeps_existing_ui(qtbot) -> 
     with pytest.raises(ValueError, match="2D DataArray"):
         win.validate_update_inputs({"data": bad_data})
 
+    uncertainty = xr.full_like(data, 0.2)
+    validated = win.validate_update_inputs({"data": data, "uncertainty": uncertainty})
+    xr.testing.assert_identical(validated["data"], data)
+    xr.testing.assert_identical(validated["uncertainty"], uncertainty)
+
+    win._set_direct_weights(xr.ones_like(data))
+    with pytest.raises(ValueError, match="align exactly"):
+        win.validate_update_inputs(
+            {"data": data.assign_coords(x=np.asarray(data.x) + 1.0)}
+        )
+
     assert win.centralWidget() is old_central
     assert old_central is not None
     assert old_central.parent() is not None
@@ -1830,6 +1841,29 @@ def test_fit2d_open_saved_fit_dataset(qtbot, exp_decay_model, monkeypatch) -> No
     assert win_restored.copy_full_button.isEnabled()
     assert win_restored.save_full_button.isEnabled()
     assert not win_restored.scale_covar_check.isChecked()
+
+
+def test_fit2d_failed_saved_fit_restore_closes_new_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fit_ds = xr.Dataset({"modelfit_data": _make_2d_data()})
+    closed: list[Fit2DTool] = []
+    original_close = Fit2DTool.close
+
+    def fail_restore(*_args, **_kwargs):
+        raise RuntimeError("restore failed")
+
+    def record_close(tool: Fit2DTool) -> bool:
+        closed.append(tool)
+        return original_close(tool)
+
+    monkeypatch.setattr(Fit2DTool, "_restore_from_fit_dataset", fail_restore)
+    monkeypatch.setattr(Fit2DTool, "close", record_close)
+
+    with pytest.raises(RuntimeError, match="restore failed"):
+        erlab.interactive.ftool(fit_ds, execute=False)
+
+    assert len(closed) == 1
 
 
 def test_fit2d_open_weighted_saved_fit_dataset(
@@ -3887,6 +3921,69 @@ def test_fit2d_param_plot_open_parameter_values_does_not_launch_without_valid_st
     assert not manager.weighted_ftool_calls
 
 
+def test_fit2d_param_plot_reports_empty_parameter_data(qtbot, monkeypatch) -> None:
+    win = erlab.interactive.ftool(_make_2d_data(), execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+    _seed_param_plot_for_figure(win, "p0_center")
+    empty = xr.DataArray([], dims="y")
+    warnings: list[tuple[str, str]] = []
+    monkeypatch.setattr(win, "_param_plot_dataarrays", lambda _name: (empty, empty))
+    monkeypatch.setattr(
+        win, "_show_warning", lambda title, text: warnings.append((title, text))
+    )
+
+    assert win.param_plot._current_param_dataarrays() is None
+    assert len(warnings) == 1
+
+
+def test_fit2d_parameter_output_target_uses_managed_output_state(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+    opened: list[tuple[xr.DataArray, dict[str, object]]] = []
+    state: dict[str, object | None] = {"tool": None, "target": None}
+
+    def open_output(output_data: xr.DataArray, **kwargs: object) -> object | None:
+        opened.append((output_data, kwargs))
+        return state["tool"]
+
+    monkeypatch.setattr(win, "_open_output_imagetool", open_output)
+    monkeypatch.setattr(
+        win,
+        "_output_imagetool_target",
+        lambda _output_id: state["target"],
+    )
+
+    assert (
+        win._parameter_output_target(
+            "p0_center", Fit2DTool.Output.PARAMETER_VALUES, data
+        )
+        is None
+    )
+
+    state.update(tool=object(), target="values_target")
+    assert (
+        win._parameter_output_target(
+            "p0_center", Fit2DTool.Output.PARAMETER_VALUES, data
+        )
+        == "values_target"
+    )
+
+    state["target"] = object()
+    assert (
+        win._parameter_output_target(
+            "p0_center", Fit2DTool.Output.PARAMETER_VALUES, data
+        )
+        is None
+    )
+    assert len(opened) == 3
+    assert all(call[1]["prompt_on_reuse"] is False for call in opened)
+
+
 @pytest.mark.parametrize(
     ("failed_output", "values_preexisting", "expected_removals"),
     [
@@ -3954,8 +4051,29 @@ def test_fit2d_param_plot_open_parameter_values_does_not_launch_on_output_failur
     assert not manager.weighted_ftool_calls
 
 
+@pytest.mark.parametrize(
+    ("preexisting", "expected_removals"),
+    [
+        ((), ["values_target", "stderr_target"]),
+        (
+            (Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT,),
+            ["stderr_target"],
+        ),
+        ((Fit2DTool.Output.PARAMETER_STDERR,), ["values_target"]),
+        (
+            (
+                Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT,
+                Fit2DTool.Output.PARAMETER_STDERR,
+            ),
+            [],
+        ),
+    ],
+)
 def test_fit2d_param_plot_open_parameter_values_cleans_up_failed_launch(
-    qtbot, monkeypatch
+    qtbot,
+    monkeypatch,
+    preexisting: tuple[Fit2DTool.Output, ...],
+    expected_removals: list[str],
 ) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)
@@ -3977,6 +4095,22 @@ def test_fit2d_param_plot_open_parameter_values_cleans_up_failed_launch(
             else "stderr_target"
         ),
     )
+    output_ids = {
+        output: win._parameter_output_id(output, param_name)
+        for output in (
+            Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT,
+            Fit2DTool.Output.PARAMETER_STDERR,
+        )
+    }
+    monkeypatch.setattr(
+        win,
+        "_output_imagetool_target",
+        lambda output_id: (
+            "preexisting"
+            if any(output_id == output_ids[output] for output in preexisting)
+            else None
+        ),
+    )
     cleared_output_ids: list[str] = []
     monkeypatch.setattr(
         win, "_clear_output_imagetool_target", cleared_output_ids.append
@@ -3985,12 +4119,14 @@ def test_fit2d_param_plot_open_parameter_values_cleans_up_failed_launch(
     win.param_plot._open_parameter_values_in_ftool()
 
     assert manager.weighted_ftool_calls == [("values_target", "stderr_target")]
-    assert manager.remove_calls == ["values_target", "stderr_target"]
+    assert manager.remove_calls == expected_removals
     assert cleared_output_ids == [
-        win._parameter_output_id(
-            Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT, param_name
-        ),
-        win._parameter_output_id(Fit2DTool.Output.PARAMETER_STDERR, param_name),
+        output_ids[
+            Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT
+            if target == "values_target"
+            else Fit2DTool.Output.PARAMETER_STDERR
+        ]
+        for target in expected_removals
     ]
 
 

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -957,7 +957,10 @@ def test_fit2d_weighted_fit_broadcasts_uncertainty(
     assert values is not None
     assert win.output_imagetool_provenance(values_output_id, values) is None
 
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        win.to_dataset(),
+        _code_trust=new_document_trust(),
+    )
     qtbot.addWidget(restored)
     assert isinstance(restored, Fit2DTool)
     xr.testing.assert_identical(restored.uncertainty, uncertainty)
@@ -1880,7 +1883,8 @@ def test_fit2d_open_weighted_saved_fit_dataset(
         np.testing.assert_array_equal(result.weights, weights)
 
     workspace_restored = erlab.interactive.utils.ToolWindow.from_dataset(
-        win.to_dataset()
+        win.to_dataset(),
+        _code_trust=new_document_trust(),
     )
     qtbot.addWidget(workspace_restored)
     assert isinstance(workspace_restored, Fit2DTool)
@@ -3411,7 +3415,9 @@ def test_fit2d_parameter_output_provenance_preserves_managed_uncertainty(
         assert spec is not None
         assert isinstance(spec.operations[-1], ScriptCodeOperation)
         replayed = replay_script_provenance(
-            spec, {"data": data, "uncertainty": uncertainty}
+            spec,
+            {"data": data, "uncertainty": uncertainty},
+            authorize=_authorize_execution,
         )
         xr.testing.assert_allclose(replayed, expected)
 

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -4312,11 +4312,11 @@ def test_fit2d_param_plot_save_dataarray_as_hdf5_branches(
 
     real_dialog = QtWidgets.QFileDialog
     captured_dirs: list[str] = []
+    captured_files: list[str] = []
 
     class _DialogStub:
         AcceptMode = real_dialog.AcceptMode
         FileMode = real_dialog.FileMode
-        Option = real_dialog.Option
 
         def __init__(self, *args, **kwargs) -> None:
             self._selected = [str(tmp_path / "unused.h5")]
@@ -4333,11 +4333,11 @@ def test_fit2d_param_plot_save_dataarray_as_hdf5_branches(
         def setDefaultSuffix(self, suffix) -> None:
             self._suffix = suffix
 
-        def setOption(self, *args, **kwargs) -> None:
-            self._option = (args, kwargs)
-
         def setDirectory(self, directory: str) -> None:
             captured_dirs.append(directory)
+
+        def selectFile(self, filename: str) -> None:
+            captured_files.append(filename)
 
         def exec(self) -> bool:
             return False
@@ -4346,7 +4346,6 @@ def test_fit2d_param_plot_save_dataarray_as_hdf5_branches(
             return self._selected
 
     monkeypatch.setattr(QtWidgets, "QFileDialog", _DialogStub)
-    monkeypatch.delenv("PYTEST_VERSION", raising=False)
 
     monkeypatch.setattr(pg.PlotItem, "lastFileDir", str(tmp_path), raising=False)
     monkeypatch.setattr(
@@ -4357,18 +4356,20 @@ def test_fit2d_param_plot_save_dataarray_as_hdf5_branches(
 
     win.param_plot._save_dataarray_as_hdf5(xr.DataArray([1.0], name=""))
     win.param_plot._save_dataarray_as_hdf5(xr.DataArray([2.0], name=5))
-    assert captured_dirs[-2].endswith("data.h5")
-    assert captured_dirs[-1].endswith("5.h5")
+    assert captured_dirs[-2:] == [str(tmp_path), str(tmp_path)]
+    assert captured_files[-2:] == ["data.h5", "5.h5"]
 
     monkeypatch.setattr(pg.PlotItem, "lastFileDir", "", raising=False)
     win.param_plot._save_dataarray_as_hdf5(xr.DataArray([3.0], name="named"))
-    assert captured_dirs[-1] == str(tmp_path / "recent" / "named.h5")
+    assert captured_dirs[-1] == str(tmp_path / "recent")
+    assert captured_files[-1] == "named.h5"
 
     monkeypatch.setattr(
         erlab.interactive.imagetool.manager, "_get_recent_directory", lambda: ""
     )
     win.param_plot._save_dataarray_as_hdf5(xr.DataArray([4.0], name="cwdname"))
-    assert captured_dirs[-1] == os.path.join(os.getcwd(), "cwdname.h5")
+    assert captured_dirs[-1] == os.getcwd()
+    assert captured_files[-1] == "cwdname.h5"
 
 
 def test_fit2d_param_plot_save_dataarray_as_hdf5_handles_write_error(
@@ -4382,7 +4383,6 @@ def test_fit2d_param_plot_save_dataarray_as_hdf5_handles_write_error(
     class _DialogStub:
         AcceptMode = QtWidgets.QFileDialog.AcceptMode
         FileMode = QtWidgets.QFileDialog.FileMode
-        Option = QtWidgets.QFileDialog.Option
 
         def __init__(self, *args, **kwargs) -> None:
             self._init_args = (args, kwargs)
@@ -4399,11 +4399,11 @@ def test_fit2d_param_plot_save_dataarray_as_hdf5_handles_write_error(
         def setDefaultSuffix(self, suffix) -> None:
             self._suffix = suffix
 
-        def setOption(self, *args, **kwargs) -> None:
-            self._option = (args, kwargs)
-
         def setDirectory(self, directory: str) -> None:
             self._directory = directory
+
+        def selectFile(self, filename: str) -> None:
+            self._filename = filename
 
         def exec(self) -> bool:
             return True

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -30,7 +30,7 @@ from erlab.interactive._figurecomposer import (
 )
 from erlab.interactive._fit2d import Fit2DTool
 from erlab.interactive.imagetool._provenance._execution import replay_script_provenance
-from erlab.interactive.imagetool._provenance._model import script
+from erlab.interactive.imagetool._provenance._model import ScriptInput, script
 from erlab.interactive.imagetool._provenance._operations import (
     ModelFitOperation,
     ScriptCodeOperation,
@@ -515,7 +515,7 @@ def test_ftool_2d_fill_and_transpose(qtbot, accept_dialog) -> None:
     assert win._y_dim_name == win._data_full.dims[0]
 
 
-def test_fit2d_update_data_preserves_transpose_orientation(qtbot) -> None:
+def test_fit2d_update_inputs_preserves_transpose_orientation(qtbot) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win)
@@ -526,7 +526,7 @@ def test_fit2d_update_data_preserves_transpose_orientation(qtbot) -> None:
 
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) * 1.1
-    win.update_data(updated)
+    win.update_inputs({"data": updated})
 
     xr.testing.assert_identical(win.tool_data, updated.transpose("x", "y"))
     assert win._y_dim_name == "x"
@@ -708,7 +708,7 @@ def test_fit2d_status_and_persistence_preserve_transpose_orientation(qtbot) -> N
 
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) + 1.0
-    win_roundtripped.update_data(updated)
+    win_roundtripped.update_inputs({"data": updated})
     xr.testing.assert_identical(win_roundtripped.tool_data, updated.transpose("x", "y"))
     qtbot.wait_until(
         lambda: win_roundtripped.cbar.spanRegion() == pytest.approx((0.5, 1.0))
@@ -964,6 +964,29 @@ def test_fit2d_weighted_fit_broadcasts_uncertainty(
     assert restored.scale_covar_check.isChecked() is False
 
 
+def test_fit2d_managed_uncertainty_persistence_preserves_dimensions(qtbot) -> None:
+    data = _make_2d_data()
+    uncertainty = xr.full_like(data, 0.2).rename("sigma")
+    win = erlab.interactive.ftool(data, uncertainty=uncertainty, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+    bindings = (ScriptInput(name="data"), ScriptInput(name="uncertainty"))
+    win.set_script_inputs(bindings, primary_input="data")
+
+    items = win._persistence_data_items()
+    assert "uncertainty" in items
+    xr.testing.assert_identical(items["uncertainty"], uncertainty)
+    assert items["uncertainty"].dims == data.dims
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit2DTool)
+    assert restored.script_inputs == bindings
+    xr.testing.assert_identical(restored.uncertainty, uncertainty)
+    assert restored.uncertainty is not None
+    assert restored.uncertainty.dims == data.dims
+
+
 def test_fit2d_full_provenance_handles_spaced_fit_axis(qtbot) -> None:
     x = np.linspace(-1.0, 1.0, 5)
     motor = np.array([10.0, 11.0, 12.0])
@@ -989,7 +1012,7 @@ def test_fit2d_full_provenance_handles_spaced_fit_axis(qtbot) -> None:
     win.y_max_spin.setValue(len(params_full) - 1)
 
     assert win.current_provenance_spec() is not None
-    prelude = win._detached_full_copy_prelude(input_name="derived_crop")
+    prelude = win._detached_full_copy_prelude(primary_input="derived_crop")
     assert prelude is not None
     assert "fit_data" not in prelude
 
@@ -1041,7 +1064,7 @@ def test_fit2d_file_roundtrip_preserves_spaced_associated_coord(
     )
 
 
-def test_fit2d_update_data_preserves_state_and_refit(
+def test_fit2d_update_inputs_preserves_state_and_refit(
     qtbot, exp_decay_model, monkeypatch
 ) -> None:
     data = _make_2d_data()
@@ -1066,7 +1089,7 @@ def test_fit2d_update_data_preserves_state_and_refit(
     status = win.tool_status
     new_data = data.copy(deep=True)
     new_data.data = np.asarray(new_data.data) * 1.1
-    win.update_data(new_data)
+    win.update_inputs({"data": new_data})
 
     assert win.tool_status == status
     xr.testing.assert_identical(win.tool_data, new_data)
@@ -1077,12 +1100,12 @@ def test_fit2d_update_data_preserves_state_and_refit(
     win.refit_on_source_update_check.setChecked(True)
     newer_data = new_data.copy(deep=True)
     newer_data.data = np.asarray(newer_data.data) * 1.05
-    win.update_data(newer_data)
+    win.update_inputs({"data": newer_data})
 
     assert called == [True]
 
 
-def test_fit2d_update_data_resizes_slice_state_and_keeps_param_sync(
+def test_fit2d_update_inputs_resizes_slice_state_and_keeps_param_sync(
     qtbot, exp_decay_model
 ) -> None:
     data = _make_2d_data()
@@ -1099,7 +1122,7 @@ def test_fit2d_update_data_resizes_slice_state_and_keeps_param_sync(
 
     new_data = data.isel(y=slice(0, 2)).copy(deep=True)
     new_data.data = np.asarray(new_data.data) * 1.1
-    win.update_data(new_data)
+    win.update_inputs({"data": new_data})
 
     assert win._current_idx == 1
     assert len(win._params_full) == 2
@@ -1113,7 +1136,7 @@ def test_fit2d_update_data_resizes_slice_state_and_keeps_param_sync(
     assert win._params_full[win._current_idx]["n0"].value == pytest.approx(3.0)
 
 
-def test_fit2d_update_data_preserves_initial_params_full_for_reset_all(
+def test_fit2d_update_inputs_preserves_initial_params_full_for_reset_all(
     qtbot, exp_decay_model, monkeypatch
 ) -> None:
     data = _make_2d_data()
@@ -1137,7 +1160,7 @@ def test_fit2d_update_data_preserves_initial_params_full_for_reset_all(
 
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) * 1.1
-    win.update_data(updated)
+    win.update_inputs({"data": updated})
 
     assert win._initial_params_full is not None
     assert win._initial_params_full[0]["n0"].value == pytest.approx(1.0)
@@ -1156,7 +1179,7 @@ def test_fit2d_update_data_preserves_initial_params_full_for_reset_all(
     assert win._params_full[1]["n0"].value == pytest.approx(2.0)
 
 
-def test_fit2d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
+def test_fit2d_validate_update_inputs_invalid_input_keeps_existing_ui(qtbot) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win)
@@ -1166,7 +1189,7 @@ def test_fit2d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     bad_data = _make_1d_data()
 
     with pytest.raises(ValueError, match="2D DataArray"):
-        win.update_data(bad_data)
+        win.validate_update_inputs({"data": bad_data})
 
     assert win.centralWidget() is old_central
     assert old_central is not None
@@ -1174,7 +1197,7 @@ def test_fit2d_update_data_invalid_input_keeps_existing_ui(qtbot) -> None:
     xr.testing.assert_identical(win.tool_data, data)
 
 
-def test_fit2d_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
+def test_fit2d_apply_inputs_returns_false_if_fit_thread_stays_alive(qtbot) -> None:
     data = _make_2d_data()
     win = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win)
@@ -1206,7 +1229,9 @@ def test_fit2d_update_data_returns_false_if_fit_thread_stays_alive(qtbot) -> Non
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) * 1.1
 
-    assert win.update_data(updated) is False
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs((script_input,), primary_input="data")
+    assert win._apply_inputs({"data": updated}, (script_input,)) is False
     assert stuck_thread.cancel_called
     assert stuck_thread.interrupted
     assert stuck_thread.wait_timeout_ms == win.BACKGROUND_TASK_TIMEOUT_MS
@@ -1226,7 +1251,7 @@ def test_fit2d_rebuild_paths_keep_fit_finished_receivers_constant(qtbot) -> None
 
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) * 1.1
-    win.update_data(updated)
+    win.update_inputs({"data": updated})
     assert (
         signal_receiver_count(win, win.sigFitFinished, "sigFitFinished")
         == initial_receivers
@@ -1239,7 +1264,7 @@ def test_fit2d_rebuild_paths_keep_fit_finished_receivers_constant(qtbot) -> None
     )
 
 
-def test_fit2d_update_data_auto_refit_after_waiting_cancelled_thread(
+def test_fit2d_apply_inputs_auto_refit_after_waiting_cancelled_thread(
     qtbot, monkeypatch
 ) -> None:
     data = _make_2d_data()
@@ -1284,7 +1309,9 @@ def test_fit2d_update_data_auto_refit_after_waiting_cancelled_thread(
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) * 1.1
 
-    assert win.update_data(updated) is False
+    script_input = ScriptInput(name="data")
+    win.set_script_inputs((script_input,), primary_input="data")
+    assert win._apply_inputs({"data": updated}, (script_input,)) is False
     assert started == [True]
     assert old_thread.cancel_called
     assert old_thread.interrupted
@@ -1884,7 +1911,7 @@ def test_fit2d_open_weighted_saved_fit_dataset(
     )
     assert workspace_restored._fit_is_current
     updated_data = data * 1.01
-    assert workspace_restored.update_data(updated_data)
+    assert workspace_restored.update_inputs({"data": updated_data})
     xr.testing.assert_identical(
         workspace_restored._direct_weights_full,
         weighted_fit_ds.modelfit_weights,
@@ -3312,10 +3339,19 @@ def test_fit2d_parameter_output_resolution_edges(qtbot, monkeypatch) -> None:
         seed_code="derived = watched_data",
         active_name="derived",
     )
-    win.set_input_provenance_spec(direct_input)
+    win.set_script_inputs(
+        (
+            ScriptInput(
+                name="derived",
+                provenance_spec=direct_input.model_dump(mode="json"),
+            ),
+        ),
+        primary_input="derived",
+    )
     direct_spec = win.output_imagetool_provenance(values_output_id, values)
     assert direct_spec is not None
-    assert direct_spec.start_label == "Start from watched data"
+    assert direct_spec.script_inputs == win.script_inputs
+    assert direct_spec.start_label == "Start from current fit-tool input data"
     direct_code = direct_spec.display_code()
     assert direct_code is not None
     assert "watched_data.isel" in direct_code

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -3155,7 +3155,7 @@ def test_fit2d_param_plot_dataarray_context_actions(qtbot, monkeypatch) -> None:
     values = win._param_plot_dataarray(center_name)
     stderr = win._param_plot_dataarray(center_name, stderr=True)
     np.testing.assert_allclose(values.values, [0.1, 0.2, 0.3])
-    np.testing.assert_allclose(stderr.values, [0.01, 0.02, 0.0])
+    np.testing.assert_allclose(stderr.values, [0.01, 0.02, np.nan])
     assert values.name == f"{center_name}_values"
     assert stderr.name == f"{center_name}_stderr"
 
@@ -3190,6 +3190,7 @@ def test_fit2d_param_plot_dataarray_context_actions(qtbot, monkeypatch) -> None:
         Fit2DTool._parameter_output_id(Fit2DTool.Output.PARAMETER_STDERR, center_name),
     ]
     action_names = {action.objectName() for action in win.param_plot.vb.menu.actions()}
+    assert "fit2dParamPlotOpenInFtoolAction" in action_names
     assert "fit2dParamPlotAddToFigureAction" in action_names
 
 
@@ -3213,11 +3214,21 @@ def test_fit2d_parameter_output_provenance_uses_distinct_active_names(qtbot) -> 
     win.param_plot_combo.setCurrentText(center_name)
 
     values = win.output_imagetool_data(Fit2DTool.Output.PARAMETER_VALUES)
+    weighted_fit_values = win.output_imagetool_data(
+        Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT
+    )
     stderr = win.output_imagetool_data(Fit2DTool.Output.PARAMETER_STDERR)
     assert values is not None
+    assert weighted_fit_values is not None
     assert stderr is not None
+    np.testing.assert_allclose(values.values, [0.1, 0.2, 0.3])
+    np.testing.assert_allclose(weighted_fit_values.values, [0.1, 0.2, np.nan])
+    np.testing.assert_allclose(stderr.values, [0.01, 0.02, np.nan])
     values_output_id = Fit2DTool._parameter_output_id(
         Fit2DTool.Output.PARAMETER_VALUES, center_name
+    )
+    weighted_fit_values_output_id = Fit2DTool._parameter_output_id(
+        Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT, center_name
     )
     stderr_output_id = Fit2DTool._parameter_output_id(
         Fit2DTool.Output.PARAMETER_STDERR, center_name
@@ -3229,18 +3240,26 @@ def test_fit2d_parameter_output_provenance_uses_distinct_active_names(qtbot) -> 
     stderr_spec = win.output_imagetool_provenance(
         Fit2DTool.Output.PARAMETER_STDERR, stderr
     )
+    weighted_fit_values_spec = win.output_imagetool_provenance(
+        weighted_fit_values_output_id, weighted_fit_values
+    )
 
     assert values_spec is not None
     assert stderr_spec is not None
+    assert weighted_fit_values_spec is not None
     assert values_spec.active_name == "parameter_values"
     assert stderr_spec.active_name == "parameter_stderr"
+    assert weighted_fit_values_spec.active_name == "parameter_values"
     assert isinstance(values_spec.operations[-1], ModelFitOperation)
     assert isinstance(stderr_spec.operations[-1], ModelFitOperation)
+    assert isinstance(weighted_fit_values_spec.operations[-1], ScriptCodeOperation)
 
     values_code = values_spec.display_code()
     stderr_code = stderr_spec.display_code()
+    weighted_fit_values_code = weighted_fit_values_spec.display_code()
     assert values_code is not None
     assert stderr_code is not None
+    assert weighted_fit_values_code is not None
     assert ".modelfit_coefficients.sel(" in values_code
     assert ".modelfit_stderr.sel(" in stderr_code
     assert "param='p0_center'" in values_code
@@ -3255,14 +3274,29 @@ def test_fit2d_parameter_output_provenance_uses_distinct_active_names(qtbot) -> 
     assert "imagetool" not in stderr_code
     assert max(map(len, values_code.splitlines())) <= 88
     assert max(map(len, stderr_code.splitlines())) <= 88
+    assert max(map(len, weighted_fit_values_code.splitlines())) <= 88
 
     fit_data = data.isel(y=slice(0, 3))
     expected_values = values_spec.operations[-1].apply(fit_data)
     expected_stderr = stderr_spec.operations[-1].apply(fit_data)
     values_namespace = _exec_generated_code(values_code, data=data)
     stderr_namespace = _exec_generated_code(stderr_code, data=data)
+    weighted_fit_values_namespace = _exec_generated_code(
+        weighted_fit_values_code,
+        data=data,
+        era=erlab.analysis,
+        xr=xr,
+    )
     xr.testing.assert_identical(values_namespace["parameter_values"], expected_values)
     xr.testing.assert_identical(stderr_namespace["parameter_stderr"], expected_stderr)
+    expected_weighted_values = expected_values.where(
+        np.isfinite(expected_values)
+        & np.isfinite(expected_stderr)
+        & (expected_stderr > 0)
+    )
+    xr.testing.assert_identical(
+        weighted_fit_values_namespace["parameter_values"], expected_weighted_values
+    )
 
     win.param_plot_combo.setCurrentText("p0_width")
     bound_values = win.output_imagetool_data(values_output_id)
@@ -3296,6 +3330,90 @@ def test_fit2d_parameter_output_provenance_uses_distinct_active_names(qtbot) -> 
     assert win.output_imagetool_data(missing_id) is None
     assert win.output_imagetool_provenance(malformed_id, values) is None
     assert win.output_imagetool_provenance(missing_id, values) is None
+
+
+def test_fit2d_parameter_output_provenance_preserves_managed_uncertainty(
+    qtbot,
+) -> None:
+    x = np.linspace(-1.0, 1.0, 9)
+    y = np.array([0.0, 1.0])
+    data = xr.DataArray(
+        np.stack((1.0 + 2.0 * x + x**2, 2.0 - x + 0.5 * x**2)),
+        dims=("y", "x"),
+        coords={"y": y, "x": x},
+        name="data",
+    )
+    uncertainty = xr.DataArray(
+        np.broadcast_to(np.linspace(0.1, 0.5, x.size), data.shape),
+        dims=data.dims,
+        coords=data.coords,
+        name="uncertainty",
+    )
+    model = erlab.analysis.fit.models.PolynomialModel(degree=1)
+    params = model.make_params(c0=0.0, c1=0.0)
+    win = erlab.interactive.ftool(
+        data,
+        model=model,
+        params=params,
+        uncertainty=uncertainty,
+        data_name="data",
+        uncertainty_name="uncertainty",
+        scale_covar=True,
+        execute=False,
+    )
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+    win.set_script_inputs(
+        (ScriptInput(name="data"), ScriptInput(name="uncertainty")),
+        primary_input="data",
+    )
+
+    fitted_params = []
+    for _ in y:
+        fitted = params.copy()
+        fitted["c1"].stderr = 0.1
+        fitted_params.append(fitted)
+    _seed_fit2d_param_results(win, fitted_params)
+    win.param_plot_combo.setCurrentText("c1")
+
+    expected_fit = data.xlm.modelfit(
+        "x",
+        model=model,
+        params=params,
+        weights=1.0 / uncertainty,
+        method=win.method_combo.currentText(),
+        scale_covar=True,
+    ).load()
+    expected_values = expected_fit.modelfit_coefficients.sel(
+        param="c1", drop=True
+    ).rename("c1_values")
+    expected_stderr = (
+        expected_fit.modelfit_stderr.sel(param="c1", drop=True)
+        .where(lambda error: np.isfinite(error) & (error > 0))
+        .rename("c1_stderr")
+    )
+    expected_weighted_values = expected_values.where(
+        np.isfinite(expected_values)
+        & np.isfinite(expected_stderr)
+        & (expected_stderr > 0)
+    )
+
+    expected_outputs = {
+        Fit2DTool.Output.PARAMETER_VALUES: expected_values,
+        Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT: expected_weighted_values,
+        Fit2DTool.Output.PARAMETER_STDERR: expected_stderr,
+    }
+    for output, expected in expected_outputs.items():
+        output_id = win._parameter_output_id(output, "c1")
+        output_data = win.output_imagetool_data(output_id)
+        assert output_data is not None
+        spec = win.output_imagetool_provenance(output_id, output_data)
+        assert spec is not None
+        assert isinstance(spec.operations[-1], ScriptCodeOperation)
+        replayed = replay_script_provenance(
+            spec, {"data": data, "uncertainty": uncertainty}
+        )
+        xr.testing.assert_allclose(replayed, expected)
 
 
 def test_fit2d_parameter_output_resolution_edges(qtbot, monkeypatch) -> None:
@@ -3535,21 +3653,28 @@ def test_fit2d_param_plot_context_actions_missing_selection(qtbot, monkeypatch) 
     win.param_plot._show_parameter_values()
     win.param_plot._save_parameter_stderr()
     win.param_plot._show_parameter_stderr()
+    win.param_plot._open_parameter_values_in_ftool()
     win.param_plot._add_parameter_plot_to_figure()
 
-    assert len(warnings) == 5
-    assert all(title == "No parameter selected" for title, _ in warnings)
+    assert len(warnings) == 6
     assert not saved
     assert not shown
 
 
-def _seed_param_plot_for_figure(win: Fit2DTool, param_name: str) -> None:
+def _seed_param_plot_for_figure(
+    win: Fit2DTool,
+    param_name: str,
+    *,
+    stderrs: tuple[float | None, float | None, float | None] = (0.01, 0.02, 0.03),
+) -> None:
     params_0 = win._params.copy()
     params_1 = win._params.copy()
     params_2 = win._params.copy()
-    for idx, params in enumerate((params_0, params_1, params_2), start=1):
+    for idx, (params, stderr) in enumerate(
+        zip((params_0, params_1, params_2), stderrs, strict=True), start=1
+    ):
         params[param_name].set(value=0.1 * idx)
-        params[param_name].stderr = 0.01 * idx
+        params[param_name].stderr = stderr
     _seed_fit2d_param_results(win, [params_0, params_1, params_2])
     win.param_plot_combo.setCurrentText(param_name)
 
@@ -3570,10 +3695,12 @@ class _FakeFigureManager:
         figure_uids: tuple[str, ...] = (),
         append_return: bool = True,
         prompt_return: object = _DEFAULT_FIGURE_PROMPT,
+        weighted_ftool_return: str | None = "weighted_ftool",
     ) -> None:
         self._managed = managed
         self._figure_uids_value = figure_uids
         self._append_return = append_return
+        self._weighted_ftool_return = weighted_ftool_return
         if prompt_return is _DEFAULT_FIGURE_PROMPT:
             prompt_return = (
                 (
@@ -3593,6 +3720,8 @@ class _FakeFigureManager:
         self.append_calls: list[
             tuple[tuple[str, ...], str | None, object | None, object]
         ] = []
+        self.weighted_ftool_calls: list[tuple[str, str]] = []
+        self.remove_calls: list[str] = []
 
     def _node_uid_from_window(self, widget) -> str | None:
         return "ftool" if widget is self._managed else None
@@ -3634,6 +3763,231 @@ class _FakeFigureManager:
         )
         return self._append_return
 
+    def open_weighted_ftool(self, values_target: str, stderr_target: str) -> str | None:
+        self.weighted_ftool_calls.append((values_target, stderr_target))
+        return self._weighted_ftool_return
+
+    def _remove_childtool(self, target: str) -> None:
+        self.remove_calls.append(target)
+
+
+def test_fit2d_param_plot_open_parameter_values_uses_managed_outputs(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    param_name = "p0_center"
+    _seed_param_plot_for_figure(win, param_name, stderrs=(0.01, None, 0.03))
+    manager = _FakeFigureManager(win)
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager, "_manager_instance", manager
+    )
+    output_calls: list[tuple[str, Fit2DTool.Output, xr.DataArray]] = []
+
+    def _target_stub(param: str, output: Fit2DTool.Output, da: xr.DataArray) -> str:
+        output_calls.append((param, output, da.copy(deep=True)))
+        return (
+            "values_target"
+            if output == Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT
+            else "stderr_target"
+        )
+
+    param_data_calls = 0
+    param_plot_data = win._param_plot_data
+
+    def _param_plot_data(param: str):
+        nonlocal param_data_calls
+        param_data_calls += 1
+        return param_plot_data(param)
+
+    monkeypatch.setattr(win, "_param_plot_data", _param_plot_data)
+    monkeypatch.setattr(win, "_parameter_output_target", _target_stub)
+
+    win.param_plot._open_parameter_values_in_ftool()
+
+    assert [(param, output, da.name) for param, output, da in output_calls] == [
+        (
+            param_name,
+            Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT,
+            f"{param_name}_values",
+        ),
+        (param_name, Fit2DTool.Output.PARAMETER_STDERR, f"{param_name}_stderr"),
+    ]
+    np.testing.assert_allclose(output_calls[0][2].values, [0.1, np.nan, 0.3])
+    np.testing.assert_allclose(output_calls[1][2].values, [0.01, np.nan, 0.03])
+    assert param_data_calls == 1
+    np.testing.assert_allclose(
+        win._param_plot_dataarray(param_name).values, [0.1, 0.2, 0.3]
+    )
+    assert manager.weighted_ftool_calls == [("values_target", "stderr_target")]
+    assert not manager.create_calls
+    assert not manager.append_calls
+
+
+def test_fit2d_param_plot_open_parameter_values_requires_managed_context(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    _seed_param_plot_for_figure(win, "p0_center")
+    monkeypatch.setattr(erlab.interactive.imagetool.manager, "_manager_instance", None)
+    warnings: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        win.param_plot,
+        "_current_param_dataarrays",
+        lambda **_kwargs: pytest.fail("parameter data was computed without a manager"),
+    )
+    monkeypatch.setattr(
+        win, "_show_warning", lambda title, text: warnings.append((title, text))
+    )
+
+    win.param_plot._open_parameter_values_in_ftool()
+
+    assert len(warnings) == 1
+
+
+def test_fit2d_param_plot_open_parameter_values_does_not_launch_without_valid_stderr(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    param_name = "p0_center"
+    _seed_param_plot_for_figure(win, param_name, stderrs=(None, None, None))
+    manager = _FakeFigureManager(win)
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager, "_manager_instance", manager
+    )
+    output_calls: list[object] = []
+    warnings: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        win, "_parameter_output_target", lambda *_args: output_calls.append(None)
+    )
+    monkeypatch.setattr(
+        win, "_show_warning", lambda title, text: warnings.append((title, text))
+    )
+
+    win.param_plot._open_parameter_values_in_ftool()
+
+    assert len(warnings) == 1
+    assert not output_calls
+    assert not manager.weighted_ftool_calls
+
+
+@pytest.mark.parametrize(
+    ("failed_output", "values_preexisting", "expected_removals"),
+    [
+        (Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT, False, []),
+        (Fit2DTool.Output.PARAMETER_STDERR, False, ["values_target"]),
+        (Fit2DTool.Output.PARAMETER_STDERR, True, []),
+    ],
+)
+def test_fit2d_param_plot_open_parameter_values_does_not_launch_on_output_failure(
+    qtbot,
+    monkeypatch,
+    failed_output: Fit2DTool.Output,
+    values_preexisting: bool,
+    expected_removals: list[str],
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    _seed_param_plot_for_figure(win, "p0_center")
+    manager = _FakeFigureManager(win)
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager, "_manager_instance", manager
+    )
+    output_calls: list[Fit2DTool.Output] = []
+
+    def _target_stub(
+        _param: str, output: Fit2DTool.Output, _data: xr.DataArray
+    ) -> str | None:
+        output_calls.append(output)
+        if output == failed_output:
+            return None
+        return (
+            "values_target"
+            if output == Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT
+            else None
+        )
+
+    if values_preexisting:
+        values_output_id = win._parameter_output_id(
+            Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT, "p0_center"
+        )
+        monkeypatch.setattr(
+            win,
+            "_output_imagetool_target",
+            lambda output_id: (
+                "values_target" if output_id == values_output_id else None
+            ),
+        )
+    monkeypatch.setattr(win, "_parameter_output_target", _target_stub)
+    warnings: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        win, "_show_warning", lambda title, text: warnings.append((title, text))
+    )
+
+    win.param_plot._open_parameter_values_in_ftool()
+
+    expected_calls = [Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT]
+    if failed_output == Fit2DTool.Output.PARAMETER_STDERR:
+        expected_calls.append(Fit2DTool.Output.PARAMETER_STDERR)
+    assert output_calls == expected_calls
+    assert manager.remove_calls == expected_removals
+    assert len(warnings) == 1
+    assert not manager.weighted_ftool_calls
+
+
+def test_fit2d_param_plot_open_parameter_values_cleans_up_failed_launch(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    param_name = "p0_center"
+    _seed_param_plot_for_figure(win, param_name)
+    manager = _FakeFigureManager(win, weighted_ftool_return=None)
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager, "_manager_instance", manager
+    )
+    monkeypatch.setattr(
+        win,
+        "_parameter_output_target",
+        lambda _param, output, _data: (
+            "values_target"
+            if output == Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT
+            else "stderr_target"
+        ),
+    )
+    cleared_output_ids: list[str] = []
+    monkeypatch.setattr(
+        win, "_clear_output_imagetool_target", cleared_output_ids.append
+    )
+
+    win.param_plot._open_parameter_values_in_ftool()
+
+    assert manager.weighted_ftool_calls == [("values_target", "stderr_target")]
+    assert manager.remove_calls == ["values_target", "stderr_target"]
+    assert cleared_output_ids == [
+        win._parameter_output_id(
+            Fit2DTool.Output.PARAMETER_VALUES_FOR_WEIGHTED_FIT, param_name
+        ),
+        win._parameter_output_id(Fit2DTool.Output.PARAMETER_STDERR, param_name),
+    ]
+
 
 def test_fit2d_param_plot_add_to_figure_requires_manager(qtbot, monkeypatch) -> None:
     data = _make_2d_data()
@@ -3651,8 +4005,7 @@ def test_fit2d_param_plot_add_to_figure_requires_manager(qtbot, monkeypatch) -> 
 
     win.param_plot._add_parameter_plot_to_figure()
 
-    assert warnings
-    assert warnings[-1][0] == "ImageTool Manager required"
+    assert len(warnings) == 1
 
 
 @pytest.mark.parametrize(
@@ -3697,7 +4050,7 @@ def test_fit2d_param_plot_add_to_figure_manager_paths(
             return "values_target"
         return "stderr_target"
 
-    monkeypatch.setattr(win, "_parameter_figure_output_target", _target_stub)
+    monkeypatch.setattr(win, "_parameter_output_target", _target_stub)
 
     win.param_plot._add_parameter_plot_to_figure()
 
@@ -3721,8 +4074,7 @@ def test_fit2d_param_plot_add_to_figure_manager_paths(
     if append_return:
         assert not warnings
     else:
-        assert warnings
-        assert warnings[-1][0] == "Could not add to Figure"
+        assert len(warnings) == 1
     assert targets == ("values_target", "stderr_target")
     assert operation.method_family == FigureMethodFamily.AXES
     assert operation.method_name == "errorbar"
@@ -3762,7 +4114,7 @@ def test_fit2d_param_plot_add_to_figure_cancel_does_not_open_outputs(
     output_calls: list[tuple[str, Fit2DTool.Output, str]] = []
     monkeypatch.setattr(
         win,
-        "_parameter_figure_output_target",
+        "_parameter_output_target",
         lambda param, output, da: output_calls.append((param, output, str(da.name))),
     )
 
@@ -3789,7 +4141,7 @@ def test_fit2d_param_plot_add_to_figure_warns_when_outputs_fail(
     monkeypatch.setattr(
         erlab.interactive.imagetool.manager, "_manager_instance", manager
     )
-    monkeypatch.setattr(win, "_parameter_figure_output_target", lambda *_args: None)
+    monkeypatch.setattr(win, "_parameter_output_target", lambda *_args: None)
     warnings: list[tuple[str, str]] = []
     monkeypatch.setattr(
         win, "_show_warning", lambda title, text: warnings.append((title, text))
@@ -3797,8 +4149,7 @@ def test_fit2d_param_plot_add_to_figure_warns_when_outputs_fail(
 
     win.param_plot._add_parameter_plot_to_figure()
 
-    assert warnings
-    assert warnings[-1][0] == "Could not open parameter data"
+    assert len(warnings) == 1
     assert not manager.create_calls
     assert not manager.append_calls
 
@@ -3836,8 +4187,7 @@ def test_fit2d_param_plot_rejects_cached_guess_params(qtbot, monkeypatch) -> Non
     win.param_plot_combo.setCurrentText("p0_center")
     win.param_plot._show_parameter_values()
 
-    assert warnings
-    assert warnings[-1][0] == "No parameter selected"
+    assert len(warnings) == 1
 
 
 def test_fit2d_param_plot_rejects_placeholder_result_objects(qtbot) -> None:

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -140,7 +140,7 @@ def _trust_allows_local_code_edit(trust) -> bool:
     return issue_execution_capability(trust, (entry,))[1] is not None
 
 
-def test_fit_dataset_scale_covar_requires_one_common_value(monkeypatch) -> None:
+def test_fit_dataset_settings_require_common_values(monkeypatch) -> None:
     model = lmfit.models.LinearModel()
 
     class _Result:
@@ -183,10 +183,9 @@ def test_fit_dataset_scale_covar_requires_one_common_value(monkeypatch) -> None:
     assert fit2d_module._fit_dataset_settings(common) == (False, False)
     assert fit2d_module._fit_dataset_settings(weighted) == (False, True)
     assert fit2d_module._fit_dataset_settings(mixed_weighted) == (False, None)
-    assert fit2d_module._fit_dataset_scale_covar(common) is False
-    assert fit2d_module._fit_dataset_scale_covar(mixed) is None
-    assert fit2d_module._fit_dataset_scale_covar(missing) is None
-    assert fit2d_module._fit_dataset_scale_covar(xr.Dataset()) is None
+    assert fit2d_module._fit_dataset_settings(mixed) == (None, False)
+    assert fit2d_module._fit_dataset_settings(missing) == (None, None)
+    assert fit2d_module._fit_dataset_settings(xr.Dataset()) == (None, None)
 
     original_compute = xr.DataArray.compute
 
@@ -196,7 +195,7 @@ def test_fit_dataset_scale_covar_requires_one_common_value(monkeypatch) -> None:
         return original_compute(self, **kwargs)
 
     monkeypatch.setattr(xr.DataArray, "compute", _raise_compute)
-    assert fit2d_module._fit_dataset_scale_covar(common) is None
+    assert fit2d_module._fit_dataset_settings(common) == (None, None)
 
 
 def test_ftool_uncertainty_name_fallback(qtbot, monkeypatch) -> None:

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -17,6 +17,7 @@ from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.imagetool import _dialog_widgets, _kspace_conversion
 from erlab.interactive.imagetool import dialogs as imagetool_dialogs
 from erlab.interactive.imagetool._provenance._model import (
+    ScriptInput,
     full_data,
     operation_group_range,
     script,
@@ -1700,7 +1701,7 @@ def test_ktool_angle_energy_cut(qtbot, anglemap) -> None:
 
     updated = cut.copy(deep=True)
     updated.data = np.asarray(updated.data) + 1.0
-    win.update_data(updated)
+    win.update_inputs({"data": updated})
     assert win.energy_group.isEnabled() is False
     assert win.bz_group.isEnabled() is False
     assert win.images[1].data_array is not None
@@ -2886,7 +2887,7 @@ def test_ktool_configuration_state_edges(qtbot, anglemap) -> None:
     KspaceTool._clear_layout(LayoutReturningNone())
 
 
-def test_ktool_configuration_state_round_trip_output_provenance_and_update_data(
+def test_ktool_configuration_state_round_trip_output_provenance_and_update_inputs(
     qtbot, anglemap
 ) -> None:
     data = _make_da_ktool_data(anglemap)
@@ -2923,7 +2924,7 @@ def test_ktool_configuration_state_round_trip_output_provenance_and_update_data(
 
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) + 1.0
-    win.update_data(updated)
+    win.update_inputs({"data": updated})
     assert win._source_configuration == int(AxesConfiguration.Type1DA)
     assert win.data.kspace.configuration == target_configuration
     xr.testing.assert_allclose(
@@ -3053,33 +3054,51 @@ def test_ktool_copy_code_aliases_expression_input_names(qtbot) -> None:
     data = generate_hvdep_cuts((15, 30, 20), hvrange=(20.0, 30.0), noise=False)
     win = ktool(data, execute=False)
     _add_hidden_tool(qtbot, win)
-    win.set_input_provenance_spec(
-        script(
-            start_label="Start from watched variable 'my_data'",
-            seed_code='derived = my_data.astype("float64")',
-            active_name="derived",
-        )
+    input_provenance = script(
+        start_label="Start from watched variable 'my_data'",
+        seed_code="derived = my_data.astype(np.float64)",
+        active_name="derived",
+    )
+    win.set_script_inputs(
+        (
+            ScriptInput(
+                name="input_data",
+                provenance_spec=input_provenance.model_dump(mode="json"),
+            ),
+        ),
+        primary_input="input_data",
     )
 
     code = win.copy_code()
 
-    assert "my_data.astype" in code
+    assert "input_data = my_data.astype(np.float64)" in code
     assert ".copy(deep=False)" not in code
-    assert "derived_kconv.kspace.set_normal(" in code
-    assert "derived_kconv = derived_kconv.kspace.convert(" in code
-    namespace = _exec_generated_code(code, my_data=data.copy(deep=True))
-    xr.testing.assert_allclose(namespace["derived_kconv"], win._converted_output())
+    assert "input_data.kspace.set_normal(" in code
+    assert "input_data_kconv = input_data.kspace.convert(" in code
+    assert "astype(np.float64)_kconv" not in code
+    namespace = _exec_generated_code(
+        code,
+        my_data=data.copy(deep=True),
+        np=np,
+    )
+    xr.testing.assert_allclose(namespace["input_data_kconv"], win._converted_output())
 
 
-def test_ktool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> None:
+def test_ktool_copy_code_replays_script_input_provenance(qtbot) -> None:
     data = generate_hvdep_cuts((15, 30, 20), hvrange=(20.0, 30.0), noise=False)
     source = selection(IselOperation(kwargs={"alpha": slice(2, 24)}))
-    parent_provenance = selection(IselOperation(kwargs={"hv": slice(0, 5)}))
     source_data = source.apply(data)
     win = ktool(source_data, execute=False)
     _add_hidden_tool(qtbot, win)
-    win.set_source_binding(source)
-    win.set_input_provenance_parent_fetcher(lambda: parent_provenance)
+    win.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                provenance_spec=source.to_replay_spec().model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+    )
 
     code = win.copy_code()
 
@@ -3089,7 +3108,7 @@ def test_ktool_copy_code_ignores_parent_provenance_but_keeps_source(qtbot) -> No
     expected = win._assign_params(source_data.copy(deep=True)).kspace.convert(
         bounds=win.bounds, resolution=win.resolution
     )
-    xr.testing.assert_allclose(expected, namespace["derived_kconv"])
+    xr.testing.assert_allclose(expected, namespace["data_kconv"])
 
 
 def test_ktool_update_rate_limited(qtbot, anglemap, monkeypatch) -> None:
@@ -3219,7 +3238,7 @@ def test_ktool_deferred_restore_skips_default_calculations(
     assert restored_status.cmap_gamma == pytest.approx(1.4)
 
 
-def test_ktool_standalone_and_update_data_calculate_defaults_eager(
+def test_ktool_standalone_and_update_inputs_calculate_defaults_eager(
     qtbot, anglemap, monkeypatch
 ) -> None:
     data = _make_da_ktool_data(anglemap)
@@ -3245,7 +3264,7 @@ def test_ktool_standalone_and_update_data_calculate_defaults_eager(
     calls.clear()
     updated = data.copy(deep=True)
     updated.data = np.asarray(updated.data) + 1.0
-    win.update_data(updated)
+    win.update_inputs({"data": updated})
     assert calls == [("bounds", win), ("resolution", win)]
 
 
@@ -3368,7 +3387,7 @@ def test_ktool_suppresses_missing_kspace_parameter_warnings(qtbot) -> None:
         win.calculate_resolution()
         win.get_data()
         win.copy_code()
-        win.update_data(updated)
+        win.update_inputs({"data": updated})
 
     assert not _missing_kspace_parameter_warnings(caught)
     assert win.data.attrs == original_attrs
@@ -3709,7 +3728,7 @@ def test_get_bz_lines_uses_legacy_hv_path_for_scalar_other_axis(monkeypatch) -> 
     assert np.allclose(midpoints, expected_midpoints)
 
 
-def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
+def test_ktool_update_inputs_preserves_state(qtbot, anglemap) -> None:
     data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5)).copy(
         deep=True
     )
@@ -3735,7 +3754,7 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
     status = win.tool_status
     new_data = data.copy(deep=True)
     new_data.data = np.asarray(new_data.data) * 1.1
-    win.update_data(new_data)
+    win.update_inputs({"data": new_data})
 
     assert win.tool_status == status
     assert win.data.kspace.alpha_scale == pytest.approx(1.1)
@@ -3748,27 +3767,44 @@ def test_ktool_update_data_preserves_state(qtbot, anglemap) -> None:
     assert win.images[1].data_array is not None
 
 
-def test_ktool_update_data_cancel_keeps_current_data(
+def test_ktool_update_inputs_cancel_keeps_current_data(
     qtbot,
     anglemap,
     accept_dialog,
+    monkeypatch,
 ) -> None:
     data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5))
     win = ktool(data, execute=False)
     assert isinstance(win, KspaceTool)
     _add_hidden_tool(qtbot, win)
     original_data = win.data.copy(deep=True)
+    old_snapshot = "old"
+    old_binding = ScriptInput(name="data", node_snapshot_token=old_snapshot)
+    refreshed_binding = old_binding.model_copy(update={"node_snapshot_token": "new"})
+    win.set_script_inputs((old_binding,), primary_input="data")
+    monkeypatch.setattr(win, "validate_update_inputs", lambda inputs: inputs)
+    results: list[bool] = []
 
     accept_dialog(
-        lambda: win.update_data(data.drop_vars("hv")),
+        lambda: results.append(
+            win._apply_inputs(
+                {"data": data.drop_vars("hv")},
+                (refreshed_binding,),
+            )
+        ),
         pre_call=lambda dialog: _set_input_coordinates(dialog, {"hv": 52.0}),
         accept_call=lambda dialog: dialog.reject(),
     )
 
+    assert results == [False]
     xr.testing.assert_identical(win.data, original_data)
+    assert win.source_state == "stale"
+    assert win.script_inputs == (old_binding,)
+    assert win._pending_script_inputs is None
+    assert win._source_refresh_deferred is False
 
 
-def test_ktool_update_data_rejects_unmappable_configuration(
+def test_ktool_validate_update_inputs_rejects_unmappable_configuration(
     qtbot,
     anglemap,
     monkeypatch,
@@ -3788,10 +3824,10 @@ def test_ktool_update_data_rejects_unmappable_configuration(
     )
 
     with pytest.raises(ValueError, match="incompatible configuration"):
-        win.update_data(object())
+        win.validate_update_inputs({"data": object()})
 
 
-def test_ktool_update_data_assigns_missing_coordinate(
+def test_ktool_update_inputs_assigns_missing_coordinate(
     qtbot,
     anglemap,
     accept_dialog,
@@ -3803,7 +3839,7 @@ def test_ktool_update_data_assigns_missing_coordinate(
     updated = data.drop_vars("hv")
 
     accept_dialog(
-        lambda: win.update_data(updated),
+        lambda: win.update_inputs({"data": updated}),
         pre_call=lambda dialog: _set_input_coordinates(dialog, {"hv": 52.0}),
     )
 
@@ -3837,7 +3873,7 @@ def test_ktool_undo_redo_colormap_state(qtbot, anglemap) -> None:
     assert win.tool_status.cmap_gamma == initial.cmap_gamma + 0.1
 
 
-def test_ktool_update_data_with_single_energy_disables_energy_group(
+def test_ktool_update_inputs_with_single_energy_disables_energy_group(
     qtbot, anglemap
 ) -> None:
     initial = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5)).copy(
@@ -3849,14 +3885,14 @@ def test_ktool_update_data_with_single_energy_disables_energy_group(
     win = ktool(initial, execute=False)
     _add_hidden_tool(qtbot, win)
 
-    win.update_data(data)
+    win.update_inputs({"data": data})
     fixed_energy = float(data.eV.values[0])
     assert win.energy_group.isEnabled() is False
     assert win.center_spin.minimum() == pytest.approx(fixed_energy - 0.1, abs=1e-3)
     assert win.center_spin.maximum() == pytest.approx(fixed_energy + 0.1, abs=1e-3)
 
 
-def test_ktool_update_data_reconnects_energy_controls_after_single_energy(
+def test_ktool_update_inputs_reconnects_energy_controls_after_single_energy(
     qtbot, anglemap, monkeypatch
 ) -> None:
     data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(1, 2)).copy(
@@ -3877,7 +3913,7 @@ def test_ktool_update_data_reconnects_energy_controls_after_single_energy(
 
     monkeypatch.setattr(win, "update", _wrapped_update)
 
-    win.update_data(updated)
+    win.update_inputs({"data": updated})
     assert win.energy_group.isEnabled() is True
 
     update_calls.clear()
@@ -3889,7 +3925,7 @@ def test_ktool_update_data_reconnects_energy_controls_after_single_energy(
     qtbot.wait_until(lambda: len(update_calls) > 0, timeout=5000)
 
 
-def test_ktool_update_data_rejects_noninteractive_replacement_for_cut(
+def test_ktool_validate_update_inputs_rejects_noninteractive_replacement_for_cut(
     qtbot, anglemap
 ) -> None:
     data = (
@@ -3899,7 +3935,7 @@ def test_ktool_update_data_rejects_noninteractive_replacement_for_cut(
     _add_hidden_tool(qtbot, win)
 
     with pytest.raises(ValueError, match="not compatible with the interactive tool"):
-        win.update_data(data.isel(eV=0))
+        win.validate_update_inputs({"data": data.isel(eV=0)})
 
 
 @pytest.mark.parametrize(
@@ -3915,7 +3951,7 @@ def test_ktool_update_data_rejects_noninteractive_replacement_for_cut(
         ("_has_hv", True, "incompatible photon-energy dimensions"),
     ],
 )
-def test_ktool_validate_update_data_rejects_incompatible_metadata(
+def test_ktool_validate_update_inputs_rejects_incompatible_metadata(
     qtbot, anglemap, monkeypatch, field, value, match
 ) -> None:
     data = anglemap.isel(alpha=slice(0, 3), beta=slice(0, 3), eV=slice(0, 5)).copy(
@@ -3939,4 +3975,4 @@ def test_ktool_validate_update_data_rejects_incompatible_metadata(
     )
 
     with pytest.raises(ValueError, match=match):
-        win.validate_update_data(object())
+        win.validate_update_inputs({"data": object()})

--- a/tests/interactive/test_mesh.py
+++ b/tests/interactive/test_mesh.py
@@ -525,7 +525,7 @@ def test_meshtool_autofind_invalid_peaks_reraises_in_manager(
     assert win.p1_spin1.value() == 20
 
 
-def test_meshtool_update_data_preserves_state(qtbot, meshy_data) -> None:
+def test_meshtool_update_inputs_preserves_state(qtbot, meshy_data) -> None:
     win: MeshTool = meshtool(meshy_data, execute=False)
     qtbot.addWidget(win)
 
@@ -548,7 +548,7 @@ def test_meshtool_update_data_preserves_state(qtbot, meshy_data) -> None:
     assert win._corrected is not None
     assert win._mesh is not None
 
-    win.update_data(new_data)
+    win.update_inputs({"data": new_data})
 
     assert win.tool_status == status
     xr.testing.assert_identical(win.tool_data, new_data)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -1,3 +1,4 @@
+import builtins
 import contextlib
 import enum
 import importlib
@@ -8,6 +9,7 @@ import tempfile
 import types
 import typing
 import warnings
+from collections.abc import Mapping
 
 import lmfit
 import numpy as np
@@ -36,8 +38,15 @@ from erlab.interactive._file_loaders import (
     builtin_file_loader_for_name_filter,
 )
 from erlab.interactive.imagetool import ImageTool
+from erlab.interactive.imagetool._provenance._execution import rebuild_script_inputs
 from erlab.interactive.imagetool._provenance._model import (
+    FileDataSelection,
+    FileLoadSource,
+    FileReplayCall,
+    ScriptInput,
     ToolProvenanceSpec,
+    compose_full_provenance,
+    file_load,
     full_data,
     script,
     selection,
@@ -88,7 +97,7 @@ from erlab.interactive.utils import (
 def _exec_generated_code(
     code: str, namespace: dict[str, typing.Any]
 ) -> dict[str, typing.Any]:
-    output = dict(namespace)
+    output = {"__builtins__": vars(builtins), **namespace}
     exec(code, output, output)  # noqa: S102
     return output
 
@@ -230,8 +239,38 @@ class _PersistentTool(erlab.interactive.utils.ToolWindow[_PersistentToolState]):
     def tool_data(self) -> xr.DataArray:
         return self._data
 
-    def update_data(self, new_data: xr.DataArray) -> None:
-        self._data = new_data
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self._data = inputs["data"]
+
+
+class _TwoInputPersistentTool(_PersistentTool):
+    def __init__(
+        self,
+        data: xr.DataArray,
+        weights: xr.DataArray | None = None,
+    ) -> None:
+        super().__init__(data)
+        self.weights = xr.zeros_like(data) if weights is None else weights
+        self.result = data + self.weights
+        self.update_calls = 0
+
+    def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
+        return {
+            erlab.interactive.utils._SAVED_TOOL_DATA_NAME: self._data,
+            "weights": self.weights,
+        }
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self.update_calls += 1
+        self._data = inputs["data"]
+        self.weights = inputs["weights"]
+        self.result = self._data + self.weights
+
+    def _append_persistence_payload(self, ds: xr.Dataset) -> xr.Dataset:
+        return ds.assign(cached_result=self.result)
+
+    def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
+        self.result = ds["cached_result"]
 
 
 def _expression_fit_operation(expression: str = "2 * c0") -> ModelFitOperation:
@@ -287,6 +326,29 @@ class _PlotPersistentTool(_PersistentTool):
         self.graphics.addItem(self.colorbar, row=0, col=1)
         self._register_plot_appearance("data", self.colorbar)
         return old_colorbar
+
+
+class _DeferredInputTool(_PersistentTool):
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__(data)
+        self.pending_data: xr.DataArray | None = None
+        self.update_calls = 0
+        self.events: list[str] = []
+
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+        self.update_calls += 1
+        self.events.append(f"update-{self.update_calls}")
+        self.pending_data = inputs["data"]
+        self._defer_source_refresh()
+        return False
+
+    def finish_deferred_update(self) -> None:
+        if self.pending_data is None:
+            raise RuntimeError("No deferred update is pending")
+        self._data = self.pending_data
+        self.pending_data = None
+        self.finalize_source_refresh()
+        self.events.append(f"cleanup-{self.update_calls}")
 
 
 class _DeferredRestoreToolState(pydantic.BaseModel):
@@ -349,8 +411,8 @@ class _DeferredRestoreTool(
     def tool_data(self) -> xr.DataArray:
         return self._data
 
-    def update_data(self, new_data: xr.DataArray) -> None:
-        self._data = new_data
+    def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+        self._data = inputs["data"]
 
     def _run_deferred_restore_task(self) -> None:
         if self.fail_next_deferred_restore:
@@ -361,10 +423,10 @@ class _DeferredRestoreTool(
     def _copy_expression(
         self,
         *,
-        input_name: str | None = None,
+        primary_input: str | None = None,
         data: xr.DataArray | None = None,
     ) -> str:
-        del input_name, data
+        del primary_input, data
         return f"data + {self.deferred_runs}"
 
     def _result_output_data(self) -> xr.DataArray:
@@ -526,30 +588,58 @@ def test_tool_window_provenance_setters_advance_revision_once(qtbot) -> None:
     win.sigProvenanceChanged.connect(
         lambda: provenance_changes.append(win.provenance_revision)
     )
-    provenance = full_data(IselOperation(kwargs={"x": slice(0, 2)}))
+    source_spec = full_data(IselOperation(kwargs={"x": slice(0, 2)}))
+    first_snapshot = "first"
+    second_snapshot = "second"
+    script_input = ScriptInput(
+        name="data",
+        data_role="source",
+        source_spec=source_spec.model_dump(mode="json"),
+        node_snapshot_token=first_snapshot,
+    )
 
-    win.set_input_provenance_spec(provenance)
+    win.set_script_inputs((script_input,), primary_input="data")
     first_revision = win.provenance_revision
-    win.set_input_provenance_spec(provenance)
+    win.set_script_inputs(
+        (script_input.model_copy(update={"node_snapshot_token": second_snapshot}),),
+        primary_input="data",
+    )
     second_revision = win.provenance_revision
 
     assert first_revision == 1
     assert second_revision == first_revision + 1
     assert provenance_changes == [first_revision, second_revision]
 
-    win.set_source_binding(provenance, state="fresh")
-    third_revision = win.provenance_revision
-    win.set_source_binding(provenance, state="fresh")
-    fourth_revision = win.provenance_revision
+    win.set_script_inputs(win.script_inputs, primary_input="data")
+    assert win.provenance_revision == second_revision
+    assert provenance_changes == [first_revision, second_revision]
 
-    assert third_revision == second_revision + 1
-    assert fourth_revision == third_revision + 1
-    assert provenance_changes == [
-        first_revision,
-        second_revision,
-        third_revision,
-        fourth_revision,
-    ]
+
+def test_tool_window_script_input_transforms_are_defensive_copies(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    tool = _PersistentTool(data)
+    qtbot.addWidget(tool)
+    binding = ScriptInput(
+        name="data",
+        source_spec=selection(IselOperation(kwargs={"x": slice(0, 2)})).model_dump(
+            mode="json"
+        ),
+    )
+    expected = binding.model_copy(deep=True)
+
+    tool.set_script_inputs((binding,), primary_input="data")
+    assert binding.source_spec is not None
+    binding.source_spec["operations"].clear()
+    assert tool.script_inputs == (expected,)
+
+    exposed = tool.script_inputs[0]
+    assert exposed.source_spec is not None
+    exposed.source_spec["operations"].clear()
+    assert tool.script_inputs == (expected,)
+
+    refreshed = expected.model_copy(update={"node_snapshot_token": "new"})
+    assert tool._apply_inputs({"data": data}, (refreshed,))
+    assert tool.script_inputs == (refreshed,)
 
 
 def test_tool_window_custom_history_cannot_skip_provenance_signal(
@@ -573,48 +663,6 @@ def test_tool_window_custom_history_cannot_skip_provenance_signal(
 
     assert provenance_changes == [None]
     assert recorded_changes == [None]
-
-
-@pytest.mark.parametrize(
-    ("setter_name", "attribute_name"),
-    [
-        (
-            "set_input_provenance_parent_fetcher",
-            "_input_provenance_parent_fetcher",
-        ),
-        ("set_source_parent_fetcher", "_source_parent_fetcher"),
-    ],
-)
-def test_tool_window_fetcher_replacement_commits_revision_after_sync_failure(
-    qtbot,
-    monkeypatch,
-    setter_name: str,
-    attribute_name: str,
-) -> None:
-    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
-    win = _PersistentTool(data)
-    qtbot.addWidget(win)
-    win._source_spec = full_data()
-
-    def callback() -> xr.DataArray:
-        return data
-
-    def fail_sync() -> None:
-        raise RuntimeError("snapshot sync failed")
-
-    monkeypatch.setattr(win, "_sync_input_provenance_snapshot", fail_sync)
-    initial_revision = win.provenance_revision
-    provenance_changes: list[int] = []
-    win.sigProvenanceChanged.connect(
-        lambda: provenance_changes.append(win.provenance_revision)
-    )
-
-    with pytest.raises(RuntimeError, match="snapshot sync failed"):
-        getattr(win, setter_name)(callback)
-
-    assert getattr(win, attribute_name) is callback
-    assert win.provenance_revision == initial_revision + 1
-    assert provenance_changes == [win.provenance_revision]
 
 
 def test_tool_window_history_guard_edges(qtbot, monkeypatch) -> None:
@@ -3528,8 +3576,8 @@ def test_tool_window_declared_output_dispatch_and_validation(qtbot) -> None:
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
         def _result_output_data(self) -> xr.DataArray:
             return self._data + 1
@@ -3537,7 +3585,7 @@ def test_tool_window_declared_output_dispatch_and_validation(qtbot) -> None:
         def _result_output_label(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             return "Compute dummy output"
@@ -3545,11 +3593,11 @@ def test_tool_window_declared_output_dispatch_and_validation(qtbot) -> None:
         def _result_output_expression(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             del data
-            return f"{input_name or 'data'} + 1"
+            return f"{primary_input or 'data'} + 1"
 
     tool = _DummyTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))
     qtbot.addWidget(tool)
@@ -3588,66 +3636,7 @@ def test_tool_window_declared_output_dispatch_and_validation(qtbot) -> None:
         tool.output_imagetool_data("dummy.unknown")
 
 
-def test_tool_window_script_provenance_preserves_status_name_and_avoids_reserved_input(
-    qtbot,
-) -> None:
-    class _DummyState(pydantic.BaseModel):
-        data_name: str = "xr"
-
-    class _DummyTool(erlab.interactive.utils.ToolWindow[_DummyState]):
-        StateModel = _DummyState
-        tool_name = "dummy"
-
-        def __init__(self) -> None:
-            super().__init__()
-            self._data = xr.DataArray([1.0], dims=("x",))
-
-        @property
-        def tool_status(self) -> _DummyState:
-            return _DummyState()
-
-        @tool_status.setter
-        def tool_status(self, status: _DummyState) -> None:
-            del status
-
-        @property
-        def tool_data(self) -> xr.DataArray:
-            return self._data
-
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
-
-        def _expression(self, *, input_name, data) -> str:
-            del data
-            return f"{input_name} + 1"
-
-    tool = _DummyTool()
-    qtbot.addWidget(tool)
-    definition = erlab.interactive.utils.ToolScriptProvenanceDefinition(
-        start_label="Start",
-        label="Add one",
-        expression_method="_expression",
-        assign="result",
-    )
-
-    assert tool._script_provenance_input_name() == "xr"
-    spec = tool._build_script_provenance(
-        definition,
-        input_name="xr",
-        data=tool.tool_data,
-    )
-
-    assert spec is not None
-    assert spec.seed_code == "input_data = xr"
-    assert len(spec.steps) == 1
-    operation = spec.steps[0].operation
-    assert isinstance(operation, ScriptCodeOperation)
-    assert operation.code == "result = input_data + 1"
-
-
-def test_tool_window_copy_code_ignores_parent_provenance_but_keeps_source(
-    qtbot,
-) -> None:
+def test_tool_window_copy_code_uses_canonical_script_input(qtbot) -> None:
 
     class _DummyState(pydantic.BaseModel):
         value: int = 0
@@ -3695,8 +3684,8 @@ def test_tool_window_copy_code_ignores_parent_provenance_but_keeps_source(
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
         def _result_output_data(self) -> xr.DataArray:
             return self._data.mean()
@@ -3704,26 +3693,32 @@ def test_tool_window_copy_code_ignores_parent_provenance_but_keeps_source(
         def _result_output_expression(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             del data
-            return f"{input_name or 'data'}.mean()"
+            return f"{primary_input or 'data'}.mean()"
 
     data = xr.DataArray(np.arange(16).reshape((4, 4)), dims=("x", "y"), name="data")
-    parent_provenance = selection(IselOperation(kwargs={"x": slice(0, 2)}))
     source = selection(IselOperation(kwargs={"y": slice(1, 3)}))
     tool = _DummyTool(source.apply(data))
     qtbot.addWidget(tool)
-    tool.set_source_binding(source)
-    tool.set_input_provenance_parent_fetcher(lambda: parent_provenance)
+    tool.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                data_role="source",
+                source_spec=source.model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+    )
 
     code = tool.copy_code()
     namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
     result = namespace["result"]
     assert isinstance(result, xr.DataArray)
     xr.testing.assert_identical(result, data.isel(y=slice(1, 3)).mean())
-    assert "x=slice" not in code
     assert "y=slice" in code
 
 
@@ -3886,16 +3881,16 @@ def test_tool_script_provenance_rejects_invalid_expression(qtbot) -> None:
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
         def _invalid_expression(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
-            del input_name, data
+            del primary_input, data
             return "result = data + 1"
 
     tool = _DummyTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))
@@ -3938,85 +3933,97 @@ def test_tool_window_dynamic_expression_provenance_uses_input_provenance(qtbot) 
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
         def _dynamic_label(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             del data
-            assert input_name == "watched"
+            assert primary_input == "watched"
             return "Build dynamic outputs"
 
         def _dynamic_expression(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             del data
-            assert input_name == "watched"
+            assert primary_input == "watched"
             return "(watched * scale, watched + 1)"
 
         def _dynamic_assign(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> tuple[str, str]:
-            del input_name, data
+            del primary_input, data
             return ("left", "right")
 
         def _dynamic_prelude(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
-            del input_name, data
+            del primary_input, data
             return "scale = 2"
 
         def _dynamic_active_name(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
-            del input_name, data
+            del primary_input, data
             return "right"
 
         def _dynamic_seed_code(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
-            del input_name, data
+            del primary_input, data
             return "derived = watched"
 
     tool = _DynamicTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))
     qtbot.addWidget(tool)
-    tool.set_input_provenance_spec(
-        script(
-            start_label="Start from watched data",
-            seed_code="derived = watched",
-            active_name="derived",
-        )
+    input_spec = script(
+        start_label="Start from watched data",
+        seed_code="derived = watched",
+        active_name="derived",
+    )
+    tool.set_script_inputs(
+        (
+            ScriptInput(
+                name="watched",
+                provenance_spec=input_spec.model_dump(mode="json"),
+            ),
+        ),
+        primary_input="watched",
     )
 
     spec = tool.current_provenance_spec()
 
     assert spec is not None
-    assert spec.start_label == "Start from watched data"
+    assert spec.start_label == "Start from dynamic input"
+    input_provenance = spec.script_inputs[0].parsed_provenance_spec()
+    assert input_provenance is not None
+    assert input_provenance.start_label == "Start from watched data"
     assert spec.active_name == "right"
     code = spec.display_code()
     assert code is not None
     assert "derived = watched" not in code
-    assert "scale = 2" in code
-    assert "left, right = (watched * scale, watched + 1)" in code
+    namespace = {"watched": tool.tool_data}
+    exec(code, namespace)  # noqa: S102
+    xr.testing.assert_identical(namespace["left"], tool.tool_data * 2)
+    xr.testing.assert_identical(namespace["right"], tool.tool_data + 1)
 
 
 def test_tool_window_operations_provenance_methods_normalize_results(qtbot) -> None:
@@ -4053,34 +4060,34 @@ def test_tool_window_operations_provenance_methods_normalize_results(qtbot) -> N
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
         def _dynamic_operations(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> object:
-            del input_name, data
+            del primary_input, data
             return self._operations
 
         def _dynamic_active_name(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
-            del input_name, data
+            del primary_input, data
             return "derived"
 
         def _dynamic_seed_code(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
-            del input_name, data
+            del primary_input, data
             return "derived = data"
 
     operation = ScriptCodeOperation(
@@ -4262,7 +4269,7 @@ def test_tool_window_prompt_existing_output_choices(qtbot, monkeypatch) -> None:
         assert tool._prompt_existing_output_imagetool() == choice
 
 
-def test_tool_window_dataset_roundtrips_source_and_input_provenance(qtbot) -> None:
+def test_tool_window_dataset_roundtrips_transformed_script_input(qtbot) -> None:
     data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4)})
     tool = _PersistentTool(data)
     qtbot.addWidget(tool)
@@ -4274,24 +4281,46 @@ def test_tool_window_dataset_roundtrips_source_and_input_provenance(qtbot) -> No
         seed_code="derived = watched",
         active_name="derived",
     )
-    tool.set_source_binding(source_spec, auto_update=True, state="stale")
-    tool.set_input_provenance_spec(input_spec)
+    inputs = (
+        ScriptInput(
+            name="watched",
+            data_role="source",
+            source_spec=source_spec.model_dump(mode="json"),
+            provenance_spec=input_spec.model_dump(mode="json"),
+        ),
+    )
+    tool.set_script_inputs(
+        inputs,
+        primary_input="watched",
+        auto_update=True,
+        state="stale",
+    )
 
     restored = erlab.interactive.utils.ToolWindow.from_dataset(tool.to_dataset())
     qtbot.addWidget(restored)
 
     assert isinstance(restored, _PersistentTool)
-    assert restored.source_spec == source_spec
+    assert restored.script_inputs == inputs
+    assert restored.primary_input == "watched"
     assert restored.source_auto_update is True
     assert restored.source_state == "stale"
-    assert restored.input_provenance_spec == input_spec.to_replay_spec()
 
 
 def test_tool_window_dataset_normalizes_invalid_source_state(qtbot) -> None:
     data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4)})
     tool = _PersistentTool(data)
     qtbot.addWidget(tool)
-    tool.set_source_binding(full_data(), auto_update=True, state="stale")
+    tool.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                source_spec=full_data().model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+        auto_update=True,
+        state="stale",
+    )
     saved = tool.to_dataset()
     saved.attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = "unknown"
 
@@ -4304,6 +4333,702 @@ def test_tool_window_dataset_normalizes_invalid_source_state(qtbot) -> None:
 
 def test_tool_window_dataset_prefers_source_spec_over_legacy_binding(qtbot) -> None:
     data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4)})
+    source_spec = ImageToolSelectionSourceBinding(
+        selection_mode="isel",
+        selection_indexers={"x": slice(1, 3)},
+    ).materialize(data)
+    tool = _PersistentTool(source_spec.apply(data))
+    qtbot.addWidget(tool)
+    tool.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                source_spec=source_spec.model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+        auto_update=True,
+        state="stale",
+    )
+
+    saved = tool.to_dataset()
+    assert "tool_source_binding" not in saved.attrs
+    saved.attrs["tool_source_binding"] = json.dumps(
+        ImageToolSelectionSourceBinding(
+            selection_mode="isel",
+            selection_indexers={"x": 0},
+        ).model_dump(mode="json")
+    )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _source_parent_data=data,
+    )
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, _PersistentTool)
+    assert restored.script_inputs[0].parsed_source_spec() == source_spec
+    assert restored.source_auto_update is True
+    assert restored.source_state == "stale"
+
+
+def test_tool_window_dataset_roundtrips_script_inputs(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0), dims="x")
+    weights = xr.ones_like(data).rename("weights")
+    tool = _TwoInputPersistentTool(data, weights)
+    qtbot.addWidget(tool)
+    inputs = (
+        ScriptInput(name="data", label="Data", node_uid="old-data"),
+        ScriptInput(name="weights", label="Weights", node_uid="old-weights"),
+    )
+    tool.set_script_inputs(
+        inputs,
+        primary_input="data",
+        auto_update=True,
+        state="stale",
+    )
+
+    saved = tool.to_dataset()
+    saved["cached_result"] = xr.full_like(data, 99.0)
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, _TwoInputPersistentTool)
+    assert restored.update_calls == 1
+    xr.testing.assert_identical(restored.weights, weights)
+    xr.testing.assert_identical(
+        restored.result,
+        xr.full_like(data, 99.0).rename("cached_result"),
+    )
+    assert restored.script_inputs == inputs
+    assert restored.primary_input == "data"
+    assert restored.source_auto_update is True
+    assert restored.source_state == "stale"
+
+    missing = _PersistentTool(data)
+    qtbot.addWidget(missing)
+    missing.set_script_inputs(inputs, primary_input="data")
+    with pytest.raises(ValueError, match="canonical input item 'weights'"):
+        missing.to_dataset()
+
+
+def test_tool_window_named_input_update_validates_before_mutation(qtbot) -> None:
+    class _MultiInputTool(_PersistentTool):
+        def __init__(self, data: xr.DataArray) -> None:
+            super().__init__(data)
+            self.update_calls = 0
+
+        def validate_update_inputs(
+            self, inputs: Mapping[str, xr.DataArray]
+        ) -> Mapping[str, xr.DataArray]:
+            validated = dict(super().validate_update_inputs(inputs))
+            if validated["data"].sizes != validated["weights"].sizes:
+                raise ValueError("input sizes differ")
+            return validated
+
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self.update_calls += 1
+            self._data = inputs["data"] * inputs["weights"]
+
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    tool = _MultiInputTool(data)
+    qtbot.addWidget(tool)
+    bindings = (ScriptInput(name="data"), ScriptInput(name="weights"))
+    tool.set_script_inputs(bindings, primary_input="data", auto_update=True)
+
+    with pytest.raises(ValueError, match="input sizes differ"):
+        tool._apply_inputs(
+            {"data": data, "weights": xr.DataArray([2.0], dims="x")},
+            bindings,
+        )
+    assert tool.update_calls == 0
+    xr.testing.assert_identical(tool.tool_data, data)
+    assert tool.source_state == "fresh"
+
+    weights = xr.DataArray([3.0, 4.0], dims="x")
+    assert tool._apply_inputs(
+        {"data": data, "weights": weights},
+        bindings,
+    )
+    assert tool.update_calls == 1
+    xr.testing.assert_identical(tool.tool_data, data * weights)
+    assert tool.source_state == "fresh"
+
+
+def test_tool_window_persistence_replacement_uses_complete_named_inputs(
+    qtbot,
+    monkeypatch,
+) -> None:
+    events: list[str] = []
+
+    class _TwoInputPersistenceTool(_PersistentTool):
+        def __init__(
+            self,
+            data: xr.DataArray,
+            weights: xr.DataArray,
+            auxiliary: xr.DataArray,
+        ) -> None:
+            super().__init__(data)
+            self.weights = weights
+            self.auxiliary = auxiliary
+
+        def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
+            return {
+                erlab.interactive.utils._SAVED_TOOL_DATA_NAME: self._data,
+                "weights": self.weights,
+                "auxiliary": self.auxiliary,
+            }
+
+        def validate_update_inputs(
+            self, inputs: Mapping[str, xr.DataArray]
+        ) -> Mapping[str, xr.DataArray]:
+            events.append("validate")
+            if set(inputs) != {"data", "weights"}:
+                raise ValueError("incomplete inputs")
+            return dict(inputs)
+
+        def _cancel_background_work(self, *, timeout_ms: int) -> bool:
+            assert timeout_ms == self.BACKGROUND_TASK_TIMEOUT_MS
+            events.append("cancel")
+            return True
+
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            events.append("update")
+            self._data = inputs["data"]
+            self.weights = inputs["weights"]
+
+        def _restore_persistence_data_items(
+            self, data_items: Mapping[str, xr.DataArray], ds: xr.Dataset
+        ) -> None:
+            assert ds.attrs["marker"] == "replacement"
+            events.append("restore")
+            self.auxiliary = data_items["auxiliary"]
+
+    data = xr.DataArray(np.arange(6.0).reshape(2, 3), dims=("y", "x"), name="data")
+    weights = xr.full_like(data, 0.5).rename("weights")
+    auxiliary = xr.DataArray(1.0)
+    tool = _TwoInputPersistenceTool(data, weights, auxiliary)
+    qtbot.addWidget(tool)
+    bindings = (
+        ScriptInput(name="data", node_uid="data-node"),
+        ScriptInput(name="weights", node_uid="weights-node"),
+    )
+    tool.set_script_inputs(
+        bindings,
+        primary_input="data",
+        auto_update=True,
+        state="stale",
+    )
+
+    saved_name = erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+    replacement_data = (data + 10.0).rename("stored-data")
+    replacement_weights = (weights + 1.0).rename("stored-weights")
+    replacement_auxiliary = xr.DataArray(2.0)
+    replacement_ds = xr.Dataset(attrs={"marker": "replacement"})
+
+    for incomplete, missing in (
+        ({saved_name: replacement_data}, "weights"),
+        ({"weights": replacement_weights}, saved_name),
+    ):
+        with pytest.raises(ValueError, match=rf"missing '{missing}'"):
+            tool._replace_persistence_data_items(incomplete, replacement_ds)
+    assert events == []
+
+    tool._replace_persistence_data_items(
+        {
+            saved_name: replacement_data,
+            "weights": replacement_weights,
+            "auxiliary": replacement_auxiliary,
+        },
+        replacement_ds,
+    )
+
+    assert events == ["validate", "cancel", "update", "restore"]
+    xr.testing.assert_identical(tool.tool_data, replacement_data.rename(data.name))
+    xr.testing.assert_identical(tool.weights, replacement_weights)
+    xr.testing.assert_identical(tool.auxiliary, replacement_auxiliary)
+    assert tool.script_inputs == bindings
+    assert tool.primary_input == "data"
+    assert tool.source_auto_update is True
+    assert tool.source_state == "stale"
+
+    monkeypatch.setattr(tool, "update_inputs", lambda _inputs: False)
+    with pytest.raises(RuntimeError, match="replacement was deferred"):
+        tool._replace_persistence_data_items(
+            {saved_name: replacement_data, "weights": replacement_weights},
+            replacement_ds,
+        )
+
+
+def test_source_free_persistence_replacement_requires_direct_restore(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x")
+    saved_name = erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+    tool = _PersistentTool(data)
+    qtbot.addWidget(tool)
+    with pytest.raises(NotImplementedError, match="_restore_persistence_data_items"):
+        tool._replace_persistence_data_items({saved_name: data + 1.0}, xr.Dataset())
+
+    class _DirectRestoreTool(_PersistentTool):
+        def _restore_persistence_data_items(
+            self, data_items: Mapping[str, xr.DataArray], ds: xr.Dataset
+        ) -> None:
+            del ds
+            self._data = data_items[saved_name]
+
+    direct = _DirectRestoreTool(data)
+    qtbot.addWidget(direct)
+    replacement = data + 2.0
+    direct._replace_persistence_data_items({saved_name: replacement}, xr.Dataset())
+    xr.testing.assert_identical(direct.tool_data, replacement)
+
+
+def test_tool_window_deferred_named_input_update_commits_current_bindings(
+    qtbot,
+) -> None:
+    class _DeferredMultiInputTool(_PersistentTool):
+        def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
+            return {
+                erlab.interactive.utils._SAVED_TOOL_DATA_NAME: self._data,
+                "weights": self.weights,
+            }
+
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            self.weights = inputs["weights"]
+            self._data = inputs["data"] * inputs["weights"]
+            self._defer_source_refresh()
+            return False
+
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    weights = xr.DataArray([3.0, 4.0], dims="x")
+    old_bindings = tuple(
+        ScriptInput(
+            name=name,
+            node_uid=f"{name}-node",
+            node_snapshot_token=f"old-{name}",
+        )
+        for name in ("data", "weights")
+    )
+    refreshed_bindings = tuple(
+        item.model_copy(
+            update={"node_snapshot_token": f"new-{item.name}"},
+        )
+        for item in old_bindings
+    )
+    tool = _DeferredMultiInputTool(data)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs(
+        old_bindings,
+        primary_input="data",
+        auto_update=True,
+    )
+
+    assert not tool._apply_inputs(
+        {"data": data, "weights": weights},
+        refreshed_bindings,
+    )
+    assert tool.source_state == "stale"
+    assert tool.script_inputs == old_bindings
+    saved_inputs = json.loads(tool.to_dataset().attrs["tool_script_inputs"])
+    assert tuple(item["node_snapshot_token"] for item in saved_inputs) == (
+        "old-data",
+        "old-weights",
+    )
+
+    tool.finalize_source_refresh()
+
+    assert tool.source_state == "fresh"
+    assert tool.script_inputs == refreshed_bindings
+    xr.testing.assert_identical(tool.tool_data, data * weights)
+
+
+def test_tool_window_false_update_discards_pending_bindings(qtbot) -> None:
+    class _RejectedInputTool(_PersistentTool):
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            del inputs
+            return False
+
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    old_snapshot = "old"
+    old_binding = ScriptInput(name="data", node_snapshot_token=old_snapshot)
+    refreshed_binding = old_binding.model_copy(update={"node_snapshot_token": "new"})
+    tool = _RejectedInputTool(data)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs((old_binding,), primary_input="data")
+
+    assert not tool._apply_inputs({"data": data + 1.0}, (refreshed_binding,))
+    assert tool.source_state == "stale"
+    assert tool.script_inputs == (old_binding,)
+    assert tool._pending_script_inputs is None
+    assert tool._source_refresh_deferred is False
+
+
+def test_tool_window_false_update_clears_reentrant_rerun(qtbot) -> None:
+    class _ReentrantRejectedInputTool(_PersistentTool):
+        def __init__(self, data: xr.DataArray) -> None:
+            super().__init__(data)
+            self.update_calls = 0
+
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            del inputs
+            self.update_calls += 1
+            self.handle_input_sources_replaced()
+            return False
+
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    old_snapshot = "old"
+    binding = ScriptInput(name="data", node_snapshot_token=old_snapshot)
+    refreshed_binding = binding.model_copy(update={"node_snapshot_token": "new"})
+    tool = _ReentrantRejectedInputTool(data)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs((binding,), primary_input="data", auto_update=True)
+    tool._set_input_resolver(lambda: ({"data": data + 2.0}, (refreshed_binding,)))
+
+    assert not tool._apply_inputs({"data": data + 1.0}, (refreshed_binding,))
+
+    assert tool.update_calls == 1
+    assert tool.source_state == "stale"
+    assert tool._source_refresh_rerun_requested is False
+    assert tool._pending_script_inputs is None
+
+
+def test_tool_window_abort_discards_deferred_bindings_without_data_signal(
+    qtbot,
+) -> None:
+    class _DeferredInputTool(_PersistentTool):
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            del inputs
+            self._defer_source_refresh()
+            return False
+
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    old_snapshot = "old"
+    old_binding = ScriptInput(name="data", node_snapshot_token=old_snapshot)
+    refreshed_binding = old_binding.model_copy(update={"node_snapshot_token": "new"})
+    tool = _DeferredInputTool(data)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs((old_binding,), primary_input="data")
+    data_changes: list[None] = []
+    tool.sigDataChanged.connect(lambda: data_changes.append(None))
+    revision = tool.provenance_revision
+
+    assert not tool._apply_inputs({"data": data + 1.0}, (refreshed_binding,))
+    tool.abort_source_refresh()
+
+    assert tool.source_state == "stale"
+    assert tool.script_inputs == (old_binding,)
+    assert tool._pending_script_inputs is None
+    assert tool._source_refresh_deferred is False
+    assert tool.provenance_revision == revision
+    assert data_changes == []
+
+
+def test_tool_window_standalone_deferred_refresh_coalesces_latest_input(
+    qtbot,
+) -> None:
+    initial = xr.DataArray([1.0, 2.0], dims="x")
+    first = initial + 10.0
+    latest = initial + 20.0
+    initial_snapshot = "initial"
+    binding = ScriptInput(name="data", node_snapshot_token=initial_snapshot)
+    resolved: dict[str, typing.Any] = {"data": first, "snapshot": "first"}
+
+    def resolve_inputs() -> tuple[dict[str, xr.DataArray], tuple[ScriptInput, ...]]:
+        return {"data": resolved["data"]}, (
+            binding.model_copy(update={"node_snapshot_token": resolved["snapshot"]}),
+        )
+
+    tool = _DeferredInputTool(initial)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs(
+        (binding,),
+        primary_input="data",
+        auto_update=True,
+    )
+    tool._set_input_resolver(resolve_inputs)
+
+    tool.handle_input_sources_replaced()
+    assert tool.update_calls == 1
+    latest_snapshot = "latest"
+    resolved["data"] = latest
+    resolved["snapshot"] = latest_snapshot
+    tool.handle_input_sources_replaced()
+    assert tool.update_calls == 1
+
+    tool.finish_deferred_update()
+    assert tool.update_calls == 1
+    assert tool.events == ["update-1", "cleanup-1"]
+    qtbot.wait_until(lambda: tool.update_calls == 2)
+    assert tool.events == ["update-1", "cleanup-1", "update-2"]
+    assert tool._source_refresh_deferred is True
+    tool.finish_deferred_update()
+
+    assert tool.source_state == "fresh"
+    assert tool.script_inputs[0].node_snapshot_token == latest_snapshot
+    xr.testing.assert_identical(tool.tool_data, latest)
+
+
+def test_tool_window_standalone_rerun_stops_when_auto_update_is_disabled(
+    qtbot,
+) -> None:
+    initial = xr.DataArray([1.0, 2.0], dims="x")
+    completed = initial + 10.0
+    latest = initial + 20.0
+    initial_snapshot = "initial"
+    completed_snapshot = "completed"
+    binding = ScriptInput(name="data", node_snapshot_token=initial_snapshot)
+    resolved: dict[str, typing.Any] = {
+        "data": completed,
+        "snapshot": completed_snapshot,
+    }
+
+    def resolve_inputs() -> tuple[dict[str, xr.DataArray], tuple[ScriptInput, ...]]:
+        return {"data": resolved["data"]}, (
+            binding.model_copy(update={"node_snapshot_token": resolved["snapshot"]}),
+        )
+
+    tool = _DeferredInputTool(initial)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs((binding,), primary_input="data", auto_update=True)
+    tool._set_input_resolver(resolve_inputs)
+
+    tool.handle_input_sources_replaced()
+    resolved["data"] = latest
+    resolved["snapshot"] = "latest"
+    tool.handle_input_sources_replaced()
+    tool.finish_deferred_update()
+    tool._set_source_auto_update(False)
+    qtbot.wait(10)
+
+    assert tool.events == ["update-1", "cleanup-1"]
+    assert tool.update_calls == 1
+    assert tool.source_state == "stale"
+    assert tool.script_inputs[0].node_snapshot_token == completed_snapshot
+    xr.testing.assert_identical(tool.tool_data, completed)
+
+
+@pytest.mark.parametrize(
+    "started_automatically",
+    [False, True],
+    ids=["manual-update", "disabled-during-update"],
+)
+def test_tool_window_deferred_refresh_respects_disabled_auto_update(
+    qtbot,
+    started_automatically: bool,
+) -> None:
+    initial = xr.DataArray([1.0, 2.0], dims="x")
+    first = initial + 10.0
+    latest = initial + 20.0
+    initial_snapshot = "initial"
+    first_snapshot = "first"
+    latest_snapshot = "latest"
+    binding = ScriptInput(name="data", node_snapshot_token=initial_snapshot)
+    resolved: dict[str, typing.Any] = {
+        "data": first,
+        "snapshot": first_snapshot,
+    }
+
+    def resolve_inputs() -> tuple[dict[str, xr.DataArray], tuple[ScriptInput, ...]]:
+        return {"data": resolved["data"]}, (
+            binding.model_copy(update={"node_snapshot_token": resolved["snapshot"]}),
+        )
+
+    tool = _DeferredInputTool(initial)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs(
+        (binding,),
+        primary_input="data",
+        auto_update=started_automatically,
+    )
+    tool._set_input_resolver(resolve_inputs)
+
+    if started_automatically:
+        tool.handle_input_sources_replaced()
+        tool._set_source_auto_update(False)
+    else:
+        assert not tool._update_from_input_source()
+    assert tool.update_calls == 1
+
+    resolved["data"] = latest
+    resolved["snapshot"] = latest_snapshot
+    tool.handle_input_sources_replaced()
+    tool.finish_deferred_update()
+    qtbot.wait(10)
+
+    assert tool.update_calls == 1
+    assert tool.source_state == "stale"
+    assert tool._source_refresh_rerun_requested is False
+    assert tool.script_inputs[0].node_snapshot_token == first_snapshot
+    xr.testing.assert_identical(tool.tool_data, first)
+
+
+@pytest.mark.parametrize("auto_update", [False, True])
+def test_tool_window_standalone_abort_rerun_waits_for_event_loop(
+    qtbot,
+    auto_update: bool,
+) -> None:
+    class _DeferredInputTool(_PersistentTool):
+        def __init__(self, data: xr.DataArray) -> None:
+            super().__init__(data)
+            self.update_calls = 0
+
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            del inputs
+            self.update_calls += 1
+            self._defer_source_refresh()
+            return False
+
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    old_snapshot = "old"
+    binding = ScriptInput(name="data", node_snapshot_token=old_snapshot)
+    refreshed_binding = binding.model_copy(update={"node_snapshot_token": "new"})
+    tool = _DeferredInputTool(data)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs((binding,), primary_input="data", auto_update=auto_update)
+    tool._set_input_resolver(lambda: ({"data": data + 1.0}, (refreshed_binding,)))
+
+    if auto_update:
+        tool.handle_input_sources_replaced()
+    else:
+        assert not tool._update_from_input_source()
+    tool.handle_input_sources_replaced()
+    assert tool.update_calls == 1
+
+    tool.abort_source_refresh()
+    assert tool.update_calls == 1
+    if not auto_update:
+        qtbot.wait(10)
+        assert tool.source_state == "stale"
+        assert tool._source_refresh_rerun_requested is False
+        return
+    qtbot.wait_until(lambda: tool.update_calls == 2)
+
+    assert tool._source_refresh_deferred is True
+    assert tool.script_inputs == (binding,)
+    tool.abort_source_refresh()
+
+
+def test_tool_window_failed_named_input_update_discards_pending_bindings(qtbot) -> None:
+    class _FailingMultiInputTool(_PersistentTool):
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            raise RuntimeError("update failed")
+
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    old_bindings = tuple(
+        ScriptInput(name=name, node_snapshot_token=f"old-{name}")
+        for name in ("data", "weights")
+    )
+    refreshed_bindings = tuple(
+        item.model_copy(update={"node_snapshot_token": f"new-{item.name}"})
+        for item in old_bindings
+    )
+    tool = _FailingMultiInputTool(data)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs(old_bindings, primary_input="data")
+
+    with pytest.raises(RuntimeError, match="update failed"):
+        tool._apply_inputs(
+            {"data": data, "weights": data},
+            refreshed_bindings,
+        )
+
+    assert tool.script_inputs == old_bindings
+    assert tool._pending_script_inputs is None
+
+
+def test_tool_window_rebinding_discards_deferred_named_input_bindings(qtbot) -> None:
+    class _DeferredMultiInputTool(_PersistentTool):
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> bool:
+            self._defer_source_refresh()
+            return False
+
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    old_bindings = tuple(
+        ScriptInput(name=name, node_snapshot_token=f"old-{name}")
+        for name in ("data", "weights")
+    )
+    refreshed_bindings = tuple(
+        item.model_copy(
+            update={"node_snapshot_token": f"new-{item.name}"},
+        )
+        for item in old_bindings
+    )
+    replacement_bindings = tuple(
+        item.model_copy(
+            update={"node_snapshot_token": f"replacement-{item.name}"},
+        )
+        for item in old_bindings
+    )
+    tool = _DeferredMultiInputTool(data)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs(
+        old_bindings,
+        primary_input="data",
+        auto_update=True,
+    )
+
+    assert not tool._apply_inputs(
+        {"data": data, "weights": data},
+        refreshed_bindings,
+    )
+    pending_bindings = tool._pending_script_inputs
+    invalid_contracts = (
+        (
+            (old_bindings[0].model_copy(update={"name": "renamed"}), old_bindings[1]),
+            "data",
+        ),
+        (tuple(reversed(old_bindings)), "data"),
+        (
+            (
+                old_bindings[0],
+                old_bindings[1].model_copy(update={"data_role": "source"}),
+            ),
+            "data",
+        ),
+        (
+            (
+                old_bindings[0],
+                old_bindings[1].model_copy(
+                    update={"source_spec": full_data().model_dump(mode="json")}
+                ),
+            ),
+            "data",
+        ),
+        ((), None),
+        (old_bindings, "weights"),
+    )
+    for invalid_bindings, primary_input in invalid_contracts:
+        with pytest.raises(ValueError, match="fixed"):
+            tool.set_script_inputs(
+                invalid_bindings,
+                primary_input=primary_input,
+                auto_update=True,
+            )
+        assert tool.script_inputs == old_bindings
+        assert tool._pending_script_inputs == pending_bindings
+
+    invalid_refresh = (
+        refreshed_bindings[0],
+        refreshed_bindings[1].model_copy(update={"data_role": "source"}),
+    )
+    with pytest.raises(ValueError, match="fixed input binding"):
+        tool._apply_inputs(
+            {"data": data, "weights": data},
+            invalid_refresh,
+        )
+    assert tool._pending_script_inputs == pending_bindings
+
+    tool.set_script_inputs(
+        replacement_bindings,
+        primary_input="data",
+        auto_update=True,
+    )
+    tool.finalize_source_refresh()
+
+    assert tool.script_inputs == replacement_bindings
+
+
+def test_tool_window_dataset_migrates_legacy_input_metadata(qtbot) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4)})
     tool = _PersistentTool(data.isel(x=slice(1, 3)))
     qtbot.addWidget(tool)
 
@@ -4312,16 +5037,8 @@ def test_tool_window_dataset_prefers_source_spec_over_legacy_binding(qtbot) -> N
         selection_indexers={"x": slice(1, 3)},
     )
     source_spec = source_binding.materialize(data)
-    tool.set_source_binding(
-        source_spec,
-        source_binding=source_binding,
-        auto_update=True,
-        state="stale",
-    )
-    assert tool.source_binding is None
-
     saved = tool.to_dataset()
-    assert "tool_source_binding" not in saved.attrs
+    saved.attrs["tool_source_spec"] = json.dumps(source_spec.model_dump(mode="json"))
     saved.attrs["tool_source_binding"] = json.dumps(
         ImageToolSelectionSourceBinding(
             selection_mode="isel",
@@ -4333,21 +5050,78 @@ def test_tool_window_dataset_prefers_source_spec_over_legacy_binding(qtbot) -> N
     qtbot.addWidget(restored)
 
     assert isinstance(restored, _PersistentTool)
-    assert restored.source_spec == source_spec
-    assert restored.source_binding is None
-    assert restored.source_auto_update is True
-    assert restored.source_state == "stale"
+    assert restored.primary_input == "data"
+    assert len(restored.script_inputs) == 1
+    assert restored.script_inputs[0].parsed_source_spec() == source_spec
 
     legacy = _PersistentTool(data.isel(x=slice(1, 3))).to_dataset()
     legacy.attrs["tool_source_binding"] = json.dumps(
         source_binding.model_dump(mode="json")
     )
-    legacy_restored = erlab.interactive.utils.ToolWindow.from_dataset(legacy)
+    legacy_restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        legacy,
+        _source_parent_data=data,
+    )
     qtbot.addWidget(legacy_restored)
 
     assert isinstance(legacy_restored, _PersistentTool)
-    assert legacy_restored.source_spec is None
-    assert legacy_restored.source_binding == source_binding
+    assert legacy_restored.primary_input == "data"
+    assert len(legacy_restored.script_inputs) == 1
+    assert legacy_restored.script_inputs[0].parsed_source_spec() == source_spec
+
+    legacy.attrs["tool_source_spec"] = "{not-json"
+    legacy.attrs["tool_input_provenance_spec"] = "{not-json"
+    fallback_restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        legacy,
+        _source_parent_data=data,
+    )
+    qtbot.addWidget(fallback_restored)
+
+    assert fallback_restored.script_inputs[0].parsed_source_spec() == source_spec
+
+
+def test_tool_window_legacy_input_fallback_replays_source_transform_once(
+    qtbot,
+    tmp_path,
+) -> None:
+    data = xr.DataArray(
+        np.arange(6.0),
+        dims=("x",),
+        coords={"x": np.arange(6)},
+        name="data",
+    )
+    path = tmp_path / "legacy-input.nc"
+    data.to_netcdf(path)
+    source_spec = selection(IselOperation(kwargs={"x": slice(1, 5, 2)}))
+    parent_spec = file_load(
+        start_label="Load source",
+        seed_code=f"derived = xr.load_dataarray({str(path)!r})",
+        file_load_source=FileLoadSource(
+            path=str(path),
+            loader_label="xarray.load_dataarray",
+            loader_text="xarray.load_dataarray",
+            kwargs_text="",
+            replay_call=FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                selection=FileDataSelection(kind="dataarray"),
+            ),
+        ),
+    )
+    complete_fallback = compose_full_provenance(parent_spec, source_spec)
+    assert complete_fallback is not None
+    expected = source_spec.apply(data)
+    saved = _PersistentTool(expected).to_dataset()
+    saved.attrs["tool_source_spec"] = json.dumps(source_spec.model_dump(mode="json"))
+    saved.attrs["tool_input_provenance_spec"] = json.dumps(
+        complete_fallback.model_dump(mode="json")
+    )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+    resolved, _refreshed = rebuild_script_inputs(restored.script_inputs)
+
+    xr.testing.assert_identical(resolved["data"], expected)
 
 
 def test_tool_window_saved_reference_requires_matching_resolved_data(qtbot) -> None:
@@ -4381,8 +5155,19 @@ def test_tool_window_saved_reference_requires_matching_resolved_data(qtbot) -> N
         is True
     )
 
-    tool.set_source_parent_fetcher(lambda: parent_data)
-    tool.set_source_binding(full_data(), state="fresh")
+    tool.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                node_uid="parent",
+                source_spec=full_data(
+                    IselOperation(kwargs={"x": slice(0, 2)})
+                ).model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+        state="fresh",
+    )
     with tool._save_tool_data_reference_context(available_node_uids=frozenset()):
         assert (
             tool._tool_data_reference_payload(
@@ -4404,17 +5189,17 @@ def test_tool_window_dataset_ignores_invalid_saved_provenance(
     ds.attrs["tool_source_spec"] = "{not-json"
     ds.attrs["tool_source_binding"] = "{not-json"
     ds.attrs["tool_input_provenance_spec"] = "{not-json"
+    ds.attrs["tool_script_inputs"] = "{not-json"
 
     with caplog.at_level("WARNING", logger="erlab.interactive.utils"):
         restored = erlab.interactive.utils.ToolWindow.from_dataset(ds)
     qtbot.addWidget(restored)
 
     assert isinstance(restored, _PersistentTool)
-    assert restored.source_spec is None
-    assert restored.input_provenance_spec is None
-    assert "Ignoring invalid saved tool source provenance" in caplog.text
-    assert "Ignoring invalid saved tool source binding" in caplog.text
-    assert "Ignoring invalid saved tool input provenance" in caplog.text
+    assert restored.script_inputs == ()
+    assert restored.primary_input is None
+    assert "Ignoring invalid saved ToolWindow script inputs" in caplog.text
+    assert "Ignoring invalid legacy ToolWindow input metadata" in caplog.text
 
 
 def test_application_quit_requested_handles_missing_and_closing_app(
@@ -4530,22 +5315,28 @@ def test_tool_window_rejects_unreplayable_saved_source_reference() -> None:
     tool = _PersistentTool(data)
     ds = tool.to_dataset()
 
-    with pytest.raises(TypeError, match="missing source provenance"):
-        erlab.interactive.utils.ToolWindow._saved_source_spec_from_attrs(ds)
-
-    ds.attrs["tool_source_spec"] = json.dumps(None)
-    with pytest.raises(ValueError, match="not replayable"):
-        erlab.interactive.utils.ToolWindow._saved_source_spec_from_attrs(ds)
-
-    ds.attrs["tool_source_spec"] = json.dumps(
-        script(
-            ScriptCodeOperation(label="derive", code="out = data"),
-            start_label="Start from data",
-            active_name="out",
-        ).model_dump(mode="json")
-    )
-    with pytest.raises(TypeError, match="must be a live"):
-        erlab.interactive.utils.ToolWindow._saved_source_spec_from_attrs(ds)
+    for raw_source_spec in (
+        None,
+        json.dumps(None),
+        json.dumps(
+            script(
+                ScriptCodeOperation(label="derive", code="out = data"),
+                start_label="Start from data",
+                active_name="out",
+            ).model_dump(mode="json")
+        ),
+    ):
+        if raw_source_spec is None:
+            ds.attrs.pop("tool_source_spec", None)
+        else:
+            ds.attrs["tool_source_spec"] = raw_source_spec
+        with pytest.raises(ValueError, match="not replayable"):
+            erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+                {"kind": "parent_source"},
+                ds,
+                source_parent_data=data,
+                reference_resolver=None,
+            )
 
 
 def test_tool_window_resolves_saved_reference_errors() -> None:
@@ -4868,7 +5659,7 @@ def test_tool_window_materializes_referenced_data_without_mutating_source() -> N
     xr.testing.assert_identical(data_items[variable_name], source.compute())
 
 
-def test_tool_window_source_binding_empty_and_type_error_branches(qtbot) -> None:
+def test_tool_window_without_inputs_has_no_source_controls(qtbot) -> None:
     tool = _PersistentTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))
     qtbot.addWidget(tool)
 
@@ -4876,17 +5667,9 @@ def test_tool_window_source_binding_empty_and_type_error_branches(qtbot) -> None
     assert tool.show_source_update_dialog() == int(
         QtWidgets.QDialog.DialogCode.Rejected
     )
-    with pytest.raises(TypeError, match="source_binding must be"):
-        tool.set_source_binding(
-            None,
-            source_binding=typing.cast(
-                "ImageToolSelectionSourceBinding",
-                object(),
-            ),
-        )
 
 
-def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) -> None:
+def test_managed_window_node_kind_specific_source_branches(qtbot, monkeypatch) -> None:
 
     class _FakeTreeView:
         def __init__(self) -> None:
@@ -4918,6 +5701,18 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
                 _configure_tool_code_trust=lambda _tool, **_kwargs: None,
                 _configure_imagetool_code_trust=lambda _tool, **_kwargs: None,
             )
+            self._lineage_controller = types.SimpleNamespace(
+                _propagate_source_change_from_uid=(
+                    self._propagate_source_change_from_uid
+                ),
+                _propagate_source_state_from_uid=(
+                    self._propagate_source_state_from_uid
+                ),
+                _resume_pending_source_refreshes=(
+                    self._resume_pending_source_refreshes
+                ),
+                _refresh_tool_inputs=self._refresh_tool_inputs,
+            )
 
         def _handle_node_change(
             self,
@@ -4939,14 +5734,20 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
         ) -> None:
             self.propagated.append((uid, parent_data))
 
-        def _mark_descendants_source_state(self, uid: str, state: str) -> None:
+        def _propagate_source_state_from_uid(self, uid: str, state: str) -> None:
             self.marked.append((uid, state))
-
-        def _mark_descendants_source_unavailable(self, uid: str) -> None:
-            self.unavailable.append(uid)
+            node = self._tool_graph.nodes.get(uid)
+            if node is not None:
+                node._set_source_state(state)
+            if state == "unavailable":
+                self.unavailable.append(uid)
 
         def _resume_pending_source_refreshes(self, uid: str) -> None:
             self.updated.append(f"resumed:{uid}")
+
+        def _refresh_tool_inputs(self, uid: str, **_kwargs) -> bool:
+            self.updated.append(f"reload:{uid}")
+            return True
 
         def _remove_childtool(self, uid: str) -> None:
             self.removed.append(uid)
@@ -5005,10 +5806,25 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
     )
     manager._tool_graph.nodes["child"] = node
 
+    with pytest.raises(TypeError, match="ImageTool nodes"):
+        node.set_source_binding(full_data())
+    with pytest.raises(TypeError, match="ImageTool nodes"):
+        node.set_output_binding("out")
+    with pytest.raises(TypeError, match="ImageTool nodes"):
+        node.set_detached_provenance(None, replay_source_data=None)
+
+    image_node = _ManagedWindowNode(
+        manager,
+        "image-child",
+        None,
+        None,
+        window_kind="imagetool",
+    )
+    manager._tool_graph.nodes["image-child"] = image_node
     with pytest.raises(TypeError, match="source_spec must be"):
-        node.set_source_binding(typing.cast("object", {"kind": "full_data"}))
+        image_node.set_source_binding(typing.cast("object", {"kind": "full_data"}))
     with pytest.raises(TypeError, match="source_binding must be"):
-        node.set_source_binding(
+        image_node.set_source_binding(
             None,
             source_binding=typing.cast(
                 "ImageToolSelectionSourceBinding",
@@ -5016,33 +5832,38 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
             ),
         )
     with pytest.raises(ValueError, match="output_id must not be None"):
-        node.set_output_binding(typing.cast("str", None))
+        image_node.set_output_binding(typing.cast("str", None))
     with pytest.raises(TypeError, match="output_id must be a string"):
-        node.set_output_binding(typing.cast("str", 1))
+        image_node.set_output_binding(typing.cast("str", 1))
     with pytest.raises(ValueError, match="output_id must not be empty"):
-        node.set_output_binding("")
+        image_node.set_output_binding("")
     with pytest.raises(TypeError, match="provenance_spec must be"):
-        node.set_output_binding(
+        image_node.set_output_binding(
             "out",
             provenance_spec=typing.cast("object", {"kind": "script"}),
         )
 
-    node.set_output_binding("out", auto_update=True, state="stale")
-    assert node.output_id == "out"
-    assert node._source_state == "stale"
-    assert node._source_auto_update is True
-    assert node._output_id == "out"
-    assert manager.tree_view.refreshed[-1] == "child"
+    image_node.set_output_binding("out", auto_update=True, state="stale")
+    assert image_node.output_id == "out"
+    assert image_node._source_state == "stale"
+    assert image_node._source_auto_update is True
+    assert image_node._output_id == "out"
+    assert manager.tree_view.refreshed[-1] == "image-child"
 
-    source_binding = ImageToolSelectionSourceBinding()
     source_spec = full_data()
-    tool.set_source_binding(
-        source_spec,
-        source_binding=source_binding,
+    tool.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                source_spec=source_spec.model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
         auto_update=True,
         state="stale",
     )
-    assert node.source_spec == source_spec
+    assert node.source_spec is None
+    assert node.tool_script_inputs[0].parsed_source_spec() == source_spec
     assert node.source_binding is None
     assert node.source_state == "stale"
     assert node.source_auto_update is True
@@ -5056,7 +5877,11 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
     node._handle_tool_data_changed()
     assert manager.marked[-1] == ("child", "stale")
 
-    tool.set_source_binding(source_spec, state="fresh")
+    tool.set_script_inputs(
+        tool.script_inputs,
+        primary_input="data",
+        state="fresh",
+    )
     node._handle_tool_data_changed()
     assert manager.propagated[-1] == ("child", None)
 
@@ -5076,15 +5901,13 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
     manager._tool_graph.nodes["unbound"] = unbound_node
     assert not unbound_node.handle_parent_source_replaced(tool.tool_data)
 
-    updated = xr.DataArray(np.arange(4.0) + 10.0, dims=("x",), name="updated")
-    tool.set_source_binding(source_spec, state="stale")
-    assert not node._update_from_parent_source()
-    assert manager.marked[-1] == ("child", "stale")
-
-    tool.set_source_parent_fetcher(lambda: updated)
-    assert node._update_from_parent_source()
-    xr.testing.assert_identical(tool.tool_data, updated)
-    assert manager.propagated[-1] == ("child", None)
+    tool.set_script_inputs(
+        tool.script_inputs,
+        primary_input="data",
+        state="stale",
+    )
+    assert node.reload_source_data()
+    assert manager.updated[-1] == "reload:child"
 
     node.window = None
     assert node._detach_imagetool() is None
@@ -5109,10 +5932,7 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
     assert node.imagetool is None
 
 
-def test_managed_tool_window_node_detached_update_branches(
-    qtbot,
-    monkeypatch,
-) -> None:
+def test_managed_imagetool_node_detached_update_branches(qtbot) -> None:
     parent_data = xr.DataArray(np.arange(4.0), dims=("x",), name="parent")
 
     class _FakeTreeView:
@@ -5174,9 +5994,20 @@ def test_managed_tool_window_node_detached_update_branches(
                 _configure_tool_code_trust=lambda _tool, **_kwargs: None,
                 _configure_imagetool_code_trust=lambda _tool, **_kwargs: None,
             )
+            self._lineage_controller = types.SimpleNamespace(
+                _parent_source_data_for_uid=self._parent_source_data_for_uid,
+                _propagate_source_state_from_uid=(
+                    self._propagate_source_state_from_uid
+                ),
+                _refresh_source_chain_to_uid=self._refresh_source_chain_to_uid,
+                _resume_pending_source_refreshes=(
+                    self._resume_pending_source_refreshes
+                ),
+            )
             self.parent_node = types.SimpleNamespace(
                 tool_window=parent_tool,
                 provenance_spec=None,
+                displayed_provenance_spec=None,
                 current_source_data=lambda: parent_tool.tool_data,
             )
 
@@ -5190,11 +6021,13 @@ def test_managed_tool_window_node_detached_update_branches(
             assert uid == "child"
             return typing.cast("_OutputTool", self.parent_node.tool_window).tool_data
 
-        def _mark_descendants_source_state(self, uid: str, state: str) -> None:
+        def _propagate_source_state_from_uid(self, uid: str, state: str) -> None:
             self.marked.append((uid, state))
-
-        def _mark_descendants_source_unavailable(self, uid: str) -> None:
-            self.unavailable.append(uid)
+            node = self._tool_graph.nodes.get(uid)
+            if node is not None:
+                node._set_source_state(state)
+            if state == "unavailable":
+                self.unavailable.append(uid)
 
         def _resume_pending_source_refreshes(self, uid: str) -> None:
             self.updated.append(f"resumed:{uid}")
@@ -5250,15 +6083,18 @@ def test_managed_tool_window_node_detached_update_branches(
 
     parent_tool = _OutputTool(parent_data)
     qtbot.addWidget(parent_tool)
+    parent_tool.set_script_inputs(
+        (ScriptInput(name="data"),),
+        primary_input="data",
+    )
     manager = _FakeManager(parent_tool)
     qtbot.addWidget(manager)
-    tool = _PersistentTool(parent_data)
-    qtbot.addWidget(tool)
     node = _ManagedWindowNode(
         manager,
         "child",
         "parent",
-        tool,
+        None,
+        window_kind="imagetool",
     )
     manager._tool_graph.nodes["child"] = node
     with pytest.raises(RuntimeError, match="not bound"):
@@ -5268,13 +6104,12 @@ def test_managed_tool_window_node_detached_update_branches(
         selection_mode="isel",
         selection_indexers={"x": slice(0, 2)},
     )
-    bound_tool = _PersistentTool(parent_data.isel(x=slice(0, 2)))
-    qtbot.addWidget(bound_tool)
     bound_node = _ManagedWindowNode(
         manager,
         "bound",
         "parent",
-        bound_tool,
+        None,
+        window_kind="imagetool",
         source_binding=source_binding,
     )
     manager._tool_graph.nodes["bound"] = bound_node
@@ -5319,12 +6154,20 @@ def test_managed_tool_window_node_detached_update_branches(
     node.show()
 
     node.set_output_binding("out", state="fresh")
-    parent_tool.set_source_binding(full_data(), state="stale")
+    parent_tool.set_script_inputs(
+        parent_tool.script_inputs,
+        primary_input="data",
+        state="stale",
+    )
     assert not node._update_from_parent_source()
     assert node.source_state == "stale"
     assert manager.marked[-1] == ("child", "stale")
 
-    parent_tool.set_source_binding(full_data(), state="fresh")
+    parent_tool.set_script_inputs(
+        parent_tool.script_inputs,
+        primary_input="data",
+        state="fresh",
+    )
     parent_tool.output_data = None
     assert not node._update_from_parent_source()
     assert node.source_state == "unavailable"
@@ -5348,51 +6191,6 @@ def test_managed_tool_window_node_detached_update_branches(
 
     node.set_detached_provenance(None, replay_source_data=None)
     assert not node.handle_parent_source_replaced(parent_data)
-
-    node.set_source_binding(
-        full_data(IselOperation(kwargs={"missing": 0})),
-        state="stale",
-    )
-    assert not node.handle_parent_source_replaced(parent_data)
-    assert node.source_state == "stale"
-
-    node.set_source_binding(full_data(), auto_update=True, state="stale")
-    assert not node.handle_parent_source_replaced(parent_data)
-    assert node.source_state == "stale"
-
-    node.set_detached_provenance(None, replay_source_data=None)
-    assert node.show_source_update_dialog(parent=manager) == int(
-        QtWidgets.QDialog.DialogCode.Rejected
-    )
-
-    class _FakeSourceUpdateDialog:
-        def __init__(
-            self,
-            parent: QtWidgets.QWidget,
-            *,
-            state: str,
-            auto_update: bool,
-        ) -> None:
-            assert parent is manager
-            assert state == "stale"
-            assert auto_update is False
-            self.update_requested = True
-            self.auto_update_check = types.SimpleNamespace(isChecked=lambda: True)
-
-        def exec(self) -> int:
-            return int(QtWidgets.QDialog.DialogCode.Accepted)
-
-    monkeypatch.setattr(
-        erlab.interactive.utils,
-        "_ToolSourceUpdateDialog",
-        _FakeSourceUpdateDialog,
-    )
-    node.set_output_binding("out", auto_update=False, state="stale")
-    assert node.show_source_update_dialog(parent=manager) == int(
-        QtWidgets.QDialog.DialogCode.Accepted
-    )
-    assert node.source_auto_update is True
-    assert manager.updated[-1] == "refresh:child"
 
 
 def test_imagetool_wrapper_item_model_child_edge_branches(qtbot, monkeypatch) -> None:
@@ -5624,8 +6422,8 @@ def test_tool_window_launch_paths_keep_declared_outputs_and_unbound_windows_sepa
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
         def _result_output_data(self) -> xr.DataArray:
             return self._data + 1
@@ -5633,7 +6431,7 @@ def test_tool_window_launch_paths_keep_declared_outputs_and_unbound_windows_sepa
         def _result_output_label(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             return "Compute dummy output"
@@ -5641,11 +6439,11 @@ def test_tool_window_launch_paths_keep_declared_outputs_and_unbound_windows_sepa
         def _result_output_expression(
             self,
             *,
-            input_name: str | None = None,
+            primary_input: str | None = None,
             data: xr.DataArray | None = None,
         ) -> str:
             del data
-            return f"{input_name or 'data'} + 1"
+            return f"{primary_input or 'data'} + 1"
 
     tool = _DummyTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))
     qtbot.addWidget(tool)
@@ -5732,8 +6530,8 @@ def test_tool_window_managed_detached_output_preserves_provenance(
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
     root_data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
     output_data = xr.DataArray(np.arange(3.0), dims=("x",), name="detached")
@@ -5754,7 +6552,12 @@ def test_tool_window_managed_detached_output_preserves_provenance(
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         tool = _DummyTool(root_data)
-        child_uid = manager.add_childtool(tool, 0, show=False)
+        tool.set_script_inputs((ScriptInput(name="data"),), primary_input="data")
+        child_uid = manager.add_childtool(
+            tool,
+            script_inputs={"data": 0},
+            show=False,
+        )
         assert manager._child_node(child_uid).tool_window is tool
 
         launched = tool._launch_detached_output_imagetool(
@@ -5798,8 +6601,8 @@ def test_tool_window_unbound_launches_open_distinct_windows(qtbot) -> None:
         def tool_data(self) -> xr.DataArray:
             return self._data
 
-        def update_data(self, new_data: xr.DataArray) -> None:
-            self._data = new_data
+        def update_inputs(self, inputs: Mapping[str, xr.DataArray]) -> None:
+            self._data = inputs["data"]
 
     tool = _DummyTool(xr.DataArray(np.arange(4.0), dims=("x",), name="data"))
     qtbot.addWidget(tool)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -642,6 +642,51 @@ def test_tool_window_script_input_transforms_are_defensive_copies(qtbot) -> None
     assert tool.script_inputs == (refreshed,)
 
 
+@pytest.mark.parametrize(
+    ("script_inputs", "primary_input", "error_type", "message"),
+    [
+        ((object(),), "data", TypeError, "ScriptInput"),
+        (
+            (ScriptInput(name="data"), ScriptInput(name="data")),
+            "data",
+            ValueError,
+            "unique",
+        ),
+        (
+            (ScriptInput(name="data"),),
+            None,
+            ValueError,
+            "explicit primary_input",
+        ),
+        (
+            (ScriptInput(name="data"),),
+            "missing",
+            ValueError,
+            "must name",
+        ),
+        ((), "data", ValueError, "requires at least"),
+    ],
+)
+def test_tool_window_rejects_invalid_script_input_bindings(
+    qtbot,
+    script_inputs: tuple[object, ...],
+    primary_input: str | None,
+    error_type: type[Exception],
+    message: str,
+) -> None:
+    tool = _PersistentTool(xr.DataArray([1.0], dims="x"))
+    qtbot.addWidget(tool)
+
+    with pytest.raises(error_type, match=message):
+        tool.set_script_inputs(
+            typing.cast("tuple[ScriptInput, ...]", script_inputs),
+            primary_input=primary_input,
+        )
+
+    assert tool.script_inputs == ()
+    assert tool.primary_input is None
+
+
 def test_tool_window_custom_history_cannot_skip_provenance_signal(
     qtbot, monkeypatch
 ) -> None:
@@ -4455,6 +4500,65 @@ def test_tool_window_named_input_update_validates_before_mutation(qtbot) -> None
     assert tool.source_state == "fresh"
 
 
+def test_tool_window_input_transaction_rejects_name_changes(qtbot, monkeypatch) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    tool = _PersistentTool(data)
+    qtbot.addWidget(tool)
+
+    def update(_inputs: Mapping[str, xr.DataArray]) -> typing.NoReturn:
+        pytest.fail("invalid inputs must not be applied")
+
+    with pytest.raises(ValueError, match="declared input names"):
+        tool._update_inputs_transaction(
+            {"data": data},
+            expected_names={"data", "weights"},
+            update=update,
+        )
+
+    monkeypatch.setattr(
+        tool,
+        "validate_update_inputs",
+        lambda inputs: {"data": inputs["data"]},
+    )
+    with pytest.raises(ValueError, match="validated inputs"):
+        tool._update_inputs_transaction(
+            {"data": data, "weights": data},
+            expected_names={"data", "weights"},
+            update=update,
+        )
+
+
+def test_tool_window_source_refresh_guards(qtbot, monkeypatch) -> None:
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    tool = _PersistentTool(data)
+    qtbot.addWidget(tool)
+    update_calls: list[None] = []
+    monkeypatch.setattr(
+        tool,
+        "_update_from_input_source",
+        lambda: update_calls.append(None),
+    )
+
+    tool.abort_source_refresh()
+    assert tool.source_state == "fresh"
+    with pytest.raises(RuntimeError, match="only be deferred"):
+        tool._defer_source_refresh()
+
+    tool._source_auto_update = True
+    tool._source_refreshing = True
+    tool._rerun_source_refresh()
+    tool._source_refreshing = False
+    tool._source_refresh_deferred = True
+    tool._rerun_source_refresh()
+    assert update_calls == []
+
+    tool._source_refresh_deferred = False
+    tool._source_auto_update = False
+    tool._rerun_source_refresh()
+    assert update_calls == []
+    assert tool.source_state == "stale"
+
+
 def test_tool_window_persistence_replacement_uses_complete_named_inputs(
     qtbot,
     monkeypatch,
@@ -5452,6 +5556,47 @@ def test_tool_window_manifest_includes_saved_source_expressions() -> None:
     ]
     assert manifest.entries[0].location == (
         "tool-inputs/0:data/source/operations/0/parameters/c1"
+    )
+
+
+def test_tool_window_saved_script_input_attrs_validate_primary_input() -> None:
+    assert erlab.interactive.utils.ToolWindow._saved_script_input_attrs((), None) == {}
+
+    with pytest.raises(ValueError, match="requires at least"):
+        erlab.interactive.utils.ToolWindow._saved_script_input_attrs((), "data")
+    with pytest.raises(ValueError, match="must name"):
+        erlab.interactive.utils.ToolWindow._saved_script_input_attrs(
+            (ScriptInput(name="data"),),
+            "missing",
+        )
+
+
+def test_tool_window_current_manifest_includes_input_expressions(qtbot) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x")
+    tool = _PersistentTool(data)
+    qtbot.addWidget(tool)
+
+    assert tool._current_code_trust_manifest() is None
+
+    tool.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                provenance_spec=full_data(_expression_fit_operation()).model_dump(
+                    mode="json"
+                ),
+            ),
+        ),
+        primary_input="data",
+    )
+    manifest = tool._current_code_trust_manifest()
+
+    assert manifest is not None
+    assert [entry.feature for entry in manifest.entries] == [
+        "erlab.provenance.model-fit-parameter-expression"
+    ]
+    assert manifest.entries[0].location == (
+        "tool-inputs/0:data/provenance/operations/0/parameters/c1"
     )
 
 

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -5332,6 +5332,7 @@ def test_tool_window_rejects_unreplayable_saved_source_reference() -> None:
             ds.attrs["tool_source_spec"] = raw_source_spec
         with pytest.raises(ValueError, match="not replayable"):
             erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+                "data",
                 {"kind": "parent_source"},
                 ds,
                 source_parent_data=data,
@@ -5345,6 +5346,7 @@ def test_tool_window_resolves_saved_reference_errors() -> None:
 
     with pytest.raises(ValueError, match="parent data is unavailable"):
         erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+            "data",
             {"kind": "parent_source"},
             ds,
             source_parent_data=None,
@@ -5353,6 +5355,7 @@ def test_tool_window_resolves_saved_reference_errors() -> None:
 
     with pytest.raises(ValueError, match="no manager-node resolver"):
         erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+            "data",
             {"kind": "manager_node"},
             ds,
             source_parent_data=None,
@@ -5361,6 +5364,7 @@ def test_tool_window_resolves_saved_reference_errors() -> None:
 
     with pytest.raises(ValueError, match="could not be resolved"):
         erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+            "data",
             {"kind": "manager_node", "node_uid": "missing"},
             ds,
             source_parent_data=None,
@@ -5369,6 +5373,7 @@ def test_tool_window_resolves_saved_reference_errors() -> None:
 
     with pytest.raises(ValueError, match="Unsupported"):
         erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+            "data",
             {"kind": "unexpected"},
             ds,
             source_parent_data=None,
@@ -5405,6 +5410,7 @@ def test_tool_window_saved_source_reference_authorizes_before_execution(
 
     with pytest.raises(ValueError, match="untrusted code"):
         erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+            "data",
             {"kind": "parent_source"},
             ds,
             source_parent_data=data,
@@ -5414,6 +5420,7 @@ def test_tool_window_saved_source_reference_authorizes_before_execution(
     assert executions == []
 
     resolved = erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+        "data",
         {"kind": "parent_source"},
         ds,
         source_parent_data=data,

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -5425,16 +5425,16 @@ def test_tool_window_saved_source_reference_authorizes_before_execution(
 
 
 def test_tool_window_manifest_includes_saved_source_expressions() -> None:
-    class _SourceTrustTool(_PersistentTool):
-        _CODE_TRUST_DOMAIN = "test.tool-source"
+    script_input = ScriptInput(
+        name="data",
+        source_spec=full_data(_expression_fit_operation()).model_dump(mode="json"),
+    )
+    attrs = erlab.interactive.utils.ToolWindow._saved_script_input_attrs(
+        (script_input,),
+        "data",
+    )
 
-    attrs = {
-        erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR: json.dumps(
-            full_data(_expression_fit_operation()).model_dump(mode="json")
-        )
-    }
-
-    manifest = _SourceTrustTool._code_trust_manifest_from_saved_metadata(
+    manifest = _PersistentTool._code_trust_manifest_from_saved_metadata(
         _PersistentToolState(),
         attrs,
     )
@@ -5444,43 +5444,8 @@ def test_tool_window_manifest_includes_saved_source_expressions() -> None:
         "erlab.provenance.model-fit-parameter-expression"
     ]
     assert manifest.entries[0].location == (
-        "tool-source/provenance/operations/0/parameters/c1"
+        "tool-inputs/0:data/source/operations/0/parameters/c1"
     )
-
-
-def test_tool_window_local_code_edit_changes_signed_trust_to_local_lineage(
-    qtbot,
-) -> None:
-    class _SourceTrustTool(_PersistentTool):
-        _CODE_TRUST_DOMAIN = "test.tool-source"
-
-    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
-    tool = _SourceTrustTool(data)
-    qtbot.addWidget(tool)
-
-    def source(expression: str) -> ToolProvenanceSpec:
-        return full_data(_expression_fit_operation(expression))
-
-    tool.set_source_binding(source("2 * c0"))
-    manifest = tool._current_code_trust_manifest()
-    assert manifest is not None
-    signed = _document_trust_after_save(
-        new_document_trust(),
-        manifest,
-        saved_trusted_lineage=True,
-        signature_stored=True,
-    )
-    tool.set_document_trust(signed)
-    changed_source = source("3 * c0")
-    changed_entries = tuple(tool._source_spec_code_trust_entries(changed_source))
-    with tool._local_code_edit(
-        changed_entries,
-        edited_entries=changed_entries,
-    ) as capability:
-        assert execution_capability_allows(capability, changed_entries)
-        tool.set_source_binding(changed_source)
-
-    assert tool._authorize_code_execution(changed_entries)
 
 
 def test_tool_window_local_code_edit_commits_only_after_success(qtbot) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1060,7 +1060,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66.2" },
     { name = "varname", specifier = ">=0.13.0" },
     { name = "xarray", specifier = ">=2024.10.0" },
-    { name = "xarray-lmfit", specifier = ">=0.5.5" },
+    { name = "xarray-lmfit", specifier = ">=0.6.0" },
     { name = "xraydb", specifier = ">=4.5.8" },
     { name = "zarr", marker = "extra == 'io'", specifier = ">=3.1.2" },
 ]
@@ -5452,7 +5452,7 @@ wheels = [
 
 [[package]]
 name = "xarray-lmfit"
-version = "0.5.6"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lazy-loader" },
@@ -5460,9 +5460,9 @@ dependencies = [
     { name = "numpy" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/0e/6e50f32759076c9ffeaf59ceea20fe8d865fb7ee8aaed3bb8b6820a958c4/xarray_lmfit-0.5.6.tar.gz", hash = "sha256:043560eecfd0d474dc997cc6705833be125a9439fade925ce23e68c77387b8e3", size = 41442, upload-time = "2026-07-23T06:00:45.866Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/2d/25d05ed8f2633746c49e663a7ba05ba87b0559c09afda88f48dae2923c5d/xarray_lmfit-0.6.0.tar.gz", hash = "sha256:3df9c2c0f4f1e95e012379fb1d04aedc815e6100a51346105722b97cb6b716da", size = 42217, upload-time = "2026-08-14T01:49:08.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/e6/10c8215ba81503e5c59bc84c4d4f88ad894347234eb2ea42ef26e0e9d6b3/xarray_lmfit-0.5.6-py3-none-any.whl", hash = "sha256:9e603138153794c719c8bf50f1f2c5326a91a2e81efce6caa8b9683e6eb9adb9", size = 29072, upload-time = "2026-07-23T06:00:44.732Z" },
+    { url = "https://files.pythonhosted.org/packages/af/fa/246c81cb6049211df61b8acb185879605dd7c560f2f707affc9e4e456170/xarray_lmfit-0.6.0-py3-none-any.whl", hash = "sha256:6685a0d5d92b2721ebf15043011ec2fd814ad0c7caf0a28dec85cc9900d4876d", size = 29315, upload-time = "2026-08-14T01:49:07.76Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add named multi-input handling to ToolWindow and ImageTool Manager provenance.
- Add a weighted ftool workflow that uses separate data and standard-uncertainty ImageTools.
- Add a Fit2D action that opens parameter values and available standard errors in ftool.
- Keep multi-input replay, refresh, workspace persistence, and Figure Composer dependencies consistent.

## Validation

- Focused PyQt6 manager and ftool tests passed.
- Focused PySide6 manager tests passed.
- The 17 regressions found during the final audit passed with fail-fast enabled.
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`

The full test suite was not rerun after the final fixes. CI will run it.