### PR TITLE
feat(explorer): preview general data files

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -522,7 +522,7 @@ it is faster than the interactive summary table in the I/O guide. Use
 or when you are developing loaders.
 
 The loader list includes general xarray HDF5 (`.h5`), NetCDF (`.nc`, `.nc4`, and
-`.cdf`), and Igor Binary Wave (`.ibw`) files.
+`.cdf`), Zarr (`.zarr`), and supported Igor (`.ibw` and `.pxt`) files.
 
 The explorer can also be launched standalone from Python or the command line for browsing
 and previewing. Opening selected files into ImageTool analysis still requires a running

--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -521,6 +521,9 @@ it is faster than the interactive summary table in the I/O guide. Use
 {func}`erlab.io.summarize` instead when you want the overview as a DataFrame in Python
 or when you are developing loaders.
 
+The loader list includes general xarray HDF5 (`.h5`), NetCDF (`.nc`, `.nc4`, and
+`.cdf`), and Igor Binary Wave (`.ibw`) files.
+
 The explorer can also be launched standalone from Python or the command line for browsing
 and previewing. Opening selected files into ImageTool analysis still requires a running
 ImageTool manager, which is why launching it from the manager is the recommended path.

--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -597,7 +597,7 @@ Provides a file-browser-like interface for exploring and visualizing ARPES data 
 your disk.
 
 The loader list also supports general xarray HDF5 (`.h5`), NetCDF (`.nc`, `.nc4`, and
-`.cdf`), and Igor Binary Wave (`.ibw`) files.
+`.cdf`), Zarr (`.zarr`), and supported Igor (`.ibw` and `.pxt`) files.
 
 For most day-to-day browsing and loading, this is faster than the interactive summary
 table described in the {ref}`I/O guide <io-summarizing-data>`. Use the summary table when

--- a/docs/source/user-guide/interactive/misc-tools.md
+++ b/docs/source/user-guide/interactive/misc-tools.md
@@ -596,6 +596,9 @@ Mesh removal is currently experimental and may not work well for all datasets, a
 Provides a file-browser-like interface for exploring and visualizing ARPES data stored on
 your disk.
 
+The loader list also supports general xarray HDF5 (`.h5`), NetCDF (`.nc`, `.nc4`, and
+`.cdf`), and Igor Binary Wave (`.ibw`) files.
+
 For most day-to-day browsing and loading, this is faster than the interactive summary
 table described in the {ref}`I/O guide <io-summarizing-data>`. Use the summary table when
 you want the overview as a DataFrame inside Python or when you are implementing loaders.

--- a/src/erlab/interactive/_file_loaders.py
+++ b/src/erlab/interactive/_file_loaders.py
@@ -1,0 +1,79 @@
+"""Built-in file loader specifications shared by interactive tools."""
+
+from __future__ import annotations
+
+import dataclasses
+import types
+import typing
+
+import xarray as xr
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BuiltinFileLoaderSpec:
+    """Describe one built-in callable file loader."""
+
+    id: str
+    label: str
+    description: str
+    name_filter: str
+    extensions: frozenset[str]
+    load_func: Callable[..., xr.DataArray]
+    default_kwargs: Mapping[str, typing.Any] = dataclasses.field(
+        default_factory=lambda: types.MappingProxyType({})
+    )
+
+
+BUILTIN_FILE_LOADER_SPECS = (
+    BuiltinFileLoaderSpec(
+        id="builtin:xarray-hdf5",
+        label="xarray HDF5 DataArray",
+        description="Load an xarray DataArray from an HDF5 file.",
+        name_filter="xarray HDF5 Files (*.h5)",
+        extensions=frozenset({".h5"}),
+        load_func=xr.load_dataarray,
+        default_kwargs=types.MappingProxyType({"engine": "h5netcdf"}),
+    ),
+    BuiltinFileLoaderSpec(
+        id="builtin:xarray-netcdf",
+        label="xarray NetCDF DataArray",
+        description="Load an xarray DataArray from a NetCDF file.",
+        name_filter="NetCDF Files (*.nc *.nc4 *.cdf)",
+        extensions=frozenset({".nc", ".nc4", ".cdf"}),
+        load_func=xr.load_dataarray,
+    ),
+    BuiltinFileLoaderSpec(
+        id="builtin:igor-binary-wave",
+        label="Igor Binary Wave",
+        description="Load an Igor Binary Wave as an xarray DataArray.",
+        name_filter="Igor Binary Waves (*.ibw)",
+        extensions=frozenset({".ibw"}),
+        load_func=xr.load_dataarray,
+        default_kwargs=types.MappingProxyType({"engine": "erlab-igor"}),
+    ),
+)
+
+_BUILTIN_FILE_LOADER_BY_ID = {spec.id: spec for spec in BUILTIN_FILE_LOADER_SPECS}
+_BUILTIN_FILE_LOADER_BY_NAME_FILTER = {
+    spec.name_filter: spec for spec in BUILTIN_FILE_LOADER_SPECS
+}
+
+if len(_BUILTIN_FILE_LOADER_BY_ID) != len(BUILTIN_FILE_LOADER_SPECS):
+    raise RuntimeError("Built-in file loader IDs must be unique")
+if len(_BUILTIN_FILE_LOADER_BY_NAME_FILTER) != len(BUILTIN_FILE_LOADER_SPECS):
+    raise RuntimeError("Built-in file loader filters must be unique")
+
+
+def builtin_file_loader_for_id(loader_id: str) -> BuiltinFileLoaderSpec | None:
+    """Return the built-in specification for a stable loader ID."""
+    return _BUILTIN_FILE_LOADER_BY_ID.get(loader_id)
+
+
+def builtin_file_loader_for_name_filter(
+    name_filter: str,
+) -> BuiltinFileLoaderSpec | None:
+    """Return the built-in specification for a file-dialog filter."""
+    return _BUILTIN_FILE_LOADER_BY_NAME_FILTER.get(name_filter)

--- a/src/erlab/interactive/_file_loaders.py
+++ b/src/erlab/interactive/_file_loaders.py
@@ -25,13 +25,14 @@ class BuiltinFileLoaderSpec:
     default_kwargs: Mapping[str, typing.Any] = dataclasses.field(
         default_factory=lambda: types.MappingProxyType({})
     )
+    file_dialog: bool = True
 
 
 BUILTIN_FILE_LOADER_SPECS = (
     BuiltinFileLoaderSpec(
         id="builtin:xarray-hdf5",
-        label="xarray HDF5 DataArray",
-        description="Load an xarray DataArray from an HDF5 file.",
+        label="HDF5",
+        description="Load an HDF5 file.",
         name_filter="xarray HDF5 Files (*.h5)",
         extensions=frozenset({".h5"}),
         load_func=xr.load_dataarray,
@@ -39,18 +40,37 @@ BUILTIN_FILE_LOADER_SPECS = (
     ),
     BuiltinFileLoaderSpec(
         id="builtin:xarray-netcdf",
-        label="xarray NetCDF DataArray",
-        description="Load an xarray DataArray from a NetCDF file.",
+        label="NetCDF",
+        description="Load a NetCDF file.",
         name_filter="NetCDF Files (*.nc *.nc4 *.cdf)",
         extensions=frozenset({".nc", ".nc4", ".cdf"}),
         load_func=xr.load_dataarray,
     ),
     BuiltinFileLoaderSpec(
+        id="builtin:xarray-zarr",
+        label="Zarr",
+        description="Load a Zarr store.",
+        name_filter="xarray Zarr Stores (*.zarr)",
+        extensions=frozenset({".zarr"}),
+        load_func=xr.load_dataarray,
+        default_kwargs=types.MappingProxyType({"engine": "zarr"}),
+        file_dialog=False,
+    ),
+    BuiltinFileLoaderSpec(
         id="builtin:igor-binary-wave",
-        label="Igor Binary Wave",
-        description="Load an Igor Binary Wave as an xarray DataArray.",
+        label="IBW",
+        description="Load an Igor Binary Wave.",
         name_filter="Igor Binary Waves (*.ibw)",
         extensions=frozenset({".ibw"}),
+        load_func=xr.load_dataarray,
+        default_kwargs=types.MappingProxyType({"engine": "erlab-igor"}),
+    ),
+    BuiltinFileLoaderSpec(
+        id="builtin:igor-packed-experiment",
+        label="PXT",
+        description="Load a single-wave Igor packed experiment.",
+        name_filter="Igor Packed Experiment Templates (*.pxt)",
+        extensions=frozenset({".pxt"}),
         load_func=xr.load_dataarray,
         default_kwargs=types.MappingProxyType({"engine": "erlab-igor"}),
     ),

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -51,6 +51,10 @@ import typing
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 import erlab
+from erlab.interactive._file_loaders import (
+    BUILTIN_FILE_LOADER_SPECS,
+    builtin_file_loader_for_id,
+)
 
 __all__ = [
     "AppOptions",
@@ -254,13 +258,23 @@ class IOOptions(BaseModel):
     default_loader: str = Field(
         default="None",
         title="Default loader",
-        description="Loader to pre-select in the data explorer.",
-        json_schema_extra={
-            **_workspace_extra(
-                ui_type="list",
-                ui_limits=["None", *list(erlab.io.loaders.keys())],
-            )
-        },
+        description="Loader to pre-select in Data Explorer and file dialogs.",
+        json_schema_extra=_workspace_extra(
+            ui_type="list",
+            ui_choices=[
+                {"label": "None", "value": "None"},
+                *sorted(
+                    [
+                        *({"label": name, "value": name} for name in erlab.io.loaders),
+                        *(
+                            {"label": spec.label, "value": spec.id}
+                            for spec in BUILTIN_FILE_LOADER_SPECS
+                        ),
+                    ],
+                    key=lambda choice: choice["label"].casefold(),
+                ),
+            ],
+        ),
     )
     default_directory: str = Field(
         default="",
@@ -290,8 +304,11 @@ class IOOptions(BaseModel):
     def loader_exists(cls, v: str | None):
         if not v or v == "None":
             return "None"
-        if v not in erlab.io.loaders:
-            available = list(erlab.io.loaders.keys())
+        if v not in erlab.io.loaders and builtin_file_loader_for_id(v) is None:
+            available = [
+                *erlab.io.loaders.keys(),
+                *(spec.id for spec in BUILTIN_FILE_LOADER_SPECS),
+            ]
             raise ValueError(
                 "Loader '" + v + "' not registered; available: " + str(available)
             )

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -263,14 +263,12 @@ class IOOptions(BaseModel):
             ui_type="list",
             ui_choices=[
                 {"label": "None", "value": "None"},
+                *(
+                    {"label": spec.label, "value": spec.id}
+                    for spec in BUILTIN_FILE_LOADER_SPECS
+                ),
                 *sorted(
-                    [
-                        *({"label": name, "value": name} for name in erlab.io.loaders),
-                        *(
-                            {"label": spec.label, "value": spec.id}
-                            for spec in BUILTIN_FILE_LOADER_SPECS
-                        ),
-                    ],
+                    ({"label": name, "value": name} for name in erlab.io.loaders),
                     key=lambda choice: choice["label"].casefold(),
                 ),
             ],

--- a/src/erlab/interactive/_options/tree.py
+++ b/src/erlab/interactive/_options/tree.py
@@ -49,14 +49,7 @@ def _build_leaf_param(
 
     if "enum" in schema:
         param_type = "list"
-        choices = extras.get("ui_choices") if isinstance(extras, dict) else None
-        if isinstance(choices, list):
-            opts["limits"] = {
-                str(choice.get("label", choice.get("value"))): choice.get("value")
-                for choice in choices
-            }
-        else:
-            opts["limits"] = schema["enum"]
+        opts["limits"] = schema["enum"]
     else:
         stype = schema.get("type")
         if ui_type:
@@ -81,6 +74,12 @@ def _build_leaf_param(
                     param_type = "str"
 
     if isinstance(extras, dict):
+        choices = extras.get("ui_choices")
+        if param_type == "list" and isinstance(choices, list):
+            opts["limits"] = {
+                str(choice.get("label", choice.get("value"))): choice.get("value")
+                for choice in choices
+            }
         for k, v in extras.items():
             if k.startswith("ui_") and k not in {"ui_type", "ui_choices"}:
                 opts[k.removeprefix("ui_")] = v

--- a/src/erlab/interactive/explorer/__init__.py
+++ b/src/erlab/interactive/explorer/__init__.py
@@ -46,8 +46,8 @@ def data_explorer(
     directory
         Initial directory to display in the explorer.
     loader_name
-        Name of the loader to use to load the data. The loader must be registered in
-        :attr:`erlab.io.loaders`.
+        Stable name of the loader to use. This can identify a registered loader or a
+        built-in Data Explorer loader.
     """
     with erlab.interactive.utils.setup_qapp(execute):
         win = _TabbedExplorer(root_path=directory, loader_name=loader_name)

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -24,6 +24,10 @@ import pyqtgraph as pg
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+from erlab.interactive.explorer._loaders import (
+    BUILTIN_EXPLORER_LOADERS,
+    _BuiltinExplorerLoader,
+)
 from erlab.io.dataloader import _filename_matches_extensions
 
 if typing.TYPE_CHECKING:
@@ -550,8 +554,8 @@ class _ReprFetcher(QtCore.QRunnable):
     ----------
     file_path
         Path to the file.
-    loader_name
-        Name of the loader plugin to use.
+    load_method
+        Loader method to use.
     """
 
     def __init__(
@@ -601,12 +605,16 @@ class _ReprFetcher(QtCore.QRunnable):
                 dat,
                 additional_info=[],
                 show_size=self.include_values,
-                # Preview-off loads replace only data values; keep coordinate summaries.
+                # Metadata-only loads may defer data values; keep coordinate summaries.
                 load_values=True,
             )
-            if not self.include_values:
-                dat = None
         finally:
+            if dat is not None and not self.include_values:
+                close = getattr(dat, "close", None)
+                if callable(close):
+                    with contextlib.suppress(Exception):
+                        close()
+                dat = None
             if text is not None and not self._aborted.is_set():
                 self.signals.fetched.emit(file_path, text, dat)
             self.signals.finished.emit(self)
@@ -631,10 +639,16 @@ class _LoaderInfoModel(QtCore.QAbstractTableModel):
 
             match index.column():
                 case 0:
-                    return loader_name
+                    return getattr(
+                        self._file_browser._loader(loader_name),
+                        "display_name",
+                        loader_name,
+                    )
                 case 1:
                     loader = self._file_browser._loader(loader_name)
                     return loader.description if hasattr(loader, "description") else ""
+        elif role == QtCore.Qt.ItemDataRole.UserRole and index.column() == 0:
+            return self._file_browser._loader_names()[index.row()]
         return None
 
     def headerData(
@@ -979,22 +993,47 @@ class _DataExplorer(QtWidgets.QMainWindow):
             loader_name = erlab.interactive.options.model.io.default_loader
 
         if loader_name:
-            self._loader_combo.setCurrentText(loader_name)
+            self._set_loader_name(loader_name)
 
         self._dir_loaded()
 
     @property
     def loader_name(self) -> str:
         """Name of the selected loader."""
-        return self._loader_combo.currentText()
+        loader_name = self._loader_combo.currentData(QtCore.Qt.ItemDataRole.UserRole)
+        return "" if loader_name is None else str(loader_name)
 
     def _loader_names(self) -> tuple[str, ...]:
-        builtin_names = set(erlab.io.loaders.keys()) - self._excluded_loaders
-        return tuple(sorted({*builtin_names, *self._external_loaders}))
+        plugin_names = set(erlab.io.loaders.keys()) - self._excluded_loaders
+        loader_names = {
+            *BUILTIN_EXPLORER_LOADERS,
+            *plugin_names,
+            *self._external_loaders,
+        }
+        return tuple(
+            sorted(
+                loader_names,
+                key=lambda name: str(
+                    getattr(self._loader(name), "display_name", name)
+                ).casefold(),
+            )
+        )
 
     def _loader(self, name: str) -> typing.Any:
+        builtin = BUILTIN_EXPLORER_LOADERS.get(name)
+        if builtin is not None:
+            return builtin
         external = self._external_loaders.get(name)
         return erlab.io.loaders[name] if external is None else external
+
+    def _set_loader_name(self, name: str) -> bool:
+        """Select a loader by its stable name."""
+        try:
+            index = self._loader_names().index(name)
+        except ValueError:
+            return False
+        self._loader_combo.setCurrentIndex(index)
+        return True
 
     def refresh_loader_choices(self) -> None:
         """Refresh choices after the manager catalog generation changes."""
@@ -1072,7 +1111,7 @@ class _DataExplorer(QtWidgets.QMainWindow):
                 state.loader_name is not None
                 and state.loader_name in self._loader_names()
             ):
-                self._loader_combo.setCurrentText(state.loader_name)
+                self._set_loader_name(state.loader_name)
 
             self._preview_check.setChecked(state.preview)
 
@@ -1469,6 +1508,34 @@ class _DataExplorer(QtWidgets.QMainWindow):
 
         loader_name = self.loader_name
         loader = self._loader(loader_name)
+        if isinstance(loader, _BuiltinExplorerLoader):
+            dialog = _NameFilterDialog(
+                self,
+                {
+                    loader.spec.name_filter: (
+                        loader.spec.load_func,
+                        dict(loader.spec.default_kwargs)
+                        | self._loader_kwargs_by_name.get(loader_name, {}),
+                    )
+                },
+                sample_paths=self._current_selection,
+            )
+            dialog.check_filter(loader.spec.name_filter)
+            if not dialog.exec():
+                return
+            _, _, selected_kwargs = dialog.checked_filter()
+            self._loader_kwargs_by_name[loader_name] = loader.option_overrides(
+                selected_kwargs
+            )
+            self._loader_extensions_by_name[loader_name] = {}
+            self.sigLoaderStateChanged.emit(
+                self.loader_kwargs_by_name(),
+                self.loader_extensions_by_name(),
+            )
+            self._emit_workspace_state_changed()
+            self._on_selection_changed()
+            return
+
         descriptor = getattr(loader, "descriptor", None)
         if isinstance(descriptor, erlab.extensions.LoaderDescriptor) and not bool(
             getattr(loader, "uses_standard_loader_options", False)

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -629,14 +629,71 @@ class _LoaderInfoModel(QtCore.QAbstractTableModel):
         self.beginResetModel()
         self.endResetModel()
 
+    def _rows(self) -> tuple[tuple[str, str | None], ...]:
+        rows: list[tuple[str, str | None]] = []
+        for group_name, loader_names in self._file_browser._loader_name_groups():
+            if not loader_names:
+                continue
+            rows.append((group_name, None))
+            rows.extend((group_name, loader_name) for loader_name in loader_names)
+        return tuple(rows)
+
+    def loader_name_for_row(self, row: int) -> str | None:
+        """Return the stable loader name for a model row."""
+        rows = self._rows()
+        if 0 <= row < len(rows):
+            return rows[row][1]
+        return None
+
+    def row_for_loader_name(self, loader_name: str) -> int | None:
+        """Return the model row for a stable loader name."""
+        return next(
+            (
+                row
+                for row, (_, current_name) in enumerate(self._rows())
+                if current_name == loader_name
+            ),
+            None,
+        )
+
+    def group_rows(self) -> tuple[int, ...]:
+        """Return rows that contain non-selectable group headings."""
+        return tuple(
+            row
+            for row, (_, loader_name) in enumerate(self._rows())
+            if loader_name is None
+        )
+
+    def first_loader_row(self) -> int | None:
+        """Return the first selectable loader row."""
+        return next(
+            (
+                row
+                for row, (_, loader_name) in enumerate(self._rows())
+                if loader_name is not None
+            ),
+            None,
+        )
+
     def data(
         self, index: QtCore.QModelIndex, role: int = QtCore.Qt.ItemDataRole.DisplayRole
     ) -> typing.Any:
         if not index.isValid():
             return None
+        group_name, loader_name = self._rows()[index.row()]
+        if loader_name is None:
+            if role == QtCore.Qt.ItemDataRole.DisplayRole and index.column() == 0:
+                return group_name
+            if role == QtCore.Qt.ItemDataRole.FontRole:
+                font = QtGui.QFont()
+                font.setBold(True)
+                return font
+            if role == QtCore.Qt.ItemDataRole.BackgroundRole:
+                return QtWidgets.QApplication.palette().brush(
+                    QtGui.QPalette.ColorRole.AlternateBase
+                )
+            return None
         if role == QtCore.Qt.ItemDataRole.DisplayRole:
-            loader_name = self._file_browser._loader_names()[index.row()]
-
             match index.column():
                 case 0:
                     return getattr(
@@ -648,8 +705,13 @@ class _LoaderInfoModel(QtCore.QAbstractTableModel):
                     loader = self._file_browser._loader(loader_name)
                     return loader.description if hasattr(loader, "description") else ""
         elif role == QtCore.Qt.ItemDataRole.UserRole and index.column() == 0:
-            return self._file_browser._loader_names()[index.row()]
+            return loader_name
         return None
+
+    def flags(self, index: QtCore.QModelIndex) -> QtCore.Qt.ItemFlag:
+        if index.isValid() and self.loader_name_for_row(index.row()) is None:
+            return QtCore.Qt.ItemFlag.NoItemFlags
+        return super().flags(index)
 
     def headerData(
         self,
@@ -671,7 +733,7 @@ class _LoaderInfoModel(QtCore.QAbstractTableModel):
     def rowCount(self, parent: QtCore.QModelIndex | None = None) -> int:
         if parent is not None and parent.isValid():
             return 0
-        return len(self._file_browser._loader_names())
+        return len(self._rows())
 
     def columnCount(self, parent: QtCore.QModelIndex | None = None) -> int:
         if parent is not None and parent.isValid():
@@ -693,10 +755,23 @@ class _LoaderWidget(QtWidgets.QComboBox):
 
         self.setModel(model)
         self.setView(view)
+        model.modelReset.connect(self._update_group_spans)
+        self._update_group_spans()
+        first_loader_row = model.first_loader_row()
+        if first_loader_row is not None:
+            self.setCurrentIndex(first_loader_row)
         view.resizeColumnsToContents()
         view.setMinimumWidth(
             sum(view.columnWidth(i) for i in range(model.columnCount()))
         )
+
+    @QtCore.Slot()
+    def _update_group_spans(self) -> None:
+        model = typing.cast("_LoaderInfoModel", self.model())
+        view = typing.cast("QtWidgets.QTableView", self.view())
+        view.clearSpans()
+        for row in model.group_rows():
+            view.setSpan(row, 0, 1, model.columnCount())
 
 
 class _DataPreviewSelectionWidget(QtWidgets.QWidget):
@@ -1004,19 +1079,33 @@ class _DataExplorer(QtWidgets.QMainWindow):
         return "" if loader_name is None else str(loader_name)
 
     def _loader_names(self) -> tuple[str, ...]:
-        plugin_names = set(erlab.io.loaders.keys()) - self._excluded_loaders
-        loader_names = {
-            *BUILTIN_EXPLORER_LOADERS,
-            *plugin_names,
-            *self._external_loaders,
-        }
         return tuple(
-            sorted(
-                loader_names,
-                key=lambda name: str(
-                    getattr(self._loader(name), "display_name", name)
-                ).casefold(),
+            loader_name
+            for _, loader_names in self._loader_name_groups()
+            for loader_name in loader_names
+        )
+
+    def _loader_name_groups(self) -> tuple[tuple[str, tuple[str, ...]], ...]:
+        """Return loader names grouped for display in the loader popup."""
+        builtin_names = set(BUILTIN_EXPLORER_LOADERS)
+        plugin_names = (
+            (set(erlab.io.loaders.keys()) - self._excluded_loaders)
+            | set(self._external_loaders)
+        ) - builtin_names
+
+        def sorted_names(names: set[str]) -> tuple[str, ...]:
+            return tuple(
+                sorted(
+                    names,
+                    key=lambda name: str(
+                        getattr(self._loader(name), "display_name", name)
+                    ).casefold(),
+                )
             )
+
+        return (
+            ("General files", sorted_names(builtin_names)),
+            ("Loader plugins", sorted_names(plugin_names)),
         )
 
     def _loader(self, name: str) -> typing.Any:
@@ -1028,11 +1117,11 @@ class _DataExplorer(QtWidgets.QMainWindow):
 
     def _set_loader_name(self, name: str) -> bool:
         """Select a loader by its stable name."""
-        try:
-            index = self._loader_names().index(name)
-        except ValueError:
+        model = typing.cast("_LoaderInfoModel", self._loader_combo.model())
+        row = model.row_for_loader_name(name)
+        if row is None:
             return False
-        self._loader_combo.setCurrentIndex(index)
+        self._loader_combo.setCurrentIndex(row)
         return True
 
     def refresh_loader_choices(self) -> None:
@@ -1043,9 +1132,10 @@ class _DataExplorer(QtWidgets.QMainWindow):
             model.refresh()
             loader_names = self._loader_names()
             if current in loader_names:
-                self._loader_combo.setCurrentIndex(loader_names.index(current))
+                row = model.row_for_loader_name(current)
             else:
-                self._loader_combo.setCurrentIndex(0)
+                row = model.first_loader_row()
+            self._loader_combo.setCurrentIndex(-1 if row is None else row)
         self._loader_changed()
         self._on_selection_changed()
         if self.loader_name != current:

--- a/src/erlab/interactive/explorer/_loaders.py
+++ b/src/erlab/interactive/explorer/_loaders.py
@@ -1,0 +1,59 @@
+"""Loader adapters used by Data Explorer."""
+
+from __future__ import annotations
+
+import typing
+
+import xarray as xr
+
+from erlab.interactive._file_loaders import (
+    BUILTIN_FILE_LOADER_SPECS,
+    BuiltinFileLoaderSpec,
+)
+
+if typing.TYPE_CHECKING:
+    import os
+
+
+class _BuiltinExplorerLoader:
+    """Adapt a direct callable loader to the Data Explorer loader contract."""
+
+    always_single = True
+
+    def __init__(self, spec: BuiltinFileLoaderSpec) -> None:
+        self.spec = spec
+        self.name = spec.id
+        self.display_name = spec.label
+        self.description = spec.description
+        self.extensions = set(spec.extensions)
+
+    def load(
+        self,
+        file_path: str | os.PathLike[str],
+        *,
+        single: bool = True,
+        load_kwargs: dict[str, typing.Any] | None = None,
+        **kwargs: typing.Any,
+    ) -> xr.DataArray:
+        """Load one DataArray for metadata display or graphical preview."""
+        del single
+        options = dict(self.spec.default_kwargs)
+        options.update(load_kwargs or {})
+        options.update(kwargs)
+        without_values = bool(options.pop("without_values", False))
+        load_func = xr.open_dataarray if without_values else self.spec.load_func
+        return load_func(file_path, **options)
+
+    def option_overrides(self, kwargs: dict[str, typing.Any]) -> dict[str, typing.Any]:
+        """Return user options without unchanged built-in defaults."""
+        return {
+            key: value
+            for key, value in kwargs.items()
+            if key not in self.spec.default_kwargs
+            or value != self.spec.default_kwargs[key]
+        }
+
+
+BUILTIN_EXPLORER_LOADERS = {
+    spec.id: _BuiltinExplorerLoader(spec) for spec in BUILTIN_FILE_LOADER_SPECS
+}

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -13,6 +13,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 import erlab.interactive.imagetool.manager._workspace._saving as workspace_saving
 import erlab.interactive.imagetool.slicer
+from erlab.interactive._file_loaders import builtin_file_loader_for_id
 from erlab.interactive.imagetool import _kspace_conversion
 from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool._provenance._model import (
@@ -1091,6 +1092,20 @@ class _ActionsController:
         """Load data from the given files using the specified loader."""
         if loader_name == "ask":
             self._manager._handle_dropped_files([pathlib.Path(p) for p in paths])
+            return
+
+        builtin_loader = builtin_file_loader_for_id(loader_name)
+        if builtin_loader is not None:
+            self._manager._data_ingress.add_from_multiple_files(
+                [],
+                [pathlib.Path(p) for p in paths],
+                [],
+                func=builtin_loader.load_func,
+                kwargs=dict(builtin_loader.default_kwargs) | kwargs,
+                retry_callback=lambda _: self._manager._data_load(
+                    paths, loader_name, kwargs
+                ),
+            )
             return
 
         extension_loader = self._manager._extensions.loader_by_name(loader_name)

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -14,6 +14,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 import erlab.interactive._options.core
 from erlab.interactive import _qt_state
+from erlab.interactive._file_loaders import builtin_file_loader_for_name_filter
 from erlab.interactive.imagetool.manager._dialogs import _NameFilterDialog
 
 if typing.TYPE_CHECKING:
@@ -354,7 +355,16 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         entry = self._available_file_loaders().get(name_filter)
         if entry is None:
             return None
-        return self._manager_loader_name_for_callable(entry[0])
+        return self._manager_loader_name_for_entry(name_filter, entry[0])
+
+    def _manager_loader_name_for_entry(
+        self, name_filter: str, func: Callable
+    ) -> str | None:
+        """Return the shared manager identity for one file-dialog entry."""
+        builtin = builtin_file_loader_for_name_filter(name_filter)
+        if builtin is not None:
+            return builtin.id
+        return self._manager_loader_name_for_callable(func)
 
     def _manager_loader_name_for_callable(self, func: Callable) -> str | None:
         """Return the shared manager identity for any supported loader call."""
@@ -544,7 +554,9 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
             loader_entry = valid_loaders.get(name_filter)
             if loader_entry is None:
                 continue
-            loader_name = self._manager_loader_name_for_callable(loader_entry[0])
+            loader_name = self._manager_loader_name_for_entry(
+                name_filter, loader_entry[0]
+            )
             if loader_name is not None:
                 shared_kwargs.setdefault(
                     loader_name,
@@ -554,7 +566,9 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
             loader_entry = valid_loaders.get(name_filter)
             if loader_entry is None:
                 continue
-            loader_name = self._manager_loader_name_for_callable(loader_entry[0])
+            loader_name = self._manager_loader_name_for_entry(
+                name_filter, loader_entry[0]
+            )
             if loader_name is not None:
                 shared_extensions.setdefault(loader_name, dict(extensions))
         return shared_kwargs, shared_extensions
@@ -581,7 +595,9 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         if recent_filter is not None:
             loader_entry = self._available_file_loaders().get(recent_filter)
             if loader_entry is not None:
-                loader_name = self._manager_loader_name_for_callable(loader_entry[0])
+                loader_name = self._manager_loader_name_for_entry(
+                    recent_filter, loader_entry[0]
+                )
                 if loader_name is not None and loader_name in shared_kwargs:
                     self._recent_loader_kwargs_by_filter[recent_filter] = (
                         dict(loader_entry[1]) | shared_kwargs[loader_name]
@@ -688,7 +704,9 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
                 getattr(selected_func, "uses_standard_loader_options", False)
             ):
                 initial_parameters = dict(defaults)
-                loader_name = self._manager_loader_name_for_callable(selected_func)
+                loader_name = self._manager_loader_name_for_entry(
+                    selected_filter, selected_func
+                )
                 if loader_name is not None and loader_name in shared_kwargs:
                     initial_parameters.update(shared_kwargs[loader_name])
                 else:
@@ -716,7 +734,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         dialog_extensions: dict[str, dict[str, typing.Any]] = {}
         for current_filter, (func, kwargs) in valid_loaders.items():
             dialog_kwargs = kwargs.copy()
-            loader_name = self._manager_loader_name_for_callable(func)
+            loader_name = self._manager_loader_name_for_entry(current_filter, func)
             if loader_name is not None and loader_name in shared_kwargs:
                 dialog_kwargs.update(shared_kwargs[loader_name])
             else:
@@ -759,7 +777,7 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
         self._recent_loader_extensions_by_filter[selected_filter] = (
             loader_extensions.copy() if isinstance(loader_extensions, dict) else {}
         )
-        loader_name = self._manager_loader_name_for_callable(func)
+        loader_name = self._manager_loader_name_for_entry(selected_filter, func)
         if loader_name is not None:
             self._set_shared_loader_options(
                 loader_name,

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -14,7 +14,10 @@ from qtpy import QtCore, QtGui, QtWidgets
 import erlab
 import erlab.interactive._options.core
 from erlab.interactive import _qt_state
-from erlab.interactive._file_loaders import builtin_file_loader_for_name_filter
+from erlab.interactive._file_loaders import (
+    builtin_file_loader_for_id,
+    builtin_file_loader_for_name_filter,
+)
 from erlab.interactive.imagetool.manager._dialogs import _NameFilterDialog
 
 if typing.TYPE_CHECKING:
@@ -657,6 +660,13 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
             return self._recent_name_filter
 
         default_loader = self.effective_interactive_options.io.default_loader
+        builtin_loader = builtin_file_loader_for_id(default_loader)
+        if builtin_loader is not None:
+            return (
+                builtin_loader.name_filter
+                if builtin_loader.name_filter in valid_loaders
+                else None
+            )
         if default_loader == "None" or default_loader not in erlab.io.loaders:
             return None
 

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -44,10 +44,7 @@ from qtpy import PYQT6, PYSIDE6, QtCore, QtGui, QtWidgets, uic
 
 import erlab
 from erlab.interactive import _qt_state
-from erlab.interactive._file_loaders import (
-    BuiltinFileLoaderSpec,
-    builtin_file_loader_for_id,
-)
+from erlab.interactive._file_loaders import BUILTIN_FILE_LOADER_SPECS
 from erlab.interactive._plot_state import TOOL_VIEW_STATE_ATTR, ToolPlotStateRegistry
 from erlab.interactive._widgets import _Separator
 from erlab.utils._code import (
@@ -1331,34 +1328,19 @@ def file_loaders(
     name to avoid conflicts. Duplicate filters from separate loader hierarchies raise a
     ValueError.
     """
-    hdf5_spec = typing.cast(
-        "BuiltinFileLoaderSpec",
-        builtin_file_loader_for_id("builtin:xarray-hdf5"),
-    )
-    netcdf_spec = typing.cast(
-        "BuiltinFileLoaderSpec",
-        builtin_file_loader_for_id("builtin:xarray-netcdf"),
-    )
-    ibw_spec = typing.cast(
-        "BuiltinFileLoaderSpec",
-        builtin_file_loader_for_id("builtin:igor-binary-wave"),
-    )
-    valid_loaders: dict[str, tuple[Callable, dict]] = {
-        hdf5_spec.name_filter: (hdf5_spec.load_func, dict(hdf5_spec.default_kwargs)),
-        "xarray HDF5 Files Chunked (*.h5)": (
-            xr.open_dataarray,
-            {"engine": "h5netcdf", "chunks": "auto"},
-        ),
-        netcdf_spec.name_filter: (
-            netcdf_spec.load_func,
-            dict(netcdf_spec.default_kwargs),
-        ),
-        ibw_spec.name_filter: (ibw_spec.load_func, dict(ibw_spec.default_kwargs)),
-        "Igor Packed Experiment Templates (*.pxt)": (
-            xr.load_dataarray,
-            {"engine": "erlab-igor"},
-        ),
-    }
+    valid_loaders: dict[str, tuple[Callable, dict]] = {}
+    for spec in BUILTIN_FILE_LOADER_SPECS:
+        if not spec.file_dialog:
+            continue
+        valid_loaders[spec.name_filter] = (
+            spec.load_func,
+            dict(spec.default_kwargs),
+        )
+        if spec.id == "builtin:xarray-hdf5":
+            valid_loaders["xarray HDF5 Files Chunked (*.h5)"] = (
+                xr.open_dataarray,
+                {"engine": "h5netcdf", "chunks": "auto"},
+            )
     if importlib.util.find_spec("zarr"):  # pragma: no branch
         valid_loaders["Zarr Store (*.zarr)"] = (
             xr.open_dataarray,

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -44,6 +44,10 @@ from qtpy import PYQT6, PYSIDE6, QtCore, QtGui, QtWidgets, uic
 
 import erlab
 from erlab.interactive import _qt_state
+from erlab.interactive._file_loaders import (
+    BuiltinFileLoaderSpec,
+    builtin_file_loader_for_id,
+)
 from erlab.interactive._plot_state import TOOL_VIEW_STATE_ATTR, ToolPlotStateRegistry
 from erlab.interactive._widgets import _Separator
 from erlab.utils._code import (
@@ -1327,14 +1331,29 @@ def file_loaders(
     name to avoid conflicts. Duplicate filters from separate loader hierarchies raise a
     ValueError.
     """
+    hdf5_spec = typing.cast(
+        "BuiltinFileLoaderSpec",
+        builtin_file_loader_for_id("builtin:xarray-hdf5"),
+    )
+    netcdf_spec = typing.cast(
+        "BuiltinFileLoaderSpec",
+        builtin_file_loader_for_id("builtin:xarray-netcdf"),
+    )
+    ibw_spec = typing.cast(
+        "BuiltinFileLoaderSpec",
+        builtin_file_loader_for_id("builtin:igor-binary-wave"),
+    )
     valid_loaders: dict[str, tuple[Callable, dict]] = {
-        "xarray HDF5 Files (*.h5)": (xr.load_dataarray, {"engine": "h5netcdf"}),
+        hdf5_spec.name_filter: (hdf5_spec.load_func, dict(hdf5_spec.default_kwargs)),
         "xarray HDF5 Files Chunked (*.h5)": (
             xr.open_dataarray,
             {"engine": "h5netcdf", "chunks": "auto"},
         ),
-        "NetCDF Files (*.nc *.nc4 *.cdf)": (xr.load_dataarray, {}),
-        "Igor Binary Waves (*.ibw)": (xr.load_dataarray, {"engine": "erlab-igor"}),
+        netcdf_spec.name_filter: (
+            netcdf_spec.load_func,
+            dict(netcdf_spec.default_kwargs),
+        ),
+        ibw_spec.name_filter: (ibw_spec.load_func, dict(ibw_spec.default_kwargs)),
         "Igor Packed Experiment Templates (*.pxt)": (
             xr.load_dataarray,
             {"engine": "erlab-igor"},

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -117,6 +117,76 @@ def test_manager_rejects_unavailable_named_loader(
         ]
 
 
+def test_manager_resolves_and_dispatches_builtin_file_loader(
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "source.h5"
+    calls: list[tuple[list[pathlib.Path], object, dict[str, object]]] = []
+
+    with manager_context() as manager:
+        assert (
+            manager._loader_name_for_name_filter("xarray HDF5 Files (*.h5)")
+            == "builtin:xarray-hdf5"
+        )
+        monkeypatch.setattr(
+            manager._data_ingress,
+            "add_from_multiple_files",
+            lambda _waiting, paths, _loaded, *, func, kwargs, retry_callback: (
+                calls.append((paths, func, kwargs))
+            ),
+        )
+
+        manager._data_load(
+            [str(path)],
+            "builtin:xarray-hdf5",
+            {"decode_times": False},
+        )
+
+    assert calls == [
+        ([path], xr.load_dataarray, {"engine": "h5netcdf", "decode_times": False})
+    ]
+
+
+def test_manager_builtin_file_loader_preserves_callable_provenance(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(
+        [[1.0, 2.0], [3.0, 4.0]],
+        dims=("x", "y"),
+        name="source",
+    )
+    path = tmp_path / "source.h5"
+    data.to_netcdf(path, engine="h5netcdf")
+
+    with manager_context() as manager:
+        manager._data_load([str(path)], "builtin:xarray-hdf5", {})
+        qtbot.wait_until(
+            lambda: manager.ntools == 1 and len(manager._file_handlers) == 0,
+            timeout=15000,
+        )
+
+        tool = manager.get_imagetool(0)
+        provenance = tool.provenance_spec
+        assert provenance is not None
+        assert provenance.file_load_source is not None
+        assert provenance.file_load_source.replay_call is not None
+        assert provenance.file_load_source.replay_call.target == "xarray.load_dataarray"
+        assert provenance.file_load_source.replay_call.kwargs == {"engine": "h5netcdf"}
+        code = provenance.display_code()
+        assert code is not None
+        namespace: dict[str, object] = {}
+        exec(code, namespace, namespace)  # noqa: S102
+        xr.testing.assert_identical(namespace["derived"], data)
+
+
 def test_manager_uses_registered_extension_loader(
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]

--- a/tests/interactive/imagetool/manager/test_extensions.py
+++ b/tests/interactive/imagetool/manager/test_extensions.py
@@ -1231,6 +1231,9 @@ def test_manager_extension_loader_dialog_uses_recent_values(monkeypatch) -> None
         _manager_loader_name_for_callable=(
             manager_base._builtin_loader_name_for_callable
         ),
+        _manager_loader_name_for_entry=lambda _name_filter, func: (
+            manager_base._builtin_loader_name_for_callable(func)
+        ),
         _shared_loader_state=lambda: ({}, {}),
         _set_shared_loader_options=lambda name, kwargs, extensions: (
             shared_updates.append((name, dict(kwargs), dict(extensions)))
@@ -1292,6 +1295,10 @@ def test_direct_extension_loader_uses_shared_loader_state(
     )
     manager._manager_loader_name_for_callable = types.MethodType(
         manager_base._ImageToolManagerBase._manager_loader_name_for_callable,
+        manager,
+    )
+    manager._manager_loader_name_for_entry = types.MethodType(
+        manager_base._ImageToolManagerBase._manager_loader_name_for_entry,
         manager,
     )
 

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -3573,6 +3573,9 @@ def test_select_loader_options_cancel_keeps_recent_filter(
         _manager_loader_name_for_callable=(
             manager_base._builtin_loader_name_for_callable
         ),
+        _manager_loader_name_for_entry=lambda _name_filter, func: (
+            manager_base._builtin_loader_name_for_callable(func)
+        ),
         _shared_loader_state=lambda: ({}, {}),
     )
 
@@ -3762,6 +3765,11 @@ def test_open_multiple_files_preselects_default_loader_filter(
         _available_file_loaders=lambda _paths=None: valid_loaders,
         _manager_loader_name_for_callable=(
             manager_base._builtin_loader_name_for_callable
+        ),
+        _manager_loader_name_for_entry=lambda name_filter, func: (
+            "builtin:xarray-hdf5"
+            if name_filter == "xarray HDF5 Files (*.h5)"
+            else manager_base._builtin_loader_name_for_callable(func)
         ),
         _shared_loader_state=lambda: ({}, {}),
         effective_interactive_options=erlab.interactive.options.model,

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -3613,6 +3613,8 @@ def _manager_for_loader_preference(recent_filter: str | None = None):
         ("example", "xarray HDF5 Files (*.h5)", "xarray HDF5 Files (*.h5)"),
         ("example", None, "Example Raw Data (*.h5)"),
         ("example", "Missing (*.missing)", "Example Raw Data (*.h5)"),
+        ("builtin:xarray-hdf5", None, "xarray HDF5 Files (*.h5)"),
+        ("builtin:xarray-netcdf", None, None),
         ("None", None, None),
     ],
 )

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -2,6 +2,7 @@ import pathlib
 import typing
 from collections.abc import Callable
 
+import pytest
 import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -15,6 +16,7 @@ from erlab.interactive.explorer._base_explorer import (
     _FileSystem,
     _ReprFetcher,
 )
+from erlab.interactive.explorer._loaders import BUILTIN_EXPLORER_LOADERS
 from erlab.interactive.explorer._tabbed_explorer import (
     DataExplorerState,
     _TabbedExplorer,
@@ -435,6 +437,25 @@ def test_explorer_general(
         explorer.close()
 
 
+def test_manager_recent_builtin_filter_selects_explorer_loader(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager._recent_directory = str(tmp_path)
+        manager._recent_name_filter = "xarray HDF5 Files (*.h5)"
+
+        explorer = manager._create_explorer_window()
+        qtbot.addWidget(explorer)
+
+        assert isinstance(explorer, _TabbedExplorer)
+        assert explorer.current_explorer is not None
+        assert explorer.current_explorer.loader_name == "builtin:xarray-hdf5"
+
+
 def test_explorer_loader_extensions_apply_only_to_manager_loads(
     qtbot,
     monkeypatch,
@@ -501,6 +522,35 @@ def test_explorer_loader_extensions_apply_only_to_manager_loads(
             },
         }
     ]
+
+
+def test_explorer_builtin_loader_sends_stable_id_to_manager(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    loader_name = "builtin:xarray-hdf5"
+    file_path = tmp_path / "data.h5"
+    explorer = _DataExplorer(root_path=tmp_path, loader_name=loader_name)
+    qtbot.addWidget(explorer)
+    explorer._loader_kwargs_by_name[loader_name] = {"decode_times": False}
+    load_calls: list[tuple[list[pathlib.Path], str | None, dict[str, object]]] = []
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager,
+        "is_running",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        erlab.interactive.imagetool.manager,
+        "load_in_manager",
+        lambda files, loader_name=None, **kwargs: load_calls.append(
+            (list(files), loader_name, kwargs)
+        ),
+    )
+
+    explorer.to_manager(files=[file_path])
+
+    assert load_calls == [([file_path], loader_name, {"decode_times": False})]
 
 
 def test_explorer_loader_refresh_keeps_selection_atomic(
@@ -581,6 +631,87 @@ def test_repr_fetcher_keeps_coordinate_values_without_preview(
     assert "0 : 0.5 : 1.5" in text
     assert "float64 [3]" not in text
     assert "float64 [4]" not in text
+
+
+def test_builtin_explorer_loader_uses_open_dataarray_without_preview(
+    monkeypatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    data = xr.DataArray(
+        [[1.0, 2.0], [3.0, 4.0]],
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [2.0, 3.0]},
+    )
+    closed: list[None] = []
+    data.set_close(lambda: closed.append(None))
+    calls: list[tuple[object, dict[str, object]]] = []
+
+    def _open_dataarray(path, **kwargs):
+        calls.append((path, kwargs))
+        return data
+
+    monkeypatch.setattr(xr, "open_dataarray", _open_dataarray)
+    fetched: list[object] = []
+    loader = BUILTIN_EXPLORER_LOADERS["builtin:xarray-hdf5"]
+    worker = _ReprFetcher(tmp_path / "data.h5", loader.load, include_values=False)
+    worker.signals.fetched.connect(
+        lambda _path, _text, preview_data: fetched.append(preview_data)
+    )
+
+    worker.run()
+
+    assert calls == [(str(tmp_path / "data.h5"), {"engine": "h5netcdf"})]
+    assert fetched == [None]
+    assert closed == [None]
+
+
+@pytest.mark.parametrize(
+    ("loader_name", "suffix"),
+    [
+        ("builtin:xarray-hdf5", ".h5"),
+        ("builtin:xarray-netcdf", ".nc"),
+        ("builtin:igor-binary-wave", ".ibw"),
+    ],
+)
+def test_explorer_builtin_dataarray_preview(
+    qtbot,
+    tmp_path: pathlib.Path,
+    loader_name: str,
+    suffix: str,
+) -> None:
+    data = xr.DataArray(
+        [[1.0, 2.0], [3.0, 4.0]],
+        dims=("x", "y"),
+        coords={"x": [0.0, 1.0], "y": [2.0, 3.0]},
+        name="preview",
+    )
+    path = tmp_path / f"preview{suffix}"
+    if suffix == ".ibw":
+        erlab.io.igor.save_wave(data, path)
+    else:
+        data.to_netcdf(path, engine="h5netcdf")
+
+    loader = BUILTIN_EXPLORER_LOADERS[loader_name]
+    expected = loader.spec.load_func(path, **loader.spec.default_kwargs)
+    explorer = _DataExplorer(root_path=tmp_path, loader_name=loader_name)
+    qtbot.addWidget(explorer)
+    assert explorer.loader_name == loader_name
+    loader_row = explorer._loader_names().index(loader_name)
+    loader_index = explorer._loader_combo.model().index(loader_row, 0)
+    assert loader_index.data() == loader.display_name
+    assert loader_index.data(QtCore.Qt.ItemDataRole.UserRole) == loader_name
+
+    explorer._preview_check.setChecked(True)
+    index = explorer._model_index_for_path(path)
+    explorer._tree_view.selectionModel().select(
+        index,
+        QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect
+        | QtCore.QItemSelectionModel.SelectionFlag.Rows,
+    )
+
+    qtbot.wait_until(lambda: explorer._preview._data is not None)
+    xr.testing.assert_allclose(explorer._preview._data, expected)
+    assert explorer.workspace_state_payload()["loader_name"] == loader_name
 
 
 def test_repr_fetcher_aborted_before_run_skips_loader(
@@ -952,6 +1083,29 @@ def test_explorer_extension_loader_matches_uppercase_compound_suffix(
 
     assert matching_index.isValid()
     assert unsupported_index.isValid()
+    assert explorer._fs_model.flags(matching_index) & QtCore.Qt.ItemFlag.ItemIsEnabled
+    assert not (
+        explorer._fs_model.flags(unsupported_index) & QtCore.Qt.ItemFlag.ItemIsEnabled
+    )
+
+
+def test_explorer_builtin_loader_filters_files_by_extension(
+    qtbot,
+    tmp_path: pathlib.Path,
+) -> None:
+    matching_path = tmp_path / "values.H5"
+    unsupported_path = tmp_path / "values.txt"
+    matching_path.touch()
+    unsupported_path.touch()
+    explorer = _DataExplorer(
+        root_path=tmp_path,
+        loader_name="builtin:xarray-hdf5",
+    )
+    qtbot.addWidget(explorer)
+
+    matching_index = explorer._model_index_for_path(matching_path)
+    unsupported_index = explorer._model_index_for_path(unsupported_path)
+
     assert explorer._fs_model.flags(matching_index) & QtCore.Qt.ItemFlag.ItemIsEnabled
     assert not (
         explorer._fs_model.flags(unsupported_index) & QtCore.Qt.ItemFlag.ItemIsEnabled
@@ -1357,6 +1511,52 @@ def test_explorer_loader_options_dialog_updates_kwargs(
     }
 
 
+def test_explorer_builtin_loader_options_store_only_overrides(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    loader_name = "builtin:xarray-hdf5"
+    loader = BUILTIN_EXPLORER_LOADERS[loader_name]
+    explorer = _DataExplorer(root_path=tmp_path, loader_name=loader_name)
+    qtbot.addWidget(explorer)
+    explorer._loader_kwargs_by_name[loader_name] = {"decode_times": True}
+
+    class _FakeNameFilterDialog:
+        def __init__(
+            self, parent, valid_loaders, *, loader_extensions=None, sample_paths=None
+        ) -> None:
+            assert parent is explorer
+            assert valid_loaders == {
+                loader.spec.name_filter: (
+                    xr.load_dataarray,
+                    {"engine": "h5netcdf", "decode_times": True},
+                )
+            }
+            assert loader_extensions is None
+            assert list(sample_paths or ()) == []
+
+        def check_filter(self, name_filter: str | None) -> None:
+            assert name_filter == loader.spec.name_filter
+
+        def exec(self) -> bool:
+            return True
+
+        def checked_filter(self):
+            return (
+                loader.spec.name_filter,
+                xr.load_dataarray,
+                {"engine": "h5netcdf", "decode_times": False},
+            )
+
+    monkeypatch.setattr(_dialogs, "_NameFilterDialog", _FakeNameFilterDialog)
+
+    explorer._open_loader_options()
+
+    assert explorer.loader_kwargs_by_name()[loader_name] == {"decode_times": False}
+    assert explorer.loader_extensions_by_name()[loader_name] == {}
+
+
 def test_explorer_extension_loader_options_dialog_uses_saved_values(
     qtbot,
     monkeypatch,
@@ -1386,7 +1586,7 @@ def test_explorer_extension_loader_options_dialog_uses_saved_values(
         (),
         {"descriptor": descriptor, "uses_standard_loader_options": False},
     )()
-    monkeypatch.setattr(explorer, "_loader", lambda _name: loader)
+    explorer._external_loaders["example"] = loader
 
     exec_results = [False, True]
 

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -1521,6 +1521,14 @@ def test_explorer_builtin_loader_options_store_only_overrides(
     explorer = _DataExplorer(root_path=tmp_path, loader_name=loader_name)
     qtbot.addWidget(explorer)
     explorer._loader_kwargs_by_name[loader_name] = {"decode_times": True}
+    explorer._loader_extensions_by_name[loader_name] = {"stale": {}}
+    exec_results = [False, True]
+    loader_state_changes: list[tuple[object, object]] = []
+    workspace_state_changes: list[None] = []
+    explorer.sigLoaderStateChanged.connect(
+        lambda kwargs, extensions: loader_state_changes.append((kwargs, extensions))
+    )
+    explorer.sigStateChanged.connect(lambda: workspace_state_changes.append(None))
 
     class _FakeNameFilterDialog:
         def __init__(
@@ -1540,7 +1548,7 @@ def test_explorer_builtin_loader_options_store_only_overrides(
             assert name_filter == loader.spec.name_filter
 
         def exec(self) -> bool:
-            return True
+            return exec_results.pop(0)
 
         def checked_filter(self):
             return (
@@ -1553,8 +1561,17 @@ def test_explorer_builtin_loader_options_store_only_overrides(
 
     explorer._open_loader_options()
 
+    assert explorer.loader_kwargs_by_name()[loader_name] == {"decode_times": True}
+    assert explorer.loader_extensions_by_name()[loader_name] == {"stale": {}}
+    assert loader_state_changes == []
+    assert workspace_state_changes == []
+
+    explorer._open_loader_options()
+
     assert explorer.loader_kwargs_by_name()[loader_name] == {"decode_times": False}
     assert explorer.loader_extensions_by_name()[loader_name] == {}
+    assert len(loader_state_changes) == 1
+    assert len(workspace_state_changes) == 1
 
 
 def test_explorer_extension_loader_options_dialog_uses_saved_values(

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -1,5 +1,7 @@
 import pathlib
+import shutil
 import typing
+import warnings
 from collections.abc import Callable
 
 import pytest
@@ -437,23 +439,35 @@ def test_explorer_general(
         explorer.close()
 
 
+@pytest.mark.parametrize(
+    ("recent_filter", "loader_name"),
+    [
+        ("xarray HDF5 Files (*.h5)", "builtin:xarray-hdf5"),
+        (
+            "Igor Packed Experiment Templates (*.pxt)",
+            "builtin:igor-packed-experiment",
+        ),
+    ],
+)
 def test_manager_recent_builtin_filter_selects_explorer_loader(
     qtbot,
     tmp_path: pathlib.Path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
+    recent_filter: str,
+    loader_name: str,
 ) -> None:
     with manager_context() as manager:
         manager._recent_directory = str(tmp_path)
-        manager._recent_name_filter = "xarray HDF5 Files (*.h5)"
+        manager._recent_name_filter = recent_filter
 
         explorer = manager._create_explorer_window()
         qtbot.addWidget(explorer)
 
         assert isinstance(explorer, _TabbedExplorer)
         assert explorer.current_explorer is not None
-        assert explorer.current_explorer.loader_name == "builtin:xarray-hdf5"
+        assert explorer.current_explorer.loader_name == loader_name
 
 
 def test_explorer_loader_extensions_apply_only_to_manager_loads(
@@ -670,6 +684,7 @@ def test_builtin_explorer_loader_uses_open_dataarray_without_preview(
     [
         ("builtin:xarray-hdf5", ".h5"),
         ("builtin:xarray-netcdf", ".nc"),
+        ("builtin:xarray-zarr", ".zarr"),
         ("builtin:igor-binary-wave", ".ibw"),
     ],
 )
@@ -688,6 +703,14 @@ def test_explorer_builtin_dataarray_preview(
     path = tmp_path / f"preview{suffix}"
     if suffix == ".ibw":
         erlab.io.igor.save_wave(data, path)
+    elif suffix == ".zarr":
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Consolidated metadata is currently not part.*",
+                category=UserWarning,
+            )
+            data.to_zarr(path)
     else:
         data.to_netcdf(path, engine="h5netcdf")
 
@@ -696,10 +719,13 @@ def test_explorer_builtin_dataarray_preview(
     explorer = _DataExplorer(root_path=tmp_path, loader_name=loader_name)
     qtbot.addWidget(explorer)
     assert explorer.loader_name == loader_name
-    loader_row = explorer._loader_names().index(loader_name)
-    loader_index = explorer._loader_combo.model().index(loader_row, 0)
+    loader_model = explorer._loader_combo.model()
+    loader_row = loader_model.row_for_loader_name(loader_name)
+    assert loader_row is not None
+    loader_index = loader_model.index(loader_row, 0)
     assert loader_index.data() == loader.display_name
     assert loader_index.data(QtCore.Qt.ItemDataRole.UserRole) == loader_name
+    assert loader_model.index(loader_row, 1).data() == loader.description
 
     explorer._preview_check.setChecked(True)
     index = explorer._model_index_for_path(path)
@@ -712,6 +738,56 @@ def test_explorer_builtin_dataarray_preview(
     qtbot.wait_until(lambda: explorer._preview._data is not None)
     xr.testing.assert_allclose(explorer._preview._data, expected)
     assert explorer.workspace_state_payload()["loader_name"] == loader_name
+
+
+def test_explorer_builtin_pxt_preview(qtbot, tmp_path: pathlib.Path) -> None:
+    source_path = pathlib.Path(__file__).parents[1] / "io/test_igor/exp0.pxt"
+    path = tmp_path / "preview.pxt"
+    shutil.copyfile(source_path, path)
+    loader_name = "builtin:igor-packed-experiment"
+    expected = xr.load_dataarray(path, engine="erlab-igor")
+    explorer = _DataExplorer(root_path=tmp_path, loader_name=loader_name)
+    qtbot.addWidget(explorer)
+
+    explorer._preview_check.setChecked(True)
+    index = explorer._model_index_for_path(path)
+    explorer._tree_view.selectionModel().select(
+        index,
+        QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect
+        | QtCore.QItemSelectionModel.SelectionFlag.Rows,
+    )
+
+    qtbot.wait_until(lambda: explorer._preview._data is not None)
+    xr.testing.assert_allclose(explorer._preview._data, expected)
+
+
+def test_explorer_loader_popup_groups_general_files_before_plugins(
+    qtbot,
+    tmp_path: pathlib.Path,
+) -> None:
+    explorer = _DataExplorer(root_path=tmp_path)
+    qtbot.addWidget(explorer)
+    model = explorer._loader_combo.model()
+    view = explorer._loader_combo.view()
+    group_rows = model.group_rows()
+
+    assert len(group_rows) == 2
+    assert group_rows[0] == 0
+    assert all(
+        model.flags(model.index(row, 0)) == QtCore.Qt.ItemFlag.NoItemFlags
+        for row in group_rows
+    )
+    assert (
+        model.data(model.index(group_rows[0], 0), QtCore.Qt.ItemDataRole.UserRole)
+        is None
+    )
+    assert all(view.columnSpan(row, 0) == model.columnCount() for row in group_rows)
+    general_file_rows = [
+        model.row_for_loader_name(loader_name)
+        for loader_name in BUILTIN_EXPLORER_LOADERS
+    ]
+    assert all(row is not None and row < group_rows[1] for row in general_file_rows)
+    assert explorer.loader_name in BUILTIN_EXPLORER_LOADERS
 
 
 def test_repr_fetcher_aborted_before_run_skips_loader(

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -7,6 +7,7 @@ import pytest
 from qtpy import QtCore, QtWidgets
 
 import erlab.interactive._options.ui as options_ui
+from erlab.interactive._file_loaders import BUILTIN_FILE_LOADER_SPECS
 from erlab.interactive._options import OptionDialog, options
 from erlab.interactive._options.core import (
     OptionManager,
@@ -369,6 +370,18 @@ def test_user_edit_saves_immediately(dialog: OptionDialog):
 
     assert options.model.colors.cmap.name == "bwr"
     assert dialog.modified
+
+
+def test_default_loader_control_includes_builtin_loader_ids(
+    dialog: OptionDialog,
+) -> None:
+    combo = typing.cast(
+        "QtWidgets.QComboBox",
+        _control(dialog, "user", "io/default_loader", QtWidgets.QComboBox),
+    )
+
+    for spec in BUILTIN_FILE_LOADER_SPECS:
+        assert combo.findData(spec.id) >= 0
 
 
 def test_session_revert_restores_user_baseline(dialog: OptionDialog):
@@ -1185,6 +1198,16 @@ def test_options_get_set():
 def test_recent_workspace_limit_validates_bounds(value: int) -> None:
     with pytest.raises(pydantic.ValidationError):
         IOOptions(recent_workspace_limit=value)
+
+
+@pytest.mark.parametrize("loader", BUILTIN_FILE_LOADER_SPECS)
+def test_default_loader_accepts_builtin_loader(loader) -> None:
+    assert IOOptions(default_loader=loader.id).default_loader == loader.id
+
+
+def test_default_loader_rejects_unknown_loader() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        IOOptions(default_loader="missing")
 
 
 @pytest.mark.parametrize(

--- a/tests/interactive/test_options_tree.py
+++ b/tests/interactive/test_options_tree.py
@@ -1,6 +1,7 @@
 import math
 import types
 
+from erlab.interactive._file_loaders import BUILTIN_FILE_LOADER_SPECS
 from erlab.interactive._options.schema import AppOptions
 from erlab.interactive._options.tree import (
     _build_leaf_param,
@@ -101,6 +102,17 @@ def test_make_parameter_round_trips_default_directory() -> None:
     directory_param.setValue("~/other-data")
 
     assert parameter_to_options(param).io.default_directory == "~/other-data"
+
+
+def test_make_parameter_round_trips_builtin_default_loader() -> None:
+    loader_id = BUILTIN_FILE_LOADER_SPECS[0].id
+    options = AppOptions.model_validate({"io": {"default_loader": loader_id}})
+    param = make_parameter(options)
+
+    loader_param = param.child("io").child("default_loader")
+    assert loader_id in loader_param.opts["limits"].values()
+    assert loader_param.value() == loader_id
+    assert parameter_to_options(param).io.default_loader == loader_id
 
 
 def test_make_parameter_workspace_compression_uses_display_labels() -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -173,7 +173,9 @@ def test_builtin_file_loader_specs_match_file_dialog_entries() -> None:
     assert {spec.id for spec in specs} == {
         "builtin:xarray-hdf5",
         "builtin:xarray-netcdf",
+        "builtin:xarray-zarr",
         "builtin:igor-binary-wave",
+        "builtin:igor-packed-experiment",
     }
     assert len({spec.name_filter for spec in specs}) == len(specs)
 
@@ -181,6 +183,9 @@ def test_builtin_file_loader_specs_match_file_dialog_entries() -> None:
     for spec in specs:
         assert builtin_file_loader_for_id(spec.id) is spec
         assert builtin_file_loader_for_name_filter(spec.name_filter) is spec
+        if not spec.file_dialog:
+            assert spec.name_filter not in valid_loaders
+            continue
         func, kwargs = valid_loaders[spec.name_filter]
         assert func is spec.load_func
         assert kwargs == dict(spec.default_kwargs)

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -21,6 +21,11 @@ from qtpy import PYQT6, QtCore, QtGui, QtTest, QtWidgets
 import erlab.interactive._plot_state
 import erlab.interactive.colors
 import erlab.interactive.utils
+from erlab.interactive._file_loaders import (
+    BUILTIN_FILE_LOADER_SPECS,
+    builtin_file_loader_for_id,
+    builtin_file_loader_for_name_filter,
+)
 from erlab.interactive.imagetool import ImageTool
 from erlab.interactive.imagetool._provenance._model import (
     ToolProvenanceSpec,
@@ -160,6 +165,25 @@ def test_file_loaders_match_mixed_extensions() -> None:
 
     assert da30_filter in valid_loaders
     assert (xr.load_dataarray, {"engine": "erlab-igor"}) not in valid_loaders.values()
+
+
+def test_builtin_file_loader_specs_match_file_dialog_entries() -> None:
+    specs = BUILTIN_FILE_LOADER_SPECS
+
+    assert {spec.id for spec in specs} == {
+        "builtin:xarray-hdf5",
+        "builtin:xarray-netcdf",
+        "builtin:igor-binary-wave",
+    }
+    assert len({spec.name_filter for spec in specs}) == len(specs)
+
+    valid_loaders = erlab.interactive.utils.file_loaders()
+    for spec in specs:
+        assert builtin_file_loader_for_id(spec.id) is spec
+        assert builtin_file_loader_for_name_filter(spec.name_filter) is spec
+        func, kwargs = valid_loaders[spec.name_filter]
+        assert func is spec.load_func
+        assert kwargs == dict(spec.default_kwargs)
 
 
 class _PersistentToolState(pydantic.BaseModel):


### PR DESCRIPTION
## Summary

- Add built-in Data Explorer choices for HDF5, NetCDF, Zarr, IBW, and PXT data.
- Group general files before loader plugins in the loader popup.
- Use short format names and keep concise descriptions visible.
- Keep visible labels separate from stable loader IDs and save the IDs in workspace state.
- Share loader defaults with manager dialogs and preserve direct `xarray.load_dataarray` provenance.
- Use metadata-only opens for file information and close open data objects after formatting.

## Validation

- `uv run ruff check .`
- `uv run mypy src`
- `uv run python -m scripts.ci_test_groups --check-partition`
- Focused explorer, manager, and utility tests with PyQt6 on Python 3.13 and Python 3.14: 273 passed per run.
- Focused explorer, manager, and utility tests with PySide6 on Python 3.13 and Python 3.14: 273 passed per run.
- Current Data Explorer module with PySide6: 51 passed.
- Current general-file and grouping tests with PyQt6: 7 passed.
- The full test suite was not run.