### PR TITLE
feat(interactive): protect executable workspace content

### DIFF
--- a/docs/source/user-guide/interactive/manager.md
+++ b/docs/source/user-guide/interactive/manager.md
@@ -398,6 +398,94 @@ their variable-name badges. The rows stay disconnected until a notebook defines 
 matching variables and reconnects them, as described in
 {ref}`imagetool-manager-reconnect-watches`.
 
+(imagetool-manager-code-trust)=
+
+### Code trust
+
+A `.itws` file stores more than arrays and window positions. It can also preserve
+arbitrary user code that makes a figure or reproduces an analysis step. Treat a shared
+workspace in the same way as a notebook that you received from another person.
+
+Code from a workspace can run at four boundaries:
+
+1. **Script provenance.** The manager can record Python entered in its console. This
+   code is executed upon replaying the recorded result, for example when you select
+   {guilabel}`Reload Data`.
+2. **Figure Composer Python.** A figure recipe can contain a {guilabel}`Python` step or
+   a custom `transform` expression. ERLab runs these items every time it renders the
+   figure.
+3. **Saved lmfit model or result code.** A serialized lmfit model or result can contain
+   executable model content. This includes an {class}`lmfit.models.ExpressionModel`
+   expression or initialization script, and a serialized callable fallback. This content
+   can run while ERLab restores {ref}`ftool <guide-ftool>`, when lmfit evaluates a
+   model, or when provenance replays a recorded edge correction that embeds a fit
+   result.
+4. **lmfit parameter expressions.** A fitting tool or recorded fitting operation can
+   store expressions that constrain parameters. lmfit evaluates these expressions
+   during restoration, replay, parameter updates, and fitting.
+
+These are the only places where an `.itws` file can run unrestricted stored Python or
+deserialize stored callable content.
+
+Registered extension routines and loaders use a separate approval check. A workspace
+can identify an extension by its script name, source digest, and capability ID. It
+cannot execute the recovery copy stored in the workspace. The manager runs the
+operation only when the same script is installed, enabled, approved separately, and
+unchanged. See {ref}`imagetool-manager-extensions`.
+
+When ERLab cannot verify a workspace, it pauses execution at these four boundaries.
+This lets you inspect the safe parts of the workspace without first granting stored code
+access to your computer.
+
+Code that you add or change with an ERLab code editor is local work. ERLab does not ask
+you to approve that new code. Code from the opened workspace that you did not change
+must still pass the workspace trust check.
+
+A Figure Composer preview can be incomplete while code is paused. ERLab also prevents
+export of that incomplete figure.
+
+Stored script provenance runs only through ImageTool Manager. A standalone ImageTool
+does not run script provenance restored from a file. Open the original workspace in
+ImageTool Manager when you need to review and replay that code.
+
+To approve the workspace:
+
+1. Confirm that the file came from a source that you trust.
+2. Select {guilabel}`Review and Trust…` in the warning banner. You can also open
+   {menuselection}`File --> Workspace Properties` and select the same action there.
+3. Review the source text and execution context shown in the dialog. The headings
+   identify the figure, provenance, or fitting item that owns each block. When an lmfit
+   payload cannot show the original source for a serialized callable, the dialog
+   identifies the payload and shows a digest of its executable fragments.
+4. Select {guilabel}`Trust Workspace and Run Code` only when you are prepared to run
+   all listed content.
+
+If a provenance replay was blocked, run that action again after approval. If you are not
+ready to approve the code, close the dialog. The safe parts of the workspace remain
+available.
+
+Approval applies immediately to the open workspace. ERLab stores durable approval only
+after it saves a workspace with trusted local lineage. The local signature covers the
+executable code and the controls that change its execution. It does not cover array
+values, previews, window names, or the workspace ID. An unchanged workspace then opens
+without another review. A failed save or a save from untrusted lineage does not create a
+signature.
+
+A workspace created before this feature normally needs one review after upgrade. Save
+the approved workspace once to make later unchanged opens automatic. Use
+{guilabel}`Reset Saved Trust…` in {guilabel}`Settings` → {guilabel}`Security` when you
+want all signed workspaces to require review again.
+
+#### Using a trusted workspace folder
+
+For a folder that only you or your laboratory controls, you can choose to trust every
+`.itws` file in that folder and its subfolders. This is useful for an analysis directory
+that repeatedly produces new workspaces.
+
+Configure these folders in {guilabel}`Settings` → {guilabel}`Security`. See
+{ref}`options-trusted-workspace-folders` for the procedure and permission guidance. A
+trusted folder deliberately skips the code review and local-signature check.
+
 (imagetool-manager-nested-results)=
 
 ## Nested windows
@@ -479,7 +567,8 @@ If those recorded files moved, edit the file load row in the operation history a
 {guilabel}`Also relink selected file loads` to update the moved inputs together.
 
 For results from console scripts, {guilabel}`Reload Data` replays the recorded code in
-the console if possible. Only reload derived results from workspaces you trust.
+the console if possible. Execution is paused until you approve code from an unverified
+workspace. See {ref}`imagetool-manager-code-trust`.
 
 (imagetool-manager-replay-code)=
 
@@ -573,9 +662,11 @@ many of the same operations and keep track of the manager history. For example:
   # xarray module calls also keep manager inputs when they receive tool handles
   xr.concat([tools[0], tools[1]], dim="scan")
 
+
   # Simple helper functions defined in the console can receive tool handles directly
   def normalize(data):
       return data / data.max()
+
 
   normalize(tools[0])
 
@@ -771,7 +862,11 @@ If you are using VS Code (or other editor that supports VS Code extensions), the
 If you wish to integrate the manager into custom workflows, you can programmatically load data and control ImageTool windows in the manager. Use the public functions exported from {mod}`erlab.interactive.imagetool.manager`:
 
 ```python
-from erlab.interactive.imagetool.manager import load_in_manager, replace_data, show_in_manager
+from erlab.interactive.imagetool.manager import (
+    load_in_manager,
+    replace_data,
+    show_in_manager,
+)
 
 # Open raw files and let the manager choose the loader interactively
 load_in_manager(["scan1.pxt", "scan2.pxt"])

--- a/docs/source/user-guide/interactive/options.md
+++ b/docs/source/user-guide/interactive/options.md
@@ -26,6 +26,8 @@ Use the sidebar to switch between setting groups:
 - {guilabel}`ktool` controls defaults for newly opened momentum-conversion tools.
 - {guilabel}`Figure Composer` controls default Matplotlib stylesheets, figure DPI, and
   export settings.
+- {guilabel}`Security` controls which workspace locations can run stored executable
+  content without review.
 
 Rows in the {guilabel}`User` scope include a reset action that restores the application
 default for that setting. Broadly resetting all user settings still asks for
@@ -34,3 +36,18 @@ confirmation.
 When Settings is opened from ImageTool Manager, a {guilabel}`Workspace` scope is also
 available. Workspace settings are local overrides saved inside the manager's `.itws`
 workspace file. Turn on the checkbox to store a value.
+
+(options-trusted-workspace-folders)=
+
+## Trusting a workspace folder
+
+A trusted workspace folder is an explicit choice to let every `.itws` file below that
+folder execute code stored in the file. Choose a dedicated analysis folder that only
+you and trusted collaborators can modify. Do not trust a download folder, a temporary
+folder, or a shared folder that untrusted users or processes can write to.
+
+To add a folder:
+
+1. Open the {guilabel}`Security` page in the {guilabel}`User` scope.
+2. Select {guilabel}`Add Folder…` beside {guilabel}`Trusted workspace folders`.
+3. Select the analysis folder that you control.

--- a/docs/source/user-guide/interactive/tool-authoring.md
+++ b/docs/source/user-guide/interactive/tool-authoring.md
@@ -256,6 +256,26 @@ That is the minimum `ToolWindow` surface to keep in your head:
 
 Everything below is optional integration that you add when the tool needs it.
 
+### Make an installed tool available during workspace restore
+
+A workspace records the class that created each saved tool. ERLab does not import the
+recorded module name directly because the workspace can come from an untrusted source.
+Instead, a fresh manager process accepts built-in classes and classes declared by
+locally installed packages.
+
+Add this entry point to the package that provides your tool:
+
+```toml
+[project.entry-points."erlab.interactive.tool_windows"]
+my-tool = "my_package.tools:MyTool"
+```
+
+The entry-point value must match the module and qualified class name stored by
+`ToolWindow`. ERLab reads installed entry-point metadata first. It imports the package
+only when a workspace requests that exact registered class. A class defined in a
+notebook or an ordinary script remains available after its module is imported in the
+current process, but a fresh manager cannot discover it automatically.
+
 ### Full example: a tool that works well inside the manager
 
 The next example uses the same core `ToolWindow` interface, but it also implements the
@@ -326,9 +346,7 @@ class MyTool(erlab.interactive.utils.ToolWindow):
         # This example shows two image layers: the filtered output and the reference.
         self.plot = pg.PlotWidget()
         self.filtered_image = erlab.interactive.utils.xImageItem(axisOrder="row-major")
-        self.reference_image = erlab.interactive.utils.xImageItem(
-            axisOrder="row-major"
-        )
+        self.reference_image = erlab.interactive.utils.xImageItem(axisOrder="row-major")
         self.window_spin = QtWidgets.QSpinBox()
         self.reference_check = QtWidgets.QCheckBox("Show reference")
         self.copy_btn = QtWidgets.QPushButton("Copy Code")
@@ -437,13 +455,9 @@ class MyTool(erlab.interactive.utils.ToolWindow):
         del data
         input_expr = input_name or "data"
         window = self._filter_window()
-        rolling_kwargs = ", ".join(
-            f"{dim}={window}" for dim in self.tool_data.dims
-        )
+        rolling_kwargs = ", ".join(f"{dim}={window}" for dim in self.tool_data.dims)
         return (
-            f"{input_expr}.rolling("
-            f"{rolling_kwargs}, center=True, min_periods=1"
-            ").mean()"
+            f"{input_expr}.rolling({rolling_kwargs}, center=True, min_periods=1).mean()"
         )
 
     @QtCore.Slot()

--- a/scripts/_ci_test_groups.py
+++ b/scripts/_ci_test_groups.py
@@ -129,6 +129,7 @@ COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
         "tests/interactive/imagetool/manager/workspace/test_pending_preview.py",
         "tests/interactive/imagetool/manager/workspace/test_storage.py",
         "tests/interactive/imagetool/manager/workspace/test_store.py",
+        "tests/interactive/imagetool/manager/workspace/test_trust.py",
     ),
     "cov-qt-manager-provenance-console": (
         "tests/interactive/imagetool/manager/provenance",
@@ -152,6 +153,7 @@ COVERAGE_GROUPS: dict[str, tuple[str, ...]] = {
         "tests/interactive/test_mesh.py",
     ),
     "cov-qt-ux": (
+        "tests/interactive/test_code_trust.py",
         "tests/interactive/test_colors.py",
         "tests/interactive/test_options.py",
         "tests/interactive/test_options_parameters.py",

--- a/src/erlab/interactive/_code_trust/__init__.py
+++ b/src/erlab/interactive/_code_trust/__init__.py
@@ -1,0 +1,162 @@
+"""Authorize saved documents that contain user-provided Python.
+
+This private package owns the security policy. Feature code describes executable
+content with :func:`create_entry`. A document host builds one ordered manifest and owns
+one opaque trust value. The feature must not inspect trust reasons, signatures, or
+lineage.
+
+An ``.itws`` workspace has four execution boundaries:
+
+1. Provenance passes a recorded script to ``exec``.
+2. Figure Composer passes custom Python to ``exec`` or ``eval``.
+3. A fitting tool or provenance replay decodes an lmfit model or result that contains
+   custom Python.
+4. lmfit evaluates a saved parameter expression.
+
+Guard the call that executes or decodes this content. File paths, loaders, tool names,
+numeric arrays, previews, and declarative provenance are not trust boundaries. Safe
+work must continue when executable content is paused.
+
+Each entry contains a stable feature name, a document location, exact code, and the
+JSON-compatible context that changes execution. Include such values as enabled state,
+mode, inputs, and order. Exclude labels and unrelated interface state. A saved manifest
+includes disabled code because a user can enable it later. Opaque lmfit entries also
+contain a SHA-256 digest of their executable payload fragments.
+
+A saved signature covers the complete canonical manifest. The domain separates file
+formats. The policy version invalidates signatures after execution semantics change.
+Document identifiers, paths, and serialized trust flags are never proof of trust.
+The manifest bound to a trust value is only the in-memory baseline for the next
+transaction. It is not trust proof. Binding changed content to signature trust revokes
+the signature instead of transferring it.
+
+To add an executable feature:
+
+* Keep a small entry producer beside the feature. Do not scan object graphs or use a
+  contributor registry.
+* Include all stored content that can reach an execution boundary.
+* Build the same entry immediately before execution.
+* Ask the document host for authorization. Normal execution requests receive a
+  capability only when every requested entry is allowed. A graph executor can use
+  :func:`issue_execution_capability` directly and check each entry at its boundary.
+  This low-level capability can allow only a subset in a mixed document.
+  :func:`execute_with_capability` keeps the final check and the guarded call together.
+* Stop only the unauthorized execution.
+
+An explicit user edit uses :func:`issue_local_edit_capability`. The feature supplies
+the candidate execution inventory and the exact entries that the user added or
+changed. The capability allows those entries and any entries already allowed by the
+stored-content policy. It remains an allow-list, so other external entries in the same
+graph stay paused. The returned trust state is prospective. Apply it only after
+candidate validation and the edit commit both succeed. A cancelled or failed edit must
+leave the document trust unchanged. Deletion is also an explicit edit, even when the
+edited-entry inventory is empty. After commit, the host compares the complete document
+manifest before and after the transaction. The framework adds explicit and derived
+current document identities to an ephemeral local allow-list and removes identities
+that are no longer present. A document identity includes the exact entry location.
+Execution capabilities omit the location so they remain valid after a runtime path
+translation. The document remains untrusted while any current entry is outside the
+prior policy and this allow-list. During validation, the host can expose the capability,
+but it must not expose the prospective local lineage. After commit, pass the current
+manifest to :func:`commit_local_edit_trust` or bind it with
+:func:`bind_document_trust_manifest` for use as the next transaction baseline.
+
+An explicitly selected external executable file is a separate case. Review an
+isolated manifest for the candidate, issue a capability for only its exact entries,
+and decode the exact reviewed bytes. Commit the resulting document state as a local
+edit only after decoding and validation succeed.
+
+For example::
+
+    def code_trust_entries(state):
+        return (
+            create_entry(
+                "erlab.example.expression",
+                "operations/0",
+                state.expression,
+                {"enabled": state.enabled, "mode": state.mode},
+            ),
+        )
+
+New local documents have trusted lineage. External documents do not. Explicit approval
+grants local lineage. A successful save signs only a committed manifest with trusted
+lineage. A mixed untrusted save keeps its local allow-list only in memory. Reopening it
+requires review again. Imports combine lineage, and untrusted executable content makes
+the result untrusted. A non-replacing import can retain exact known local identities.
+A replacement discards identities from the replaced document. Trusted folders are an
+explicit application policy that bypasses signature checks for matching resolved
+paths.
+
+A standalone ImageTool is not a document-trust host. It does not run executable stored
+provenance. ImageTool Manager injects the stored-code authorizer when it owns the
+provenance document.
+
+Keep future integration at these entry, authorization, and document-lifecycle seams.
+Do not add feature lifecycle state to this package. This is not a public API.
+"""
+
+from erlab.interactive._code_trust._api import (
+    approve_document_trust,
+    authorize_document_execution,
+    bind_document_trust_manifest,
+    commit_local_edit_trust,
+    create_entry,
+    create_manifest,
+    document_trust_description,
+    document_trust_has_trusted_lineage,
+    document_trust_is_trusted,
+    document_trust_needs_review,
+    execute_with_capability,
+    execution_capability_allows,
+    external_document_trust,
+    issue_complete_execution_capability,
+    issue_execution_capability,
+    issue_local_edit_capability,
+    manifest_has_code,
+    manifest_review_text,
+    merge_document_trust,
+    new_document_trust,
+    relocate_document_trust,
+    relocate_manifest_entries,
+    trusted_location_document_trust,
+    untrusted_document_trust,
+    verify_document_payload_entries,
+)
+from erlab.interactive._code_trust._application import reset_saved_code_trust
+from erlab.interactive._code_trust._locations import (
+    document_path_is_trusted,
+    validate_trusted_location,
+)
+from erlab.interactive._code_trust._payloads import create_payload_entry
+
+__all__ = [
+    "approve_document_trust",
+    "authorize_document_execution",
+    "bind_document_trust_manifest",
+    "commit_local_edit_trust",
+    "create_entry",
+    "create_manifest",
+    "create_payload_entry",
+    "document_path_is_trusted",
+    "document_trust_description",
+    "document_trust_has_trusted_lineage",
+    "document_trust_is_trusted",
+    "document_trust_needs_review",
+    "execute_with_capability",
+    "execution_capability_allows",
+    "external_document_trust",
+    "issue_complete_execution_capability",
+    "issue_execution_capability",
+    "issue_local_edit_capability",
+    "manifest_has_code",
+    "manifest_review_text",
+    "merge_document_trust",
+    "new_document_trust",
+    "relocate_document_trust",
+    "relocate_manifest_entries",
+    "reset_saved_code_trust",
+    "trusted_location_document_trust",
+    "untrusted_document_trust",
+    "validate_trusted_location",
+    "verify_document_payload_entries",
+]

--- a/src/erlab/interactive/_code_trust/_api.py
+++ b/src/erlab/interactive/_code_trust/_api.py
@@ -1,0 +1,618 @@
+"""Small functional interface for executable-document code trust."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import typing
+
+from erlab.interactive._code_trust._core import (
+    CodeTrustEntry,
+    CodeTrustEntrySource,
+    CodeTrustManifest,
+    CodeTrustReason,
+)
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping
+
+    _T = typing.TypeVar("_T")
+
+
+def create_entry(
+    feature: str,
+    location: str,
+    code: str,
+    context: Mapping[str, typing.Any] | None = None,
+) -> CodeTrustEntry:
+    """Create one validated executable-content entry."""
+    return CodeTrustEntry(feature, location, code, {} if context is None else context)
+
+
+def create_manifest(
+    domain: str,
+    policy_version: int,
+    entries: Iterable[CodeTrustEntry],
+) -> CodeTrustManifest:
+    """Create one validated executable-content manifest."""
+    return CodeTrustManifest(domain, policy_version, tuple(entries))
+
+
+def manifest_has_code(manifest: CodeTrustManifest) -> bool:
+    """Return whether a manifest contains executable content."""
+    return bool(manifest.entries)
+
+
+def relocate_manifest_entries(
+    manifest: CodeTrustManifest,
+    *,
+    location_prefix: str,
+    remove_location_prefix: str = "",
+) -> tuple[CodeTrustEntry, ...]:
+    """Return entries with locations relative to an embedding document."""
+    return tuple(
+        create_entry(
+            entry.feature,
+            (
+                f"{location_prefix}/"
+                f"{entry.location.removeprefix(remove_location_prefix)}"
+            ),
+            entry.code,
+            entry.context,
+        )
+        for entry in manifest.entries
+    )
+
+
+def relocate_document_trust(
+    trust: _DocumentTrust,
+    manifest: CodeTrustManifest,
+    *,
+    location_prefix: str,
+) -> _DocumentTrust:
+    """Move feature-relative trust into an embedding document location."""
+    relocated = create_manifest(
+        manifest.domain,
+        manifest.policy_version,
+        relocate_manifest_entries(manifest, location_prefix=location_prefix),
+    )
+    if (
+        trust.reason == CodeTrustReason.SIGNATURE
+        and trust.manifest_identity != manifest.canonical_bytes()
+    ):
+        return _document_trust(CodeTrustReason.UNTRUSTED, relocated)
+    if document_trust_has_trusted_lineage(trust):
+        return _document_trust(CodeTrustReason.LOCAL_LINEAGE, relocated)
+    if trust.reason == CodeTrustReason.NO_EXECUTABLE_CODE:
+        return _document_trust(CodeTrustReason.NO_EXECUTABLE_CODE, relocated)
+    local_document_identities = {
+        relocated_entry.document_identity()
+        for source_entry, relocated_entry in zip(
+            manifest.entries, relocated.entries, strict=True
+        )
+        if source_entry.document_identity() in trust.local_document_identities
+    }
+    return _document_trust(
+        CodeTrustReason.UNTRUSTED,
+        relocated,
+        local_document_identities=local_document_identities,
+    )
+
+
+def manifest_review_text(manifest: CodeTrustManifest) -> str:
+    """Return plain text for review of all executable manifest entries."""
+    blocks: list[str] = []
+    for entry in manifest.entries:
+        block = f"[{entry.feature} — {entry.location}]\n{entry.code}"
+        if entry.context:
+            context = json.dumps(
+                entry.payload()["context"], ensure_ascii=False, sort_keys=True, indent=2
+            )
+            block = f"{block}\nExecution context:\n{context}"
+        blocks.append(block)
+    return "\n\n".join(blocks)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _DocumentTrust:
+    """Complete private trust state for one executable document."""
+
+    reason: CodeTrustReason
+    manifest: CodeTrustManifest | None
+    manifest_identity: bytes | None
+    execution_identities: frozenset[bytes]
+    document_identities: frozenset[bytes]
+    local_document_identities: frozenset[bytes]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _ExecutionCapability:
+    """Opaque allow-list of exact executable-content identities."""
+
+    execution_identities: frozenset[bytes]
+
+
+def _document_trust(
+    reason: CodeTrustReason,
+    manifest: CodeTrustManifest | None,
+    *,
+    local_document_identities: Iterable[bytes] = (),
+) -> _DocumentTrust:
+    execution_identities = (
+        frozenset()
+        if manifest is None
+        else frozenset(entry.execution_identity() for entry in manifest.entries)
+    )
+    return _DocumentTrust(
+        reason,
+        manifest,
+        None if manifest is None else manifest.canonical_bytes(),
+        execution_identities,
+        (
+            frozenset()
+            if manifest is None
+            else frozenset(entry.document_identity() for entry in manifest.entries)
+        ),
+        frozenset(local_document_identities),
+    )
+
+
+def new_document_trust() -> _DocumentTrust:
+    """Create trust state for a new local document."""
+    return _document_trust(CodeTrustReason.LOCAL_LINEAGE, None)
+
+
+def external_document_trust(
+    manifest: CodeTrustManifest | None,
+) -> _DocumentTrust:
+    """Create safe trust state for externally supplied document content."""
+    has_executable_code = manifest is not None and manifest_has_code(manifest)
+    return _document_trust(
+        CodeTrustReason.UNTRUSTED
+        if has_executable_code
+        else CodeTrustReason.NO_EXECUTABLE_CODE,
+        manifest,
+    )
+
+
+def untrusted_document_trust(
+    manifest: CodeTrustManifest | None = None,
+) -> _DocumentTrust:
+    """Create trust state for external content that must be treated as executable."""
+    return _document_trust(CodeTrustReason.UNTRUSTED, manifest)
+
+
+def trusted_location_document_trust() -> _DocumentTrust:
+    """Create trust state for content from a trusted document location."""
+    return _document_trust(CodeTrustReason.TRUSTED_LOCATION, None)
+
+
+def merge_document_trust(
+    current: _DocumentTrust,
+    incoming: _DocumentTrust,
+    *,
+    replace: bool,
+) -> _DocumentTrust:
+    """Return document trust after a load or import operation."""
+    if replace:
+        return incoming
+    if incoming == current:
+        return current
+    if incoming.reason == CodeTrustReason.NO_EXECUTABLE_CODE:
+        return current
+    reason = CodeTrustReason.LOCAL_LINEAGE
+    if not (
+        document_trust_has_trusted_lineage(current)
+        and document_trust_has_trusted_lineage(incoming)
+    ):
+        reason = CodeTrustReason.UNTRUSTED
+    local_document_identities: set[bytes] = set()
+    if reason == CodeTrustReason.UNTRUSTED:
+        local_document_identities.update(current.local_document_identities)
+        local_document_identities.update(incoming.local_document_identities)
+        if document_trust_has_trusted_lineage(current) and current.manifest is not None:
+            local_document_identities.update(current.document_identities)
+        if (
+            document_trust_has_trusted_lineage(incoming)
+            and incoming.manifest is not None
+        ):
+            local_document_identities.update(incoming.document_identities)
+    return _document_trust(
+        reason,
+        None,
+        local_document_identities=local_document_identities,
+    )
+
+
+def approve_document_trust(
+    current: _DocumentTrust,
+    manifest: CodeTrustManifest | None = None,
+) -> _DocumentTrust:
+    """Return locally approved trust while retaining the review manifest."""
+    if manifest is None:
+        manifest = current.manifest
+    return _document_trust(CodeTrustReason.LOCAL_LINEAGE, manifest)
+
+
+def bind_document_trust_manifest(
+    trust: _DocumentTrust,
+    manifest: CodeTrustManifest,
+) -> _DocumentTrust:
+    """Bind trust to the last committed executable manifest.
+
+    This binding is process-local state. It does not create a durable signature. A
+    signature remains valid only for its complete original manifest.
+    """
+    current_identities = {entry.document_identity() for entry in manifest.entries}
+    local_document_identities = trust.local_document_identities & current_identities
+    reason = trust.reason
+    if (
+        reason == CodeTrustReason.SIGNATURE
+        and trust.manifest_identity != manifest.canonical_bytes()
+    ):
+        reason = CodeTrustReason.UNTRUSTED
+    return _document_trust(
+        reason,
+        manifest,
+        local_document_identities=local_document_identities,
+    )
+
+
+def _document_trust_after_save(
+    current: _DocumentTrust,
+    manifest: CodeTrustManifest,
+    *,
+    saved_trusted_lineage: bool,
+    signature_stored: bool,
+) -> _DocumentTrust:
+    if not manifest_has_code(manifest):
+        return _document_trust(CodeTrustReason.LOCAL_LINEAGE, manifest)
+    if not saved_trusted_lineage:
+        if document_trust_has_trusted_lineage(current):
+            # Approval can occur while an untrusted snapshot is being saved. The
+            # completed save must not overwrite that newer document decision.
+            return current
+        committed_identities = {entry.document_identity() for entry in manifest.entries}
+        return _document_trust(
+            CodeTrustReason.UNTRUSTED,
+            manifest,
+            local_document_identities=(
+                current.local_document_identities & committed_identities
+            ),
+        )
+    if not document_trust_has_trusted_lineage(current):
+        # A payload check can revoke trust while an approved snapshot is being
+        # saved. The completed save must not restore the older decision.
+        return current
+    return _document_trust(
+        CodeTrustReason.SIGNATURE
+        if signature_stored
+        else CodeTrustReason.LOCAL_LINEAGE,
+        manifest,
+    )
+
+
+def authorize_document_execution(
+    trust: _DocumentTrust,
+    entries: CodeTrustEntrySource,
+) -> tuple[_DocumentTrust, bool]:
+    """Apply the document policy and return updated trust plus authorization."""
+    if document_trust_has_trusted_lineage(trust) and (
+        trust.reason != CodeTrustReason.SIGNATURE
+    ):
+        return trust, True
+    resolved_entries = tuple(entries() if callable(entries) else entries)
+    if not resolved_entries:
+        return trust, True
+    if trust.reason == CodeTrustReason.SIGNATURE and all(
+        entry.execution_identity() in trust.execution_identities
+        for entry in resolved_entries
+    ):
+        return trust, True
+    if trust.reason == CodeTrustReason.UNTRUSTED and all(
+        entry.document_identity() in trust.local_document_identities
+        for entry in resolved_entries
+    ):
+        return trust, True
+    return (
+        trust
+        if trust.reason == CodeTrustReason.UNTRUSTED
+        else untrusted_document_trust(trust.manifest),
+        False,
+    )
+
+
+def issue_execution_capability(
+    trust: _DocumentTrust,
+    entries: CodeTrustEntrySource,
+) -> tuple[_DocumentTrust, object | None]:
+    """Issue an allow-list for the authorized subset of exact entry content."""
+    resolved_entries = tuple(entries() if callable(entries) else entries)
+    trust, allowed = authorize_document_execution(trust, resolved_entries)
+    allowed_identities = frozenset(
+        entry.execution_identity() for entry in resolved_entries
+    )
+    if not allowed and trust.reason == CodeTrustReason.UNTRUSTED:
+        locally_allowed = {
+            entry.execution_identity()
+            for entry in resolved_entries
+            if entry.document_identity() in trust.local_document_identities
+        }
+        externally_owned = {
+            entry.execution_identity()
+            for entry in resolved_entries
+            if entry.document_identity() not in trust.local_document_identities
+        }
+        # A location-free capability cannot distinguish equal content at two
+        # locations. Do not issue that identity when this request contains both.
+        allowed_identities = frozenset(locally_allowed - externally_owned)
+    capability = (
+        _ExecutionCapability(allowed_identities)
+        if allowed or allowed_identities
+        else None
+    )
+    return trust, capability
+
+
+def issue_complete_execution_capability(
+    trust: _DocumentTrust,
+    entries: CodeTrustEntrySource,
+) -> tuple[_DocumentTrust, object | None]:
+    """Issue a capability only when it allows the complete request."""
+    resolved_entries = tuple(entries() if callable(entries) else entries)
+    trust, capability = issue_execution_capability(trust, resolved_entries)
+    if not execution_capability_allows(capability, resolved_entries):
+        capability = None
+    return trust, capability
+
+
+def _execution_identities_allowed_before_local_edit(
+    trust: _DocumentTrust,
+    entries: Iterable[CodeTrustEntry],
+) -> frozenset[bytes]:
+    resolved_entries = tuple(entries)
+    if trust.reason == CodeTrustReason.SIGNATURE:
+        return frozenset(
+            entry.execution_identity()
+            for entry in resolved_entries
+            if entry.execution_identity() in trust.execution_identities
+        )
+    if trust.reason == CodeTrustReason.UNTRUSTED:
+        return frozenset(
+            entry.execution_identity()
+            for entry in resolved_entries
+            if entry.document_identity() in trust.local_document_identities
+        )
+    if trust.reason in {
+        CodeTrustReason.LOCAL_LINEAGE,
+        CodeTrustReason.TRUSTED_LOCATION,
+    }:
+        return frozenset(entry.execution_identity() for entry in resolved_entries)
+    return frozenset()
+
+
+def issue_local_edit_capability(
+    trust: _DocumentTrust,
+    execution_entries: CodeTrustEntrySource,
+    *,
+    edited_entries: CodeTrustEntrySource,
+) -> tuple[_DocumentTrust, object | None]:
+    """Authorize validation of an explicit local executable-content edit.
+
+    Entries supplied in ``edited_entries`` are locally authored. The capability
+    allows those entries plus each requested entry allowed by the prior stored-content
+    policy. It can therefore guard separate entry boundaries in one mixed graph. The
+    returned trust value is prospective: the document host must apply it only after
+    validation and commit both succeed.
+    """
+    resolved_entries = tuple(
+        execution_entries() if callable(execution_entries) else execution_entries
+    )
+    resolved_edited_entries = tuple(
+        edited_entries() if callable(edited_entries) else edited_entries
+    )
+    prior_allowed_identities = _execution_identities_allowed_before_local_edit(
+        trust, resolved_entries
+    )
+    edited_document_identities = frozenset(
+        entry.document_identity() for entry in resolved_edited_entries
+    )
+    edited_execution_identities = {
+        entry.execution_identity()
+        for entry in resolved_entries
+        if entry.document_identity() in edited_document_identities
+    }
+    if trust.reason == CodeTrustReason.UNTRUSTED:
+        externally_owned_identities = {
+            entry.execution_identity()
+            for entry in resolved_entries
+            if entry.document_identity()
+            not in (trust.local_document_identities | edited_document_identities)
+        }
+        # A location-free capability cannot distinguish a local edit from equal
+        # external content at another location. Prior-policy authorization remains
+        # valid because it predates this edit request.
+        edited_execution_identities.difference_update(externally_owned_identities)
+    allowed_identities = frozenset(
+        prior_allowed_identities | edited_execution_identities
+    )
+
+    prospective_trust = trust
+    if trust.reason in {
+        CodeTrustReason.NO_EXECUTABLE_CODE,
+        CodeTrustReason.SIGNATURE,
+        CodeTrustReason.UNTRUSTED,
+    }:
+        prospective_trust = _document_trust(
+            CodeTrustReason.LOCAL_LINEAGE,
+            trust.manifest,
+        )
+    return prospective_trust, _ExecutionCapability(allowed_identities)
+
+
+def commit_local_edit_trust(
+    trust: _DocumentTrust,
+    capability: object | None,
+    previous_document_entries: CodeTrustEntrySource,
+    document_entries: CodeTrustEntrySource,
+    *,
+    edited_entries: CodeTrustEntrySource,
+    document_manifest: CodeTrustManifest | None = None,
+) -> _DocumentTrust:
+    """Commit local lineage only when the full document remains authorized.
+
+    The validation capability is intentionally scoped to one feature edit. The
+    document host must call this function after the edit commits with the complete
+    executable inventories from before and after the transaction. New entries created
+    during validation belong to the local edit. Retained entries must still pass the
+    prior document policy. This prevents one local edit from authorizing unrelated
+    external code.
+    """
+    resolved_previous_entries = tuple(
+        previous_document_entries()
+        if callable(previous_document_entries)
+        else previous_document_entries
+    )
+    resolved_document_entries = tuple(
+        document_entries() if callable(document_entries) else document_entries
+    )
+    resolved_edited_entries = tuple(
+        edited_entries() if callable(edited_entries) else edited_entries
+    )
+    if not isinstance(capability, _ExecutionCapability) or not all(
+        entry.execution_identity() in capability.execution_identities
+        for entry in resolved_edited_entries
+    ):
+        return trust
+    previous_execution_identities = frozenset(
+        entry.execution_identity() for entry in resolved_previous_entries
+    )
+    current_identities = frozenset(
+        entry.document_identity() for entry in resolved_document_entries
+    )
+    local_identities = set(trust.local_document_identities)
+    local_identities.update(
+        entry.document_identity()
+        for entry in resolved_edited_entries
+        if entry.document_identity() in current_identities
+    )
+    # Validation can create derived entries. Adopt only content that is new by
+    # location-free execution identity. A location-only move of external content
+    # must not become a local edit.
+    local_identities.update(
+        entry.document_identity()
+        for entry in resolved_document_entries
+        if entry.execution_identity() not in previous_execution_identities
+    )
+    local_identities.intersection_update(current_identities)
+
+    if trust.reason == CodeTrustReason.SIGNATURE:
+        prior_policy_identities = trust.document_identities
+    elif trust.reason == CodeTrustReason.UNTRUSTED:
+        prior_policy_identities = trust.local_document_identities
+    elif trust.reason in {
+        CodeTrustReason.LOCAL_LINEAGE,
+        CodeTrustReason.TRUSTED_LOCATION,
+    }:
+        committed = trust
+    else:
+        prior_policy_identities = frozenset()
+    if trust.reason not in {
+        CodeTrustReason.LOCAL_LINEAGE,
+        CodeTrustReason.TRUSTED_LOCATION,
+    }:
+        if current_identities <= prior_policy_identities | local_identities:
+            committed = _document_trust(CodeTrustReason.LOCAL_LINEAGE, trust.manifest)
+        else:
+            committed = _document_trust(
+                CodeTrustReason.UNTRUSTED,
+                trust.manifest,
+                local_document_identities=local_identities,
+            )
+    if document_manifest is not None:
+        committed = bind_document_trust_manifest(committed, document_manifest)
+    return committed
+
+
+def execution_capability_allows(
+    capability: object | None,
+    entries: CodeTrustEntrySource,
+) -> bool:
+    """Return whether a capability allows all supplied exact content identities."""
+    resolved_entries = tuple(entries() if callable(entries) else entries)
+    if not resolved_entries:
+        return True
+    if not isinstance(capability, _ExecutionCapability):
+        return False
+    return all(
+        entry.execution_identity() in capability.execution_identities
+        for entry in resolved_entries
+    )
+
+
+def execute_with_capability(
+    capability: object | None,
+    entries: CodeTrustEntrySource,
+    execute: Callable[[], _T],
+) -> tuple[bool, _T | None]:
+    """Execute one callback only when the capability allows its exact entries."""
+    resolved_entries = tuple(entries() if callable(entries) else entries)
+    if not execution_capability_allows(capability, resolved_entries):
+        return False, None
+    return True, execute()
+
+
+def verify_document_payload_entries(
+    trust: _DocumentTrust,
+    expected_entries: Iterable[CodeTrustEntry],
+    actual_entries: Iterable[CodeTrustEntry],
+) -> _DocumentTrust:
+    """Verify opaque payload bytes before trusted lineage can be preserved.
+
+    A legacy external document can contain payloads without digest metadata. Such a
+    document uses the normal approval flow after its actual payload inventory is known.
+    A document that was already authorized must declare every payload unless it is in a
+    trusted location. Once digest metadata exists, it must match the bytes exactly.
+    """
+    expected = tuple(expected_entries)
+    actual = tuple(actual_entries)
+    if expected == actual:
+        return trust
+    if expected or (
+        document_trust_has_trusted_lineage(trust)
+        and trust.reason != CodeTrustReason.TRUSTED_LOCATION
+    ):
+        return untrusted_document_trust(trust.manifest)
+    return trust
+
+
+def document_trust_is_trusted(trust: _DocumentTrust) -> bool:
+    """Return whether document executable content is authorized."""
+    return trust.reason != CodeTrustReason.UNTRUSTED
+
+
+def document_trust_has_trusted_lineage(trust: _DocumentTrust) -> bool:
+    """Return whether later document saves can preserve durable trust."""
+    return trust.reason in {
+        CodeTrustReason.SIGNATURE,
+        CodeTrustReason.TRUSTED_LOCATION,
+        CodeTrustReason.LOCAL_LINEAGE,
+    }
+
+
+def document_trust_needs_review(trust: _DocumentTrust) -> bool:
+    """Return whether the document needs approval before code can run."""
+    return trust.reason == CodeTrustReason.UNTRUSTED
+
+
+def document_trust_description(trust: _DocumentTrust) -> str:
+    """Return the user-facing description of the document trust state."""
+    if trust.manifest is not None and not manifest_has_code(trust.manifest):
+        return "No stored executable content"
+    return {
+        CodeTrustReason.NO_EXECUTABLE_CODE: "No stored executable content",
+        CodeTrustReason.SIGNATURE: "Trusted by saved signature",
+        CodeTrustReason.TRUSTED_LOCATION: "Trusted location",
+        CodeTrustReason.LOCAL_LINEAGE: "Trusted local document",
+        CodeTrustReason.UNTRUSTED: "Stored executable content is paused",
+    }[trust.reason]

--- a/src/erlab/interactive/_code_trust/_application.py
+++ b/src/erlab/interactive/_code_trust/_application.py
@@ -1,0 +1,135 @@
+"""Application storage adapter for the general code-trust notary."""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import pathlib
+import typing
+
+from qtpy import QtCore
+
+from erlab.interactive._code_trust._api import (
+    _document_trust,
+    _document_trust_after_save,
+    _DocumentTrust,
+    document_trust_has_trusted_lineage,
+    manifest_has_code,
+)
+from erlab.interactive._code_trust._core import CodeTrustReason
+from erlab.interactive._code_trust._notary import CodeTrustError, CodeTrustNotary
+
+if typing.TYPE_CHECKING:
+    from erlab.interactive._code_trust._core import CodeTrustManifest
+
+_CODE_TRUST_DIRECTORY_ENV_VAR = "ERLAB_CODE_TRUST_DIRECTORY"
+_APPLICATION_DATA_DIRECTORY_NAME = "ImageTool Manager"
+logger = logging.getLogger(__name__)
+
+
+def application_code_trust_directory() -> pathlib.Path:
+    """Return the stable private directory used for code-trust state.
+
+    ``GenericDataLocation/ImageTool Manager`` is independent of the Qt host's
+    application and organization names. It is also the path that
+    ``AppDataLocation`` returns for ImageTool Manager when the organization name is
+    empty. Existing approvals from the standalone manager therefore stay available.
+    """
+    if configured := os.environ.get(_CODE_TRUST_DIRECTORY_ENV_VAR):
+        return pathlib.Path(configured)
+    location = QtCore.QStandardPaths.writableLocation(
+        QtCore.QStandardPaths.StandardLocation.GenericDataLocation
+    )
+    if not location:
+        raise RuntimeError("Could not determine the code trust storage directory")
+    return pathlib.Path(location) / _APPLICATION_DATA_DIRECTORY_NAME / "code-trust"
+
+
+@functools.cache
+def _application_code_trust_notary() -> CodeTrustNotary:
+    """Return the process-wide code-trust notary."""
+    return CodeTrustNotary(application_code_trust_directory())
+
+
+def reset_saved_code_trust(*, domain: str | None = None) -> None:
+    """Remove saved executable-content signatures."""
+    try:
+        _application_code_trust_notary().reset(domain=domain)
+    except (CodeTrustError, RuntimeError) as exc:
+        raise RuntimeError(str(exc)) from exc
+
+
+def _code_trust_reason(manifest: CodeTrustManifest) -> CodeTrustReason:
+    """Return a fail-closed reason when application storage is unavailable."""
+    if not manifest_has_code(manifest):
+        return CodeTrustReason.NO_EXECUTABLE_CODE
+    try:
+        signed = _application_code_trust_notary().check(manifest)
+    except (CodeTrustError, RuntimeError):
+        logger.warning("Could not read durable code trust", exc_info=True)
+        signed = False
+    return CodeTrustReason.SIGNATURE if signed else CodeTrustReason.UNTRUSTED
+
+
+def load_document_trust(manifest: CodeTrustManifest) -> _DocumentTrust:
+    """Load complete trust state for one application document manifest."""
+    return _document_trust(_code_trust_reason(manifest), manifest)
+
+
+def load_imported_document_trust(
+    document_manifest: CodeTrustManifest,
+    imported_manifest: CodeTrustManifest,
+) -> _DocumentTrust:
+    """Load trust for selected content from a complete saved document.
+
+    A saved signature covers the complete document manifest. Selected imports retain
+    that authorization. An unsigned source can still use an approval for the exact
+    selected manifest when one exists.
+    """
+    reason = _code_trust_reason(document_manifest)
+    remaining_entries = iter(document_manifest.entries)
+    is_ordered_subset = (
+        imported_manifest.domain == document_manifest.domain
+        and imported_manifest.policy_version == document_manifest.policy_version
+        and all(
+            any(candidate == entry for candidate in remaining_entries)
+            for entry in imported_manifest.entries
+        )
+    )
+    if reason == CodeTrustReason.SIGNATURE and is_ordered_subset:
+        return _document_trust(reason, imported_manifest)
+    return load_document_trust(imported_manifest)
+
+
+def save_document_trust(
+    trust: _DocumentTrust,
+    manifest: CodeTrustManifest,
+    *,
+    saved_trusted_lineage: bool | None = None,
+) -> tuple[_DocumentTrust, bool]:
+    """Store durable trust and return the state for committed content."""
+    if saved_trusted_lineage is None:
+        saved_trusted_lineage = document_trust_has_trusted_lineage(trust)
+    if (
+        trust.reason == CodeTrustReason.SIGNATURE
+        and trust.manifest_identity != manifest.canonical_bytes()
+    ):
+        saved_trusted_lineage = False
+        trust = _document_trust(CodeTrustReason.UNTRUSTED, manifest)
+    signature_stored = True
+    if manifest_has_code(manifest) and saved_trusted_lineage:
+        try:
+            _application_code_trust_notary().sign(manifest)
+        except (CodeTrustError, RuntimeError):
+            logger.warning("Could not store durable code trust", exc_info=True)
+            signature_stored = False
+    return (
+        _document_trust_after_save(
+            trust,
+            manifest,
+            saved_trusted_lineage=saved_trusted_lineage,
+            signature_stored=signature_stored,
+        ),
+        signature_stored,
+    )

--- a/src/erlab/interactive/_code_trust/_core.py
+++ b/src/erlab/interactive/_code_trust/_core.py
@@ -80,21 +80,22 @@ class CodeTrustEntry:
             raise ValueError("Code trust location must not be empty")
         if not isinstance(self.code, str):
             raise TypeError("Code trust code must be a string")
-        context = _normalize_json(self.context, "context")
-        if not isinstance(context, dict):  # pragma: no cover - annotation is Mapping
+        if not isinstance(self.context, Mapping):
             raise TypeError("Code trust context must be a mapping")
+        context = _normalize_json(self.context, "context")
         # Keep the signed value independent from mutable feature state. The
         # normalization recursively copies all supported mappings and lists.
-        object.__setattr__(self, "context", context)
+        object.__setattr__(
+            self, "context", typing.cast("dict[str, JSONValue]", context)
+        )
 
     def payload(self) -> dict[str, JSONValue]:
         """Return the signed JSON payload for this entry."""
-        context = _normalize_json(self.context, "context")
-        if not isinstance(context, dict):  # pragma: no cover - validated above
-            raise TypeError("Code trust context must be a mapping")
         return {
             "code": self.code,
-            "context": context,
+            "context": typing.cast(
+                "dict[str, JSONValue]", _normalize_json(self.context, "context")
+            ),
             "feature": self.feature,
             "location": self.location,
         }

--- a/src/erlab/interactive/_code_trust/_core.py
+++ b/src/erlab/interactive/_code_trust/_core.py
@@ -1,0 +1,150 @@
+"""Validated values and canonical JSON for code trust."""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import json
+import math
+import typing
+from collections.abc import Callable, Iterable, Mapping
+
+JSONScalar = str | int | float | bool | None
+JSONValue = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+CodeTrustEntrySource = (
+    Iterable["CodeTrustEntry"] | Callable[[], Iterable["CodeTrustEntry"]]
+)
+
+
+class CodeTrustReason(enum.StrEnum):
+    """Reason for one executable-document trust decision."""
+
+    NO_EXECUTABLE_CODE = "no_executable_code"
+    SIGNATURE = "signature"
+    TRUSTED_LOCATION = "trusted_location"
+    LOCAL_LINEAGE = "local_lineage"
+    UNTRUSTED = "untrusted"
+
+
+def _normalize_json(value: typing.Any, path: str) -> JSONValue:
+    if value is None or isinstance(value, str | bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} contains a non-finite float")
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, JSONValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{path} contains a non-string mapping key")
+            normalized[key] = _normalize_json(item, f"{path}.{key}")
+        return normalized
+    if isinstance(value, list):
+        return [
+            _normalize_json(item, f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    raise TypeError(f"{path} contains unsupported value {type(value).__name__}")
+
+
+def _canonical_json(value: JSONValue) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CodeTrustEntry:
+    """One executable contribution to a document trust manifest."""
+
+    feature: str
+    location: str
+    code: str
+    context: Mapping[str, typing.Any] = dataclasses.field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.feature, str):
+            raise TypeError("Code trust feature must be a string")
+        if not self.feature.strip():
+            raise ValueError("Code trust feature must not be empty")
+        if not isinstance(self.location, str):
+            raise TypeError("Code trust location must be a string")
+        if not self.location.strip():
+            raise ValueError("Code trust location must not be empty")
+        if not isinstance(self.code, str):
+            raise TypeError("Code trust code must be a string")
+        context = _normalize_json(self.context, "context")
+        if not isinstance(context, dict):  # pragma: no cover - annotation is Mapping
+            raise TypeError("Code trust context must be a mapping")
+        # Keep the signed value independent from mutable feature state. The
+        # normalization recursively copies all supported mappings and lists.
+        object.__setattr__(self, "context", context)
+
+    def payload(self) -> dict[str, JSONValue]:
+        """Return the signed JSON payload for this entry."""
+        context = _normalize_json(self.context, "context")
+        if not isinstance(context, dict):  # pragma: no cover - validated above
+            raise TypeError("Code trust context must be a mapping")
+        return {
+            "code": self.code,
+            "context": context,
+            "feature": self.feature,
+            "location": self.location,
+        }
+
+    def execution_identity(self) -> bytes:
+        """Return canonical content identity without its document location."""
+        payload = self.payload()
+        payload.pop("location")
+        return _canonical_json(payload)
+
+    def document_identity(self) -> bytes:
+        """Return canonical content identity at its exact document location."""
+        return _canonical_json(self.payload())
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class CodeTrustManifest:
+    """Ordered executable content signed as one trust unit."""
+
+    domain: str
+    policy_version: int
+    entries: tuple[CodeTrustEntry, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.domain, str):
+            raise TypeError("Code trust domain must be a string")
+        if not self.domain.strip():
+            raise ValueError("Code trust domain must not be empty")
+        if type(self.policy_version) is not int:
+            raise TypeError("Code trust policy version must be an integer")
+        if self.policy_version < 1:
+            raise ValueError("Code trust policy version must be positive")
+        if not isinstance(self.entries, tuple):
+            raise TypeError("Code trust manifest entries must be a tuple")
+        if not all(isinstance(entry, CodeTrustEntry) for entry in self.entries):
+            raise TypeError("Code trust manifest entries must be CodeTrustEntry values")
+
+    @property
+    def has_executable_code(self) -> bool:
+        """Return whether this manifest contains executable entries."""
+        return bool(self.entries)
+
+    def payload(self) -> dict[str, JSONValue]:
+        """Return the complete signed JSON payload."""
+        return {
+            "domain": self.domain,
+            "entries": [entry.payload() for entry in self.entries],
+            "policy_version": self.policy_version,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        """Return a deterministic byte representation for signing."""
+        return _canonical_json(self.payload())

--- a/src/erlab/interactive/_code_trust/_locations.py
+++ b/src/erlab/interactive/_code_trust/_locations.py
@@ -1,0 +1,53 @@
+"""Feature-neutral trusted-location matching for executable documents.
+
+Folder trust is an explicit user decision. It uses resolved path containment and does
+not try to classify filesystems as local or remote. A filesystem label cannot reliably
+identify who can change a folder.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import typing
+
+if typing.TYPE_CHECKING:
+    import os
+    from collections.abc import Iterable
+
+
+def _normalized_path(path: str | os.PathLike[str], *, strict: bool) -> pathlib.Path:
+    return pathlib.Path(path).expanduser().resolve(strict=strict)
+
+
+def validate_trusted_location(path: str | os.PathLike[str]) -> pathlib.Path:
+    """Resolve and validate a folder before it enters trusted settings."""
+    resolved = _normalized_path(path, strict=True)
+    if not resolved.is_dir():
+        raise ValueError("Trusted location must be a folder")
+    root = pathlib.Path(resolved.anchor).resolve(strict=False)
+    if resolved == root:
+        raise ValueError("A filesystem root cannot be trusted")
+    return resolved
+
+
+def document_path_is_trusted(
+    domain: str,
+    document_path: str | os.PathLike[str],
+    locations: Iterable[tuple[str, str | os.PathLike[str]]],
+) -> bool:
+    """Return whether a document is below a trusted folder for its domain."""
+    try:
+        document = _normalized_path(document_path, strict=True)
+    except OSError:
+        return False
+    for location_domain, location_path in locations:
+        if location_domain != domain:
+            continue
+        try:
+            folder = validate_trusted_location(location_path)
+        except (OSError, ValueError):
+            continue
+        if not document.is_relative_to(folder):
+            continue
+        return True
+    return False

--- a/src/erlab/interactive/_code_trust/_notary.py
+++ b/src/erlab/interactive/_code_trust/_notary.py
@@ -1,0 +1,270 @@
+"""HMAC and SQLite notary for executable-content manifests."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import hmac
+import logging
+import os
+import pathlib
+import secrets
+import sqlite3
+import tempfile
+import time
+import typing
+
+if typing.TYPE_CHECKING:
+    from erlab.interactive._code_trust._core import CodeTrustManifest
+
+logger = logging.getLogger(__name__)
+
+_ALGORITHM = "sha256"
+_SECRET_BYTES = 1024
+_STORE_SCHEMA_VERSION = 1
+_DEFAULT_CACHE_SIZE = 65535
+
+
+class CodeTrustError(RuntimeError):
+    """Raised when durable code-trust state cannot be accessed safely."""
+
+
+class CodeTrustNotary:
+    """Sign and verify code manifests with one per-user secret."""
+
+    def __init__(
+        self,
+        storage_directory: str | os.PathLike[str],
+        *,
+        cache_size: int = _DEFAULT_CACHE_SIZE,
+    ) -> None:
+        if cache_size < 1:
+            raise ValueError("Code trust cache size must be positive")
+        self._storage_directory = pathlib.Path(storage_directory)
+        self._secret_path = self._storage_directory / "code_trust_secret"
+        self._database_path = self._storage_directory / "code_signatures.db"
+        self._cache_size = cache_size
+
+    def _prepare_directory(self) -> None:
+        try:
+            self._storage_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+            if os.name == "posix":
+                self._storage_directory.chmod(0o700)
+        except OSError as exc:
+            raise CodeTrustError(
+                f"Could not prepare code trust directory {self._storage_directory}"
+            ) from exc
+
+    def _secret(self) -> bytes:
+        self._prepare_directory()
+        if not self._secret_path.exists():
+            self._create_secret()
+        try:
+            secret = self._secret_path.read_bytes()
+            if len(secret) != _SECRET_BYTES:
+                raise CodeTrustError("Code trust secret has an invalid size")
+            if os.name == "posix":
+                self._secret_path.chmod(0o600)
+        except OSError as exc:
+            raise CodeTrustError(
+                f"Could not read code trust secret {self._secret_path}"
+            ) from exc
+        else:
+            return secret
+
+    def _create_secret(self) -> None:
+        """Atomically publish one complete secret without replacing a race winner."""
+        descriptor = -1
+        temporary_path: pathlib.Path | None = None
+        try:
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix=".code_trust_secret-",
+                dir=self._storage_directory,
+            )
+            temporary_path = pathlib.Path(temporary_name)
+            if os.name == "posix":
+                os.fchmod(descriptor, 0o600)
+            stream = os.fdopen(descriptor, "wb")
+            descriptor = -1
+            with stream:
+                stream.write(secrets.token_bytes(_SECRET_BYTES))
+                stream.flush()
+                os.fsync(stream.fileno())
+            # Another process can publish its complete secret first.
+            with contextlib.suppress(FileExistsError):
+                os.link(temporary_path, self._secret_path)
+        except OSError as exc:
+            raise CodeTrustError(
+                f"Could not create code trust secret {self._secret_path}"
+            ) from exc
+        finally:
+            if descriptor >= 0:
+                with contextlib.suppress(OSError):
+                    os.close(descriptor)
+            if temporary_path is not None:
+                with contextlib.suppress(OSError):
+                    temporary_path.unlink()
+
+    def _connect(self) -> sqlite3.Connection:
+        self._prepare_directory()
+        try:
+            connection = sqlite3.connect(self._database_path)
+        except sqlite3.Error as exc:
+            raise CodeTrustError(
+                f"Could not access code trust database {self._database_path}"
+            ) from exc
+        try:
+            self._initialize_database(connection)
+        except sqlite3.OperationalError as exc:
+            connection.close()
+            raise CodeTrustError(
+                f"Could not access code trust database {self._database_path}"
+            ) from exc
+        except sqlite3.DatabaseError:
+            connection.close()
+            connection = self._replace_unreadable_database()
+        try:
+            if os.name == "posix":
+                self._database_path.chmod(0o600)
+        except OSError as exc:
+            connection.close()
+            raise CodeTrustError(
+                f"Could not protect code trust database {self._database_path}"
+            ) from exc
+        return connection
+
+    def _initialize_database(self, connection: sqlite3.Connection) -> None:
+        connection.execute("PRAGMA journal_mode=DELETE")
+        schema_version = typing.cast(
+            "tuple[int]", connection.execute("PRAGMA user_version").fetchone()
+        )[0]
+        if schema_version not in {0, _STORE_SCHEMA_VERSION}:
+            raise CodeTrustError(
+                f"Unsupported code trust store schema {schema_version}"
+            )
+        connection.execute(
+            "CREATE TABLE IF NOT EXISTS signatures ("
+            "domain TEXT NOT NULL, algorithm TEXT NOT NULL, "
+            "signature TEXT NOT NULL, last_seen REAL NOT NULL, "
+            "PRIMARY KEY (domain, algorithm, signature))"
+        )
+        if schema_version == 0:
+            connection.execute(f"PRAGMA user_version={_STORE_SCHEMA_VERSION}")
+        connection.commit()
+
+    def _replace_unreadable_database(self) -> sqlite3.Connection:
+        """Quarantine an unreadable store and create an empty one, as Jupyter does."""
+        backup_path = self._database_path.with_name(f"{self._database_path.name}.bak")
+        connection: sqlite3.Connection | None = None
+        try:
+            self._database_path.replace(backup_path)
+            connection = sqlite3.connect(self._database_path)
+            self._initialize_database(connection)
+            if os.name == "posix":
+                self._database_path.chmod(0o600)
+        except (OSError, sqlite3.Error) as exc:
+            if connection is not None:
+                connection.close()
+            raise CodeTrustError(
+                f"Could not recover code trust database {self._database_path}"
+            ) from exc
+        logger.warning(
+            "The code trust database was unreadable. It was moved to %s and "
+            "replaced with an empty database.",
+            backup_path,
+        )
+        return connection
+
+    def _signature(self, manifest: CodeTrustManifest) -> str:
+        return hmac.new(
+            self._secret(), manifest.canonical_bytes(), hashlib.sha256
+        ).hexdigest()
+
+    def check(self, manifest: CodeTrustManifest) -> bool:
+        """Return whether the current user previously signed the manifest."""
+        if not manifest.has_executable_code:
+            return True
+        try:
+            expected = self._signature(manifest)
+            with contextlib.closing(self._connect()) as connection:
+                row = connection.execute(
+                    "SELECT signature FROM signatures "
+                    "WHERE domain = ? AND algorithm = ? AND signature = ?",
+                    (manifest.domain, _ALGORITHM, expected),
+                ).fetchone()
+                if row is None or not hmac.compare_digest(row[0], expected):
+                    return False
+                connection.execute(
+                    "UPDATE signatures SET last_seen = ? "
+                    "WHERE domain = ? AND algorithm = ? AND signature = ?",
+                    (time.time(), manifest.domain, _ALGORITHM, expected),
+                )
+                connection.commit()
+        except (CodeTrustError, sqlite3.Error):
+            logger.warning("Could not verify saved code trust", exc_info=True)
+            return False
+        else:
+            return True
+
+    def sign(self, manifest: CodeTrustManifest) -> None:
+        """Remember trust for one executable manifest."""
+        if not manifest.has_executable_code:
+            return
+        signature = self._signature(manifest)
+        try:
+            with contextlib.closing(self._connect()) as connection:
+                connection.execute(
+                    "INSERT INTO signatures "
+                    "(domain, algorithm, signature, last_seen) VALUES (?, ?, ?, ?) "
+                    "ON CONFLICT(domain, algorithm, signature) "
+                    "DO UPDATE SET last_seen = excluded.last_seen",
+                    (manifest.domain, _ALGORITHM, signature, time.time()),
+                )
+                self._cull(connection)
+                connection.commit()
+        except sqlite3.Error as exc:
+            raise CodeTrustError("Could not store code trust signature") from exc
+
+    def remove(self, manifest: CodeTrustManifest) -> None:
+        """Remove saved trust for one manifest."""
+        if not manifest.has_executable_code:
+            return
+        signature = self._signature(manifest)
+        try:
+            with contextlib.closing(self._connect()) as connection:
+                connection.execute(
+                    "DELETE FROM signatures "
+                    "WHERE domain = ? AND algorithm = ? AND signature = ?",
+                    (manifest.domain, _ALGORITHM, signature),
+                )
+                connection.commit()
+        except sqlite3.Error as exc:
+            raise CodeTrustError("Could not remove code trust signature") from exc
+
+    def reset(self, *, domain: str | None = None) -> None:
+        """Remove all signatures, optionally limited to one trust domain."""
+        try:
+            with contextlib.closing(self._connect()) as connection:
+                if domain is None:
+                    connection.execute("DELETE FROM signatures")
+                else:
+                    connection.execute(
+                        "DELETE FROM signatures WHERE domain = ?", (domain,)
+                    )
+                connection.commit()
+        except sqlite3.Error as exc:
+            raise CodeTrustError("Could not reset saved code trust") from exc
+
+    def _cull(self, connection: sqlite3.Connection) -> None:
+        (count,) = typing.cast(
+            "tuple[int]",
+            connection.execute("SELECT COUNT(*) FROM signatures").fetchone(),
+        )
+        if count <= self._cache_size:
+            return
+        keep = max(int(0.75 * self._cache_size), 1)
+        connection.execute(
+            "DELETE FROM signatures WHERE rowid IN ("
+            "SELECT rowid FROM signatures ORDER BY last_seen DESC LIMIT -1 OFFSET ?)",
+            (keep,),
+        )

--- a/src/erlab/interactive/_code_trust/_notary.py
+++ b/src/erlab/interactive/_code_trust/_notary.py
@@ -115,6 +115,9 @@ class CodeTrustNotary:
             ) from exc
         try:
             self._initialize_database(connection)
+        except CodeTrustError:
+            connection.close()
+            raise
         except sqlite3.OperationalError as exc:
             connection.close()
             raise CodeTrustError(

--- a/src/erlab/interactive/_code_trust/_payloads.py
+++ b/src/erlab/interactive/_code_trust/_payloads.py
@@ -65,7 +65,7 @@ def code_payload_entries_from_metadata(
         raise TypeError("Saved code payload metadata must be JSON text")
     try:
         payload = json.loads(raw)
-    except (TypeError, ValueError) as exc:
+    except ValueError as exc:
         raise TypeError("Saved code payload metadata is invalid JSON") from exc
     if not isinstance(payload, list):
         raise TypeError("Saved code payload metadata must be a JSON list")

--- a/src/erlab/interactive/_code_trust/_payloads.py
+++ b/src/erlab/interactive/_code_trust/_payloads.py
@@ -1,0 +1,106 @@
+"""Metadata for opaque saved payloads that can execute Python when decoded."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import typing
+
+from erlab.interactive._code_trust._core import CodeTrustEntry
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, MutableMapping
+
+CODE_PAYLOAD_ENTRIES_ATTR = "erlab_code_trust_payload_entries"
+_PAYLOAD_SHA256_KEY = "payload_sha256"
+
+
+def create_payload_entry(
+    feature: str,
+    location: str,
+    code: str,
+    payload: bytes,
+    context: Mapping[str, typing.Any] | None = None,
+) -> CodeTrustEntry:
+    """Create an entry that binds an opaque executable payload by SHA-256."""
+    entry_context = {} if context is None else dict(context)
+    if _PAYLOAD_SHA256_KEY in entry_context:
+        raise ValueError(f"{_PAYLOAD_SHA256_KEY!r} is reserved by code trust")
+    entry_context[_PAYLOAD_SHA256_KEY] = hashlib.sha256(payload).hexdigest()
+    return CodeTrustEntry(feature, location, code, entry_context)
+
+
+def _validated_entries(entries: Iterable[CodeTrustEntry]) -> tuple[CodeTrustEntry, ...]:
+    validated = tuple(entries)
+    locations: set[tuple[str, str]] = set()
+    for entry in validated:
+        digest = entry.context.get(_PAYLOAD_SHA256_KEY)
+        try:
+            valid_digest = (
+                isinstance(digest, str)
+                and len(digest) == 64
+                and len(bytes.fromhex(digest)) == 32
+            )
+        except ValueError:
+            valid_digest = False
+        if not valid_digest:
+            raise TypeError("Code payload entry contains an invalid SHA-256 digest")
+        key = (entry.feature, entry.location)
+        if key in locations:
+            raise ValueError("Code payload entries must have unique locations")
+        locations.add(key)
+    return validated
+
+
+def code_payload_entries_from_metadata(
+    attrs: Mapping[str, typing.Any],
+) -> tuple[CodeTrustEntry, ...]:
+    """Read validated opaque-payload entries from saved document metadata."""
+    raw = attrs.get(CODE_PAYLOAD_ENTRIES_ATTR)
+    if raw is None:
+        return ()
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+    if not isinstance(raw, str):
+        raise TypeError("Saved code payload metadata must be JSON text")
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("Saved code payload metadata is invalid JSON") from exc
+    if not isinstance(payload, list):
+        raise TypeError("Saved code payload metadata must be a JSON list")
+
+    entries: list[CodeTrustEntry] = []
+    for item in payload:
+        if not isinstance(item, dict) or set(item) != {
+            "code",
+            "context",
+            "feature",
+            "location",
+        }:
+            raise TypeError("Saved code payload entry has invalid fields")
+        context = item["context"]
+        if not isinstance(context, dict):
+            raise TypeError("Saved code payload entry context must be an object")
+        entries.append(
+            CodeTrustEntry(item["feature"], item["location"], item["code"], context)
+        )
+    return _validated_entries(entries)
+
+
+def store_code_payload_entries(
+    attrs: MutableMapping[typing.Any, typing.Any],
+    entries: Iterable[CodeTrustEntry],
+) -> None:
+    """Store opaque-payload entries as deterministic document metadata."""
+    validated = _validated_entries(entries)
+    if not validated:
+        attrs.pop(CODE_PAYLOAD_ENTRIES_ATTR, None)
+        return
+    attrs[CODE_PAYLOAD_ENTRIES_ATTR] = json.dumps(
+        [entry.payload() for entry in validated],
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )

--- a/src/erlab/interactive/_code_trust/_ui.py
+++ b/src/erlab/interactive/_code_trust/_ui.py
@@ -1,0 +1,80 @@
+"""Reusable Qt widgets for executable-document trust."""
+
+from __future__ import annotations
+
+import typing
+
+from qtpy import QtCore, QtWidgets
+
+from erlab.interactive._code_trust._api import manifest_review_text
+
+if typing.TYPE_CHECKING:
+    from erlab.interactive._code_trust._core import CodeTrustManifest
+
+
+class _CodeTrustBanner(QtWidgets.QFrame):
+    """Persistent warning for a document whose executable content is paused."""
+
+    review_requested = QtCore.Signal()
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("code_trust_banner")
+        self.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
+        self.setProperty("codeTrustWarning", True)
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(8, 4, 8, 4)
+        label = QtWidgets.QLabel(
+            "Stored executable content is paused because this document is not trusted.",
+            self,
+        )
+        label.setWordWrap(True)
+        layout.addWidget(label, 1)
+
+        self.review_button = QtWidgets.QPushButton("Review and Trust…", self)
+        self.review_button.setObjectName("code_trust_review_button")
+        self.review_button.clicked.connect(self.review_requested)
+        layout.addWidget(self.review_button)
+        self.setFocusProxy(self.review_button)
+
+
+def create_code_trust_banner(
+    parent: QtWidgets.QWidget | None = None,
+) -> _CodeTrustBanner:
+    """Create the standard paused-code banner for one document window."""
+    return _CodeTrustBanner(parent)
+
+
+def confirm_code_trust(
+    parent: QtWidgets.QWidget,
+    manifest: CodeTrustManifest,
+    *,
+    document_name: str,
+    object_name: str,
+    window_title: str,
+) -> bool:
+    """Show the standard executable-content review dialog."""
+    subject = document_name.lower()
+    message = QtWidgets.QMessageBox(parent)
+    message.setObjectName(object_name)
+    message.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+    message.setWindowTitle(window_title)
+    message.setText(f"Trust stored executable content in this {subject}?")
+    message.setInformativeText(
+        "Some listed content can access files, start programs, and use your "
+        "Python environment. When present, a serialized lmfit code payload is "
+        "identified by a digest because its source cannot be displayed. Trust "
+        f"this {subject} only if you know its source."
+    )
+    details = manifest_review_text(manifest)
+    if details:
+        message.setDetailedText(details)
+    trust_button = message.addButton(
+        f"Trust {document_name} and Run Code",
+        QtWidgets.QMessageBox.ButtonRole.AcceptRole,
+    )
+    cancel_button = message.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+    message.setDefaultButton(typing.cast("QtWidgets.QPushButton", cancel_button))
+    message.exec()
+    return message.clickedButton() is trust_button

--- a/src/erlab/interactive/_figurecomposer/_model/_document.py
+++ b/src/erlab/interactive/_figurecomposer/_model/_document.py
@@ -940,7 +940,7 @@ class FigureDocument:
             if not enabled_only or operation.enabled
             if not executable_only
             or operation.kind != FigureOperationKind.CUSTOM
-            or operation.trusted
+            or bool(operation.code.strip())
             for source_name in self.operation_source_names(operation)
         }
 

--- a/src/erlab/interactive/_figurecomposer/_model/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_model/_state.py
@@ -697,9 +697,16 @@ class FigureOperationState(pydantic.BaseModel):
     method_transform_expression: str = ""
 
     code: str = ""
-    trusted: bool = False
 
     model_config = pydantic.ConfigDict(extra="forbid")
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _discard_legacy_trusted(cls, value: typing.Any) -> typing.Any:
+        if isinstance(value, Mapping) and "trusted" in value:
+            value = dict(value)
+            value.pop("trusted", None)
+        return value
 
     @pydantic.field_validator(
         "norm_kwargs",
@@ -877,12 +884,11 @@ class FigureOperationState(pydantic.BaseModel):
         )
 
     @classmethod
-    def custom(cls, *, label: str, code: str, trusted: bool) -> FigureOperationState:
+    def custom(cls, *, label: str, code: str) -> FigureOperationState:
         return cls(
             kind=FigureOperationKind.CUSTOM,
             label=label,
             code=code,
-            trusted=trusted,
             axes=FigureAxesSelectionState(axes=()),
         )
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_custom_code.py
@@ -1,4 +1,4 @@
-"""Trusted custom-code operation editor and renderer."""
+"""Custom-code operation editor and renderer."""
 
 from __future__ import annotations
 
@@ -115,19 +115,6 @@ def _build_custom_code_editor(
     editor: FigureOperationEditor, operation: FigureOperationState
 ) -> list[tuple[str, str, QtWidgets.QWidget]]:
     page, layout = editor.new_form_page("figureComposerCodePage")
-    trust = editor.check_box(
-        operation.trusted,
-        lambda checked: editor.request_update(trusted=checked),
-        parent=page,
-    )
-    trust.setObjectName("figureComposerCustomCodeTrustedCheck")
-    editor.add_form_row(
-        layout,
-        "Trusted",
-        trust,
-        "Allow this custom Python step to execute during rendering.",
-    )
-
     code_edit = erlab.interactive.utils.PythonCodeEditor(page)
     code_edit.setObjectName("figureComposerCustomCodeEdit")
     code_edit.setPlainText(operation.code)
@@ -160,15 +147,13 @@ def _render_custom(
     code = operation.code.strip()
     if not code:
         return
-    if not operation.trusted:
-        raise ValueError("Custom code is not trusted. Enable Trusted to render it.")
     namespace = _source_namespace(tool, fig, axs)
-    # Custom code is the explicit trusted escape hatch in the recipe pipeline.
+    # The whole-recipe renderer checks document trust before it calls this function.
     exec(operation.code, namespace)  # noqa: S102
 
 
 def _create_custom_operation(_tool: FigureComposerTool) -> FigureOperationState:
-    return FigureOperationState.custom(label="custom code", code="", trusted=True)
+    return FigureOperationState.custom(label="custom code", code="")
 
 
 def _display_text(_tool: FigureComposerTool, operation: FigureOperationState) -> str:
@@ -176,7 +161,7 @@ def _display_text(_tool: FigureComposerTool, operation: FigureOperationState) ->
 
 
 def _tooltip(_tool: FigureComposerTool, _operation: FigureOperationState) -> str:
-    return "Runs trusted custom Python code.\nTargets: none"
+    return "Runs custom Python code.\nTargets: none"
 
 
 def _editor_sections(
@@ -187,7 +172,7 @@ def _editor_sections(
             key,
             title,
             page,
-            "Edit the trusted custom Python code for this step.",
+            "Edit the custom Python code for this step.",
         )
         for key, title, page in _build_custom_code_editor(editor, operation)
     )
@@ -196,14 +181,12 @@ def _editor_sections(
 def _section_summary(
     _tool: FigureComposerTool, key: str, operation: FigureOperationState
 ) -> str:
-    if key == "code":
-        return "trusted" if operation.trusted else "not trusted"
     return ""
 
 
 def _code_lines(tool: FigureComposerTool, operation: FigureOperationState) -> list[str]:
     code = operation.code.strip()
-    if not operation.trusted or not code:
+    if not code:
         return []
     names = _custom_code_names(code)
     lines: list[str] = []
@@ -219,7 +202,7 @@ def _required_imports(
     _tool: FigureComposerTool, operation: FigureOperationState
 ) -> tuple[str, ...]:
     code = operation.code.strip()
-    if not operation.trusted or not code:
+    if not code:
         return ()
     names = _custom_code_names(code)
     imports: list[str] = []
@@ -260,17 +243,13 @@ def _custom_first_axis_code(tool: FigureComposerTool) -> str:
     return axes_code[0] if axes_code else "None"
 
 
-def _loaded_operation(operation: FigureOperationState) -> FigureOperationState:
-    return operation.model_copy(update={"trusted": False})
-
-
 SPEC = OperationSpec(
     kind=FigureOperationKind.CUSTOM,
     add_actions=(
         AddStepActionSpec(
             action_id=FigureOperationKind.CUSTOM.value,
             text="Python",
-            tooltip="Add a trusted custom Python step.",
+            tooltip="Add a custom Python step.",
             create_operation=_create_custom_operation,
         ),
     ),
@@ -285,5 +264,4 @@ SPEC = OperationSpec(
     render=_render_custom,
     code_lines=_code_lines,
     required_imports=_required_imports,
-    loaded_operation=_loaded_operation,
 )

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_catalog.py
@@ -706,8 +706,8 @@ def _transform_control() -> MethodControlSpec:
         object_name="figureComposerMethodTransformModeCombo",
         tooltip=(
             "Coordinate transform for this method.\n"
-            "Use custom only for trusted local expressions using ax, fig, "
-            "or mtransforms."
+            "Custom expressions can use ax, fig, or mtransforms. Saved expressions "
+            "run only when the document is trusted."
         ),
         options=(
             "data",

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_editor.py
@@ -415,18 +415,6 @@ def _add_method_control_row(
                     "Python expression for transform=.\n"
                     "Available names: ax, fig, mtransforms.",
                 )
-                trusted_check = editor.check_box(
-                    operation.trusted,
-                    _operation_trust_update_callback(editor),
-                    parent=layout.parentWidget(),
-                )
-                trusted_check.setObjectName("figureComposerMethodTransformTrustedCheck")
-                editor.add_form_row(
-                    layout,
-                    "Trusted",
-                    trusted_check,
-                    "Allow this custom transform expression to execute.",
-                )
         case MethodControlKind.ARG_COMBO:
             index = _control_arg_index(control)
             arg_value_getter: Callable[[FigureOperationState], typing.Any]
@@ -1087,17 +1075,7 @@ def _method_transform_update_callback(
     def update(text: str) -> None:
         editor.request_update_rebuild(
             method_transform=text,
-            trusted=text == "custom",
         )
-
-    return update
-
-
-def _operation_trust_update_callback(
-    editor: FigureOperationEditor,
-) -> Callable[[bool], None]:
-    def update(checked: bool) -> None:
-        editor.request_update(trusted=checked)
 
     return update
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_execution.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_execution.py
@@ -194,8 +194,6 @@ def _render_method_transform(
                 _transform_component(figure, axis, operation.method_transform_y),
             )
         case "custom":
-            if not operation.trusted:
-                raise ValueError("Custom transform expression is not trusted")
             expression = operation.method_transform_expression.strip()
             if not expression:
                 raise ValueError("Custom transform expression is empty")
@@ -235,8 +233,6 @@ def _method_transform_code(
                 f"mtransforms.blended_transform_factory({x_transform}, {y_transform})"
             )
         case "custom":
-            if not operation.trusted:
-                raise ValueError("Custom transform expression is not trusted")
             expression = operation.method_transform_expression.strip()
             if not expression:
                 raise ValueError("Custom transform expression is empty")
@@ -278,7 +274,12 @@ def _render_args_kwargs(
     ):
         kwargs.setdefault(spec.text_values_kwarg, list(operation.text_values))
     if axis is not None and figure is not None:
-        transform = _render_method_transform(operation, spec, figure=figure, axis=axis)
+        transform = _render_method_transform(
+            operation,
+            spec,
+            figure=figure,
+            axis=axis,
+        )
         if transform is not None:
             kwargs["transform"] = transform
     if _is_layout_engine_method(spec):
@@ -520,8 +521,7 @@ def _call_parts(args: Sequence[typing.Any], kwargs: dict[str, typing.Any]) -> st
 def _method_requires_transform_import(operation: FigureOperationState) -> bool:
     spec = _method_spec(operation)
     return _method_has_transform_control(spec) and (
-        operation.method_transform == "blend"
-        or (operation.method_transform == "custom" and operation.trusted)
+        operation.method_transform == "blend" or operation.method_transform == "custom"
     )
 
 

--- a/src/erlab/interactive/_figurecomposer/_operations/_method/_state.py
+++ b/src/erlab/interactive/_figurecomposer/_operations/_method/_state.py
@@ -529,6 +529,4 @@ def _loaded_operation(operation: FigureOperationState) -> FigureOperationState:
     )
     if kwargs != operation.method_kwargs:
         updates["method_kwargs"] = kwargs
-    if operation.method_transform == "custom":
-        updates["trusted"] = False
     return operation.model_copy(update=updates) if updates else operation

--- a/src/erlab/interactive/_figurecomposer/_rendering.py
+++ b/src/erlab/interactive/_figurecomposer/_rendering.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import typing
 
 import matplotlib as mpl
@@ -14,6 +15,7 @@ from matplotlib.figure import Figure
 
 import erlab
 import erlab.plotting as eplt
+from erlab.interactive._code_trust import execute_with_capability
 from erlab.interactive._figurecomposer._defaults import (
     _apply_figure_dpi,
     _figure_style_context,
@@ -33,6 +35,7 @@ from erlab.interactive._figurecomposer._model._sources import (
     _public_source_data,
     _valid_source_variable,
 )
+from erlab.interactive._figurecomposer._trust import figure_operation_execution_entries
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterator
@@ -373,6 +376,30 @@ def _iter_axes(axis_obj: object) -> tuple[matplotlib.axes.Axes, ...]:
     return (typing.cast("matplotlib.axes.Axes", axis_obj),)
 
 
+def _operation_will_render(tool: FigureComposerTool, operation: typing.Any) -> bool:
+    """Return whether the whole-recipe renderer can reach one operation."""
+    from erlab.interactive._figurecomposer._operations import _registry
+
+    if not operation.enabled:
+        return False
+    spec = _registry.spec_for(operation.kind)
+    return not (
+        spec.has_invalid_target(tool._document, operation)
+        or tool.operation_editor.has_input_error(operation)
+    )
+
+
+def _render_operation(
+    tool: FigureComposerTool,
+    spec: typing.Any,
+    operation: typing.Any,
+    figure: Figure,
+    axs: typing.Any,
+) -> None:
+    with _track_operation_artists(figure, operation.operation_id):
+        spec.render(tool, operation, figure, axs)
+
+
 def _render_into_figure(
     tool: FigureComposerTool, figure: Figure, *, sync_visible: bool
 ) -> None:
@@ -383,17 +410,33 @@ def _render_into_figure(
     render_errors: dict[str, str] = {}
     with _tool_figure_options_context(tool), _figure_style_context():
         axs = _make_axes(tool, figure, sync_visible=sync_visible)
-        for operation in tool._document.recipe.operations:
-            if not operation.enabled:
+        for operation_index, operation in enumerate(tool._document.recipe.operations):
+            if not _operation_will_render(tool, operation):
                 continue
             spec = _registry.spec_for(operation.kind)
-            if spec.has_invalid_target(
-                tool._document, operation
-            ) or tool.operation_editor.has_input_error(operation):
-                continue
+            entries = figure_operation_execution_entries(
+                tool._document.recipe,
+                operation_index,
+                location_prefix="figure",
+            )
+            capability = (
+                tool._issue_code_execution_capability(entries) if entries else None
+            )
             try:
-                with _track_operation_artists(figure, operation.operation_id):
-                    spec.render(tool, operation, figure, axs)
+                executed, _result = execute_with_capability(
+                    capability,
+                    entries,
+                    functools.partial(
+                        _render_operation,
+                        tool,
+                        spec,
+                        operation,
+                        figure,
+                        axs,
+                    ),
+                )
+                if not executed:
+                    continue
             except Exception as exc:
                 render_errors[operation.operation_id] = _render_error_text(exc)
     tool._set_operation_render_errors(render_errors)

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -137,6 +137,7 @@ from erlab.interactive._figurecomposer._rendering import (
     _axes_from_selection,
     _iter_axes,
     _live_layout_axes,
+    _operation_will_render,
     _render_error_text,
     _render_into_figure,
     _render_preview,
@@ -144,6 +145,10 @@ from erlab.interactive._figurecomposer._rendering import (
     _set_preview_draw_error,
 )
 from erlab.interactive._figurecomposer._text import _format_axes_tuple
+from erlab.interactive._figurecomposer._trust import (
+    figure_code_trust_entries,
+    figure_operation_execution_entries,
+)
 from erlab.interactive._figurecomposer._ui._axes_widgets import (
     _AxesSelectorWidget,
     _gridspec_target_preview_descriptor,
@@ -363,8 +368,18 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     tool_name = "fig"
     manager_collection = "figures"
     _PROVENANCE_IS_MODEL_OWNED = True
+    _CODE_TRUST_DOMAIN = "erlab.figure-composer-file"
+    _CODE_TRUST_POLICY_VERSION = 5
 
     StateModel = FigureRecipeState
+
+    @classmethod
+    def _code_trust_entries_from_status(cls, status: FigureRecipeState):
+        return figure_code_trust_entries(status, location_prefix="figure")
+
+    def _code_trust_changed(self) -> None:
+        if hasattr(self, "_document"):
+            _render_preview(self, show_window=True)
 
     def sizeHint(self) -> QtCore.QSize:
         hint = super().sizeHint()
@@ -453,6 +468,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             source_data=initial_source_data,
             changed_callback=self._document_changed,
         )
+        self._code_trust_recipe_entries = figure_code_trust_entries(
+            self._document.recipe,
+            location_prefix="figure",
+        )
         self._output_recipe_payload = self._output_recipe_state(self._document.recipe)
         self._figure_window: _FigureComposerDisplayWindow | None = None
         self._subplot_adjust_dialog: QtWidgets.QDialog | None = None
@@ -478,6 +497,32 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         """Publish each committed document mutation through the manager boundary."""
         if not erlab.interactive.utils.qt_is_valid(self):
             return
+        if recipe_changed:
+            entries = figure_code_trust_entries(
+                self._document.recipe,
+                location_prefix="figure",
+            )
+            previous_entries = self._code_trust_recipe_entries
+            self._code_trust_recipe_entries = entries
+            if not self._restoring_from_dataset:
+                previous_identities = tuple(
+                    entry.document_identity() for entry in previous_entries
+                )
+                previous_identity_set = frozenset(previous_identities)
+                edited_entries = tuple(
+                    entry
+                    for entry in entries
+                    if entry.document_identity() not in previous_identity_set
+                )
+                if (
+                    tuple(entry.document_identity() for entry in entries)
+                    != previous_identities
+                ):
+                    with self._local_code_edit(
+                        entries,
+                        edited_entries=edited_entries,
+                    ):
+                        pass
         output_recipe_payload = self._output_recipe_state(self._document.recipe)
         output_recipe_changed = output_recipe_payload != self._output_recipe_payload
         self._output_recipe_payload = output_recipe_payload
@@ -524,7 +569,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if any(
             operation.enabled
             and operation.kind == FigureOperationKind.CUSTOM
-            and operation.trusted
             and bool(operation.code.strip())
             for operation in self._document.recipe.operations
         ):
@@ -4344,6 +4388,19 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         if self._warn_invalid_operation_targets():
             return
         self.operation_editor.flush_pending_commits()
+        for operation_index, operation in enumerate(self._document.recipe.operations):
+            if not _operation_will_render(self, operation):
+                continue
+            if not self._authorize_code_execution(
+                functools.partial(
+                    figure_operation_execution_entries,
+                    self._document.recipe,
+                    operation_index,
+                    location_prefix="figure",
+                ),
+                focus_on_block=True,
+            ):
+                return
         filename, _filter = QtWidgets.QFileDialog.getSaveFileName(
             self,
             "Export Figure",
@@ -4602,7 +4659,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
     def _saved_tool_status(self) -> FigureRecipeState:
         self._flush_pending_figure_resize_history_write()
-        status = self.tool_status
+        status = super()._saved_tool_status()
         allowed_uids = self._save_tool_data_reference_node_uids
         if allowed_uids is None:
             return status
@@ -5263,9 +5320,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         used_code_names.update(
             bound_name
             for operation in self._document.recipe.operations
-            if operation.enabled
-            and operation.kind == FigureOperationKind.CUSTOM
-            and operation.trusted
+            if operation.enabled and operation.kind == FigureOperationKind.CUSTOM
             for bound_name in _custom_code_bound_names(operation.code)
         )
         if self._document.recipe.setup.layout_mode == "gridspec":

--- a/src/erlab/interactive/_figurecomposer/_trust.py
+++ b/src/erlab/interactive/_figurecomposer/_trust.py
@@ -1,0 +1,123 @@
+"""Figure Composer adapter for the general executable-code trust service."""
+
+from __future__ import annotations
+
+from erlab.interactive._code_trust import create_entry
+from erlab.interactive._figurecomposer._model._gridspec import _gridspec_all_axes_ids
+from erlab.interactive._figurecomposer._model._sources import _valid_source_variable
+from erlab.interactive._figurecomposer._model._state import (
+    FigureOperationKind,
+    FigureRecipeState,
+)
+from erlab.interactive._figurecomposer._operations._method._catalog import _method_spec
+from erlab.interactive._figurecomposer._operations._method._state import (
+    _method_has_transform_control,
+)
+
+
+def _figure_axes_namespace(recipe: FigureRecipeState) -> dict[str, object]:
+    if recipe.setup.layout_mode == "gridspec":
+        return {
+            "layout_mode": "gridspec",
+            "axes_ids": list(_gridspec_all_axes_ids(recipe.setup)),
+        }
+    return {
+        "layout_mode": "subplots",
+        "shape": [recipe.setup.nrows, recipe.setup.ncols],
+    }
+
+
+def _figure_operation_code_trust_entries(
+    recipe: FigureRecipeState,
+    operation_index: int,
+    *,
+    location_prefix: str,
+    include_inactive: bool,
+    axes_namespace: dict[str, object] | None = None,
+):
+    operation = recipe.operations[operation_index]
+    if not include_inactive and not operation.enabled:
+        return ()
+    is_custom_code = (
+        operation.kind == FigureOperationKind.CUSTOM and operation.code.strip()
+    )
+    is_custom_transform = (
+        operation.kind == FigureOperationKind.METHOD
+        and operation.method_transform_expression.strip()
+        and _method_has_transform_control(_method_spec(operation))
+        and (include_inactive or operation.method_transform == "custom")
+    )
+    if not is_custom_code and not is_custom_transform:
+        return ()
+    if axes_namespace is None:
+        axes_namespace = _figure_axes_namespace(recipe)
+    location = f"{location_prefix}/operations/{operation_index}"
+    common_context = {
+        "axes": operation.axes.model_dump(mode="json"),
+        "enabled": operation.enabled,
+        "kind": operation.kind.value,
+        "sources": list(operation.sources),
+    }
+    if is_custom_code:
+        return (
+            create_entry(
+                "erlab.figure-composer.custom-code",
+                location,
+                operation.code,
+                {
+                    **common_context,
+                    "namespace": {
+                        "axes": axes_namespace,
+                        "source_variables": [
+                            _valid_source_variable(source.name)
+                            for source in recipe.sources
+                        ],
+                    },
+                },
+            ),
+        )
+    return (
+        create_entry(
+            "erlab.figure-composer.custom-transform",
+            f"{location}/transform",
+            operation.method_transform_expression,
+            {
+                **common_context,
+                "axes_namespace": axes_namespace,
+                "method_family": operation.method_family.value,
+                "method_name": operation.method_name,
+                "transform": operation.method_transform,
+                "transform_x": operation.method_transform_x,
+                "transform_y": operation.method_transform_y,
+            },
+        ),
+    )
+
+
+def figure_operation_execution_entries(
+    recipe: FigureRecipeState, operation_index: int, *, location_prefix: str
+):
+    """Return the entries that one render operation is about to execute."""
+    return _figure_operation_code_trust_entries(
+        recipe,
+        operation_index,
+        location_prefix=location_prefix,
+        include_inactive=False,
+    )
+
+
+def figure_code_trust_entries(recipe: FigureRecipeState, *, location_prefix: str):
+    """Return the Python entries stored in one Figure Composer recipe."""
+    entries = []
+    axes_namespace = _figure_axes_namespace(recipe)
+    for index in range(len(recipe.operations)):
+        entries.extend(
+            _figure_operation_code_trust_entries(
+                recipe,
+                index,
+                location_prefix=location_prefix,
+                include_inactive=True,
+                axes_namespace=axes_namespace,
+            )
+        )
+    return tuple(entries)

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -6,15 +6,15 @@ import contextlib
 import dataclasses
 import functools
 import gc
-import importlib
 import logging
+import pathlib
 import re
 import threading
 import time
 import traceback
 import typing
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 
 import numpy as np
 import pydantic
@@ -23,6 +23,13 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab.interactive.utils
+from erlab.interactive._code_trust import execution_capability_allows
+from erlab.interactive._fit_code_trust import (
+    lmfit_expression_model_code_entries,
+    lmfit_model_code_entry,
+    lmfit_parameter_expression_entries,
+    lmfit_result_code_entry,
+)
 from erlab.interactive._widgets import _Separator
 
 if typing.TYPE_CHECKING:
@@ -41,6 +48,7 @@ _R = typing.TypeVar("_R")
 _T = typing.TypeVar("_T")
 logger = logging.getLogger(__name__)
 _FIT_MULTI_LIVE_REFRESH_INTERVAL_S = 0.10
+_REGISTERED_MODEL_CLASSES: dict[str, type[lmfit.Model]] = {}
 _LMFIT_CALLABLE_WARNING_RE = re.compile(
     r"^Could not unpack dill-encoded callable '([^']+)', saved with Python version .+$"
 )
@@ -49,6 +57,33 @@ _PythonCodeEditor = erlab.interactive.utils.PythonCodeEditor
 _fit_worker_gc_lock = threading.Lock()
 _fit_worker_gc_depth = 0
 _fit_worker_gc_restore_enabled = False
+
+
+class _FitCodeEditRejected(Exception):
+    """Abort one local fit-code edit without committing its trust transition."""
+
+
+def _reject_fit_code_edit(reason: str = "") -> typing.NoReturn:
+    """Exit a local edit through the framework rollback path."""
+    raise _FitCodeEditRejected(reason)
+
+
+def _model_class_reference(model_class: type[lmfit.Model]) -> str:
+    return f"{model_class.__module__}:{model_class.__qualname__}"
+
+
+@functools.cache
+def _library_lmfit_model_classes() -> tuple[type[lmfit.Model], ...]:
+    """Return model classes obtained from the installed lmfit package."""
+    classes = {lmfit.Model, lmfit.model.CompositeModel}
+    for candidate in vars(lmfit.models).values():
+        if (
+            isinstance(candidate, type)
+            and issubclass(candidate, lmfit.Model)
+            and candidate.__module__.startswith("lmfit.")
+        ):
+            classes.add(candidate)
+    return tuple(classes)
 
 
 def _load_lmfit_for_ftool_restore(
@@ -344,6 +379,11 @@ class _ParameterTableModel(QtCore.QAbstractTableModel):
         self._params_from_coord: dict[str, str] = params_from_coord
         self._param_names = list(params.keys()) if params is not None else []
 
+    @staticmethod
+    def _value(param: lmfit.Parameter) -> float:
+        """Read the cached value without evaluating a parameter expression."""
+        return float(param._val)
+
     @property
     def params(self) -> lmfit.Parameters:
         return self._params
@@ -404,7 +444,7 @@ class _ParameterTableModel(QtCore.QAbstractTableModel):
             if col == 0:
                 return param.name
             if col == 1:
-                return self._format_value(param.value)
+                return self._format_value(self._value(param))
             if col == 2:
                 if param.stderr is None:
                     return ""
@@ -484,7 +524,7 @@ class _ParameterTableModel(QtCore.QAbstractTableModel):
             return False
 
         try:
-            new_value = float(value) if col == 1 else float(param.value)
+            new_value = float(value) if col == 1 else self._value(param)
             new_min = float(param.min)
             new_max = float(param.max)
             if col == 3:
@@ -519,7 +559,7 @@ class _ParameterTableModel(QtCore.QAbstractTableModel):
     def edit_value_string(self, row: int, column: int) -> str:
         param = self._params[self._param_names[row]]
         if column == 1:
-            return self._format_value(param.value)
+            return self._format_value(self._value(param))
         if column == 2:
             if param.stderr is None:
                 return ""
@@ -543,14 +583,12 @@ class _ParameterTableModel(QtCore.QAbstractTableModel):
     def _is_expr_param(param: lmfit.Parameter) -> bool:
         return bool(param.expr)
 
-    @staticmethod
-    def _param_tooltip(param: lmfit.Parameter) -> str:
+    def _param_tooltip(self, param: lmfit.Parameter) -> str:
         expr = f"expr: {param.expr}\n" if param.expr else ""
-        value_line = f"value: {param.value}"
+        value = self._value(param)
+        value_line = f"value: {value}"
         if param.stderr is not None and np.isfinite(param.stderr):
-            uncertainty = _ParameterTableModel._format_uncertainty(
-                param.value, param.stderr
-            )
+            uncertainty = _ParameterTableModel._format_uncertainty(value, param.stderr)
             value_line = f"value: {uncertainty}"
         return (
             f"name: {param.name}\n"
@@ -794,6 +832,12 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
     _PERSISTED_FIT_RESULT_VAR: typing.ClassVar[str] = "__ftool_fit_result__"
     _PERSISTED_FIT_RESULT_DIM: typing.ClassVar[str] = "__ftool_fit_result_bytes__"
     _PERSISTED_FIT_CURRENT_ATTR: typing.ClassVar[str] = "__ftool_fit_is_current__"
+    _CODE_TRUST_DOMAIN = "erlab.fit1d-file"
+    _CODE_TRUST_POLICY_VERSION = 3
+    _MODEL_CODE_TRUST_FEATURE = "erlab.fit.serialized-model"
+    _PARAMETER_CODE_TRUST_FEATURE = "erlab.fit.parameter-expression"
+    _FIT_RESULT_CODE_TRUST_FEATURE = "erlab.fit.serialized-result"
+    _FIT_RESULT_CODE_TRUST_LOCATION = "fit-result"
 
     class StateModel(pydantic.BaseModel):
         data_name: str
@@ -811,6 +855,56 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         params: list[tuple[typing.Any, ...]]
         params_from_coord: dict[str, str]
         state2d: _State2D | None = None
+
+    @classmethod
+    def _model_code_trust_entry(cls, model_state: tuple[str, str]) -> typing.Any:
+        return lmfit_model_code_entry(
+            model_state[1],
+            feature=cls._MODEL_CODE_TRUST_FEATURE,
+            location="model",
+        )
+
+    @classmethod
+    def _parameter_code_trust_entries(
+        cls,
+        expressions: Iterable[tuple[typing.Any, typing.Any]],
+        *,
+        location_prefix: str,
+    ) -> tuple[typing.Any, ...]:
+        return lmfit_parameter_expression_entries(
+            expressions,
+            feature=cls._PARAMETER_CODE_TRUST_FEATURE,
+            location_prefix=location_prefix,
+        )
+
+    @classmethod
+    def _code_trust_entries_from_status(
+        cls, status: StateModel
+    ) -> tuple[typing.Any, ...]:
+        parameter_groups: list[tuple[str, Iterable[tuple[typing.Any, ...]]]] = [
+            ("parameters", status.params)
+        ]
+        if status.state2d is not None:
+            parameter_groups.extend(
+                (f"parameters-full/{index}", params or ())
+                for index, params in enumerate(status.state2d.params_full)
+            )
+            parameter_groups.extend(
+                (f"initial-parameters-full/{index}", params or ())
+                for index, params in enumerate(status.state2d.initial_params_full or ())
+            )
+        entries = [
+            entry
+            for location, params in parameter_groups
+            for entry in cls._parameter_code_trust_entries(
+                ((state[0], state[3]) for state in params if len(state) >= 4),
+                location_prefix=location,
+            )
+        ]
+        model_entry = cls._model_code_trust_entry(status.model_state)
+        if model_entry is not None:
+            entries.insert(0, model_entry)
+        return tuple(entries)
 
     @property
     def tool_data(self) -> xr.DataArray:
@@ -833,6 +927,21 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     sigFitFinished = QtCore.Signal(object)
 
+    @classmethod
+    def _register_model_class(cls, model_class: type[lmfit.Model]) -> None:
+        """Make one locally supplied model class available to saved state."""
+        _REGISTERED_MODEL_CLASSES[_model_class_reference(model_class)] = model_class
+
+    @classmethod
+    def _serialize_model_state(cls, model: lmfit.Model) -> tuple[str, str]:
+        """Serialize a model only at a locally authorized mutation boundary."""
+        model_class = type(model)
+        cls._register_model_class(model_class)
+        return (
+            _model_class_reference(model_class),
+            model.dumps(),
+        )
+
     def __init__(
         self,
         data: xr.DataArray,
@@ -843,6 +952,15 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         model_name: str | None = None,
     ) -> None:
         super().__init__()
+        for model_class in (
+            *_library_lmfit_model_classes(),
+            *self.MODEL_CHOICES.values(),
+        ):
+            self._register_model_class(model_class)
+        if model is not None:
+            self._register_model_class(type(model))
+        self._fit_execution_capability: object | None = None
+        self._pending_fit_status: Fit1DTool.StateModel | None = None
         self._fit_finished_connection_keys: set[tuple[object | None, object]] = set()
         self._reset_fit_state(
             data,
@@ -971,6 +1089,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         else:
             self._model = model
         self._sanitize_model_convolution_for_x()
+        self._serialized_model_state = self._serialize_model_state(self._model)
 
         self._model_load_path: str | None = None
         if data_name is None:
@@ -996,8 +1115,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._last_fit_y: np.ndarray | None = None
         self._last_residual: np.ndarray | None = None
         self._last_result_ds: xr.Dataset | None = None
-        self._pending_persisted_fit_result_blob: np.ndarray | None = None
-        self._pending_persisted_fit_is_current = False
+        self._serialized_fit_result_blob: np.ndarray | None = None
+        self._pending_persisted_fit_is_current: bool | None = None
         self._slider_drag_range: tuple[float, float] | None = None
         self._fit_is_current: bool = False
         self._table_widths_initialized: bool = False
@@ -1018,6 +1137,145 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_multi_sequence_write_history: bool | None = None
         self._param_bounds_repair_names: list[str] | None = None
         self._write_history = False
+        self._refresh_fit_code_entries()
+
+    @staticmethod
+    def _live_parameter_expressions(
+        params: lmfit.Parameters,
+    ) -> tuple[tuple[typing.Any, typing.Any], ...]:
+        """Return nonempty expression source without evaluating parameter values."""
+        return tuple(
+            (param.name, param._expr) for param in params.values() if param._expr
+        )
+
+    def _parameter_value(self, param: lmfit.Parameter) -> float:
+        """Read a parameter without evaluating its expression."""
+        return float(param._val)
+
+    def _replace_current_params(self, params: lmfit.Parameters) -> None:
+        """Replace parameters and refresh the executable inventory if needed."""
+        expressions_changed = self._live_parameter_expressions(
+            self._params
+        ) != self._live_parameter_expressions(params)
+        self._params = params
+        if expressions_changed:
+            self._refresh_fit_code_entries()
+
+    def _fit_parameter_groups(
+        self,
+    ) -> tuple[tuple[str, lmfit.Parameters | None], ...]:
+        """Return each live parameter group represented in the saved state."""
+        return (("parameters", self._params),)
+
+    def _parameter_expression_edit_locations(self) -> frozenset[str]:
+        """Return parameter groups changed by a current-row expression edit."""
+        return frozenset({"parameters"})
+
+    def _build_fit_code_entries(
+        self,
+        *,
+        parameter_expression: tuple[str, str | None] | None = None,
+        parameter_group_overrides: Mapping[str, lmfit.Parameters | None] | None = None,
+    ) -> tuple[typing.Any, ...]:
+        """Build the exact live or candidate executable inventory."""
+        entries = []
+        model_entry = type(self)._model_code_trust_entry(self._serialized_model_state)
+        if model_entry is not None:
+            entries.append(model_entry)
+        edited_locations = self._parameter_expression_edit_locations()
+        for location, params in self._fit_parameter_groups():
+            if (
+                parameter_group_overrides is not None
+                and location in parameter_group_overrides
+            ):
+                params = parameter_group_overrides[location]
+            if params is None:
+                continue
+            expressions = self._live_parameter_expressions(params)
+            if parameter_expression is not None and location in edited_locations:
+                parameter_name, expression = parameter_expression
+                expressions = tuple(
+                    (
+                        param.name,
+                        expression if param.name == parameter_name else param._expr,
+                    )
+                    for param in params.values()
+                    if (expression if param.name == parameter_name else param._expr)
+                )
+            entries.extend(
+                type(self)._parameter_code_trust_entries(
+                    expressions,
+                    location_prefix=location,
+                )
+            )
+        return tuple(entries)
+
+    @staticmethod
+    def _new_fit_code_entries(
+        current: Iterable[typing.Any], candidate: Iterable[typing.Any]
+    ) -> tuple[typing.Any, ...]:
+        """Return candidate identities that are not in the committed inventory."""
+        current_identities = {entry.document_identity() for entry in current}
+        return tuple(
+            entry
+            for entry in candidate
+            if entry.document_identity() not in current_identities
+        )
+
+    def _fit_code_entries_with_model(
+        self, model_entries: Iterable[typing.Any]
+    ) -> tuple[typing.Any, ...]:
+        """Replace the current model entry and retain every parameter entry."""
+        return (
+            *model_entries,
+            *(
+                entry
+                for entry in self._fit_code_entries
+                if entry.feature != self._MODEL_CODE_TRUST_FEATURE
+            ),
+        )
+
+    def _refresh_fit_code_entries(self) -> None:
+        """Cache the exact executable inventory after a fit-code mutation."""
+        self._fit_code_entries = self._build_fit_code_entries()
+        self._fit_execution_capability = None
+
+    def _current_fit_execution_allowed(self, *, focus_on_block: bool = False) -> bool:
+        """Authorize the current model and parameter expressions."""
+        if execution_capability_allows(
+            self._fit_execution_capability, self._fit_code_entries
+        ):
+            return True
+        self._fit_execution_capability = self._issue_code_execution_capability(
+            self._fit_code_entries,
+            focus_on_block=focus_on_block,
+        )
+        return self._fit_execution_capability is not None
+
+    def _clear_model_curves(self) -> None:
+        """Clear derived curves without evaluating the current model."""
+        self.fit_curve.setData([], [])
+        self.residual_curve.setData([], [])
+        self._last_fit_y = None
+        self._last_residual = None
+        self._update_component_curves(np.array([]))
+
+    def _code_trust_changed(self) -> None:
+        """Retry deferred restores and refresh the guarded fit preview."""
+        self._fit_execution_capability = None
+        pending = self._pending_fit_status
+        if pending is not None:
+            with self._history_suppressed():
+                self.tool_status = pending
+            if self._pending_fit_status is not None:
+                return
+            self._reset_history_stack()
+        elif not self._current_fit_execution_allowed():
+            self._cancel_fit()
+            self._clear_model_curves()
+            return
+        self._restore_pending_fit_result()
+        self._update_fit_curve()
 
     def _fit_finished_connection_key(
         self, slot: Callable[..., typing.Any]
@@ -1167,7 +1425,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self.table_splitter.setChildrenCollapsible(False)
 
         self.param_model: _ParameterTableModel = _ParameterTableModel(
-            self._params, self._params_from_coord, self
+            self._params,
+            self._params_from_coord,
+            self,
         )
         self.param_model.sigParamsChanged.connect(self._update_fit_curve)
         self.param_model.sigParamsChanged.connect(self._refresh_slider_from_model)
@@ -1610,8 +1870,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     @QtCore.Slot()
     def _refresh_multipeak_model(self) -> None:
-        self.set_model(
-            self._make_model_from_choice("MultiPeakModel"), merge_params=True
+        self._set_model_from_local_edit(
+            self._make_model_from_choice("MultiPeakModel"),
+            merge_params=True,
         )
 
     def _build_multipeak_group(self) -> QtWidgets.QWidget:
@@ -1738,8 +1999,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         degree = int(self.poly_degree_spin.value())
         if degree == self._model.func.degree:
             return
-        self.set_model(
-            self._make_model_from_choice("PolynomialModel"), merge_params=True
+        self._set_model_from_local_edit(
+            self._make_model_from_choice("PolynomialModel"),
+            merge_params=True,
         )
 
     def _make_polynomial_model_kwargs(self) -> dict[str, typing.Any]:
@@ -1770,18 +2032,53 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self.polynomial_group.setVisible(visible)
         self.polynomial_group.setEnabled(visible)
 
+    def _expression_model_edit_entries(
+        self, kwargs: Mapping[str, typing.Any]
+    ) -> tuple[typing.Any, ...]:
+        """Return the exact code that an ExpressionModel constructor can run."""
+        return lmfit_expression_model_code_entries(
+            str(kwargs["expr"]),
+            str(init_script) if (init_script := kwargs.get("init_script")) else None,
+            feature=self._MODEL_CODE_TRUST_FEATURE,
+            location="model",
+        )
+
     @QtCore.Slot()
     def _refresh_expression_model(self) -> None:
+        kwargs = self._make_expression_model_kwargs()
+        model_entries = self._expression_model_edit_entries(kwargs)
+        execution_entries = self._fit_code_entries_with_model(model_entries)
+        edited_entries = self._new_fit_code_entries(
+            self._fit_code_entries, execution_entries
+        )
+        previous_trust = self._current_document_trust()
+        applied = False
         try:
-            model = self._make_model_from_choice("ExpressionModel")
+            with self._local_code_edit(
+                execution_entries,
+                edited_entries=edited_entries,
+                focus_on_block=True,
+            ) as capability:
+                if not execution_capability_allows(capability, execution_entries):
+                    return
+                model = lmfit.models.ExpressionModel(**kwargs)
+                self._apply_model(
+                    model,
+                    model_state=self._serialize_model_state(model),
+                    merge_params=True,
+                    refresh_views=False,
+                )
+                applied = True
         except Exception:
             self._show_error(
                 "Expression error",
                 "While creating the ExpressionModel from the given expression, "
                 "an error occurred. Please check the expression syntax.",
             )
-        else:
-            self.set_model(model, merge_params=True)
+        if applied:
+            self._finish_model_change(
+                refresh_fit=self._current_document_trust() == previous_trust
+            )
 
     def _make_expression_model_kwargs(self) -> dict[str, typing.Any]:
         kwargs = {
@@ -1790,9 +2087,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         }
         init_script: str | None = self.expr_init_script_dialog.get_script()
         if init_script:
-            # Check if the init script executes without errors
-            dummy_model = lmfit.models.ExpressionModel("x", independent_vars=["x"])
-            dummy_model.asteval.eval(init_script, raise_errors=True)
             kwargs["init_script"] = init_script
 
         return kwargs
@@ -1862,77 +2156,239 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         merge_params: bool = False,
         reset_params_from_coord: bool = False,
     ) -> None:
+        if merge_params and not self._current_fit_execution_allowed(
+            focus_on_block=True
+        ):
+            return
+        self._apply_model(
+            model,
+            model_load_path=model_load_path,
+            merge_params=merge_params,
+            reset_params_from_coord=reset_params_from_coord,
+        )
+
+    def _apply_model(
+        self,
+        model: lmfit.Model,
+        *,
+        model_state: tuple[str, str] | None = None,
+        model_load_path: str | None = None,
+        merge_params: bool = False,
+        reset_params_from_coord: bool = False,
+        refresh_views: bool = True,
+    ) -> None:
+        """Commit a model after its stored or local authorization succeeds."""
+        if model_state is None:
+            model_state = self._serialize_model_state(model)
         prev_params = self._params
         prev_model = self._model
         prev_widths = dict(self._slider_widths)
-        self._model = model
-        self._sanitize_model_convolution_for_x()
-        self._model_load_path = model_load_path
-
-        if reset_params_from_coord:
-            self._params_from_coord = {}
-        self._params = self._model.make_params()
+        params_from_coord = (
+            {} if reset_params_from_coord else self._params_from_coord.copy()
+        )
+        self._sanitize_model_convolution_for_x(model)
+        params = model.make_params()
         if merge_params and prev_params is not None and prev_model is not None:
-            self._merge_params(prev_params, self._params, prev_model, model)
-        for k in list(self._params_from_coord.keys()):
-            if k not in self._params:
-                del self._params_from_coord[k]
-        self._initial_params = self._params.copy()
-        self._slider_widths = {
-            name: width for name, width in prev_widths.items() if name in self._params
+            self._merge_params(prev_params, params, prev_model, model)
+        params_from_coord = {
+            name: coord for name, coord in params_from_coord.items() if name in params
         }
-        self.param_model.set_params(self._params, self._params_from_coord)
+        initial_params = params.copy()
+        slider_widths = {
+            name: width for name, width in prev_widths.items() if name in params
+        }
+        self._model = model
+        self._serialized_model_state = model_state
+        self._model_load_path = model_load_path
+        self._params = params
+        self._initial_params = initial_params
+        self._params_from_coord = params_from_coord
+        self._slider_widths = slider_widths
+        self._refresh_fit_code_entries()
+        self.param_model.set_params(
+            self._params,
+            self._params_from_coord,
+            emit_changed=False,
+        )
         self._sync_model_display()
         self._sync_model_specific_controls()
-        self._update_fit_curve()
-        self._mark_fit_stale()
         if self.param_model.rowCount() > 0:
             self.param_view.selectRow(0)
+        if refresh_views:
+            self._finish_model_change()
+        self._register_model_class(type(model))
+
+    def _finish_model_change(self, *, refresh_fit: bool = True) -> None:
+        """Notify model consumers after executable trust is committed."""
+        if refresh_fit:
+            self._update_fit_curve()
+        self._refresh_slider_from_model()
+        self._mark_fit_stale()
+        self._write_state()
+
+    def _set_model_from_local_edit(
+        self,
+        model: lmfit.Model,
+        *,
+        model_state: tuple[str, str] | None = None,
+        model_load_path: str | None = None,
+        merge_params: bool = False,
+        reset_params_from_coord: bool = False,
+    ) -> bool:
+        """Apply one explicit UI model edit under a scoped capability."""
+        if model_state is None:
+            model_state = self._serialize_model_state(model)
+        model_entry = type(self)._model_code_trust_entry(model_state)
+        model_entries = () if model_entry is None else (model_entry,)
+        execution_entries = self._fit_code_entries_with_model(model_entries)
+        edited_entries = self._new_fit_code_entries(
+            self._fit_code_entries, execution_entries
+        )
+        previous_trust = self._current_document_trust()
+        with self._local_code_edit(
+            execution_entries,
+            edited_entries=edited_entries,
+            focus_on_block=True,
+        ) as capability:
+            if not execution_capability_allows(capability, execution_entries):
+                return False
+            self._apply_model(
+                model,
+                model_state=model_state,
+                model_load_path=model_load_path,
+                merge_params=merge_params,
+                reset_params_from_coord=reset_params_from_coord,
+                refresh_views=False,
+            )
+        self._finish_model_change(
+            refresh_fit=self._current_document_trust() == previous_trust
+        )
+        return True
 
     @QtCore.Slot(int)
     def _on_model_choice_changed(self, _index: int) -> None:
         label = self.model_combo.currentData(role=QtCore.Qt.ItemDataRole.UserRole)
-        set_model_kw: dict[str, typing.Any] = {
-            "merge_params": True,
-            "reset_params_from_coord": True,
-        }
+        if label == "__file":
+            model_load_path, _ = QtWidgets.QFileDialog.getOpenFileName(
+                self,
+                "Load lmfit model",
+                "",
+                "lmfit Model Files (*.sav *.json *.model);;All files (*)",
+            )
+            if not model_load_path:
+                self._sync_model_display()
+                return
+            try:
+                serialized = pathlib.Path(model_load_path).read_text()
+                candidate_entry = type(self)._model_code_trust_entry(("", serialized))
+                candidate_entries = (
+                    () if candidate_entry is None else (candidate_entry,)
+                )
+                capability = self._review_code_candidate(
+                    candidate_entries,
+                    document_name="lmfit model file",
+                    object_name="fit_model_file_code_trust_review_dialog",
+                    window_title="Review lmfit Model File",
+                )
+                if not execution_capability_allows(capability, candidate_entries):
+                    self._sync_model_display()
+                    return
+                model_loader = lmfit.model.Model(lambda x: x)
+                loaded_model = _load_lmfit_for_ftool_restore(
+                    lambda: model_loader.loads(serialized)
+                )
+                loaded_model_state = (
+                    _model_class_reference(type(loaded_model)),
+                    serialized,
+                )
+                if not self._set_model_from_local_edit(
+                    loaded_model,
+                    model_state=loaded_model_state,
+                    model_load_path=model_load_path,
+                    merge_params=True,
+                    reset_params_from_coord=True,
+                ):
+                    self._sync_model_display()
+            except Exception:
+                self._show_error(
+                    "Model creation failed",
+                    "Failed to load the selected model file. Reverting to the "
+                    "previous model.",
+                )
+                self._sync_model_display()
+            return
+
+        expression_kwargs: dict[str, typing.Any] | None = None
+        model_state: tuple[str, str] | None = None
+        model: lmfit.Model | None = None
+        if label == "ExpressionModel":
+            expression_kwargs = self._make_expression_model_kwargs()
+            model_entries = self._expression_model_edit_entries(expression_kwargs)
+        elif label == "__user":
+            model = self._user_model
+            if model is None:  # pragma: no cover - the User item requires a model.
+                self._sync_model_display()
+                return
+            model_state = self._serialize_model_state(model)
+            entry = type(self)._model_code_trust_entry(model_state)
+            model_entries = () if entry is None else (entry,)
+        else:
+            try:
+                model = self._make_model_from_choice(label)
+                model_state = self._serialize_model_state(model)
+                entry = type(self)._model_code_trust_entry(model_state)
+                model_entries = () if entry is None else (entry,)
+            except Exception:
+                self._show_error(
+                    "Model creation failed",
+                    f"Failed to create model '{label}'. Reverting to previous model.",
+                )
+                self._sync_model_display()
+                return
+
+        execution_entries = self._fit_code_entries_with_model(model_entries)
+        edited_entries = self._new_fit_code_entries(
+            self._fit_code_entries, execution_entries
+        )
+        previous_trust = self._current_document_trust()
+        applied = False
         try:
-            match label:
-                case "__file":
-                    path, _ = QtWidgets.QFileDialog.getOpenFileName(
-                        self,
-                        "Load lmfit model",
-                        "",
-                        "lmfit Model Files (*.sav *.json *.model);;All files (*)",
-                    )
-                    if not path:
-                        self._sync_model_display()
-                        return
-                    model = lmfit.model.load_model(path)
-                    set_model_kw["model_load_path"] = path
-                case "__user":
-                    model = self._user_model
-                case _:
-                    model = self._make_model_from_choice(label)
+            with self._local_code_edit(
+                execution_entries,
+                edited_entries=edited_entries,
+                focus_on_block=True,
+            ) as capability:
+                if not execution_capability_allows(capability, execution_entries):
+                    self._sync_model_display()
+                    return
+                if expression_kwargs is not None:
+                    model = lmfit.models.ExpressionModel(**expression_kwargs)
+                    model_state = self._serialize_model_state(model)
+                self._apply_model(
+                    typing.cast("lmfit.Model", model),
+                    model_state=typing.cast("tuple[str, str]", model_state),
+                    merge_params=True,
+                    reset_params_from_coord=True,
+                    refresh_views=False,
+                )
+                applied = True
         except Exception:
             self._show_error(
                 "Model creation failed",
                 f"Failed to create model '{label}'. Reverting to previous model.",
             )
             self._sync_model_display()
-            return
-        self.set_model(model, **set_model_kw)
+        if applied:
+            self._finish_model_change(
+                refresh_fit=self._current_document_trust() == previous_trust
+            )
 
     @property
     def tool_status(self) -> StateModel:
-        model_cls = self._model.__class__
         return self.StateModel(
             data_name=self._data_name,
             model_name=self._model_name,
-            model_state=(
-                f"{model_cls.__module__}:{model_cls.__qualname__}",
-                self._model.dumps(),
-            ),
+            model_state=self._serialized_model_state,
             model_load_path=self._model_load_path,
             domain=self._fit_domain(),
             normalize_mean=self.normalize_check.isChecked(),
@@ -1948,9 +2404,85 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     @tool_status.setter
     def tool_status(self, status: StateModel) -> None:
+        try:
+            with self._tool_status_code_execution(status) as (
+                entries,
+                capability,
+                local_edit,
+            ):
+                self._apply_fit1d_tool_status(
+                    status,
+                    entries,
+                    capability,
+                    local_edit=local_edit,
+                )
+        except _FitCodeEditRejected:
+            return
+
+    @contextlib.contextmanager
+    def _tool_status_code_execution(
+        self, status: StateModel
+    ) -> Iterator[tuple[tuple[typing.Any, ...], object | None, bool]]:
+        """Authorize status decoding as stored content or one explicit edit."""
+        entries = tuple(type(self)._code_trust_entries_from_status(status))
+        local_edit = (
+            entries != getattr(self, "_fit_code_entries", ())
+            and not self._restoring_from_dataset
+            and status is not self._pending_fit_status
+        )
+        if not local_edit:
+            yield entries, self._issue_code_execution_capability(entries), False
+            return
+
+        edited_entries = self._new_fit_code_entries(self._fit_code_entries, entries)
+        with self._local_code_edit(
+            entries,
+            edited_entries=edited_entries,
+            focus_on_block=True,
+        ) as capability:
+            if not execution_capability_allows(capability, entries):
+                _reject_fit_code_edit()
+            yield entries, capability, True
+
+    def _apply_fit1d_tool_status(
+        self,
+        status: StateModel,
+        entries: tuple[typing.Any, ...],
+        capability: object | None,
+        *,
+        local_edit: bool,
+    ) -> None:
+        """Apply one status after its complete executable inventory is authorized."""
         with self._history_suppressed():
             self._data_name = status.data_name
             self._model_name = status.model_name
+            self.components_check.setChecked(status.show_components)
+            self.refit_on_source_update_check.setChecked(status.refit_on_source_update)
+            self.timeout_spin.setValue(status.timeout)
+            self.nfev_spin.setValue(status.max_nfev)
+            self.method_combo.setCurrentText(status.method)
+            with QtCore.QSignalBlocker(self.normalize_check):
+                self.normalize_check.setChecked(status.normalize_mean)
+
+            self._slider_widths = dict(status.slider_widths)
+            if status.domain is not None:
+                with (
+                    QtCore.QSignalBlocker(self.domain_min_spin),
+                    QtCore.QSignalBlocker(self.domain_max_spin),
+                ):
+                    self.domain_min_spin.setValue(status.domain[0])
+                    self.domain_max_spin.setValue(status.domain[1])
+            self._domain_changed()
+
+            if capability is None:
+                self._pending_fit_status = status
+                self._clear_model_curves()
+                return
+            self._pending_fit_status = None
+            if not local_edit:
+                self._fit_code_entries = entries
+                self._fit_execution_capability = capability
+
             repaired_bounds = self._param_bounds_repair_names
             warn_repaired_bounds = repaired_bounds is None
             if repaired_bounds is None:
@@ -1967,20 +2499,25 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                     lambda: model.loads(model_state),
                     params=restored_params,
                 )
-                mod_name, qual = cls_info.split(":")
-            except Exception:  # pragma: no cover
+            except Exception:
                 self._show_error("Model restore failed", "Failed to restore model.")
+                if local_edit:
+                    raise _FitCodeEditRejected from None
                 model = self._model
+                restored_model_state = self._serialized_model_state
             else:
-                with contextlib.suppress(Exception):
-                    mod = importlib.import_module(mod_name)
-                    cls_obj = mod
-                    for attr in qual.split("."):
-                        cls_obj = getattr(cls_obj, attr)
-                    model.__class__ = cls_obj
+                restored_model_state = status.model_state
+                model_class = _REGISTERED_MODEL_CLASSES.get(cls_info)
+                if model_class is not None:
+                    with contextlib.suppress(TypeError):
+                        model.__class__ = model_class
 
             if restored_params is None or len(restored_params) == 0:
-                self.set_model(model, model_load_path=status.model_load_path)
+                self._apply_model(
+                    model,
+                    model_state=restored_model_state,
+                    model_load_path=status.model_load_path,
+                )
             else:
                 # Saved params are authoritative during restore; generating model
                 # defaults here can evaluate incomplete deserialized model state.
@@ -1992,33 +2529,24 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 self._sync_model_display()
                 self._sync_model_specific_controls()
 
-            self.components_check.setChecked(status.show_components)
-            self.refit_on_source_update_check.setChecked(status.refit_on_source_update)
-            self.timeout_spin.setValue(status.timeout)
-            self.nfev_spin.setValue(status.max_nfev)
-            self.method_combo.setCurrentText(status.method)
-            with QtCore.QSignalBlocker(self.normalize_check):
-                self.normalize_check.setChecked(status.normalize_mean)
-
-            self._slider_widths = dict(status.slider_widths)
+            self._serialized_model_state = restored_model_state
 
             self._params_from_coord = self._sanitize_params_from_coord(
                 status.params_from_coord
             )
+            self._refresh_fit_code_entries()
+            if self._fit_code_entries == entries:
+                self._fit_execution_capability = capability
             self.param_model.set_params(self._params, self._params_from_coord)
             self._refresh_slider_from_model()
             self._mark_fit_stale()
 
-            if status.domain is not None:
-                with (
-                    QtCore.QSignalBlocker(self.domain_min_spin),
-                    QtCore.QSignalBlocker(self.domain_max_spin),
-                ):
-                    self.domain_min_spin.setValue(status.domain[0])
-                    self.domain_max_spin.setValue(status.domain[1])
-            self._domain_changed()
             if warn_repaired_bounds:
                 self._show_repaired_parameter_bounds_warning(repaired_bounds)
+
+    def _saved_tool_status(self) -> StateModel:
+        """Preserve blocked saved state until the document is approved."""
+        return self._pending_fit_status or self.tool_status
 
     def _sanitize_params_from_coord(
         self, params_from_coord: Mapping[str, str]
@@ -2201,6 +2729,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         return values / norm
 
     def _guess_params(self) -> None:
+        if not self._current_fit_execution_allowed(focus_on_block=True):
+            return
         if not hasattr(self._model, "guess"):
             self._show_warning("Guess not supported", "Model does not support guess().")
             return
@@ -2214,7 +2744,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         except Exception:  # pragma: no cover - GUI feedback
             self._show_error("Guess failed", "Failed to estimate initial parameters.")
             return
-        self._params = typing.cast("lmfit.Parameters", params)
+        self._replace_current_params(typing.cast("lmfit.Parameters", params))
         self._params_from_coord = {}
         self.param_model.set_params(self._params, self._params_from_coord)
         self._mark_fit_stale()
@@ -2233,7 +2763,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             case _:
                 pass
         self._params_from_coord = {}
-        self._params = self._initial_params.copy()
+        self._replace_current_params(self._initial_params.copy())
         self.param_model.set_params(self._params, self._params_from_coord)
         self._set_fit_stats(None)
         self._mark_fit_stale()
@@ -2259,13 +2789,12 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         return values
 
     def _update_fit_curve(self) -> None:
+        if not self._current_fit_execution_allowed():
+            self._clear_model_curves()
+            return
         xvals = self._x_values()
         if self._has_non_finite_params():
-            self.fit_curve.setData([], [])
-            self.residual_curve.setData([], [])
-            self._last_fit_y = None
-            self._last_residual = None
-            self._update_component_curves(np.array([]))
+            self._clear_model_curves()
             self._update_peak_lines(xvals)
             return
 
@@ -2302,7 +2831,25 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
     def _serialize_params(
         params: lmfit.Parameters,
     ) -> list[tuple[typing.Any, ...]]:
-        return [p.__getstate__() for p in params.values()]
+        # lmfit's Parameter.__getstate__ reads ``value``. For an expression
+        # parameter, that read evaluates the expression. Copy the same stable state
+        # fields directly so review, history, and save code never execute it.
+        return [
+            (
+                param.name,
+                param._val,
+                param._vary,
+                param._expr,
+                param.min,
+                param.max,
+                param.brute_step,
+                param.stderr,
+                param.correl,
+                param.init_value,
+                param.user_data,
+            )
+            for param in params.values()
+        ]
 
     @staticmethod
     def _repair_equal_bound_param_state(
@@ -2515,8 +3062,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             return False
         return sum(segment.size for segment in segments) == xvals.size
 
-    def _sanitize_model_convolution_for_x(self) -> None:
-        func = getattr(self._model, "func", None)
+    def _sanitize_model_convolution_for_x(
+        self, model: lmfit.Model | None = None
+    ) -> None:
+        func = getattr(self._model if model is None else model, "func", None)
         if (
             isinstance(func, erlab.analysis.fit.functions.dynamic.MultiPeakFunction)
             and func.convolve
@@ -2728,10 +3277,15 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
     def _store_multi_fit_result(
         self, result_ds: xr.Dataset, t0: float
     ) -> lmfit.Parameters:
+        self._invalidate_fit_result_payload()
         self._last_result_ds = result_ds.copy()
         result = self._last_result_ds.modelfit_results.compute().item()
-        self._params = result.params.copy()
+        self._replace_current_params(result.params.copy())
         self._fit_is_current = True
+        # Fit2D copies the current slice into its full result state in this hook.
+        # Update subclass-owned state before serializing the shared result payload.
+        self._sync_fit_result_state(notify=False)
+        self._cache_fit_result_payload()
         self._fit_multi_last_elapsed = time.perf_counter() - t0
         self._fit_multi_live_refresh_pending = True
         self._fit_multi_refresh_pending = True
@@ -2784,9 +3338,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         pass
 
     def _set_fit_ds(self, result_ds: xr.Dataset, t0: float) -> lmfit.Parameters:
+        self._invalidate_fit_result_payload()
         self._last_result_ds = result_ds.copy()
         result = self._last_result_ds.modelfit_results.compute().item()
-        self._params = result.params.copy()
+        self._replace_current_params(result.params.copy())
         self.param_model.set_params(
             self._params, self._params_from_coord, emit_changed=False
         )
@@ -2795,6 +3350,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         elapsed = time.perf_counter() - t0
         self._set_fit_stats(result, elapsed=elapsed)
         self._sync_fit_result_state()
+        self._cache_fit_result_payload()
         self._mark_fit_fresh()
         self.sigFitFinished.emit(self._params.copy())
         if self._source_refresh_deferred:
@@ -2875,44 +3431,110 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             model_name="model",
         )
         self._last_result_ds = fit_ds.copy()
+        self._cache_fit_result_payload()
         self._set_fit_stats(restore.result)
 
+    @classmethod
+    def _fit_result_code_trust_entry(cls, blob: np.ndarray):
+        return lmfit_result_code_entry(
+            np.asarray(blob, dtype=np.uint8).tobytes(),
+            feature=cls._FIT_RESULT_CODE_TRUST_FEATURE,
+            location=cls._FIT_RESULT_CODE_TRUST_LOCATION,
+        )
+
+    def _code_trust_payload_entries(self):
+        blob = self._fit_result_blob_for_persistence()
+        if blob is None:
+            return ()
+        entry = self._fit_result_code_trust_entry(blob)
+        return () if entry is None else (entry,)
+
+    def _code_trust_payload_entries_from_dataset(self, ds: xr.Dataset):
+        if self._PERSISTED_FIT_RESULT_VAR not in ds:
+            return ()
+        blob = np.asarray(ds[self._PERSISTED_FIT_RESULT_VAR].values, dtype=np.uint8)
+        entry = self._fit_result_code_trust_entry(blob)
+        return () if entry is None else (entry,)
+
+    def _fit_result_dataset_for_persistence(self) -> xr.Dataset | None:
+        """Return the current fit-result dataset before opaque serialization."""
+        return self._last_result_ds
+
+    def _cache_fit_result_payload(self) -> None:
+        """Cache the current result payload for save and deferred restore."""
+        result = self._fit_result_dataset_for_persistence()
+        self._serialized_fit_result_blob = (
+            None
+            if result is None
+            else erlab.interactive.utils._serialize_fit_dataset_blob(result)
+        )
+        self._pending_persisted_fit_is_current = None
+
+    def _invalidate_fit_result_payload(self) -> None:
+        """Discard all saved and deferred state for replaced fit results."""
+        self._serialized_fit_result_blob = None
+        self._pending_persisted_fit_is_current = None
+        self._discard_restore_work(key=self._PERSISTED_FIT_RESULT_VAR)
+
+    def _fit_result_blob_for_persistence(self) -> np.ndarray | None:
+        if self._serialized_fit_result_blob is None:
+            if self._fit_result_dataset_for_persistence() is None:
+                return None
+            self._cache_fit_result_payload()
+        if self._serialized_fit_result_blob is None:  # pragma: no cover
+            return None
+        return np.array(self._serialized_fit_result_blob, copy=True)
+
     def _append_persistence_payload(self, ds: xr.Dataset) -> xr.Dataset:
-        if self._pending_persisted_fit_result_blob is not None:
-            ds = ds.copy()
-            ds[self._PERSISTED_FIT_RESULT_VAR] = xr.DataArray(
-                np.array(self._pending_persisted_fit_result_blob, copy=True),
-                dims=(self._PERSISTED_FIT_RESULT_DIM,),
-            )
-            ds.attrs[self._PERSISTED_FIT_CURRENT_ATTR] = bool(
-                self._pending_persisted_fit_is_current
-            )
-            return ds
-        if self._last_result_ds is None:
+        blob = self._fit_result_blob_for_persistence()
+        if blob is None:
             return ds
         ds = ds.copy()
         ds[self._PERSISTED_FIT_RESULT_VAR] = xr.DataArray(
-            erlab.interactive.utils._serialize_fit_dataset_blob(self._last_result_ds),
+            blob,
             dims=(self._PERSISTED_FIT_RESULT_DIM,),
         )
-        ds.attrs[self._PERSISTED_FIT_CURRENT_ATTR] = bool(self._fit_is_current)
+        ds.attrs[self._PERSISTED_FIT_CURRENT_ATTR] = bool(
+            self._pending_persisted_fit_is_current
+            if self._pending_persisted_fit_is_current is not None
+            else self._fit_is_current
+        )
         return ds
 
-    def _restore_persisted_fit_result_blob(
-        self, blob: np.ndarray, *, fit_is_current: bool
+    def _apply_restored_fit_result(
+        self, result_ds: xr.Dataset, *, fit_is_current: bool
     ) -> None:
-        self._last_result_ds = _load_lmfit_for_ftool_restore(
-            lambda: erlab.interactive.utils._deserialize_fit_dataset_blob(blob)
-        )
-        result = self._last_result_ds.modelfit_results.compute().item()
+        """Attach one authorized decoded result payload."""
+        self._last_result_ds = result_ds
+        result = result_ds.modelfit_results.compute().item()
         self._set_fit_stats(result)
         self._update_fit_curve()
         if fit_is_current:
             self._mark_fit_fresh()
         else:
             self._mark_fit_stale()
-        self._pending_persisted_fit_result_blob = None
-        self._pending_persisted_fit_is_current = False
+
+    def _restore_pending_fit_result(self) -> None:
+        """Materialize the one owned result blob when it is still pending."""
+        blob = self._serialized_fit_result_blob
+        fit_is_current = self._pending_persisted_fit_is_current
+        if blob is None or fit_is_current is None:
+            return
+        self._restore_persisted_fit_result_blob(blob, fit_is_current=fit_is_current)
+
+    def _restore_persisted_fit_result_blob(
+        self, blob: np.ndarray, *, fit_is_current: bool
+    ) -> None:
+        self._serialized_fit_result_blob = np.array(blob, copy=True)
+        self._pending_persisted_fit_is_current = fit_is_current
+        entry = self._fit_result_code_trust_entry(blob)
+        if entry is not None and not self._authorize_code_execution((entry,)):
+            return
+        result_ds = _load_lmfit_for_ftool_restore(
+            lambda: erlab.interactive.utils._deserialize_fit_dataset_blob(blob)
+        )
+        self._apply_restored_fit_result(result_ds, fit_is_current=fit_is_current)
+        self._pending_persisted_fit_is_current = None
 
     def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
         if self._PERSISTED_FIT_RESULT_VAR not in ds:
@@ -2922,19 +3544,16 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             copy=True,
         )
         fit_is_current = bool(ds.attrs.get(self._PERSISTED_FIT_CURRENT_ATTR, False))
-        self._pending_persisted_fit_result_blob = blob
+        self._serialized_fit_result_blob = blob
         self._pending_persisted_fit_is_current = fit_is_current
         self._run_or_defer_restore_work(
-            lambda: self._restore_persisted_fit_result_blob(
-                blob,
-                fit_is_current=fit_is_current,
-            ),
+            self._restore_pending_fit_result,
             key=self._PERSISTED_FIT_RESULT_VAR,
             run_on_show=True,
         )
 
     def _flush_restore_work_for_save(self) -> None:
-        if self._pending_persisted_fit_result_blob is None:
+        if self._pending_persisted_fit_is_current is None:
             super()._flush_restore_work_for_save()
             return
         self._flush_restore_work(skip=(self._PERSISTED_FIT_RESULT_VAR,))
@@ -2985,6 +3604,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
     ) -> bool:
         if self._fit_thread is not None:
             self._show_warning("Fit running", "A fit is already running.")
+            return False
+        if not self._current_fit_execution_allowed(focus_on_block=True):
             return False
 
         try:
@@ -3500,26 +4121,61 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         param = self.param_model.param_at(row)
         if not self._can_edit_expr(param) or not param.expr:
             return
-        param.set(expr="")
-        self._notify_param_change(row)
+        execution_entries = self._build_fit_code_entries(
+            parameter_expression=(str(param.name), None)
+        )
+        edited_entries = self._new_fit_code_entries(
+            self._fit_code_entries, execution_entries
+        )
+        with self._local_code_edit(
+            execution_entries,
+            edited_entries=edited_entries,
+            focus_on_block=True,
+        ) as capability:
+            if not execution_capability_allows(capability, execution_entries):
+                return
+            param.set(expr="")
+            self._refresh_fit_code_entries()
+            self._notify_param_change(row)
+            if self._fit_code_entries == execution_entries:
+                self._fit_execution_capability = capability
 
     def _set_param_expr(self, row: int, expr: str) -> None:
         param = self.param_model.param_at(row)
         if not self._can_edit_expr(param):
             return
-        is_valid, error = self._validate_param_expr(param, expr)
-        if not is_valid:
+        execution_entries = self._build_fit_code_entries(
+            parameter_expression=(str(param.name), expr)
+        )
+        edited_entries = self._new_fit_code_entries(
+            self._fit_code_entries, execution_entries
+        )
+        try:
+            with self._local_code_edit(
+                execution_entries,
+                edited_entries=edited_entries,
+                focus_on_block=True,
+            ) as capability:
+                if not execution_capability_allows(capability, execution_entries):
+                    return
+                is_valid, error = self._validate_param_expr(param, expr)
+                if not is_valid:
+                    _reject_fit_code_edit(error)
+                if str(param.name) in self._params_from_coord:
+                    del self._params_from_coord[str(param.name)]
+                param.set(expr=expr)
+                param.vary = False
+                self._refresh_fit_code_entries()
+                self._notify_param_change(row)
+                if self._fit_code_entries == execution_entries:
+                    self._fit_execution_capability = capability
+        except _FitCodeEditRejected as exc:
+            error = str(exc)
             details = f" due to the following reason:\n\n{error}" if error else "."
             self._show_warning(
                 "Invalid Expression",
                 f"Expression could not be parsed or evaluated{details}",
             )
-            return
-        if str(param.name) in self._params_from_coord:
-            del self._params_from_coord[str(param.name)]
-        param.set(expr=expr)
-        param.vary = False
-        self._notify_param_change(row)
 
     def _validate_param_expr(
         self, param: lmfit.Parameter, expr: str
@@ -3588,7 +4244,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         name = self._peak_param_name(peak_index, suffix)
         if name not in self._params:
             return None
-        value = self._params[name].value
+        value = self._parameter_value(self._params[name])
         if value is None:
             return None
         return float(value)
@@ -3609,19 +4265,20 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self._show_slider_message("")
             return
         param = self._get_current_param()
+        value = self._parameter_value(param)
         if self._slider_dragging and not param.expr:
             self._slider_updating = True
             with (
                 QtCore.QSignalBlocker(self.param_value_spin),
                 QtCore.QSignalBlocker(self.param_value_slider),
             ):
-                self.param_value_spin.setValue(param.value)
+                self.param_value_spin.setValue(value)
                 if self._slider_drag_range is None:
-                    slider_min, slider_max, _ = self._slider_range(param.value, param)
+                    slider_min, slider_max, _ = self._slider_range(value, param)
                     self._slider_drag_range = (slider_min, slider_max)
                 else:
                     slider_min, slider_max = self._slider_drag_range
-                self._set_slider_position(param.value, slider_min, slider_max)
+                self._set_slider_position(value, slider_min, slider_max)
             self._slider_updating = False
             return
 
@@ -3631,11 +4288,11 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
         if param.expr:
             self._show_slider_message(f"expr: {param.expr}")
-            self._set_slider_values(param.value, None, None, None)
+            self._set_slider_values(value, None, None, None)
             return
-        if not np.isfinite(param.value):
+        if not np.isfinite(value):
             self._show_slider_message(
-                f"value: {_ParameterTableModel._format_value(param.value)}"
+                f"value: {_ParameterTableModel._format_value(value)}"
             )
             return
 
@@ -3643,8 +4300,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._set_slider_enabled(not is_from_coord)
         self._set_slider_widget_visibility(True)
 
-        slider_min, slider_max, width = self._slider_range(param.value, param)
-        self._set_slider_values(param.value, width, slider_min, slider_max)
+        slider_min, slider_max, width = self._slider_range(value, param)
+        self._set_slider_values(value, width, slider_min, slider_max)
         self.param_value_spin.setReadOnly(is_from_coord)
 
         with QtCore.QSignalBlocker(self.param_mode_combo):
@@ -3783,7 +4440,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         if param_coord == "__fixed":
             if current_name in self._params_from_coord:
                 del self._params_from_coord[current_name]
-            self._update_param_value(float(param.value))
+            self._update_param_value(self._parameter_value(param))
         else:
             self._params_from_coord[current_name] = str(param_coord)
             self._update_param_value(float(self._data[param_coord].values))
@@ -3875,7 +4532,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self.elapsed_label.setText("Elapsed")
 
     def _has_non_finite_params(self) -> bool:
-        return any(not np.isfinite(param.value) for param in self._params.values())
+        return any(
+            not np.isfinite(self._parameter_value(param))
+            for param in self._params.values()
+        )
 
     def _mark_fit_stale(self, *, emit_info: bool = True) -> None:
         self._fit_is_current = False
@@ -3902,10 +4562,11 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     def update_data(self, new_data: xr.DataArray) -> bool:
         had_fit = self._last_result_ds is not None
-        status = self.tool_status
+        status = self._saved_tool_status()
         old_geom = self.saveGeometry()
 
         def _apply_update(validated: xr.DataArray) -> bool:
+            self._invalidate_fit_result_payload()
             old_cw = self.centralWidget()
             if old_cw is not None:
                 old_cw.setParent(None)

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -26,8 +26,8 @@ from xarray_lmfit.modelfit import (
 import erlab.interactive.utils
 from erlab.interactive._fit1d import (
     Fit1DTool,
+    _FitCodeEditRejected,
     _FitRestoreState,
-    _load_lmfit_for_ftool_restore,
     _SnapCursorLine,
     _State2D,
 )
@@ -87,6 +87,10 @@ def _rebuild_ui(
         def wrapper(self: Fit2DTool, *args: _P.args, **kwargs: _P.kwargs) -> _R:
             old_geom = self.saveGeometry() if hasattr(self, "saveGeometry") else None
             self._cancel_fit()
+            # A rebuild either produces a new result payload or owns no result
+            # payload. Do not carry an old serialized result through a destructive
+            # transpose or a replacement restore.
+            self._invalidate_fit_result_payload()
 
             # Remove the existing UI to avoid duplicate widgets/signals.
             if hasattr(self, "centralWidget"):
@@ -98,6 +102,9 @@ def _rebuild_ui(
             try:
                 return func(self, *args, **kwargs)
             finally:
+                rebuilt_fit_result_blob = getattr(
+                    self, "_serialized_fit_result_blob", None
+                )
                 # Reset current slice + fit state.
                 self._reset_fit_state(
                     self._data_full.isel({self._y_dim_name: self._current_idx}),
@@ -106,6 +113,7 @@ def _rebuild_ui(
                     data_name=self._data_name,
                     model_name=self._model_name,
                 )
+                self._serialized_fit_result_blob = rebuilt_fit_result_blob
 
                 # Rebuild UI and refresh views.
                 self._build_ui()
@@ -270,6 +278,7 @@ class Fit2DTool(Fit1DTool):
     """Interactive tool for fitting 1D curves to images."""
 
     tool_name = "ftool_2d"
+    _CODE_TRUST_DOMAIN = "erlab.fit2d-file"
     COPY_PROVENANCE: typing.ClassVar = (
         erlab.interactive.utils.ToolScriptProvenanceDefinition(
             start_label="Start from current ftool input data",
@@ -505,6 +514,7 @@ class Fit2DTool(Fit1DTool):
     def _rebuild_ui_for_full_data(
         self, data: xr.DataArray, params: lmfit.Parameters | None
     ) -> None:
+        self._invalidate_fit_result_payload()
         old_cw = self.centralWidget()
         if old_cw is not None:
             old_cw.setParent(None)
@@ -522,8 +532,17 @@ class Fit2DTool(Fit1DTool):
         self.param_model.sigParamsChanged.connect(self._update_params_full)
 
     def _update_params_full(self) -> None:
+        previous = self._params_full[self._current_idx]
+        previous_expressions = (
+            ()
+            if previous is None
+            else tuple(self._live_parameter_expressions(previous))
+        )
+        current_expressions = tuple(self._live_parameter_expressions(self._params))
         self._params_full[self._current_idx] = self._params
         self._params_from_coord_full[self._current_idx] = self._params_from_coord
+        if previous_expressions != current_expressions:
+            self._refresh_fit_code_entries()
         if self._fit_2d_sequence_active():
             self._fit_2d_param_plot_refresh_pending = True
             return
@@ -670,9 +689,15 @@ class Fit2DTool(Fit1DTool):
     def _sync_fit_result_state(self, *, notify: bool = True) -> None:
         if self._last_result_ds is not None:
             self._last_result_ds = self._fit_result_with_range(self._last_result_ds)
+        previous = self._params_full[self._current_idx]
+        expressions_changed = (
+            () if previous is None else self._live_parameter_expressions(previous)
+        ) != self._live_parameter_expressions(self._params)
         self._params_full[self._current_idx] = self._params
         self._params_from_coord_full[self._current_idx] = self._params_from_coord
         self._result_ds_full[self._current_idx] = self._last_result_ds
+        if expressions_changed:
+            self._refresh_fit_code_entries()
         if self._fit_2d_sequence_active():
             self._fit_2d_param_plot_refresh_pending = True
             return
@@ -1050,6 +1075,51 @@ class Fit2DTool(Fit1DTool):
         self._update_param_plot_options()
         self._update_param_plot_overlays()
 
+    def _fit_parameter_groups(
+        self,
+    ) -> tuple[tuple[str, lmfit.Parameters | None], ...]:
+        """Return current, per-slice, and initial parameter groups."""
+        return (
+            *super()._fit_parameter_groups(),
+            *(
+                (f"parameters-full/{index}", params)
+                for index, params in enumerate(self._params_full)
+            ),
+            *(
+                (f"initial-parameters-full/{index}", params)
+                for index, params in enumerate(self._initial_params_full or ())
+            ),
+        )
+
+    def _parameter_expression_edit_locations(self) -> frozenset[str]:
+        """Return live groups changed by the current-slice expression editor."""
+        return frozenset(
+            {
+                *super()._parameter_expression_edit_locations(),
+                f"parameters-full/{self._current_idx}",
+            }
+        )
+
+    def _fit_code_entries_with_params_full(
+        self, params_full: list[lmfit.Parameters | None]
+    ) -> tuple[typing.Any, ...]:
+        """Return the executable inventory for proposed per-slice parameters."""
+        current_params = params_full[self._current_idx]
+        if current_params is None:
+            current_params = (
+                self._initial_params_full[self._current_idx]
+                if self._initial_params_full is not None
+                else self._initial_params
+            )
+        overrides = {
+            "parameters": current_params,
+            **{
+                f"parameters-full/{index}": params
+                for index, params in enumerate(params_full)
+            },
+        }
+        return self._build_fit_code_entries(parameter_group_overrides=overrides)
+
     @property
     def tool_status(self) -> Fit1DTool.StateModel:
         state_dict = super().tool_status.model_dump()
@@ -1083,23 +1153,77 @@ class Fit2DTool(Fit1DTool):
 
     @tool_status.setter
     def tool_status(self, status: Fit1DTool.StateModel) -> None:
+        try:
+            with self._tool_status_code_execution(status) as (
+                entries,
+                capability,
+                local_edit,
+            ):
+                self._apply_fit2d_tool_status(
+                    status,
+                    entries,
+                    capability,
+                    local_edit=local_edit,
+                )
+        except _FitCodeEditRejected:
+            return
+
+    def _apply_fit2d_tool_status(
+        self,
+        status: Fit1DTool.StateModel,
+        entries: tuple[typing.Any, ...],
+        capability: object | None,
+        *,
+        local_edit: bool,
+    ) -> None:
+        """Apply base and per-slice state under one execution capability."""
         state2d = status.state2d
         restored_data = self._data_with_saved_dims(self._data_full, state2d)
         if restored_data.dims != self._data_full.dims:
             with self._history_suppressed():
                 self._rebuild_ui_for_full_data(restored_data, self._params.copy())
 
+        if state2d is not None:  # pragma: no branch
+            y_size = int(self._data_full.sizes[self._y_dim_name])
+            self._data_name_full = state2d.data_name_full
+            self._params_from_coord_full = [{} for _ in range(y_size)]
+            for i, mapping in enumerate(state2d.params_from_coord_full[:y_size]):
+                self._params_from_coord_full[i] = mapping.copy()
+
+            self.fill_mode_combo.setCurrentText(state2d.fill_mode.capitalize())
+            self._apply_param_plot_overlay_states(state2d.param_plot_overlay_states)
+            if state2d.y_limits is not None:  # pragma: no branch
+                max_idx = y_size - 1
+                y_min = min(max(state2d.y_limits[0], 0), max_idx)
+                y_max = min(max(state2d.y_limits[1], 0), max_idx)
+                with (
+                    QtCore.QSignalBlocker(self.y_min_spin),
+                    QtCore.QSignalBlocker(self.y_max_spin),
+                ):
+                    self.y_min_spin.setValue(min(y_min, y_max))
+                    self.y_max_spin.setValue(max(y_min, y_max))
+                self._y_minmax_changed()
+            self._current_idx = min(max(state2d.current_idx, 0), y_size - 1)
+
+        self.y_index_spin.setValue(self._current_idx)
+        self._update_param_plot_options()
+        self._update_param_plot()
+
         repaired_bounds: list[str] = []
         previous_repaired_bounds = self._param_bounds_repair_names
         self._param_bounds_repair_names = repaired_bounds
         try:
-            super(Fit2DTool, self.__class__).tool_status.__set__(  # type: ignore[attr-defined]
-                self, status
+            super()._apply_fit1d_tool_status(
+                status,
+                entries,
+                capability,
+                local_edit=local_edit,
             )
+            if self._pending_fit_status is not None:
+                return
             self._update_param_plot_options()
             if state2d is not None:  # pragma: no branch
                 y_size = int(self._data_full.sizes[self._y_dim_name])
-                self._data_name_full = state2d.data_name_full
                 restored_params_full = [
                     self._deserialize_params(params, repaired_bounds=repaired_bounds)
                     for params in state2d.params_full
@@ -1119,29 +1243,12 @@ class Fit2DTool(Fit1DTool):
                         )
                         if restored is not None:
                             self._initial_params_full[i] = restored
-
-                self._params_from_coord_full = [{} for _ in range(y_size)]
-                for i, mapping in enumerate(state2d.params_from_coord_full[:y_size]):
-                    self._params_from_coord_full[i] = mapping.copy()
-
-                self.fill_mode_combo.setCurrentText(state2d.fill_mode.capitalize())
-                self._apply_param_plot_overlay_states(state2d.param_plot_overlay_states)
-                if state2d.y_limits is not None:  # pragma: no branch
-                    max_idx = y_size - 1
-                    y_min = min(max(state2d.y_limits[0], 0), max_idx)
-                    y_max = min(max(state2d.y_limits[1], 0), max_idx)
-                    with (
-                        QtCore.QSignalBlocker(self.y_min_spin),
-                        QtCore.QSignalBlocker(self.y_max_spin),
-                    ):
-                        self.y_min_spin.setValue(min(y_min, y_max))
-                        self.y_max_spin.setValue(max(y_min, y_max))
-                    self._y_minmax_changed()
-                self._current_idx = min(max(state2d.current_idx, 0), y_size - 1)
         finally:
             self._param_bounds_repair_names = previous_repaired_bounds
         self._show_repaired_parameter_bounds_warning(repaired_bounds)
-        self.y_index_spin.setValue(self._current_idx)
+        self._refresh_fit_code_entries()
+        if self._fit_code_entries == entries:
+            self._fit_execution_capability = capability
         self._update_param_plot_options()
         self._update_param_plot()
 
@@ -1214,24 +1321,6 @@ class Fit2DTool(Fit1DTool):
         self._refresh_contents_from_index()
 
     @QtCore.Slot()
-    def _refresh_multipeak_model(self) -> None:
-        old_model = self._model
-        super()._refresh_multipeak_model()
-        new_model = self._model
-        for idx in range(self._data_full.sizes[self._y_dim_name]):
-            if idx != self._current_idx:
-                prev_params = self._params_full[idx]
-                if prev_params is not None:
-                    new_params = new_model.make_params()
-                    self._merge_params(prev_params, new_params, old_model, new_model)
-                    self._params_full[idx] = new_params
-                    prev_params_from_coord = self._params_from_coord_full[idx]
-                    for k in list(prev_params_from_coord.keys()):
-                        if k not in new_params:
-                            del prev_params_from_coord[k]
-                            self._params_from_coord_full[idx] = prev_params_from_coord
-
-    @QtCore.Slot()
     def _update_param_plot_options(self) -> None:
         with QtCore.QSignalBlocker(self.param_plot_combo):
             prev_param = self.param_plot_combo.currentText()
@@ -1283,15 +1372,26 @@ class Fit2DTool(Fit1DTool):
             return False
         return any(item[1].text == name for item in self.image_plot_legend.items)
 
-    def set_model(
+    def _apply_model(
         self,
         model: lmfit.Model,
         *,
+        model_state: tuple[str, str] | None = None,
         model_load_path: str | None = None,
         merge_params: bool = False,
         reset_params_from_coord: bool = False,
+        refresh_views: bool = True,
     ) -> None:
         old_model = self._model
+        params_full = list(self._params_full)
+        params_from_coord_full = [
+            mapping.copy() for mapping in self._params_from_coord_full
+        ]
+        initial_params_full = (
+            None
+            if self._initial_params_full is None
+            else list(self._initial_params_full)
+        )
         for i in range(self._data_full.sizes[self._y_dim_name]):
             if i == self._current_idx:
                 continue
@@ -1303,24 +1403,38 @@ class Fit2DTool(Fit1DTool):
                 new_params = model.make_params()
                 if merge_params and old_model is not None:
                     self._merge_params(prev_params, new_params, old_model, model)
-                self._params_full[i] = new_params
+                params_full[i] = new_params
 
             if reset_params_from_coord:
-                self._params_from_coord_full[i] = {}
+                params_from_coord_full[i] = {}
 
-            for k in list(self._params_from_coord_full[i].keys()):
+            for k in list(params_from_coord_full[i].keys()):
                 if new_params is not None and k not in new_params:
-                    self._params_from_coord_full[i].pop(k)
+                    params_from_coord_full[i].pop(k)
 
-            if self._initial_params_full is not None and new_params is not None:
-                self._initial_params_full[i] = new_params.copy()
+            if initial_params_full is not None and new_params is not None:
+                initial_params_full[i] = new_params.copy()
 
-        super().set_model(
+        super()._apply_model(
             model,
+            model_state=model_state,
             model_load_path=model_load_path,
             merge_params=merge_params,
             reset_params_from_coord=reset_params_from_coord,
+            refresh_views=False,
         )
+        self._params_full = params_full
+        self._params_from_coord_full = params_from_coord_full
+        self._initial_params_full = initial_params_full
+        if refresh_views:
+            self._finish_model_change()
+        else:
+            self._update_params_full()
+
+    def _finish_model_change(self, *, refresh_fit: bool = True) -> None:
+        """Refresh the fit preview and Fit2D parameter plots."""
+        self._update_params_full()
+        super()._finish_model_change(refresh_fit=refresh_fit)
         self._update_param_plot_options()
         self._update_param_plot()
 
@@ -1414,7 +1528,7 @@ class Fit2DTool(Fit1DTool):
                 continue
             param = params[param_name]
             plot_y.append(y)
-            param_values.append(param.value)
+            param_values.append(self._parameter_value(param))
             param_errors.append(param.stderr if param.stderr is not None else 0.0)
 
         return np.array(plot_y), np.array(param_values), np.array(param_errors)
@@ -1844,6 +1958,7 @@ class Fit2DTool(Fit1DTool):
                 )
 
         self._model = base_model
+        self._serialized_model_state = self._serialize_model_state(base_model)
         self._init_full_data_state(fit_data, data_name=self._data_name_full)
         self._current_idx = min(
             self._current_idx, self._data_full.sizes[self._y_dim_name] - 1
@@ -1856,20 +1971,13 @@ class Fit2DTool(Fit1DTool):
         self._params_from_coord_full = [{} for _ in range(y_size)]
         self._result_ds_full = [slice_ds for _, slice_ds in slice_states]
         self._fit_is_current = True
+        self._refresh_fit_code_entries()
+        self._cache_fit_result_payload()
         self._update_param_plot_options()
         self._update_param_plot()
 
-    def _append_persistence_payload(self, ds: xr.Dataset) -> xr.Dataset:
-        if self._pending_persisted_fit_result_blob is not None:
-            ds = ds.copy()
-            ds[self._PERSISTED_FIT_RESULT_VAR] = xr.DataArray(
-                np.array(self._pending_persisted_fit_result_blob, copy=True),
-                dims=(self._PERSISTED_FIT_RESULT_DIM,),
-            )
-            ds.attrs[self._PERSISTED_FIT_CURRENT_ATTR] = bool(
-                self._pending_persisted_fit_is_current
-            )
-            return ds
+    def _fit_result_dataset_for_persistence(self) -> xr.Dataset | None:
+        """Return all current slice results before opaque serialization."""
         saved_results = [
             self._fit_result_with_range(result_ds).expand_dims(
                 {self._PERSISTED_FIT_INDEX_DIM: [idx]}
@@ -1878,7 +1986,7 @@ class Fit2DTool(Fit1DTool):
             if result_ds is not None
         ]
         if not saved_results:
-            return ds
+            return None
         sparse = xr.concat(
             saved_results,
             dim=self._PERSISTED_FIT_INDEX_DIM,
@@ -1888,21 +1996,12 @@ class Fit2DTool(Fit1DTool):
             join="outer",
             combine_attrs="override",
         )
-        sparse = self._restore_fit_coord_order(sparse)
-        ds = ds.copy()
-        ds[self._PERSISTED_FIT_RESULT_VAR] = xr.DataArray(
-            erlab.interactive.utils._serialize_fit_dataset_blob(sparse),
-            dims=(self._PERSISTED_FIT_RESULT_DIM,),
-        )
-        ds.attrs[self._PERSISTED_FIT_CURRENT_ATTR] = bool(self._fit_is_current)
-        return ds
+        return self._restore_fit_coord_order(sparse)
 
-    def _restore_persisted_fit_result_blob(
-        self, blob: np.ndarray, *, fit_is_current: bool
+    def _apply_restored_fit_result(
+        self, sparse: xr.Dataset, *, fit_is_current: bool
     ) -> None:
-        sparse = _load_lmfit_for_ftool_restore(
-            lambda: erlab.interactive.utils._deserialize_fit_dataset_blob(blob)
-        )
+        """Attach one authorized decoded sparse result payload."""
         y_size = int(self._data_full.sizes[self._y_dim_name])
         self._result_ds_full = [None] * y_size
         for i, index in enumerate(sparse[self._PERSISTED_FIT_INDEX_DIM].values):
@@ -1924,27 +2023,6 @@ class Fit2DTool(Fit1DTool):
         self._refresh_contents_from_index(mark_fit_stale=not fit_is_current)
         self._update_param_plot_options()
         self._update_param_plot()
-        self._pending_persisted_fit_result_blob = None
-        self._pending_persisted_fit_is_current = False
-
-    def _restore_persistence_payload(self, ds: xr.Dataset) -> None:
-        if self._PERSISTED_FIT_RESULT_VAR not in ds:
-            return
-        blob = np.array(
-            ds[self._PERSISTED_FIT_RESULT_VAR].values,
-            copy=True,
-        )
-        fit_is_current = bool(ds.attrs.get(self._PERSISTED_FIT_CURRENT_ATTR, False))
-        self._pending_persisted_fit_result_blob = blob
-        self._pending_persisted_fit_is_current = fit_is_current
-        self._run_or_defer_restore_work(
-            lambda: self._restore_persisted_fit_result_blob(
-                blob,
-                fit_is_current=fit_is_current,
-            ),
-            key=self._PERSISTED_FIT_RESULT_VAR,
-            run_on_show=True,
-        )
 
     @QtCore.Slot()
     def _y_minmax_changed(self) -> None:
@@ -1999,49 +2077,93 @@ class Fit2DTool(Fit1DTool):
         if mode is None:
             mode = self.fill_mode_combo.currentText().lower()
 
-        self._params_from_coord_full[self._current_idx] = self._params_from_coord_full[
-            target_index
-        ].copy()
-
         if mode == "none":
+            self._params_from_coord_full[self._current_idx] = (
+                self._params_from_coord_full[target_index].copy()
+            )
             return
+        candidate_params_full = self._params_full.copy()
+        extrapolation_params: tuple[lmfit.Parameters, lmfit.Parameters] | None = None
+        initialize_target = False
         if mode == "extrapolate":
             i2 = target_index
             i1 = i2 + (target_index - self._current_idx)
+            if i1 < self.y_min_spin.value() or i1 > self.y_max_spin.value():
+                mode = "previous"
+            else:
+                params1 = self._params_full[i1]
+                params2 = self._params_full[i2]
+                if params1 is None or params2 is None:
+                    mode = "previous"
+                else:
+                    params = params2
+                    extrapolation_params = (params1, params2)
 
-            params1 = self._params_full[i1]
-            params2 = self._params_full[i2]
-            if (
-                i1 < self.y_min_spin.value()
-                or i1 > self.y_max_spin.value()
-                or params1 is None
-                or params2 is None
-            ):
-                self._fill_params_from(
-                    target_index, mode="previous", update_widgets=update_widgets
-                )
-                return
-
-            params = params2.copy()
-            for name in params:
-                if (
-                    name in params1
-                    and params1[name].expr is None
-                    and params2[name].expr is None
-                ):
-                    params[name].set(
-                        value=2 * params2[name].value - params1[name].value
-                    )
-
-        elif mode == "previous":
-            params = self._params_full[target_index]
+        if mode == "previous":
+            params = candidate_params_full[target_index]
             if params is None:
-                params = self._initial_params.copy()
-                self._params_full[target_index] = params.copy()
+                params = self._initial_params
+                candidate_params_full[target_index] = params
+                initialize_target = True
+        elif mode != "extrapolate":
+            raise ValueError(f"Unsupported parameter fill mode: {mode!r}")
 
-        self._params_full[self._current_idx] = params.copy()
+        candidate_params_full[self._current_idx] = params
+        candidate_entries = self._fit_code_entries_with_params_full(
+            candidate_params_full
+        )
+        evaluation_entries = (
+            *(
+                entry
+                for entry in candidate_entries
+                if entry.feature == self._MODEL_CODE_TRUST_FEATURE
+            ),
+            *self._parameter_code_trust_entries(
+                self._live_parameter_expressions(params),
+                location_prefix="evaluation",
+            ),
+        )
+        code_changed = candidate_entries != self._fit_code_entries
+        candidate_sources = self._params_from_coord_full.copy()
+        candidate_sources[self._current_idx] = self._params_from_coord_full[
+            target_index
+        ].copy()
 
-        self._refresh_contents_from_index(update_widgets=update_widgets)
+        def apply_change() -> None:
+            if extrapolation_params is None:
+                current_params = params.copy()
+            else:
+                params1, params2 = extrapolation_params
+                current_params = params2.copy()
+                for name in current_params:
+                    if (
+                        name in params1
+                        and params1[name].expr is None
+                        and params2[name].expr is None
+                    ):
+                        current_params[name].set(
+                            value=(
+                                2 * self._parameter_value(params2[name])
+                                - self._parameter_value(params1[name])
+                            )
+                        )
+            if initialize_target:
+                candidate_params_full[target_index] = params.copy()
+            candidate_params_full[self._current_idx] = current_params
+            self._params_full = candidate_params_full
+            self._params_from_coord_full = candidate_sources
+            self._load_contents_from_index()
+            if code_changed:
+                self._refresh_fit_code_entries()
+            self._refresh_contents_from_index(update_widgets=update_widgets)
+
+        self._apply_local_code_inventory_change(
+            self._fit_code_entries,
+            candidate_entries,
+            evaluation_entries,
+            apply_change,
+            focus_on_block=True,
+        )
 
     def _fill_params_from_prev(self) -> None:
         self._fill_params_from(self._current_idx - 1)
@@ -2076,18 +2198,50 @@ class Fit2DTool(Fit1DTool):
             case _:
                 pass
 
-        if self._initial_params_full is not None:
-            self._params_full = [params.copy() for params in self._initial_params_full]
-        else:
-            self._params_full = [
-                self._initial_params.copy() for _ in range(len(self._params_full))
-            ]
-        self._params_from_coord_full = [{} for _ in range(len(self._params_full))]
-        self._result_ds_full = [None] * len(self._params_full)
-        self._refresh_contents_from_index()
-        self._update_param_plot_options()
-        self._update_param_plot()
-        self._mark_fit_stale()
+        source_params_full = (
+            list(self._initial_params_full)
+            if self._initial_params_full is not None
+            else [self._initial_params] * len(self._params_full)
+        )
+        candidate_entries = self._fit_code_entries_with_params_full(source_params_full)
+        evaluation_entries = (
+            *(
+                entry
+                for entry in candidate_entries
+                if entry.feature == self._MODEL_CODE_TRUST_FEATURE
+            ),
+            *(
+                entry
+                for index, params in enumerate(source_params_full)
+                for entry in self._parameter_code_trust_entries(
+                    self._live_parameter_expressions(params),
+                    location_prefix=f"evaluation/{index}",
+                )
+            ),
+        )
+        code_changed = candidate_entries != self._fit_code_entries
+        self._invalidate_fit_result_payload()
+
+        def apply_change() -> None:
+            params_full = [params.copy() for params in source_params_full]
+            self._params_full = params_full
+            self._params_from_coord_full = [{} for _ in range(len(params_full))]
+            self._result_ds_full = [None] * len(params_full)
+            self._load_contents_from_index()
+            if code_changed:
+                self._refresh_fit_code_entries()
+            self._refresh_contents_from_index()
+            self._update_param_plot_options()
+            self._update_param_plot()
+            self._mark_fit_stale()
+
+        self._apply_local_code_inventory_change(
+            self._fit_code_entries,
+            candidate_entries,
+            evaluation_entries,
+            apply_change,
+            focus_on_block=True,
+        )
 
     def _set_fit_running(
         self,
@@ -2178,9 +2332,16 @@ class Fit2DTool(Fit1DTool):
     ) -> lmfit.model.ModelResult:
         self._last_result_ds = self._fit_result_with_range(result_ds.copy())
         result = self._last_result_ds.modelfit_results.compute().item()
-        self._params = result.params.copy()
+        self._replace_current_params(result.params.copy())
+        previous = self._params_full[idx]
+        full_expressions_changed = (
+            () if previous is None else self._live_parameter_expressions(previous)
+        ) != self._live_parameter_expressions(self._params)
         self._result_ds_full[idx] = self._last_result_ds
         self._params_full[idx] = self._params.copy()
+        self._invalidate_fit_result_payload()
+        if full_expressions_changed:
+            self._refresh_fit_code_entries()
         self._fit_is_current = True
         self._fit_2d_last_completed_idx = idx
         self._fit_2d_last_completed_elapsed = time.perf_counter() - t0
@@ -2281,6 +2442,8 @@ class Fit2DTool(Fit1DTool):
         self._fit_2d_last_completed_idx = None
         self._fit_2d_last_completed_elapsed = None
         self._fit_2d_live_refresh_pending = False
+        if self._serialized_fit_result_blob is None:
+            self._cache_fit_result_payload()
         self._update_full_fit_saveable()
         self._flush_fit_2d_sequence_param_plot(force=True)
         self._finish_fit_2d_sequence_history()
@@ -2317,7 +2480,7 @@ class Fit2DTool(Fit1DTool):
 
     def update_data(self, new_data: xr.DataArray) -> bool:
         had_fit = self._last_result_ds is not None
-        status = self.tool_status
+        status = self._saved_tool_status()
         old_geom = self.saveGeometry()
 
         def _apply_update(validated: xr.DataArray) -> bool:
@@ -2448,7 +2611,7 @@ class Fit2DTool(Fit1DTool):
                 return None
             for name in param_names:
                 param = params[name]
-                params_value[name].append(param.value)
+                params_value[name].append(self._parameter_value(param))
                 params_min[name].append(param.min if param.min is not None else -np.inf)
                 params_max[name].append(param.max if param.max is not None else np.inf)
                 if name not in params_vary:

--- a/src/erlab/interactive/_fit_code_trust.py
+++ b/src/erlab/interactive/_fit_code_trust.py
@@ -42,7 +42,7 @@ def _walk_serialized(
             if key in {"params", "init_params"} and isinstance(item, str):
                 try:
                     item = json.loads(item)
-                except (TypeError, ValueError):
+                except ValueError:
                     yield child_path, None, value[key]
                     continue
             yield from _walk_serialized(item, child_path)
@@ -167,7 +167,7 @@ def _serialized_lmfit_details(
 ) -> list[dict[str, typing.Any]]:
     try:
         value = json.loads(serialized)
-    except (TypeError, ValueError):
+    except ValueError:
         return [
             _detail(
                 "unknown-serialized-content",

--- a/src/erlab/interactive/_fit_code_trust.py
+++ b/src/erlab/interactive/_fit_code_trust.py
@@ -1,0 +1,359 @@
+"""Extract executable content from serialized lmfit data without decoding it.
+
+These helpers inspect JSON and NetCDF text. They never import a module named by a
+document and never deserialize a saved callable. Callables that resolve to exact,
+locally known library symbols produce no trust entry. Unknown callables,
+``ExpressionModel`` code, init scripts, and saved parameter expressions produce an
+entry for the shared authorization policy.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import io
+import json
+import typing
+import urllib.parse
+
+from erlab.interactive._code_trust import create_entry, create_payload_entry
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+
+def _detail(
+    kind: str, location: str, code: str, **payload: typing.Any
+) -> dict[str, typing.Any]:
+    return {"code": code, "kind": kind, "location": location, **payload}
+
+
+def _walk_serialized(
+    value: typing.Any, path: str = "root"
+) -> Iterator[tuple[str, typing.Any, str | None]]:
+    """Yield parsed lmfit values and malformed nested parameter strings."""
+    yield path, value, None
+    if isinstance(value, dict):
+        if value.get("__class__") == "Callable":
+            return
+        for key in sorted(value):
+            item = value[key]
+            child_path = f"{path}/{key}"
+            if key in {"params", "init_params"} and isinstance(item, str):
+                try:
+                    item = json.loads(item)
+                except (TypeError, ValueError):
+                    yield child_path, None, value[key]
+                    continue
+            yield from _walk_serialized(item, child_path)
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            yield from _walk_serialized(item, f"{path}/{index}")
+
+
+def _callable_references(value: typing.Any) -> set[tuple[str, str]]:
+    references = set()
+    for _path, item, malformed in _walk_serialized(value):
+        if malformed is not None or not isinstance(item, dict):
+            continue
+        importer = item.get("importer")
+        name = item.get("__name__")
+        if (
+            item.get("__class__") == "Callable"
+            and isinstance(importer, str)
+            and isinstance(name, str)
+        ):
+            references.add((importer, name))
+    return references
+
+
+@functools.cache
+def _safe_library_callable_references() -> frozenset[tuple[str, str]]:
+    """Return exact importable callable references emitted by local lmfit."""
+    import lmfit
+    import lmfit.jsonutils
+
+    import erlab.analysis.fit.functions
+
+    references = _callable_references(json.loads(lmfit.Parameters().dumps()))
+    for module, names in (
+        (lmfit.lineshapes, lmfit.lineshapes.functions),
+        (erlab.analysis.fit.functions, erlab.analysis.fit.functions.__all__),
+    ):
+        for name in names:
+            function = getattr(module, name, None)
+            if not callable(function):
+                continue
+            importer = lmfit.jsonutils.find_importer(function)
+            if isinstance(importer, str):
+                references.add((importer, str(function.__name__)))
+    return frozenset(references)
+
+
+def _executable_details(
+    value: typing.Any, path: str = "root"
+) -> list[dict[str, typing.Any]]:
+    details: list[dict[str, typing.Any]] = []
+    for item_path, item, malformed in _walk_serialized(value, path):
+        if malformed is not None:
+            details.append(
+                _detail(
+                    "unknown-serialized-content",
+                    item_path,
+                    "Invalid serialized lmfit parameters",
+                    serialized_sha256=hashlib.sha256(malformed.encode()).hexdigest(),
+                )
+            )
+            continue
+        if not isinstance(item, dict):
+            continue
+        if item.get("__class__") == "Callable":
+            importer = item.get("importer")
+            name = item.get("__name__")
+            if (
+                (importer, name)
+                if isinstance(importer, str) and isinstance(name, str)
+                else None
+            ) not in _safe_library_callable_references():
+                details.append(
+                    _detail(
+                        "serialized-callable",
+                        item_path,
+                        f"{importer or '<embedded>'}:{name or '<unknown>'}",
+                        serialized_callable=item,
+                    )
+                )
+            continue
+
+        function_definition = item.get("funcdef")
+        if item.get("funcname") == "_eval" and isinstance(function_definition, str):
+            details.append(
+                _detail(
+                    "expression-model",
+                    f"{item_path}/funcdef",
+                    function_definition,
+                )
+            )
+
+        for key, kind in (
+            ("init_script", "expression-model-init-script"),
+            ("expr", "parameter-expression"),
+        ):
+            code = item.get(key)
+            if isinstance(code, str) and code.strip():
+                details.append(_detail(kind, f"{item_path}/{key}", code))
+
+        params = item.get("params")
+        if isinstance(params, list):
+            for index, state in enumerate(params):
+                if (
+                    isinstance(state, list | tuple)
+                    and len(state) >= 4
+                    and isinstance(state[3], str)
+                    and state[3].strip()
+                ):
+                    details.append(
+                        _detail(
+                            "parameter-expression",
+                            f"{item_path}/params/{index}:{state[0]}",
+                            state[3],
+                        )
+                    )
+    return details
+
+
+def _serialized_lmfit_details(
+    serialized: str, path: str = "root"
+) -> list[dict[str, typing.Any]]:
+    try:
+        value = json.loads(serialized)
+    except (TypeError, ValueError):
+        return [
+            _detail(
+                "unknown-serialized-content",
+                path,
+                "Invalid serialized lmfit content",
+                serialized_sha256=hashlib.sha256(serialized.encode()).hexdigest(),
+            )
+        ]
+    return _executable_details(value, path)
+
+
+def _entry(
+    details: list[dict[str, typing.Any]],
+    *,
+    feature: str,
+    location: str,
+    malformed_fallback: bytes,
+    context: dict[str, typing.Any] | None = None,
+):
+    if not details:
+        return None
+    review = [
+        {key: str(detail[key]) for key in ("code", "kind", "location")}
+        for detail in details
+    ]
+    try:
+        executable_payload = json.dumps(
+            details,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    except (TypeError, ValueError):
+        executable_payload = (
+            b"malformed-lmfit-payload:" + hashlib.sha256(malformed_fallback).digest()
+        )
+    return create_payload_entry(
+        feature,
+        location,
+        "\n\n".join(
+            f"# {item['kind']} at {item['location']}\n{item['code']}" for item in review
+        ),
+        executable_payload,
+        {**(context or {}), "executable_content": review},
+    )
+
+
+def _canonical_model_details(
+    details: Iterable[dict[str, typing.Any]],
+) -> list[dict[str, typing.Any]]:
+    """Remove lmfit JSON layout details from executable model identities."""
+    counts: dict[str, int] = {}
+    canonical = []
+    for detail in details:
+        kind = str(detail["kind"])
+        index = counts.get(kind, 0)
+        counts[kind] = index + 1
+        canonical.append({**detail, "location": f"{kind}/{index}"})
+    return canonical
+
+
+def lmfit_model_code_entry(
+    serialized_model: str,
+    *,
+    feature: str,
+    location: str,
+):
+    """Return an entry only when a serialized model can run non-library code."""
+    details = (
+        _canonical_model_details(_serialized_lmfit_details(serialized_model))
+        if serialized_model
+        else []
+    )
+    return _entry(
+        details,
+        feature=feature,
+        location=location,
+        malformed_fallback=serialized_model.encode(),
+    )
+
+
+def lmfit_expression_model_code_entries(
+    expression: str,
+    init_script: str | None,
+    *,
+    feature: str,
+    location: str,
+):
+    """Return exact entries for one locally authored ExpressionModel edit."""
+    model_entry = _entry(
+        _canonical_model_details(
+            [_detail("expression-model", "expression", expression)]
+        ),
+        feature=feature,
+        location=location,
+        malformed_fallback=expression.encode(),
+    )
+    entries = [] if model_entry is None else [model_entry]
+    if init_script:
+        entries.append(
+            create_entry(
+                feature,
+                f"{location}/init-script",
+                init_script,
+                {"kind": "expression-model-init-script"},
+            )
+        )
+    return tuple(entries)
+
+
+def lmfit_parameter_expression_entries(
+    expressions: Iterable[tuple[typing.Any, typing.Any]] | None,
+    *,
+    feature: str,
+    location_prefix: str,
+):
+    """Return entries for saved ``(parameter name, expression)`` pairs."""
+    if expressions is None:
+        return ()
+    return tuple(
+        create_entry(
+            feature,
+            f"{location_prefix}/{urllib.parse.quote(str(name), safe='')}",
+            expression,
+            {"parameter": name},
+        )
+        for name, expression in expressions
+        if isinstance(expression, str) and expression.strip()
+    )
+
+
+def lmfit_result_code_entry(
+    payload: bytes,
+    *,
+    feature: str,
+    location: str,
+):
+    """Return an entry only when an xarray-lmfit payload can run custom code."""
+    import numpy as np
+    import xarray as xr
+
+    details: list[dict[str, typing.Any]] = []
+    invalid = False
+    try:
+        with xr.open_dataset(io.BytesIO(payload), engine="h5netcdf") as dataset:
+            result_names = sorted(
+                (
+                    name
+                    for name in dataset.data_vars
+                    if str(name).endswith("modelfit_results")
+                ),
+                key=str,
+            )
+            if not result_names:
+                invalid = True
+            for name in result_names:
+                for index, serialized in enumerate(
+                    np.asarray(dataset[name].values).flat
+                ):
+                    if isinstance(serialized, bytes):
+                        serialized = serialized.decode()
+                    if not isinstance(serialized, str):
+                        invalid = True
+                        continue
+                    details.extend(
+                        _serialized_lmfit_details(
+                            serialized,
+                            path=f"{name}/{index}/root",
+                        )
+                    )
+    except Exception:
+        invalid = True
+    if invalid:
+        details = [
+            _detail(
+                "unknown-serialized-content",
+                "root",
+                "Unrecognized serialized lmfit result",
+                serialized_sha256=hashlib.sha256(payload).hexdigest(),
+            )
+        ]
+
+    return _entry(
+        details,
+        feature=feature,
+        location=location,
+        malformed_fallback=payload,
+    )

--- a/src/erlab/interactive/_options/__init__.py
+++ b/src/erlab/interactive/_options/__init__.py
@@ -16,6 +16,7 @@ from erlab.interactive._options.parameters import (
     SavefigDpiParameter,
     SavefigPaddingParameter,
     StylesheetListParameter,
+    TrustedFoldersParameter,
     _CustomColorMapParameter,
 )
 
@@ -45,6 +46,10 @@ pyqtgraph.parametertree.registerParameterType(
 
 pyqtgraph.parametertree.registerParameterType(
     "directory_path", DirectoryPathParameter, override=True
+)
+
+pyqtgraph.parametertree.registerParameterType(
+    "trusted_folders", TrustedFoldersParameter, override=True
 )
 
 __getattr__, __dir__, __all__ = _lazy.attach_stub(__name__, __file__)

--- a/src/erlab/interactive/_options/parameters.py
+++ b/src/erlab/interactive/_options/parameters.py
@@ -12,6 +12,10 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive._stylesheets
+from erlab.interactive._code_trust import (
+    reset_saved_code_trust,
+    validate_trusted_location,
+)
 from erlab.interactive._widgets import _CenteredIconToolButton
 
 _STYLESHEET_AVAILABLE_ROLE = QtCore.Qt.ItemDataRole.UserRole + 1
@@ -536,6 +540,181 @@ class DirectoryPathParameter(pyqtgraph.parametertree.parameterTypes.SimpleParame
 
     def __init__(self, **opts):
         opts.setdefault("type", "directory_path")
+        super().__init__(**opts)
+
+
+class TrustedFoldersWidget(QtWidgets.QWidget):
+    """Editor for recursively trusted executable-document folders."""
+
+    sigFoldersChanged = QtCore.Signal(list)
+    _VISIBLE_LIST_ROWS = 4
+
+    def __init__(
+        self,
+        folders: list[str] | None = None,
+        *,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self.list_widget = QtWidgets.QListWidget(self)
+        self.list_widget.setObjectName("trustedFoldersList")
+        layout.addWidget(self.list_widget)
+
+        buttons = QtWidgets.QHBoxLayout()
+        buttons.setContentsMargins(0, 0, 0, 0)
+        buttons.setSpacing(4)
+
+        self.add_button = QtWidgets.QToolButton(self)
+        self.add_button.setObjectName("trustedFoldersAddButton")
+        self.add_button.setText("Add Folder…")
+        self.add_button.setToolTip("Select a trusted workspace folder.")
+        self.add_button.clicked.connect(self.add_folder)
+        buttons.addWidget(self.add_button)
+
+        self.remove_button = QtWidgets.QToolButton(self)
+        self.remove_button.setObjectName("trustedFoldersRemoveButton")
+        self.remove_button.setText("Remove")
+        self.remove_button.setToolTip("Stop trusting the selected folder.")
+        self.remove_button.clicked.connect(self.remove_selected_folder)
+        self.remove_button.setEnabled(False)
+        self.list_widget.currentRowChanged.connect(
+            lambda row: self.remove_button.setEnabled(row >= 0)
+        )
+        buttons.addWidget(self.remove_button)
+        buttons.addStretch(1)
+
+        self.reset_trust_button = QtWidgets.QToolButton(self)
+        self.reset_trust_button.setObjectName("trustedSignaturesResetButton")
+        self.reset_trust_button.setText("Reset Saved Trust…")
+        self.reset_trust_button.setToolTip(
+            "Remove all saved executable-content signatures."
+        )
+        self.reset_trust_button.clicked.connect(self.reset_saved_trust)
+        buttons.addWidget(self.reset_trust_button)
+        layout.addLayout(buttons)
+
+        self.set_folders(folders or [])
+        self._update_list_height()
+
+    def get_folders(self) -> list[str]:
+        """Return the configured folders in display order."""
+        return [
+            item.text()
+            for row in range(self.list_widget.count())
+            if (item := self.list_widget.item(row)) is not None
+        ]
+
+    def set_folders(self, folders: list[str]) -> None:
+        """Replace the configured folder list without accessing the filesystem."""
+        normalized = list(dict.fromkeys(str(item).strip() for item in folders))
+        normalized = [folder for folder in normalized if folder]
+        if normalized == self.get_folders():
+            return
+        self.list_widget.clear()
+        self.list_widget.addItems(normalized)
+        if normalized:
+            self.list_widget.setCurrentRow(0)
+        self._update_list_height()
+        self.sigFoldersChanged.emit(normalized)
+
+    @QtCore.Slot()
+    def add_folder(self) -> None:
+        """Select, validate, and add one trusted folder."""
+        directory = QtWidgets.QFileDialog.getExistingDirectory(
+            self,
+            "Select Trusted Workspace Folder",
+            "",
+        )
+        if not directory:
+            return
+        try:
+            resolved = validate_trusted_location(directory)
+        except (OSError, ValueError) as exc:
+            QtWidgets.QMessageBox.warning(self, "Folder Not Added", str(exc))
+            return
+        folder = str(resolved)
+        folders = self.get_folders()
+        if folder in folders:
+            self.list_widget.setCurrentRow(folders.index(folder))
+            return
+        reply = QtWidgets.QMessageBox.warning(
+            self,
+            "Trust Workspace Folder",
+            "Every .itws file in this folder and its subfolders is trusted. Opening "
+            "one can run recorded scripts, Figure Composer Python, saved lmfit model "
+            "or result code, and lmfit parameter expressions without review. Add this "
+            "folder only if untrusted users and programs cannot change its contents.",
+            QtWidgets.QMessageBox.StandardButton.Yes
+            | QtWidgets.QMessageBox.StandardButton.Cancel,
+            QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        if reply != QtWidgets.QMessageBox.StandardButton.Yes:
+            return
+        self.set_folders([*folders, folder])
+        self.list_widget.setCurrentRow(self.list_widget.count() - 1)
+
+    @QtCore.Slot()
+    def remove_selected_folder(self) -> None:
+        """Remove the selected folder from the trusted list."""
+        row = self.list_widget.currentRow()
+        folders = self.get_folders()
+        if not 0 <= row < len(folders):
+            return
+        folders.pop(row)
+        self.set_folders(folders)
+        if folders:
+            self.list_widget.setCurrentRow(min(row, len(folders) - 1))
+
+    @QtCore.Slot()
+    def reset_saved_trust(self) -> None:
+        """Remove saved signatures after user confirmation."""
+        reply = QtWidgets.QMessageBox.question(
+            self,
+            "Reset Saved Code Trust",
+            "Remove all saved executable-content trust signatures? Trusted folders "
+            "are not changed.",
+            QtWidgets.QMessageBox.StandardButton.Yes
+            | QtWidgets.QMessageBox.StandardButton.Cancel,
+            QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        if reply != QtWidgets.QMessageBox.StandardButton.Yes:
+            return
+        try:
+            reset_saved_code_trust()
+        except RuntimeError as exc:
+            QtWidgets.QMessageBox.warning(self, "Saved Trust Not Reset", str(exc))
+
+    def _update_list_height(self) -> None:
+        row_height = self.list_widget.sizeHintForRow(0)
+        if row_height <= 0:
+            row_height = self.list_widget.fontMetrics().height() + 6
+        frame = self.list_widget.frameWidth() * 2
+        rows = max(1, min(self._VISIBLE_LIST_ROWS, self.list_widget.count()))
+        self.list_widget.setFixedHeight(row_height * rows + frame)
+
+
+class TrustedFoldersParameterItem(
+    pyqtgraph.parametertree.parameterTypes.WidgetParameterItem
+):
+    def makeWidget(self) -> TrustedFoldersWidget:
+        widget = TrustedFoldersWidget()
+        widget.sigChanged = widget.sigFoldersChanged  # type: ignore[attr-defined]
+        widget.value = widget.get_folders  # type: ignore[attr-defined]
+        widget.setValue = widget.set_folders  # type: ignore[attr-defined]
+        self.hideWidget = False
+        return widget
+
+
+class TrustedFoldersParameter(pyqtgraph.parametertree.parameterTypes.SimpleParameter):
+    itemClass = TrustedFoldersParameterItem
+
+    def __init__(self, **opts):
+        opts.setdefault("type", "trusted_folders")
         super().__init__(**opts)
 
 

--- a/src/erlab/interactive/_options/schema.py
+++ b/src/erlab/interactive/_options/schema.py
@@ -63,6 +63,7 @@ __all__ = [
     "FigureExportOptions",
     "FigureOptions",
     "IOOptions",
+    "SecurityOptions",
     "WorkspaceCompressionMode",
     "WorkspaceOptions",
     "normalize_workspace_compression_mode",
@@ -544,6 +545,25 @@ class FigureOptions(BaseModel):
         return _str_list(v)
 
 
+class SecurityOptions(BaseModel):
+    """User-only executable-content trust settings."""
+
+    trusted_workspace_folders: list[str] = Field(
+        default_factory=list,
+        title="Trusted workspace folders",
+        description=(
+            "Workspace files in these folders and their child folders can run saved "
+            "Python code without signature verification."
+        ),
+        json_schema_extra={"ui_type": "trusted_folders"},
+    )
+
+    @field_validator("trusted_workspace_folders", mode="before")
+    @classmethod
+    def normalize_trusted_workspace_folders(cls, value: typing.Any) -> list[str]:
+        return _str_list(value)
+
+
 class AppOptions(BaseModel):
     """Root configuration model for interactive tool options."""
 
@@ -566,4 +586,9 @@ class AppOptions(BaseModel):
         default_factory=FigureOptions,
         title="Figure Composer",
         description="Matplotlib Figure Composer defaults.",
+    )
+    security: SecurityOptions = Field(
+        default_factory=SecurityOptions,
+        title="Security",
+        description="Executable-content trust settings.",
     )

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -23,12 +23,13 @@ from erlab.interactive._options.parameters import (
     SavefigNumberWidget,
     SavefigPaddingWidget,
     StylesheetListWidget,
+    TrustedFoldersWidget,
 )
 from erlab.interactive._options.schema import AppOptions
 from erlab.interactive._widgets import _Separator
 
 _Scope = typing.Literal["user", "workspace"]
-_CATEGORY_ORDER = ("colors", "io", "ktool", "figure")
+_CATEGORY_ORDER = ("colors", "io", "ktool", "figure", "security")
 
 
 def _object_path(path: str) -> str:
@@ -341,7 +342,9 @@ class _SettingsRow(QtWidgets.QFrame):
         object_path = _object_path(path)
         self.setObjectName(f"settingsRow_{scope}_{object_path}")
         self.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
-        multiline_control = isinstance(control, StylesheetListWidget)
+        multiline_control = isinstance(
+            control, StylesheetListWidget | TrustedFoldersWidget
+        )
 
         layout = QtWidgets.QGridLayout(self)
         layout.setContentsMargins(0, 8, 0, 8)
@@ -641,6 +644,8 @@ class OptionDialog(QtWidgets.QDialog):
             return SavefigPaddingWidget(parent=self)
         if ui_type == "directory_path":
             return DirectoryPathWidget(parent=self)
+        if ui_type == "trusted_folders":
+            return TrustedFoldersWidget(parent=self)
         if ui_type == "choice_slider":
             return _ChoiceSlider(extra.get("ui_choices", ()), self)
         if ui_type == "list" or "ui_limits" in extra:
@@ -744,6 +749,10 @@ class OptionDialog(QtWidgets.QDialog):
             control.sigPathChanged.connect(
                 lambda _path, row=row: self._control_changed(row)
             )
+        elif isinstance(control, TrustedFoldersWidget):
+            control.sigFoldersChanged.connect(
+                lambda _folders, row=row: self._control_changed(row)
+            )
         elif isinstance(control, QtWidgets.QLineEdit):
             control.editingFinished.connect(lambda row=row: self._control_changed(row))
 
@@ -841,6 +850,8 @@ class OptionDialog(QtWidgets.QDialog):
             return control.get_value()
         if isinstance(control, DirectoryPathWidget):
             return control.get_path()
+        if isinstance(control, TrustedFoldersWidget):
+            return control.get_folders()
         if isinstance(control, QtWidgets.QLineEdit):
             text = control.text()
             default_value = option_value(AppOptions(), path)
@@ -891,6 +902,9 @@ class OptionDialog(QtWidgets.QDialog):
             return
         if isinstance(control, DirectoryPathWidget):
             control.set_path(None if value is None else str(value))
+            return
+        if isinstance(control, TrustedFoldersWidget):
+            control.set_folders(list(value or []))
             return
         if isinstance(control, QtWidgets.QLineEdit):
             if isinstance(value, list):

--- a/src/erlab/interactive/_saved_tools.py
+++ b/src/erlab/interactive/_saved_tools.py
@@ -1,0 +1,102 @@
+"""Application registry for classes referenced by saved ToolWindow documents."""
+
+from __future__ import annotations
+
+import functools
+import importlib.metadata
+import typing
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+FIGURE_COMPOSER_TOOL_ID = "erlab.interactive._figurecomposer._tool:FigureComposerTool"
+_ENTRY_POINT_GROUP = "erlab.interactive.tool_windows"
+
+# A saved file can select only one of these application modules. Third-party tool
+# classes remain supported after their package imports and registers the class through
+# ToolWindow.__init_subclass__. Never derive an import target from document text.
+_BUILTIN_TOOL_MODULES = {
+    "erlab.interactive._fit1d:Fit1DTool": "erlab.interactive._fit1d",
+    "erlab.interactive._fit2d:Fit2DTool": "erlab.interactive._fit2d",
+    "erlab.interactive._mesh:MeshTool": "erlab.interactive._mesh",
+    FIGURE_COMPOSER_TOOL_ID: "erlab.interactive._figurecomposer._tool",
+    "erlab.interactive.derivative:DerivativeTool": "erlab.interactive.derivative",
+    "erlab.interactive.fermiedge:GoldTool": "erlab.interactive.fermiedge",
+    "erlab.interactive.fermiedge:ResolutionTool": "erlab.interactive.fermiedge",
+    "erlab.interactive.kspace:KspaceTool": "erlab.interactive.kspace",
+    "erlab.interactive.kspace:KspaceToolGUI": "erlab.interactive.kspace",
+}
+_SAVED_TOOL_CLASSES: dict[str, type] = {}
+_SAVED_TOOL_LOADERS: dict[str, Callable[[], object]] = {}
+_ENTRY_POINTS_DISCOVERED = False
+
+
+def _load_builtin_tool(module_name: str, qualname: str) -> object:
+    module = importlib.import_module(module_name)
+    value: object = module
+    for attribute in qualname.split("."):
+        value = getattr(value, attribute)
+    return value
+
+
+def _register_saved_tool_loader(
+    identifier: str,
+    loader: Callable[[], object],
+) -> None:
+    """Register a loader supplied by the installed application."""
+    _SAVED_TOOL_LOADERS[identifier] = loader
+    _SAVED_TOOL_CLASSES.pop(identifier, None)
+
+
+for _identifier, _module_name in _BUILTIN_TOOL_MODULES.items():
+    _qualname = _identifier.partition(":")[2]
+    _register_saved_tool_loader(
+        _identifier,
+        functools.partial(_load_builtin_tool, _module_name, _qualname),
+    )
+
+
+def _discover_saved_tool_entry_points() -> None:
+    """Register locally installed tool extensions without using document text."""
+    global _ENTRY_POINTS_DISCOVERED
+    if _ENTRY_POINTS_DISCOVERED:
+        return
+    _ENTRY_POINTS_DISCOVERED = True
+    for entry_point in importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP):
+        if entry_point.attr is None:
+            continue
+        identifier = f"{entry_point.module}:{entry_point.attr}"
+        if identifier in _SAVED_TOOL_CLASSES or identifier in _SAVED_TOOL_LOADERS:
+            continue
+        _register_saved_tool_loader(
+            identifier,
+            entry_point.load,
+        )
+
+
+def register_saved_tool_class(cls: type) -> None:
+    """Register the canonical identifier of an imported ToolWindow subclass."""
+    identifier = f"{cls.__module__}:{cls.__qualname__}"
+    _SAVED_TOOL_CLASSES[identifier] = cls
+    _SAVED_TOOL_LOADERS.pop(identifier, None)
+
+
+def resolve_saved_tool_class(identifier: str) -> type:
+    """Resolve a class selected by the local registry or extension metadata."""
+    _discover_saved_tool_entry_points()
+    cls = _SAVED_TOOL_CLASSES.get(identifier)
+    if cls is None and identifier in _SAVED_TOOL_LOADERS:
+        value = _SAVED_TOOL_LOADERS[identifier]()
+        if not isinstance(value, type):
+            raise TypeError(f"Saved tool reference {identifier!r} is not a class")
+        loaded_identifier = f"{value.__module__}:{value.__qualname__}"
+        if loaded_identifier != identifier:
+            raise TypeError(
+                f"Saved tool reference {identifier!r} loaded {loaded_identifier!r}"
+            )
+        cls = value
+        _SAVED_TOOL_CLASSES[identifier] = cls
+        _SAVED_TOOL_LOADERS.pop(identifier, None)
+    if cls is None:
+        raise LookupError(f"Saved tool class {identifier!r} is not registered")
+    return cls

--- a/src/erlab/interactive/imagetool/_load_source.py
+++ b/src/erlab/interactive/imagetool/_load_source.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import importlib
 import pathlib
+import types
 import typing
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 
 import numpy as np
+import xarray as xr
 
 import erlab
 from erlab.interactive.imagetool._provenance._code import _provenance_value_code
@@ -61,6 +63,23 @@ _LoadFunc: typing.TypeAlias = tuple[
 _LoadKind: typing.TypeAlias = typing.Literal[
     "erlab_loader", "callable", "extension_loader"
 ]
+
+# These are the public loaders that ImageTool provides without an extension. Keep
+# this registry explicit so a saved workspace cannot cause an import of its target.
+_SUPPORTED_CALLABLE_LOADERS: Mapping[str, Callable[..., typing.Any]] = (
+    types.MappingProxyType(
+        {
+            "xarray.load_dataarray": xr.load_dataarray,
+            "xarray.open_dataarray": xr.open_dataarray,
+            "xarray.load_dataset": xr.load_dataset,
+            "xarray.open_dataset": xr.open_dataset,
+            "xarray.load_datatree": xr.load_datatree,
+            "xarray.open_datatree": xr.open_datatree,
+        }
+    )
+)
+
+_LOCAL_CALLABLE_LOADERS: dict[str, Callable[..., typing.Any]] = {}
 
 
 def _file_path_stem(path: str | os.PathLike[str]) -> str:
@@ -482,6 +501,30 @@ def _loader_callable_text(loader: Callable[..., typing.Any]) -> str | None:
     return f"{module}.{qualname}"
 
 
+def _register_local_callable_loader(
+    loader: Callable[..., typing.Any],
+) -> str | None:
+    """Register a locally supplied callable loader by its stable identifier."""
+    identifier = _loader_callable_text(loader)
+    if identifier is not None:
+        _LOCAL_CALLABLE_LOADERS[identifier] = loader
+    return identifier
+
+
+def _registered_local_callable_loader(
+    identifier: str,
+) -> Callable[..., typing.Any] | None:
+    """Return a supported loader without importing a workspace target."""
+    module, separator, qualname = identifier.partition(":")
+    if separator:
+        if not module or not qualname or ":" in qualname:
+            return None
+        identifier = f"{module}.{qualname}"
+    return _SUPPORTED_CALLABLE_LOADERS.get(identifier) or _LOCAL_CALLABLE_LOADERS.get(
+        identifier
+    )
+
+
 def _import_for_callable(loader: Callable[..., typing.Any], target: str) -> str:
     module = getattr(loader, "__module__", None)
     if isinstance(module, str) and target.startswith(f"{module}."):
@@ -660,7 +703,7 @@ def _resolve_load_func(
             cast_float64=cast_float64,
         )
 
-    target = _loader_callable_text(loader)
+    target = _register_local_callable_loader(loader)
     if target is None:
         return None
     return _ResolvedLoadFunc(

--- a/src/erlab/interactive/imagetool/_provenance/_execution.py
+++ b/src/erlab/interactive/imagetool/_provenance/_execution.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 import builtins
-import hashlib
 import importlib
-import json
 import pathlib
 import typing
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import numpy as np
 import xarray as xr
 
 import erlab
 from erlab.extensions._api import _registered_script_capability_status
+from erlab.interactive._code_trust import execution_capability_allows
+from erlab.interactive.imagetool._load_source import (
+    _deserialize_loader_kwargs,
+    _registered_local_callable_loader,
+)
 from erlab.interactive.imagetool._provenance._code import (
     _SCRIPT_REPLAY_ALLOWED_BUILTINS,
     _code_uses_name_any_scope,
@@ -39,9 +42,14 @@ from erlab.interactive.imagetool._provenance._model import (
     iter_operation_refs,
     parse_tool_provenance_spec,
 )
+from erlab.interactive.imagetool._provenance._trust import (
+    provenance_replay_graph_code_trust_entries,
+    provenance_replay_node_code_trust_entries,
+    provenance_requires_code_trust,
+)
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Mapping
 
     from erlab.extensions._api import _CapabilityStatus
     from erlab.interactive.imagetool._provenance._operations import (
@@ -51,6 +59,9 @@ if typing.TYPE_CHECKING:
     _CapabilityStatusResolver = Callable[
         [str, str, typing.Literal["routine", "loader"], str], _CapabilityStatus
     ]
+
+
+ExecutionAuthorizer = Callable[[tuple[typing.Any, ...]], object | None]
 
 
 def _processed_replay_ndim(darr: xr.DataArray) -> int:
@@ -211,41 +222,11 @@ def _semantic_file_data_selection(
     return FileDataSelection(kind="sequence_index", value=index)
 
 
-def _resolve_importable_callable(target: str) -> Callable[..., typing.Any]:
-    parts = target.split(".")
-    if len(parts) < 2:
-        raise ValueError(f"Importable callable target {target!r} must be dotted")
-
-    module = None
-    attr_start = 0
-    for idx in range(len(parts) - 1, 0, -1):
-        module_name = ".".join(parts[:idx])
-        try:
-            module = importlib.import_module(module_name)
-        except ModuleNotFoundError as exc:
-            if exc.name != module_name:
-                raise
-            continue
-        attr_start = idx
-        break
-    if module is None:
-        raise ModuleNotFoundError(target)
-
-    obj: typing.Any = module
-    for attr in parts[attr_start:]:
-        obj = getattr(obj, attr)
-    if not callable(obj):
-        raise TypeError(f"Importable target {target!r} is not callable")
-    return typing.cast("Callable[..., typing.Any]", obj)
-
-
 def _load_file_source_object(
     load_source: FileLoadSource,
     *,
     extension_loader_executor: Callable[[FileLoadSource], typing.Any] | None = None,
 ) -> typing.Any:
-    from erlab.interactive.imagetool._load_source import _deserialize_loader_kwargs
-
     call = load_source.replay_call
     if call is None:
         raise ValueError("File load source does not define replay metadata")
@@ -263,7 +244,11 @@ def _load_file_source_object(
             parameters=_deserialize_loader_kwargs(call.kwargs),
         )
     else:
-        func = _resolve_importable_callable(call.target)
+        func = _registered_local_callable_loader(call.target)
+        if func is None:
+            raise ValueError(
+                f"Callable file loader {call.target!r} is not registered locally"
+            )
 
     return func(file_path, **_deserialize_loader_kwargs(call.kwargs))
 
@@ -300,15 +285,20 @@ def execute_replay_graph(
     extension_executor: Callable[[typing.Any, xr.DataArray], xr.DataArray]
     | None = None,
     extension_loader_executor: Callable[[FileLoadSource], typing.Any] | None = None,
+    authorization: object | None = None,
+    authorize: ExecutionAuthorizer | None = None,
 ) -> xr.DataArray:
     # Replay runs from manager actions; avoid optional native reduction accelerators
     # that can crash PySide6/Python 3.14 while Qt threads are alive.
+    if authorization is None:
+        authorization = _authorize_replay_graph(graph, authorize)
     with xr.set_options(use_numbagg=False):
         return _execute_replay_graph(
             graph,
             cache=cache,
             extension_executor=extension_executor,
             extension_loader_executor=extension_loader_executor,
+            authorization=authorization,
         )
 
 
@@ -319,11 +309,12 @@ def _execute_replay_graph(
     extension_executor: Callable[[typing.Any, xr.DataArray], xr.DataArray]
     | None = None,
     extension_loader_executor: Callable[[FileLoadSource], typing.Any] | None = None,
+    authorization: object | None = None,
 ) -> xr.DataArray:
     replay_cache = {} if cache is None else cache
     values: dict[str, xr.DataArray] = {}
 
-    for node in graph.nodes:
+    for node_index, node in enumerate(graph.nodes):
         if node.cacheable and node.key in replay_cache:
             values[node.key] = replay_cache[node.key].copy(deep=False)
             continue
@@ -349,14 +340,36 @@ def _execute_replay_graph(
             operation = node.payload["operation"]
             if extension_executor is not None and operation.op == "extension_routine":
                 data = extension_executor(operation, values[node.parents[0]])
-            elif node.payload.get("legacy_parent_context", False):
-                data = operation._apply_schema_v2(
-                    values[node.parents[0]],
-                    parent_data=values[node.parents[1]],
-                )
             else:
-                data = operation.apply(values[node.parents[0]])
+                entries = provenance_replay_node_code_trust_entries(
+                    node,
+                    location_prefix=f"runtime/nodes/{node_index}",
+                )
+                if not execution_capability_allows(authorization, entries):
+                    raise ReplayGraphError(
+                        "Recorded provenance contains Python content that is not "
+                        "trusted"
+                    )
+                if node.payload.get("legacy_parent_context", False):
+                    data = operation._apply_schema_v2(
+                        values[node.parents[0]],
+                        parent_data=values[node.parents[1]],
+                        authorization=authorization,
+                    )
+                elif entries:
+                    data = operation.apply(
+                        values[node.parents[0]],
+                        authorization=authorization,
+                    )
+                else:
+                    data = operation.apply(values[node.parents[0]])
         elif node.kind == "script":
+            entries = provenance_replay_node_code_trust_entries(
+                node,
+                location_prefix=f"runtime/nodes/{node_index}",
+            )
+            if not execution_capability_allows(authorization, entries):
+                raise ReplayGraphError("Recorded Python code is not trusted")
             codes = typing.cast("tuple[str, ...]", node.payload["codes"])
             compiled_codes = tuple(
                 compile(code, "<ImageTool script provenance>", "exec")
@@ -429,6 +442,20 @@ def _execute_replay_graph(
     return output
 
 
+def _authorize_replay_graph(
+    graph: ReplayGraph,
+    authorize: ExecutionAuthorizer | None,
+) -> object | None:
+    """Authorize the exact compiled graph once and return its opaque capability."""
+    entries = provenance_replay_graph_code_trust_entries(
+        graph,
+        location_prefix="runtime",
+    )
+    if not entries or authorize is None:
+        return None
+    return authorize(entries)
+
+
 def replay_file_provenance(
     spec: typing.Any,
     *,
@@ -436,15 +463,21 @@ def replay_file_provenance(
     extension_executor: Callable[[typing.Any, xr.DataArray], xr.DataArray]
     | None = None,
     extension_loader_executor: Callable[[FileLoadSource], typing.Any] | None = None,
+    authorize: ExecutionAuthorizer | None = None,
 ) -> xr.DataArray:
     """Replay structured file provenance without executing generated Python."""
     try:
-        graph = compile_replay_graph(spec, structured_file_replay=True)
+        graph = compile_replay_graph(
+            spec,
+            trusted_user_code=True,
+            structured_file_replay=True,
+        )
         return execute_replay_graph(
             graph,
             cache=cache,
             extension_executor=extension_executor,
             extension_loader_executor=extension_loader_executor,
+            authorize=authorize,
         )
     except ReplayGraphError as exc:
         raise TypeError("Expected structured file provenance") from exc
@@ -474,11 +507,11 @@ def file_load_source_status(
         and replay_call.target not in erlab.io.loaders
     ):
         return "missing-loader"
-    if replay_call.kind == "callable":
-        try:
-            _resolve_importable_callable(replay_call.target)
-        except (AttributeError, ModuleNotFoundError, TypeError, ValueError):
-            return "missing-loader"
+    if (
+        replay_call.kind == "callable"
+        and _registered_local_callable_loader(replay_call.target) is None
+    ):
+        return "missing-loader"
     if replay_call.kind == "extension_loader":
         capability_status = (
             _registered_script_capability_status
@@ -507,14 +540,17 @@ def file_load_source_status(
     return "loadable"
 
 
-def can_reload_without_trust(
+def _can_reload_provenance(
     value: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
     *,
+    allow_code: bool,
     extension_status_resolver: _CapabilityStatusResolver | None = None,
 ) -> bool:
     """Return whether provenance can replay with the selected extension scope."""
     spec = parse_tool_provenance_spec(value)
     if spec is None:
+        return False
+    if not allow_code and provenance_requires_code_trust(spec):
         return False
     if spec.kind not in {"file", "script"}:
         return False
@@ -522,7 +558,10 @@ def can_reload_without_trust(
         spec, extension_status_resolver=extension_status_resolver
     ) != "loadable":
         return False
-    if spec.kind == "script" and not script_provenance_replayable(spec):
+    if spec.kind == "script" and not _script_provenance_validates(
+        spec,
+        strict_replay_code=not allow_code,
+    ):
         return False
     capability_status = (
         _registered_script_capability_status
@@ -545,29 +584,53 @@ def can_reload_without_trust(
             return False
     for script_input in spec.script_inputs:
         input_spec = script_input.parsed_provenance_spec()
-        if not can_reload_without_trust(
-            input_spec, extension_status_resolver=extension_status_resolver
+        if not _can_reload_provenance(
+            input_spec,
+            allow_code=allow_code,
+            extension_status_resolver=extension_status_resolver,
         ):
             return False
     return True
+
+
+def can_reload_without_trust(
+    value: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
+    *,
+    extension_status_resolver: _CapabilityStatusResolver | None = None,
+) -> bool:
+    """Return whether recorded provenance can replay without trusted user code."""
+    return _can_reload_provenance(
+        value,
+        allow_code=False,
+        extension_status_resolver=extension_status_resolver,
+    )
+
+
+def can_reload_with_trusted_code(
+    value: ToolProvenanceSpec | Mapping[str, typing.Any] | None,
+    *,
+    extension_status_resolver: _CapabilityStatusResolver | None = None,
+) -> bool:
+    """Return whether trusted recorded provenance can rebuild its data."""
+    return _can_reload_provenance(
+        value,
+        allow_code=True,
+        extension_status_resolver=extension_status_resolver,
+    )
 
 
 def script_provenance_replayable(
     spec: typing.Any,
     *,
     external_input_names: set[str] | None = None,
+    allow_code: bool = False,
 ) -> bool:
-    parsed = parse_tool_provenance_spec(spec)
-    if parsed is None:
-        return False
-    try:
-        _validate_script_provenance(
-            parsed,
-            external_input_names=external_input_names,
-        )
-    except (ReplayGraphError, TypeError, ValueError):
-        return False
-    return True
+    """Return whether a script can replay with the supplied input namespace."""
+    return _script_provenance_validates(
+        spec,
+        external_input_names=external_input_names,
+        strict_replay_code=not allow_code,
+    )
 
 
 def _script_provenance_validates(
@@ -590,93 +653,28 @@ def _script_provenance_validates(
     return True
 
 
-def script_provenance_requires_trust(
-    spec: typing.Any,
-    *,
-    external_input_names: set[str] | None = None,
-) -> bool:
-    parsed = parse_tool_provenance_spec(spec)
-    if parsed is None or parsed.kind != "script":
-        return False
-    strict_replayable = _script_provenance_validates(
-        parsed,
-        external_input_names=external_input_names,
-        strict_replay_code=True,
-    )
-    trusted_replayable = _script_provenance_validates(
-        parsed,
-        external_input_names=external_input_names,
-        strict_replay_code=False,
-    )
-    current_requires_trust = not strict_replayable and trusted_replayable
-    if current_requires_trust:
-        return True
-    if not strict_replayable:
-        return False
-    for script_input in parsed.script_inputs:
-        input_spec = script_input.parsed_provenance_spec()
-        if script_provenance_requires_trust(input_spec):
-            return True
-    return False
-
-
-def _script_trust_payload(spec: typing.Any) -> dict[str, typing.Any] | None:
-    parsed = parse_tool_provenance_spec(spec)
-    if parsed is None or parsed.kind != "script":
-        return None
-    operations = []
-    for operation in parsed.operations:
-        if getattr(operation, "op", None) != "script_code":
-            continue
-        operations.append(
-            {
-                "code": getattr(operation, "code", None),
-                "copyable": bool(getattr(operation, "copyable", False)),
-            }
-        )
-    inputs = []
-    for script_input in parsed.script_inputs:
-        input_payload = _script_trust_payload(script_input.parsed_provenance_spec())
-        if input_payload is None:
-            continue
-        inputs.append({"name": script_input.name, "payload": input_payload})
-    return {
-        "active_name": parsed.active_name,
-        "inputs": inputs,
-        "operations": operations,
-        "seed_code": parsed.seed_code,
-    }
-
-
-def script_provenance_trust_key(spec: typing.Any) -> str | None:
-    payload = _script_trust_payload(spec)
-    if payload is None:
-        return None
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.sha256(encoded).hexdigest()
-
-
 def replay_script_provenance(
     spec: typing.Any,
     inputs: Mapping[str, xr.DataArray],
     *,
-    trusted_user_code: bool = False,
     extension_executor: Callable[[typing.Any, xr.DataArray], xr.DataArray]
     | None = None,
     extension_loader_executor: Callable[[FileLoadSource], typing.Any] | None = None,
+    authorize: ExecutionAuthorizer | None = None,
 ) -> xr.DataArray:
     """Execute script provenance from already resolved input arrays."""
     try:
         graph = compile_replay_graph(
             spec,
             external_inputs=inputs,
-            trusted_user_code=trusted_user_code,
+            trusted_user_code=True,
             structured_file_replay=True,
         )
         return execute_replay_graph(
             graph,
             extension_executor=extension_executor,
             extension_loader_executor=extension_loader_executor,
+            authorize=authorize,
         )
     except ReplayGraphError as exc:
         if "non-replayable" in str(exc):
@@ -690,10 +688,10 @@ def rebuild_script_provenance(
     live_input_resolver: LiveInputResolver | None = None,
     cache: dict[str, xr.DataArray] | None = None,
     depth: int = 0,
-    trusted_user_code: bool = False,
     extension_executor: Callable[[typing.Any, xr.DataArray], xr.DataArray]
     | None = None,
     extension_loader_executor: Callable[[FileLoadSource], typing.Any] | None = None,
+    authorize: ExecutionAuthorizer | None = None,
 ) -> tuple[xr.DataArray, typing.Any]:
     parsed = parse_tool_provenance_spec(spec)
     if parsed is None or parsed.kind != "script":
@@ -702,13 +700,10 @@ def rebuild_script_provenance(
         raise ReplayGraphError(
             "Nested script provenance exceeded the maximum reload depth"
         )
-    if trusted_user_code:
-        replayable = _script_provenance_validates(
-            parsed,
-            strict_replay_code=False,
-        )
-    else:
-        replayable = script_provenance_replayable(parsed)
+    replayable = _script_provenance_validates(
+        parsed,
+        strict_replay_code=False,
+    )
     if not replayable:
         raise ReplayGraphError(
             "The recorded operation cannot be replayed automatically"
@@ -768,13 +763,10 @@ def rebuild_script_provenance(
                 )
                 continue
             if input_spec.kind == "script":
-                if trusted_user_code:
-                    input_replayable = _script_provenance_validates(
-                        input_spec,
-                        strict_replay_code=False,
-                    )
-                else:
-                    input_replayable = script_provenance_replayable(input_spec)
+                input_replayable = _script_provenance_validates(
+                    input_spec,
+                    strict_replay_code=False,
+                )
                 if not input_replayable:
                     raise ReplayGraphError(
                         "The recorded operation cannot be replayed automatically"
@@ -801,7 +793,7 @@ def rebuild_script_provenance(
     graph = compile_replay_graph(
         rebuilt_spec,
         live_input_resolver=resolve_live,
-        trusted_user_code=trusted_user_code,
+        trusted_user_code=True,
         structured_file_replay=True,
     )
     return (
@@ -810,6 +802,7 @@ def rebuild_script_provenance(
             cache=cache,
             extension_executor=extension_executor,
             extension_loader_executor=extension_loader_executor,
+            authorize=authorize,
         ),
         rebuilt_spec,
     )

--- a/src/erlab/interactive/imagetool/_provenance/_graph.py
+++ b/src/erlab/interactive/imagetool/_provenance/_graph.py
@@ -44,7 +44,6 @@ from erlab.interactive.imagetool._provenance._model import (
 )
 
 if typing.TYPE_CHECKING:
-    from erlab.interactive.imagetool._provenance._model import FileLoadSource
     from erlab.interactive.imagetool._provenance._operations import ScriptCodeOperation
 
 
@@ -987,12 +986,15 @@ def _compile_spec(
     structured_file_replay: bool,
     external_inputs: Mapping[str, xr.DataArray] | None,
     live_input_resolver: LiveInputResolver | None,
+    allow_unresolved_inputs: bool,
 ) -> str:
     parsed = parse_tool_provenance_spec(spec)
     if parsed is None:
         raise ReplayGraphError("Expected provenance spec")
     if parsed.kind == "file":
-        load_source = typing.cast("FileLoadSource", parsed.file_load_source)
+        load_source = parsed.file_load_source
+        if load_source is None:
+            raise ReplayGraphError("File provenance has no load source")
         active_name = typing.cast("str", parsed.active_name)
         structured_replay = load_source.replay_call is not None
         extension_loader = _is_extension_loader_source(load_source)
@@ -1057,6 +1059,18 @@ def _compile_spec(
                 else:
                     input_spec = script_input.parsed_provenance_spec()
                     if input_spec is None:
+                        if allow_unresolved_inputs:
+                            input_key = graph.add_node(
+                                _canonical_key(
+                                    "unresolved_input",
+                                    {"name": script_input.name},
+                                ),
+                                "live_input",
+                                cacheable=False,
+                                payload={"data": None},
+                            )
+                            bindings.append((script_input.name, input_key))
+                            continue
                         input_reference = _script_input_reference_text(script_input)
                         raise ReplayGraphError(
                             f"{input_reference} "
@@ -1070,6 +1084,7 @@ def _compile_spec(
                         structured_file_replay=structured_file_replay,
                         external_inputs=external_inputs,
                         live_input_resolver=live_input_resolver,
+                        allow_unresolved_inputs=allow_unresolved_inputs,
                     )
                     if display:
                         graph.add_alias(script_input.name, input_key)
@@ -1103,6 +1118,7 @@ def _compile_spec(
         pending_code_hoist_imports: list[bool] = []
         pending_code_external_names: list[tuple[str, ...]] = []
         pending_code_framework_owned: list[bool] = []
+        pending_stored_code: list[str | None] = []
 
         def relay_key(source_key: str) -> str:
             return graph.add_node(
@@ -1170,7 +1186,7 @@ def _compile_spec(
         def flush_script() -> None:
             nonlocal current_bindings, current_name, pending_code_hoist_imports
             nonlocal pending_code_external_names, pending_code_framework_owned
-            nonlocal pending_codes, script_current_key
+            nonlocal pending_codes, pending_stored_code, script_current_key
             if not pending_codes:
                 return
             if len(pending_codes) > 1:
@@ -1182,6 +1198,7 @@ def _compile_spec(
                         del pending_code_external_names[0]
                         del pending_code_framework_owned[0]
                         del pending_code_hoist_imports[0]
+                        del pending_stored_code[0]
             output_name = _script_codes_output_name(
                 pending_codes,
                 active_name=active_name,
@@ -1198,6 +1215,7 @@ def _compile_spec(
                         "codes": tuple(pending_codes),
                         "external_names": tuple(pending_code_external_names),
                         "framework_owned": tuple(pending_code_framework_owned),
+                        "stored_code": tuple(pending_stored_code),
                         "hoist_imports": tuple(pending_code_hoist_imports),
                     },
                 ),
@@ -1210,6 +1228,7 @@ def _compile_spec(
                     "codes": tuple(pending_codes),
                     "external_names": tuple(pending_code_external_names),
                     "framework_owned": tuple(pending_code_framework_owned),
+                    "stored_code": tuple(pending_stored_code),
                     "hoist_imports": tuple(pending_code_hoist_imports),
                 },
             )
@@ -1221,6 +1240,7 @@ def _compile_spec(
             pending_code_external_names = []
             pending_code_framework_owned = []
             pending_code_hoist_imports = []
+            pending_stored_code = []
 
         def apply_context_binding(names: Sequence[str]) -> None:
             nonlocal current_bindings, current_name, script_current_key
@@ -1260,6 +1280,7 @@ def _compile_spec(
                     pending_code_external_names.append(tuple(sorted(seed_caller_names)))
                     pending_code_framework_owned.append(False)
                     pending_code_hoist_imports.append(False)
+                    pending_stored_code.append(parsed.seed_code)
             else:
                 seed_setup_code, seed_load_code, seed_output_name = seed_file_load_parts
                 script_current_key = _add_file_load_node(
@@ -1301,6 +1322,9 @@ def _compile_spec(
                     )
                     pending_code_hoist_imports.append(
                         bool(getattr(script_operation, "hoist_imports", False))
+                    )
+                    pending_stored_code.append(
+                        None if script_operation.framework_owned else operation_code
                     )
                 previous_input_policy = None
                 continue
@@ -1397,6 +1421,7 @@ def _compile_spec(
                     pending_code_external_names.append(())
                     pending_code_framework_owned.append(True)
                     pending_code_hoist_imports.append(False)
+                    pending_stored_code.append(None)
                     continue
 
             ensure_script_current_key()
@@ -1460,6 +1485,7 @@ def compile_replay_graph(
     structured_file_replay: bool = False,
     external_inputs: Mapping[str, xr.DataArray] | None = None,
     live_input_resolver: LiveInputResolver | None = None,
+    allow_unresolved_inputs: bool = False,
 ) -> ReplayGraph:
     """Compile provenance for code output or structured runtime execution.
 
@@ -1485,6 +1511,7 @@ def compile_replay_graph(
         structured_file_replay=structured_file_replay,
         external_inputs=external_inputs,
         live_input_resolver=live_input_resolver,
+        allow_unresolved_inputs=allow_unresolved_inputs,
     )
     return graph
 
@@ -3655,6 +3682,7 @@ def script_inputs_code(script_inputs: Sequence[typing.Any], *, display: bool) ->
             structured_file_replay=False,
             external_inputs=None,
             live_input_resolver=None,
+            allow_unresolved_inputs=False,
         )
         graph.add_alias(script_input.name, input_key)
     return emit_replay_code(graph, include_all_aliases=True)

--- a/src/erlab/interactive/imagetool/_provenance/_graph.py
+++ b/src/erlab/interactive/imagetool/_provenance/_graph.py
@@ -595,10 +595,10 @@ def _validate_script_provenance(
             if not script_operation.copyable or script_operation.code is None:
                 raise ReplayGraphError("Script provenance contains non-replayable code")
             has_replay_step = True
-            framework_owned = script_operation.framework_owned
+            uses_implicit_imports = script_operation.uses_implicit_framework_imports
             operation_available_names = available_names
             implicit_names_added: set[str] = set()
-            if framework_owned:
+            if uses_implicit_imports:
                 operation_available_names = set(available_names)
                 implicit_names_added = implicit_framework_names - available_names
                 operation_available_names.update(implicit_framework_names)
@@ -625,7 +625,7 @@ def _validate_script_provenance(
                     external_name_candidates=external_name_candidates,
                 )
             )
-            if framework_owned:
+            if uses_implicit_imports:
                 available_names.update(
                     name
                     for name in operation_available_names
@@ -1117,8 +1117,10 @@ def _compile_spec(
         pending_codes: list[str] = []
         pending_code_hoist_imports: list[bool] = []
         pending_code_external_names: list[tuple[str, ...]] = []
-        pending_code_framework_owned: list[bool] = []
-        pending_stored_code: list[str | None] = []
+        pending_code_implicit_imports: list[bool] = []
+        # This mirrors pending_codes. None identifies Python synthesized locally
+        # from a typed operation instead of source text stored in the document.
+        pending_document_codes: list[str | None] = []
 
         def relay_key(source_key: str) -> str:
             return graph.add_node(
@@ -1185,8 +1187,8 @@ def _compile_spec(
 
         def flush_script() -> None:
             nonlocal current_bindings, current_name, pending_code_hoist_imports
-            nonlocal pending_code_external_names, pending_code_framework_owned
-            nonlocal pending_codes, pending_stored_code, script_current_key
+            nonlocal pending_code_external_names, pending_code_implicit_imports
+            nonlocal pending_codes, pending_document_codes, script_current_key
             if not pending_codes:
                 return
             if len(pending_codes) > 1:
@@ -1196,9 +1198,9 @@ def _compile_spec(
                     if not _name_value_is_live(pending_codes[1:], seed_name):
                         del pending_codes[0]
                         del pending_code_external_names[0]
-                        del pending_code_framework_owned[0]
+                        del pending_code_implicit_imports[0]
                         del pending_code_hoist_imports[0]
-                        del pending_stored_code[0]
+                        del pending_document_codes[0]
             output_name = _script_codes_output_name(
                 pending_codes,
                 active_name=active_name,
@@ -1214,8 +1216,10 @@ def _compile_spec(
                         "bindings": current_bindings,
                         "codes": tuple(pending_codes),
                         "external_names": tuple(pending_code_external_names),
-                        "framework_owned": tuple(pending_code_framework_owned),
-                        "stored_code": tuple(pending_stored_code),
+                        "uses_implicit_framework_imports": tuple(
+                            pending_code_implicit_imports
+                        ),
+                        "document_codes": tuple(pending_document_codes),
                         "hoist_imports": tuple(pending_code_hoist_imports),
                     },
                 ),
@@ -1227,8 +1231,10 @@ def _compile_spec(
                     "bindings": current_bindings,
                     "codes": tuple(pending_codes),
                     "external_names": tuple(pending_code_external_names),
-                    "framework_owned": tuple(pending_code_framework_owned),
-                    "stored_code": tuple(pending_stored_code),
+                    "uses_implicit_framework_imports": tuple(
+                        pending_code_implicit_imports
+                    ),
+                    "document_codes": tuple(pending_document_codes),
                     "hoist_imports": tuple(pending_code_hoist_imports),
                 },
             )
@@ -1238,9 +1244,9 @@ def _compile_spec(
                 graph.add_alias(output_name, script_current_key)
             pending_codes = []
             pending_code_external_names = []
-            pending_code_framework_owned = []
+            pending_code_implicit_imports = []
             pending_code_hoist_imports = []
-            pending_stored_code = []
+            pending_document_codes = []
 
         def apply_context_binding(names: Sequence[str]) -> None:
             nonlocal current_bindings, current_name, script_current_key
@@ -1278,9 +1284,9 @@ def _compile_spec(
                 if not apply_simple_alias(seed_code):
                     pending_codes.append(seed_code)
                     pending_code_external_names.append(tuple(sorted(seed_caller_names)))
-                    pending_code_framework_owned.append(False)
+                    pending_code_implicit_imports.append(False)
                     pending_code_hoist_imports.append(False)
-                    pending_stored_code.append(parsed.seed_code)
+                    pending_document_codes.append(parsed.seed_code)
             else:
                 seed_setup_code, seed_load_code, seed_output_name = seed_file_load_parts
                 script_current_key = _add_file_load_node(
@@ -1314,18 +1320,16 @@ def _compile_spec(
                     pending_codes.append(operation_code)
                     accesses, _rebindings = _code_name_accesses(operation_code)
                     external_names = caller_names & accesses
-                    if script_operation.framework_owned:
+                    if script_operation.uses_implicit_framework_imports:
                         external_names -= _REPLAY_FRAMEWORK_IMPORTS.keys()
                     pending_code_external_names.append(tuple(sorted(external_names)))
-                    pending_code_framework_owned.append(
-                        script_operation.framework_owned
+                    pending_code_implicit_imports.append(
+                        script_operation.uses_implicit_framework_imports
                     )
                     pending_code_hoist_imports.append(
                         bool(getattr(script_operation, "hoist_imports", False))
                     )
-                    pending_stored_code.append(
-                        None if script_operation.framework_owned else operation_code
-                    )
+                    pending_document_codes.append(operation_code)
                 previous_input_policy = None
                 continue
 
@@ -1419,9 +1423,9 @@ def _compile_spec(
                         )
                     )
                     pending_code_external_names.append(())
-                    pending_code_framework_owned.append(True)
+                    pending_code_implicit_imports.append(True)
                     pending_code_hoist_imports.append(False)
-                    pending_stored_code.append(None)
+                    pending_document_codes.append(None)
                     continue
 
             ensure_script_current_key()
@@ -3127,7 +3131,7 @@ def emit_replay_code(
     copied_script_bindings = _copied_script_bindings(graph)
     chunks: list[tuple[str, bool]] = []
     chunk_external_names: list[tuple[str, ...]] = []
-    chunk_framework_owned: list[bool] = []
+    chunk_implicit_imports: list[bool] = []
     extension_setup_chunks: list[tuple[str, bool]] = []
     materialized_aliases: dict[str, str] = {}
     generated_copy_names: set[str] = set()
@@ -3213,11 +3217,11 @@ def emit_replay_code(
         *,
         group_imports: bool = False,
         external_names: tuple[str, ...] = (),
-        framework_owned: bool = True,
+        uses_implicit_framework_imports: bool = True,
     ) -> None:
         chunks.append((code, graph.display and group_imports))
         chunk_external_names.append(external_names)
-        chunk_framework_owned.append(framework_owned)
+        chunk_implicit_imports.append(uses_implicit_framework_imports)
 
     def extension_binding(node_key: str) -> tuple[str, str]:
         source_path, function_name = extension_references[node_key]
@@ -3347,10 +3351,10 @@ def emit_replay_code(
                     node.payload.get("external_names", ((),) * len(codes)),
                 )
             )
-            framework_owned_by_code = list(
+            implicit_imports_by_code = list(
                 typing.cast(
                     "tuple[bool, ...]",
-                    node.payload["framework_owned"],
+                    node.payload["uses_implicit_framework_imports"],
                 )
             )
             hoist_imports = list(
@@ -3443,7 +3447,7 @@ def emit_replay_code(
             if (
                 graph.display
                 and not any(hoist_imports)
-                and len(set(framework_owned_by_code)) == 1
+                and len(set(implicit_imports_by_code)) == 1
                 and _is_receiver_assignment_chain(codes, active_name)
             ):
                 codes = [
@@ -3463,20 +3467,20 @@ def emit_replay_code(
                         )
                     )
                 ]
-                framework_owned_by_code = [framework_owned_by_code[0]]
+                implicit_imports_by_code = [implicit_imports_by_code[0]]
                 hoist_imports = [False]
-            for code, group_imports, external_names, framework_owned in zip(
+            for code, group_imports, external_names, implicit_imports in zip(
                 codes,
                 hoist_imports,
                 external_names_by_code,
-                framework_owned_by_code,
+                implicit_imports_by_code,
                 strict=True,
             ):
                 append_code(
                     code,
                     group_imports=group_imports,
                     external_names=external_names,
-                    framework_owned=framework_owned,
+                    uses_implicit_framework_imports=implicit_imports,
                 )
             if active_name != name:
                 append_code(f"{name} = {active_name}")
@@ -3523,7 +3527,7 @@ def emit_replay_code(
             future_prologues.append(chunk_future_imports)
         chunks[index] = (body, group_imports)
 
-    framework_owned_names: set[str] = set()
+    implicit_framework_names: set[str] = set()
     framework_import_targets: dict[str, str] = {}
     for name, import_code in _REPLAY_FRAMEWORK_IMPORTS.items():
         bindings = typing.cast("dict[str, str]", _import_binding_targets(import_code))
@@ -3533,8 +3537,8 @@ def emit_replay_code(
     synthesize_framework_imports = (
         not graph.display or _semantic_emitted_step_count(graph) > 1
     )
-    for index, ((chunk, group_imports), framework_owned) in enumerate(
-        zip(chunks, chunk_framework_owned, strict=True)
+    for index, ((chunk, group_imports), implicit_imports) in enumerate(
+        zip(chunks, chunk_implicit_imports, strict=True)
     ):
         module = ast.parse(chunk, mode="exec")
         loaded_names = {
@@ -3550,9 +3554,9 @@ def emit_replay_code(
                 imported_bindings.update(bindings)
 
         bindings_at_body = known_framework_bindings | imported_bindings
-        if framework_owned:
+        if implicit_imports:
             framework_names = loaded_names & _REPLAY_FRAMEWORK_IMPORTS.keys()
-            framework_owned_names.update(
+            implicit_framework_names.update(
                 framework_names
                 | (imported_bindings.keys() & _REPLAY_FRAMEWORK_IMPORTS.keys())
             )
@@ -3586,7 +3590,7 @@ def emit_replay_code(
     external_capture_chunks: list[tuple[str, bool]] = []
     external_name_replacements: dict[str, str] = {}
     for external_name in sorted(
-        (graph.external_names & framework_owned_names) - {"load_script"}
+        (graph.external_names & implicit_framework_names) - {"load_script"}
     ):
         replacement = "input_data"
         suffix = 2

--- a/src/erlab/interactive/imagetool/_provenance/_model.py
+++ b/src/erlab/interactive/imagetool/_provenance/_model.py
@@ -1862,7 +1862,7 @@ def parse_tool_provenance_operation(
         original_code = payload["code"]
         payload["code"] = _migrate_legacy_nonuniform_restore_code(original_code)
         if payload["code"] != original_code:
-            payload["framework_owned"] = True
+            payload["uses_implicit_framework_imports"] = True
     return operation_type.model_validate(payload)
 
 

--- a/src/erlab/interactive/imagetool/_provenance/_model.py
+++ b/src/erlab/interactive/imagetool/_provenance/_model.py
@@ -527,10 +527,22 @@ def encode_provenance_value(value: typing.Any) -> typing.Any:
     return value
 
 
-def decode_provenance_value(value: typing.Any) -> typing.Any:
-    """Decode values produced by :func:`encode_provenance_value`."""
+def decode_provenance_value(
+    value: typing.Any,
+    *,
+    allow_code_payload: bool = False,
+) -> typing.Any:
+    """Decode values produced by :func:`encode_provenance_value`.
+
+    Opaque lmfit results can restore Python callables. They remain encoded unless the
+    caller is an authorized execution boundary.
+    """
     if isinstance(value, Mapping):
         if _FIT_DATASET_MARKER in value:
+            if not allow_code_payload:
+                raise ValueError(
+                    "Opaque lmfit result payload requires code authorization"
+                )
             return _decode_fit_dataset(value[_FIT_DATASET_MARKER])
         if _DATASET_MARKER in value:
             return xr.Dataset.from_dict(
@@ -543,28 +555,35 @@ def decode_provenance_value(value: typing.Any) -> typing.Any:
         if _SLICE_MARKER in value:
             start, stop, step = typing.cast("list[typing.Any]", value[_SLICE_MARKER])
             return slice(
-                decode_provenance_value(start),
-                decode_provenance_value(stop),
-                decode_provenance_value(step),
+                decode_provenance_value(start, allow_code_payload=allow_code_payload),
+                decode_provenance_value(stop, allow_code_payload=allow_code_payload),
+                decode_provenance_value(step, allow_code_payload=allow_code_payload),
             )
         if _TUPLE_MARKER in value:
             return tuple(
-                decode_provenance_value(item)
+                decode_provenance_value(item, allow_code_payload=allow_code_payload)
                 for item in typing.cast("list[typing.Any]", value[_TUPLE_MARKER])
             )
         if _MAPPING_MARKER in value:
             return {
-                decode_provenance_value(key): decode_provenance_value(item)
+                decode_provenance_value(
+                    key, allow_code_payload=allow_code_payload
+                ): decode_provenance_value(item, allow_code_payload=allow_code_payload)
                 for key, item in typing.cast(
                     "list[list[typing.Any]]", value[_MAPPING_MARKER]
                 )
             }
         return {
-            decode_provenance_value(key): decode_provenance_value(item)
+            decode_provenance_value(
+                key, allow_code_payload=allow_code_payload
+            ): decode_provenance_value(item, allow_code_payload=allow_code_payload)
             for key, item in value.items()
         }
     if isinstance(value, list):
-        return [decode_provenance_value(item) for item in value]
+        return [
+            decode_provenance_value(item, allow_code_payload=allow_code_payload)
+            for item in value
+        ]
     return erlab.utils.misc._convert_to_native(value)
 
 
@@ -596,8 +615,22 @@ def _is_identifier_string_mapping(value: Mapping[typing.Any, typing.Any]) -> boo
     )
 
 
+def _redact_opaque_fit_results(value: typing.Any) -> typing.Any:
+    """Return a display-safe copy that never decodes an opaque fit result."""
+    if isinstance(value, Mapping):
+        if _FIT_DATASET_MARKER in value:
+            return "<saved lmfit result>"
+        return {
+            _redact_opaque_fit_results(key): _redact_opaque_fit_results(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_opaque_fit_results(item) for item in value]
+    return value
+
+
 def _format_derivation_value(value: typing.Any) -> str:
-    decoded = decode_provenance_value(value)
+    decoded = decode_provenance_value(_redact_opaque_fit_results(value))
     if isinstance(decoded, Mapping):
         return erlab.interactive.utils.format_kwargs(dict(decoded))
     if isinstance(decoded, (tuple, list)):
@@ -1202,6 +1235,7 @@ class ToolProvenanceOperation(pydantic.BaseModel):
         data: xr.DataArray,
         *,
         parent_data: xr.DataArray,
+        authorization: object | None = None,
     ) -> xr.DataArray:
         """Apply an operation deserialized from a schema-v2 parent-data context.
 
@@ -1212,12 +1246,17 @@ class ToolProvenanceOperation(pydantic.BaseModel):
         ``ReplayStep.legacy_context``, and the schema-v2 migration together when old
         saved workspace support is retired.
         """
-        if "parent_data" in inspect.signature(self.apply).parameters:
+        parameters = inspect.signature(self.apply).parameters
+        kwargs: dict[str, typing.Any] = {}
+        if "authorization" in parameters:
+            kwargs["authorization"] = authorization
+        if "parent_data" in parameters:
             # Schema-v2 compatibility shim for operation classes defined outside
             # ERLab. Do not broaden the current unary apply() contract.
             legacy_apply = typing.cast("Callable[..., xr.DataArray]", self.apply)
-            return legacy_apply(data, parent_data=parent_data)
-        return self.apply(data)
+            kwargs["parent_data"] = parent_data
+            return legacy_apply(data, **kwargs)
+        return self.apply(data, **kwargs)
 
     def derivation_entry(self) -> DerivationEntry:
         """Return the user-visible derivation entry for this operation.
@@ -3405,8 +3444,9 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             [ToolProvenanceOperation, xr.DataArray], xr.DataArray
         ]
         | None = None,
+        authorization: object | None = None,
     ) -> xr.DataArray:
-        """Apply live operations, with an optional manager extension executor."""
+        """Apply live operations with extension and stored-code authorization."""
         require_live_source_spec(self)
         data = self._starting_data_for_kind(
             typing.cast(
@@ -3422,7 +3462,11 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             ):
                 data = extension_executor(operation, data)
             else:
-                data = operation._apply_schema_v2(data, parent_data=parent_data)
+                data = operation._apply_schema_v2(
+                    data,
+                    parent_data=parent_data,
+                    authorization=authorization,
+                )
         if self.kind == "selection":
             # Coordinate dictionary order is presentation state, not a replay step.
             # Normalize it once at the live selection boundary so it cannot split or

--- a/src/erlab/interactive/imagetool/_provenance/_operations/_analysis.py
+++ b/src/erlab/interactive/imagetool/_provenance/_operations/_analysis.py
@@ -1205,12 +1205,37 @@ class CorrectWithEdgeOperation(ToolProvenanceOperation):
 
     @property
     def decoded_edge_fit(self) -> xr.Dataset:
-        return typing.cast("xr.Dataset", self._decode_stored_field(self.edge_fit))
+        return self._decode_edge_fit()
 
-    def apply(self, data: xr.DataArray) -> xr.DataArray:
+    def _decode_edge_fit(
+        self,
+        authorization: object | None = None,
+    ) -> xr.Dataset:
+        from erlab.interactive._code_trust import execution_capability_allows
+        from erlab.interactive.imagetool._provenance._trust import (
+            provenance_operation_code_trust_entries,
+        )
+
+        entries = provenance_operation_code_trust_entries(
+            self,
+            location_prefix="operation",
+        )
+        if not execution_capability_allows(authorization, entries):
+            raise PermissionError("The serialized lmfit result is not authorized")
+        return typing.cast(
+            "xr.Dataset",
+            decode_provenance_value(self.edge_fit, allow_code_payload=True),
+        )
+
+    def apply(
+        self,
+        data: xr.DataArray,
+        *,
+        authorization: object | None = None,
+    ) -> xr.DataArray:
         return erlab.analysis.gold.correct_with_edge(
             data,
-            self.decoded_edge_fit,
+            self._decode_edge_fit(authorization),
             shift_coords=self.shift_coords,
         )
 

--- a/src/erlab/interactive/imagetool/_provenance/_operations/_core.py
+++ b/src/erlab/interactive/imagetool/_provenance/_operations/_core.py
@@ -352,13 +352,29 @@ class ModelFitOperation(ToolProvenanceOperation):
     def preferred_replay_input_name(self) -> str:
         return "fit_data"
 
-    def apply(self, data: xr.DataArray) -> xr.DataArray:
+    def apply(
+        self,
+        data: xr.DataArray,
+        *,
+        authorization: object | None = None,
+    ) -> xr.DataArray:
         if self.fit_dim not in data.dims:
             raise ValueError(
                 f"Model-fit dimension {self.fit_dim!r} was not found in data"
             )
         mean_dim = self.fit_dim if isinstance(self.fit_dim, str) else (self.fit_dim,)
         fit_data = data / data.mean(mean_dim) if self.normalize else data
+        from erlab.interactive._code_trust import execution_capability_allows
+        from erlab.interactive.imagetool._provenance._trust import (
+            provenance_operation_code_trust_entries,
+        )
+
+        entries = provenance_operation_code_trust_entries(
+            self,
+            location_prefix="operation",
+        )
+        if not execution_capability_allows(authorization, entries):
+            raise PermissionError("Model-fit parameter expressions are not authorized")
         fit_result = fit_data.xlm.modelfit(
             self.fit_dim,
             model=self._model(),

--- a/src/erlab/interactive/imagetool/_provenance/_operations/_core.py
+++ b/src/erlab/interactive/imagetool/_provenance/_operations/_core.py
@@ -28,7 +28,9 @@ class ScriptCodeOperation(ToolProvenanceOperation):
     code: str | None
     copyable: bool = True
     visible: bool = True
-    framework_owned: bool = pydantic.Field(
+    # This is a code-generation hint. Serialized values do not establish origin or
+    # trust.
+    uses_implicit_framework_imports: bool = pydantic.Field(
         default=False,
         exclude_if=lambda value: not value,
     )

--- a/src/erlab/interactive/imagetool/_provenance/_operations/_selection.py
+++ b/src/erlab/interactive/imagetool/_provenance/_operations/_selection.py
@@ -215,6 +215,7 @@ class SortCoordOrderOperation(ToolProvenanceOperation):
         data: xr.DataArray,
         *,
         parent_data: xr.DataArray,
+        authorization: object | None = None,
     ) -> xr.DataArray:
         """Replay the schema-v2 form that omitted ``coord_order``."""
         if self.coord_order is None:

--- a/src/erlab/interactive/imagetool/_provenance/_trust.py
+++ b/src/erlab/interactive/imagetool/_provenance/_trust.py
@@ -1,0 +1,283 @@
+"""Extract stored Python at the provenance replay boundaries."""
+
+from __future__ import annotations
+
+import base64
+import itertools
+import json
+import typing
+from collections.abc import Mapping
+
+from erlab.interactive._code_trust import create_entry
+from erlab.interactive._fit_code_trust import (
+    lmfit_parameter_expression_entries,
+    lmfit_result_code_entry,
+)
+from erlab.interactive.imagetool._provenance._code import _FIT_DATASET_MARKER
+from erlab.interactive.imagetool._provenance._model import (
+    _direct_replay_source_name,
+    parse_tool_provenance_spec,
+)
+
+
+def _model_fit_parameter_expressions(
+    operation: typing.Any,
+) -> tuple[tuple[str, str], ...]:
+    parameters = getattr(operation, "parameters", None)
+    if getattr(operation, "op", None) != "model_fit" or not isinstance(
+        parameters, Mapping
+    ):
+        return ()
+    return tuple(
+        (name, expression)
+        for name, parameter in parameters.items()
+        if isinstance(name, str)
+        and isinstance(expression := getattr(parameter, "expr", None), str)
+        and expression.strip()
+    )
+
+
+def _opaque_fit_dataset_payload(operation: typing.Any) -> bytes | None:
+    edge_fit = getattr(operation, "edge_fit", None)
+    if (
+        getattr(operation, "op", None) != "correct_with_edge"
+        or not isinstance(edge_fit, Mapping)
+        or _FIT_DATASET_MARKER not in edge_fit
+    ):
+        return None
+    encoded = edge_fit[_FIT_DATASET_MARKER]
+    if isinstance(encoded, str):
+        try:
+            return base64.b64decode(encoded.encode("ascii"), validate=True)
+        except (UnicodeEncodeError, ValueError):
+            pass
+    return json.dumps(
+        encoded,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+
+def provenance_operation_code_trust_entries(
+    operation: typing.Any,
+    *,
+    location_prefix: str,
+):
+    """Return executable lmfit content stored by one operation."""
+    entries = lmfit_parameter_expression_entries(
+        _model_fit_parameter_expressions(operation),
+        feature="erlab.provenance.model-fit-parameter-expression",
+        location_prefix=f"{location_prefix}/parameters",
+    )
+    payload = _opaque_fit_dataset_payload(operation)
+    if payload is None:
+        return entries
+    entry = lmfit_result_code_entry(
+        payload,
+        feature="erlab.provenance.lmfit-result",
+        location=f"{location_prefix}/edge-fit",
+    )
+    return entries if entry is None else (*entries, entry)
+
+
+def provenance_operation_requires_code_trust(operation: typing.Any) -> bool:
+    """Return whether one operation can reach an lmfit code boundary."""
+    return bool(
+        provenance_operation_code_trust_entries(
+            operation,
+            location_prefix="operation",
+        )
+    )
+
+
+def provenance_replay_node_code_trust_entries(
+    node: typing.Any,
+    *,
+    location_prefix: str,
+):
+    """Return entries attached to one executable replay node."""
+    if node.kind == "operation":
+        return provenance_operation_code_trust_entries(
+            node.payload["operation"],
+            location_prefix=location_prefix,
+        )
+    if node.kind != "script":
+        return ()
+    context = {
+        "active_name": node.payload.get("active_name"),
+        "binding_names": sorted(
+            {name for name, _key in node.payload.get("bindings", ())}
+        ),
+    }
+    return tuple(
+        create_entry(
+            feature="erlab.provenance.script-code",
+            location=f"{location_prefix}/{index}",
+            code=code,
+            context=context,
+        )
+        for index, code in enumerate(node.payload.get("stored_code", ()))
+        if isinstance(code, str) and code.strip()
+    )
+
+
+def provenance_replay_graph_code_trust_entries(
+    graph: typing.Any,
+    *,
+    location_prefix: str,
+):
+    """Return entries attached to all executable nodes in a replay graph."""
+    return tuple(
+        entry
+        for index, node in enumerate(graph.nodes)
+        for entry in provenance_replay_node_code_trust_entries(
+            node,
+            location_prefix=f"{location_prefix}/nodes/{index}",
+        )
+    )
+
+
+def _stored_spec_code_trust_entries(
+    spec: typing.Any,
+    *,
+    location_prefix: str,
+):
+    """Conservatively inventory stored code when a graph cannot compile."""
+    parsed = parse_tool_provenance_spec(spec)
+    if parsed is None:
+        return ()
+    context = {
+        "active_name": parsed.active_name if parsed.kind == "script" else "derived",
+        "binding_names": (
+            sorted({item.name for item in parsed.script_inputs})
+            if parsed.kind == "script"
+            else ["data", "derived", "parent_data"]
+        ),
+    }
+    entries = []
+    if parsed.kind == "script" and parsed.seed_code and parsed.seed_code.strip():
+        entries.append(
+            create_entry(
+                feature="erlab.provenance.script-code",
+                location=f"{location_prefix}/seed",
+                code=parsed.seed_code,
+                context=context,
+            )
+        )
+    for index, operation in enumerate(parsed.operations):
+        operation_location = f"{location_prefix}/operations/{index}"
+        entries.extend(
+            provenance_operation_code_trust_entries(
+                operation,
+                location_prefix=operation_location,
+            )
+        )
+        code = getattr(operation, "code", None)
+        if (
+            getattr(operation, "op", None) == "script_code"
+            and bool(getattr(operation, "copyable", False))
+            and not bool(getattr(operation, "framework_owned", False))
+            and isinstance(code, str)
+            and code.strip()
+        ):
+            entries.append(
+                create_entry(
+                    feature="erlab.provenance.script-code",
+                    location=operation_location,
+                    code=code,
+                    context=context,
+                )
+            )
+    for index, script_input in enumerate(parsed.script_inputs):
+        entries.extend(
+            _stored_spec_code_trust_entries(
+                script_input.parsed_provenance_spec(),
+                location_prefix=f"{location_prefix}/inputs/{index}:{script_input.name}",
+            )
+        )
+    return tuple(entries)
+
+
+def script_replay_source_input_names(spec: typing.Any) -> tuple[str, ...]:
+    """Return the smallest live-source namespace that makes a script replayable."""
+    from erlab.interactive.imagetool._provenance._graph import (
+        ReplayGraphError,
+        compile_replay_graph,
+    )
+
+    parsed = parse_tool_provenance_spec(spec)
+    if parsed is None or parsed.kind != "script" or parsed.script_inputs:
+        return ()
+
+    candidates = ["data", "derived", "parent_data"]
+    source_name = _direct_replay_source_name(parsed)
+    if source_name is not None and source_name not in candidates:
+        candidates.insert(0, source_name)
+    for count in range(len(candidates) + 1):
+        for names in itertools.combinations(candidates, count):
+            external_inputs = {name: typing.cast("typing.Any", None) for name in names}
+            try:
+                compile_replay_graph(
+                    parsed,
+                    trusted_user_code=True,
+                    external_inputs=external_inputs or None,
+                )
+            except (ReplayGraphError, TypeError, ValueError):
+                continue
+            return names
+    return ()
+
+
+def provenance_code_trust_entries(
+    spec: typing.Any,
+    *,
+    location_prefix: str,
+    external_input_names: set[str] | None = None,
+):
+    """Return stored code that can reach a provenance execution boundary."""
+    from erlab.interactive.imagetool._provenance._graph import (
+        ReplayGraphError,
+        compile_replay_graph,
+    )
+
+    parsed = parse_tool_provenance_spec(spec)
+    if parsed is None:
+        return ()
+    if external_input_names is None:
+        external_input_names = set(script_replay_source_input_names(parsed))
+    external_inputs = {
+        name: typing.cast("typing.Any", None) for name in external_input_names or ()
+    }
+    try:
+        graph = compile_replay_graph(
+            parsed,
+            trusted_user_code=True,
+            external_inputs=external_inputs or None,
+            allow_unresolved_inputs=True,
+        )
+    except (ReplayGraphError, TypeError, ValueError):
+        return _stored_spec_code_trust_entries(
+            parsed,
+            location_prefix=location_prefix,
+        )
+    return provenance_replay_graph_code_trust_entries(
+        graph,
+        location_prefix=location_prefix,
+    )
+
+
+def provenance_requires_code_trust(
+    spec: typing.Any,
+    *,
+    external_input_names: set[str] | None = None,
+) -> bool:
+    """Return whether provenance contains code at a replay boundary."""
+    return bool(
+        provenance_code_trust_entries(
+            spec,
+            location_prefix="provenance",
+            external_input_names=external_input_names,
+        )
+    )

--- a/src/erlab/interactive/imagetool/_provenance/_trust.py
+++ b/src/erlab/interactive/imagetool/_provenance/_trust.py
@@ -1,4 +1,7 @@
-"""Extract stored Python at the provenance replay boundaries."""
+"""Inventory executable document content at provenance replay boundaries.
+
+Code-generation hints, including implicit imports, do not affect this inventory.
+"""
 
 from __future__ import annotations
 
@@ -118,7 +121,7 @@ def provenance_replay_node_code_trust_entries(
             code=code,
             context=context,
         )
-        for index, code in enumerate(node.payload.get("stored_code", ()))
+        for index, code in enumerate(node.payload.get("document_codes", ()))
         if isinstance(code, str) and code.strip()
     )
 
@@ -178,7 +181,6 @@ def _stored_spec_code_trust_entries(
         if (
             getattr(operation, "op", None) == "script_code"
             and bool(getattr(operation, "copyable", False))
-            and not bool(getattr(operation, "framework_owned", False))
             and isinstance(code, str)
             and code.strip()
         ):

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -4424,6 +4424,16 @@ class EdgeCorrectionDialog(DataTransformDialog):
             shift_coords=self.shift_coord_check.isChecked(),
         )
 
+    def process_data(self, data: xr.DataArray) -> xr.DataArray:
+        edge_fit = getattr(self, "_edge_fit", None)
+        if edge_fit is None:
+            raise RuntimeError("Edge correction fit data has not been loaded.")
+        return erlab.analysis.gold.correct_with_edge(
+            data,
+            edge_fit,
+            shift_coords=self.shift_coord_check.isChecked(),
+        )
+
     def _validate(self) -> QtWidgets.QDialog.DialogCode:
         if "eV" not in self.slicer_area.data.dims:
             QtWidgets.QMessageBox.warning(

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -28,6 +28,7 @@ from erlab.interactive.imagetool._provenance._operations import (
     ImageToolSelectionSourceBinding,
     RestoreNonuniformDimsOperation,
 )
+from erlab.interactive.imagetool._provenance._trust import provenance_code_trust_entries
 from erlab.interactive.imagetool.manager._dialogs import (
     _BatchOperationDialog,
     _ConcatDialog,
@@ -665,11 +666,10 @@ class _ActionsController:
             source_spec,
         ) in preflight_plan:
             try:
-                processed = source_spec.apply(
+                processed = self._manager._apply_provenance(
+                    source_spec,
                     slicer_area.data,
-                    extension_executor=(
-                        self._manager._extensions.execution.run_operation
-                    ),
+                    reason="apply this batch operation",
                 ).rename(input_name)
                 erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(
                     processed
@@ -1608,6 +1608,18 @@ class _ActionsController:
             )
 
         parent = self._manager._node_for_target(index)
+
+        def _parent_source_fetcher(parent_uid: str = parent.uid) -> xr.DataArray:
+            return self._manager._node_for_target(parent_uid).current_source_data()
+
+        def _parent_provenance_fetcher(
+            parent_uid: str = parent.uid,
+        ) -> ToolProvenanceSpec | None:
+            return self._manager._node_for_target(parent_uid).displayed_provenance_spec
+
+        tool.set_input_provenance_spec(None)
+        tool.set_source_parent_fetcher(_parent_source_fetcher)
+        tool.set_input_provenance_parent_fetcher(_parent_provenance_fetcher)
         node = _ManagedWindowNode(
             self._manager,
             self._manager._next_node_uid(uid),
@@ -1620,17 +1632,6 @@ class _ActionsController:
         )
         if not tool._tool_display_name:
             tool._tool_display_name = parent.name
-
-        def _parent_source_fetcher(parent_uid: str = parent.uid) -> xr.DataArray:
-            return self._manager._node_for_target(parent_uid).current_source_data()
-
-        def _parent_provenance_fetcher(
-            parent_uid: str = parent.uid,
-        ) -> ToolProvenanceSpec | None:
-            return self._manager._node_for_target(parent_uid).displayed_provenance_spec
-
-        tool.set_source_parent_fetcher(_parent_source_fetcher)
-        tool.set_input_provenance_parent_fetcher(_parent_provenance_fetcher)
         self._manager._register_child_node(node)
         self._manager.tree_view.childtool_added(node.uid, index)
         self._manager._mark_node_added(node.uid)
@@ -1661,6 +1662,19 @@ class _ActionsController:
         created_time: datetime.datetime | str | bytes | None = None,
         note: str | bytes | None = None,
     ) -> str:
+        if (
+            provenance_spec is None
+            and source_spec is None
+            and source_binding is None
+            and output_id is None
+            and tool.provenance_spec is not None
+        ):
+            self._manager._workspace_controller.adopt_external_code(
+                provenance_code_trust_entries(
+                    tool.provenance_spec,
+                    location_prefix="imported-imagetool/provenance",
+                )
+            )
         parent_node = self._manager._node_for_target(parent)
         if source_spec is None and source_binding is not None:
             source_spec = source_binding.materialize(parent_node.current_source_data())

--- a/src/erlab/interactive/imagetool/manager/_base.py
+++ b/src/erlab/interactive/imagetool/manager/_base.py
@@ -244,7 +244,6 @@ class _ImageToolManagerBase(QtWidgets.QMainWindow):
     _sigReloadLinkers: QtCore.SignalInstance
     _sigReplyData: QtCore.SignalInstance
     _sigWatchedDataEdited: QtCore.SignalInstance
-    _trusted_script_replay_keys: set[str]
     _standalone_app_actions: dict[str, QtGui.QAction]
     _standalone_app_event_filters: dict[str, QtCore.QObject]
     _standalone_app_pending_states: dict[str, dict[str, typing.Any]]

--- a/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_figurecomposer/_controller.py
@@ -698,7 +698,6 @@ class _FigureComposerWorkflowController(QtCore.QObject):
                     FigureOperationState.custom(
                         label=title or "custom code",
                         code=custom_code,
-                        trusted=True,
                     ),
                     source_name_map,
                 )

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 import pathlib
 import traceback
@@ -16,8 +17,6 @@ from erlab.interactive.imagetool._provenance._execution import (
     file_load_source_status,
     rebuild_script_provenance,
     script_provenance_replayable,
-    script_provenance_requires_trust,
-    script_provenance_trust_key,
 )
 from erlab.interactive.imagetool._provenance._graph import ReplayGraphError
 from erlab.interactive.imagetool._provenance._model import (
@@ -31,13 +30,17 @@ from erlab.interactive.imagetool._provenance._model import (
     script_input_dependency_refs,
 )
 from erlab.interactive.imagetool._provenance._operations import ScriptCodeOperation
+from erlab.interactive.imagetool._provenance._trust import (
+    provenance_code_trust_entries,
+    script_replay_source_input_names,
+)
 from erlab.interactive.imagetool.manager._widgets import (
     _DEPENDENCY_STATUS_BADGES,
     _DEPENDENCY_STATUS_LABELS,
     _DEPENDENCY_STATUS_TOOLTIPS,
     _ScriptRebuildError,
     _ScriptRebuildResult,
-    _TrustedScriptReplayCancelled,
+    _TrustedProvenanceReplayCancelled,
 )
 from erlab.interactive.imagetool.manager._wrapper import (
     _ImageToolWrapper,
@@ -64,57 +67,77 @@ class _LineageController:
     def _script_provenance_runnable(
         spec: ToolProvenanceSpec,
     ) -> bool:
-        return script_provenance_replayable(spec) or script_provenance_requires_trust(
-            spec
-        )
-
-    def _ensure_script_provenance_trusted(
-        self,
-        spec: ToolProvenanceSpec,
-        *,
-        reason: str,
-        external_input_names: set[str] | None = None,
-    ) -> None:
-        if not script_provenance_requires_trust(
+        input_names = set(script_replay_source_input_names(spec))
+        return script_provenance_replayable(
             spec,
-            external_input_names=external_input_names,
-        ):
-            return
-        trust_key = script_provenance_trust_key(spec)
-        if (
-            trust_key is not None
-            and trust_key in self._manager._trusted_script_replay_keys
-        ):
-            return
-        if not self._prompt_trusted_script_replay(spec, reason=reason):
-            raise _TrustedScriptReplayCancelled
-        if trust_key is not None:
-            self._manager._trusted_script_replay_keys.add(trust_key)
+            external_input_names=input_names or None,
+            allow_code=True,
+        )
 
-    def _prompt_trusted_script_replay(
+    def _authorize_provenance_execution(
         self,
-        spec: ToolProvenanceSpec,
+        entries: tuple[typing.Any, ...],
         *,
         reason: str,
-    ) -> bool:
-        msg_box = QtWidgets.QMessageBox(self._manager)
-        msg_box.setObjectName("managerTrustedScriptReplayDialog")
-        msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
-        msg_box.setWindowTitle("Run Recorded Python Code")
-        msg_box.setText("Run recorded Python code?")
-        msg_box.setInformativeText(
-            f"ImageTool cannot verify this recorded code as safe to replay "
-            f"automatically. It needs to run Python code to {reason}."
+        raise_on_block: bool = True,
+    ) -> object | None:
+        capability = (
+            self._manager._workspace_controller.issue_code_execution_capability(
+                entries,
+                focus_on_block=True,
+                allow_partial=True,
+            )
         )
-        if code := spec.derivation_code():
-            msg_box.setDetailedText(code)
-        run_button = msg_box.addButton(
-            "Run Code", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+        if capability is not None:
+            return capability
+        logger.info("Blocked untrusted recorded Python code needed to %s", reason)
+        if raise_on_block:
+            raise _TrustedProvenanceReplayCancelled
+        return None
+
+    def _provenance_execution_authorizer(
+        self,
+        *,
+        reason: str,
+        raise_on_block: bool = True,
+    ):
+        return functools.partial(
+            self._authorize_provenance_execution,
+            reason=reason,
+            raise_on_block=raise_on_block,
         )
-        cancel_button = msg_box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
-        msg_box.setDefaultButton(typing.cast("QtWidgets.QPushButton", cancel_button))
-        msg_box.exec()
-        return msg_box.clickedButton() is run_button
+
+    def _apply_provenance(
+        self,
+        spec: ToolProvenanceSpec,
+        data: xr.DataArray,
+        *,
+        reason: str,
+        authorization: object | None = None,
+    ) -> xr.DataArray:
+        """Apply structured provenance under the workspace trust decision."""
+        entries = functools.partial(
+            provenance_code_trust_entries,
+            spec,
+            location_prefix="workspace/provenance",
+        )
+        capability = authorization
+        if capability is None:
+            capability = (
+                self._manager._workspace_controller.issue_code_execution_capability(
+                    entries,
+                    focus_on_block=True,
+                    allow_partial=True,
+                )
+            )
+        if capability is None:
+            logger.info("Blocked untrusted recorded Python code needed to %s", reason)
+            raise _TrustedProvenanceReplayCancelled
+        return spec.apply(
+            data,
+            extension_executor=self._manager._extensions.execution.run_operation,
+            authorization=capability,
+        )
 
     def _dependency_refs_for_uid(
         self, uid: str
@@ -612,6 +635,7 @@ class _LineageController:
         spec: ToolProvenanceSpec,
         *,
         target_node_uid: str | None = None,
+        authorization: object | None = None,
     ) -> _ScriptRebuildResult:
         def _resolve_live_input(
             script_input: ScriptInput,
@@ -627,21 +651,23 @@ class _LineageController:
                 target_node_uid=target_node_uid,
             )
 
-        try:
-            trusted_user_code = script_provenance_requires_trust(spec)
-            if trusted_user_code:
-                self._manager._ensure_script_provenance_trusted(
-                    spec,
+        def authorize(entries):
+            if authorization is None:
+                return self._authorize_provenance_execution(
+                    entries,
                     reason="reload this result",
                 )
+            return authorization
+
+        try:
             data, rebuilt_spec = rebuild_script_provenance(
                 spec,
                 live_input_resolver=_resolve_live_input,
-                trusted_user_code=trusted_user_code,
                 extension_executor=self._manager._extensions.execution.run_operation,
                 extension_loader_executor=self._manager._extensions.replay_loader,
+                authorize=authorize,
             )
-        except _TrustedScriptReplayCancelled:
+        except _TrustedProvenanceReplayCancelled:
             raise
         except ReplayGraphError as exc:
             raise _ScriptRebuildError(
@@ -746,11 +772,20 @@ class _LineageController:
             if reason is not None:
                 return reason
         if spec is not None and spec.kind == "script":
-            if script_provenance_requires_trust(spec):
+            if not spec.script_inputs:
                 return (
-                    "This data includes recorded script code that needs trust "
-                    "confirmation before replay. Open the ImageTool, then reload it."
+                    "This result has no recorded inputs. Reopen or recreate it "
+                    "from reloadable inputs to enable reload."
                 )
+            if self._script_provenance_runnable(spec):
+                for script_input in spec.script_inputs:
+                    reason = self._manager._script_input_unavailable_reason(
+                        script_input,
+                        target_node_uid=node.uid,
+                    )
+                    if reason is not None:
+                        return reason
+                return None
             return (
                 "This data was created from recorded script steps that cannot be "
                 "reloaded automatically from the saved provenance. Reopen or recreate "
@@ -1198,7 +1233,7 @@ class _LineageController:
                     spec,
                     target_node_uid=node.uid,
                 )
-            except _TrustedScriptReplayCancelled:
+            except _TrustedProvenanceReplayCancelled:
                 return False
             except _ScriptRebuildError as exc:
                 erlab.interactive.utils.MessageDialog.critical(

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -12,7 +12,9 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.slicer
+from erlab.interactive._code_trust._ui import create_code_trust_banner
 from erlab.interactive._dask import DaskMenu
+from erlab.interactive.imagetool._provenance._trust import provenance_code_trust_entries
 from erlab.interactive.imagetool.manager import _desktop
 from erlab.interactive.imagetool.manager import _server as _manager_server
 from erlab.interactive.imagetool.manager._acquisition_context import (
@@ -255,7 +257,6 @@ class ImageToolManager(_ImageToolManagerBase):
         self._dependency_tracker = _ManagerDependencyTracker(self._tool_graph)
         # This map is the single coalescing boundary for expensive node-derived work.
         self._pending_node_changes: dict[str, _ManagedNodeChange] = {}
-        self._trusted_script_replay_keys: set[str] = set()
         self._lineage_controller = _LineageController(self)
         self._provenance_edit_controller = _ProvenanceEditController(self)
         self._details_panel = _DetailsPanelController(self)
@@ -774,7 +775,19 @@ class ImageToolManager(_ImageToolManagerBase):
         # Initialize GUI
         self.main_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
         self.main_splitter.splitterMoved.connect(self._mark_workspace_layout_dirty)
-        self.setCentralWidget(self.main_splitter)
+        central_widget = QtWidgets.QWidget(self)
+        central_layout = QtWidgets.QVBoxLayout(central_widget)
+        central_layout.setContentsMargins(0, 0, 0, 0)
+        central_layout.setSpacing(0)
+        self.code_trust_banner = create_code_trust_banner(central_widget)
+        self.code_trust_banner.setObjectName("manager_code_trust_banner")
+        self.code_trust_banner.review_requested.connect(
+            self._workspace_controller.review_and_approve_workspace_code_trust
+        )
+        self.code_trust_banner.hide()
+        central_layout.addWidget(self.code_trust_banner)
+        central_layout.addWidget(self.main_splitter, 1)
+        self.setCentralWidget(central_widget)
 
         # Construct left side of splitter
         left_container = QtWidgets.QWidget()
@@ -2459,23 +2472,40 @@ class ImageToolManager(_ImageToolManagerBase):
         spec: ToolProvenanceSpec,
         *,
         target_node_uid: str | None = None,
+        authorization: object | None = None,
     ) -> _ScriptRebuildResult:
         return self._lineage_controller._rebuild_script_provenance(
             spec,
             target_node_uid=target_node_uid,
+            authorization=authorization,
         )
 
-    def _ensure_script_provenance_trusted(
+    def _authorize_provenance_execution(
         self,
-        spec: ToolProvenanceSpec,
+        entries: tuple[typing.Any, ...],
         *,
         reason: str,
-        external_input_names: set[str] | None = None,
-    ) -> None:
-        self._lineage_controller._ensure_script_provenance_trusted(
-            spec,
+        raise_on_block: bool = True,
+    ) -> object | None:
+        return self._lineage_controller._authorize_provenance_execution(
+            entries,
             reason=reason,
-            external_input_names=external_input_names,
+            raise_on_block=raise_on_block,
+        )
+
+    def _apply_provenance(
+        self,
+        spec: ToolProvenanceSpec,
+        data: xr.DataArray,
+        *,
+        reason: str,
+        authorization: object | None = None,
+    ) -> xr.DataArray:
+        return self._lineage_controller._apply_provenance(
+            spec,
+            data,
+            reason=reason,
+            authorization=authorization,
         )
 
     def _node_can_reload_script_inputs(
@@ -2878,6 +2908,7 @@ class ImageToolManager(_ImageToolManagerBase):
         created_time: datetime.datetime | str | bytes | None = None,
         note: str | bytes | None = None,
     ) -> str:
+        tool.set_input_provenance_spec(None)
         node = _ManagedWindowNode(
             self,
             self._next_node_uid(uid),
@@ -3032,6 +3063,13 @@ class ImageToolManager(_ImageToolManagerBase):
         int
             Index of the added ImageTool window.
         """
+        if provenance_spec is None and tool.provenance_spec is not None:
+            self._workspace_controller.adopt_external_code(
+                provenance_code_trust_entries(
+                    tool.provenance_spec,
+                    location_prefix="imported-imagetool/provenance",
+                )
+            )
         if provenance_spec is not None:
             tool.set_provenance_spec(provenance_spec)
         if index is None or index in self._tool_graph.root_wrappers:

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
-import itertools
+import functools
 import pathlib
 import traceback
 import typing
@@ -21,13 +21,11 @@ from erlab.interactive.imagetool._provenance._execution import (
     replay_file_provenance,
     replay_script_provenance,
     script_provenance_replayable,
-    script_provenance_requires_trust,
 )
 from erlab.interactive.imagetool._provenance._model import (
     DerivationEntry,
     ToolProvenanceOperation,
     ToolProvenanceSpec,
-    _direct_replay_source_name,
     _ProvenanceDisplayRow,
     _ProvenanceReorderSection,
     _ProvenanceStepRef,
@@ -48,6 +46,10 @@ from erlab.interactive.imagetool._provenance._operations import (
     NormalizeOperation,
     ScriptCodeOperation,
     SortByOperation,
+)
+from erlab.interactive.imagetool._provenance._trust import (
+    provenance_code_trust_entries,
+    script_replay_source_input_names,
 )
 from erlab.interactive.imagetool.manager._extensions._dialogs import (
     _ExtensionParameterDialog,
@@ -75,7 +77,9 @@ from erlab.interactive.imagetool.manager._provenance_edit._files import (
 from erlab.interactive.imagetool.manager._provenance_edit._reorder import (
     _ProvenanceReorderDialog,
 )
-from erlab.interactive.imagetool.manager._widgets import _TrustedScriptReplayCancelled
+from erlab.interactive.imagetool.manager._widgets import (
+    _TrustedProvenanceReplayCancelled,
+)
 
 if typing.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -257,31 +261,14 @@ class _ProvenanceEditController:
             return None
 
         if spec.kind == "script":
-            external_input_names = self._script_replay_source_input_names(spec)
-            self_contained = script_provenance_replayable(
-                spec
-            ) or script_provenance_requires_trust(spec)
-            external_input_names = (
-                None if not external_input_names else set(external_input_names)
-            )
-            if not (
-                self_contained
-                or (
-                    external_input_names is not None
-                    and (
-                        script_provenance_replayable(
-                            spec,
-                            external_input_names=external_input_names,
-                        )
-                        or script_provenance_requires_trust(
-                            spec,
-                            external_input_names=external_input_names,
-                        )
-                    )
-                )
+            external_input_names = set(script_replay_source_input_names(spec))
+            if not script_provenance_replayable(
+                spec,
+                external_input_names=external_input_names or None,
+                allow_code=True,
             ):
                 return "This provenance contains recorded code that cannot be replayed."
-            if external_input_names is not None and not node.has_replay_source:
+            if external_input_names and not node.has_replay_source:
                 return "The original replay source is no longer available."
             for script_input in spec.script_inputs:
                 reason = self._manager._script_input_unavailable_reason(
@@ -297,15 +284,10 @@ class _ProvenanceEditController:
             if not isinstance(operation, ScriptCodeOperation):
                 continue
             step_spec = self._live_script_step_spec(operation)
-            if not (
-                script_provenance_replayable(
-                    step_spec,
-                    external_input_names=external_input_names,
-                )
-                or script_provenance_requires_trust(
-                    step_spec,
-                    external_input_names=external_input_names,
-                )
+            if not script_provenance_replayable(
+                step_spec,
+                external_input_names=external_input_names,
+                allow_code=True,
             ):
                 return (
                     "This live provenance contains recorded code that cannot be "
@@ -323,56 +305,21 @@ class _ProvenanceEditController:
             return "This live provenance no longer has its parent source data."
         return None
 
-    @staticmethod
-    def _script_replay_source_input_names(
-        spec: ToolProvenanceSpec,
-    ) -> tuple[str, ...]:
-        """Return the smallest supported alias set that makes replay self-contained."""
-        if (
-            spec.kind != "script"
-            or spec.script_inputs
-            or script_provenance_replayable(spec)
-            or script_provenance_requires_trust(spec)
-        ):
-            return ()
-        # ``parent_data`` is a schema-v2 ScriptCodeOperation compatibility alias.
-        # Remove it with the legacy parent-data replay shim in _provenance._model.
-        candidates = ["data", "derived", "parent_data"]
-        source_name = _direct_replay_source_name(spec)
-        if source_name is not None and source_name not in candidates:
-            candidates.insert(0, source_name)
-        for count in range(1, len(candidates) + 1):
-            for names in itertools.combinations(candidates, count):
-                external_input_names = set(names)
-                if script_provenance_replayable(
-                    spec,
-                    external_input_names=external_input_names,
-                ) or script_provenance_requires_trust(
-                    spec,
-                    external_input_names=external_input_names,
-                ):
-                    return names
-        return ()
-
     def _script_spec_replayable_for_node(
         self,
         node: _ImageToolWrapper | _ManagedWindowNode,
         spec: ToolProvenanceSpec,
     ) -> bool:
-        external_input_names = set(self._script_replay_source_input_names(spec))
+        external_input_names = set(script_replay_source_input_names(spec))
         if external_input_names and not node.has_replay_source:
             return False
         if external_input_names:
             return script_provenance_replayable(
                 spec,
                 external_input_names=external_input_names,
-            ) or script_provenance_requires_trust(
-                spec,
-                external_input_names=external_input_names,
+                allow_code=True,
             )
-        return script_provenance_replayable(spec) or script_provenance_requires_trust(
-            spec
-        )
+        return script_provenance_replayable(spec, allow_code=True)
 
     def can_reorder_steps(self) -> tuple[bool, str]:
         node = self._metadata_node()
@@ -488,7 +435,7 @@ class _ProvenanceEditController:
                 candidate,
                 where="validating the reordered provenance",
             )
-        except _TrustedScriptReplayCancelled:
+        except _TrustedProvenanceReplayCancelled:
             dialog.set_busy(False)
             return
         except Exception as exc:
@@ -539,7 +486,7 @@ class _ProvenanceEditController:
                     active_name=active_name,
                     contains_script=contains_script,
                 )
-            except _TrustedScriptReplayCancelled:
+            except _TrustedProvenanceReplayCancelled:
                 return
             except Exception as exc:
                 failures.append((node, exc))
@@ -598,26 +545,13 @@ class _ProvenanceEditController:
             candidate = node.displayed_source_spec.append_replacement_operations(
                 *operations
             )
-            with (
-                self._manager._extensions.execution.capture_replay_sources()
-            ) as publication:
-                try:
-                    data, candidate = self._replay_candidate_result(
-                        node,
-                        "source",
-                        candidate,
-                    )
-                    erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(data)
-                except Exception as exc:
-                    raise _ProvenanceReplayFailure(
-                        "validating the pasted provenance steps: "
-                        "replaying the requested provenance",
-                        exc,
-                    ) from exc
-                publication.require_current_for_publication()
-                self._replace_node_data(node, "source", data, candidate, None)
-                publication.publish()
-            self._manager._update_info(uid=node.uid)
+            self._validate_and_replace(
+                node,
+                "source",
+                candidate,
+                where="validating the pasted provenance steps",
+                retain_active_filter=False,
+            )
             return
 
         local = full_data(*operations)
@@ -639,44 +573,6 @@ class _ProvenanceEditController:
         ) as publication:
             current_data = node.current_public_data()
             replay_source_data = node.resolved_replay_source_data()
-            try:
-                if local.kind == "script":
-                    trusted_user_code = script_provenance_requires_trust(local)
-                    if trusted_user_code:
-                        self._manager._ensure_script_provenance_trusted(
-                            local,
-                            reason="paste these provenance steps",
-                        )
-                    data = replay_script_provenance(
-                        local,
-                        {
-                            "data": current_data,
-                            "derived": current_data,
-                        },
-                        trusted_user_code=trusted_user_code,
-                        extension_executor=(
-                            self._manager._extensions.execution.run_operation
-                        ),
-                        extension_loader_executor=(
-                            self._manager._extensions.replay_loader
-                        ),
-                    )
-                else:
-                    data = local.apply(
-                        current_data,
-                        extension_executor=(
-                            self._manager._extensions.execution.run_operation
-                        ),
-                    )
-                erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(data)
-            except _TrustedScriptReplayCancelled:
-                raise
-            except Exception as exc:
-                raise _ProvenanceReplayFailure(
-                    f"{where}: replaying the requested provenance",
-                    exc,
-                ) from exc
-
             if local.kind == "script":
                 spec = compose_full_provenance(
                     node.displayed_provenance_spec,
@@ -690,14 +586,69 @@ class _ProvenanceEditController:
                 )
             if spec is None:
                 spec = local.to_replay_spec()
-            publication.require_current_for_publication()
-            node.replace_with_detached_data(
-                data,
-                spec,
-                preserve_filter=False,
-                replay_source_data=replay_source_data,
+            current_entries = self._provenance_code_entries(
+                node.displayed_provenance_spec,
+                node=node,
+                scope="display",
             )
-            publication.publish()
+            entries = self._provenance_code_entries(
+                spec,
+                node=node,
+                scope="display",
+            )
+            current_identities = {
+                entry.document_identity() for entry in current_entries
+            }
+            edited_entries = tuple(
+                entry
+                for entry in entries
+                if entry.document_identity() not in current_identities
+            )
+            with self._manager._workspace_controller.local_code_edit(
+                entries,
+                edited_entries=edited_entries,
+                focus_on_block=True,
+            ) as authorization:
+                if entries and authorization is None:
+                    raise _TrustedProvenanceReplayCancelled
+                try:
+                    if local.kind == "script":
+                        input_names = script_replay_source_input_names(local)
+                        data = replay_script_provenance(
+                            local,
+                            dict.fromkeys(input_names, current_data),
+                            extension_executor=(
+                                self._manager._extensions.execution.run_operation
+                            ),
+                            extension_loader_executor=(
+                                self._manager._extensions.replay_loader
+                            ),
+                            authorize=self._capability_authorizer(authorization),
+                        )
+                    else:
+                        data = self._manager._apply_provenance(
+                            local,
+                            current_data,
+                            reason="paste these provenance steps",
+                            authorization=authorization,
+                        )
+                    erlab.interactive.imagetool.slicer.ArraySlicer.preflight_array(data)
+                except _TrustedProvenanceReplayCancelled:
+                    raise
+                except Exception as exc:
+                    raise _ProvenanceReplayFailure(
+                        f"{where}: replaying the requested provenance",
+                        exc,
+                    ) from exc
+
+                publication.require_current_for_publication()
+                node.replace_with_detached_data(
+                    data,
+                    spec,
+                    preserve_filter=False,
+                    replay_source_data=replay_source_data,
+                )
+                publication.publish()
         self._manager._update_info(uid=node.uid)
 
     def can_delete_row(
@@ -908,7 +859,7 @@ class _ProvenanceEditController:
                 self._edit_file_load_row(node, row)
             else:
                 self._edit_operation_row(node, row)
-        except _TrustedScriptReplayCancelled:
+        except _TrustedProvenanceReplayCancelled:
             return
         except Exception as exc:
             if self._handle_missing_source_file(
@@ -957,7 +908,7 @@ class _ProvenanceEditController:
                 repair_root_candidate,
                 where="validating the provenance revert target",
             )
-        except _TrustedScriptReplayCancelled:
+        except _TrustedProvenanceReplayCancelled:
             return
         except Exception as exc:
             if self._handle_missing_source_file(
@@ -1013,7 +964,7 @@ class _ProvenanceEditController:
                 repair_root_candidate,
                 where="validating the provenance delete target",
             )
-        except _TrustedScriptReplayCancelled:
+        except _TrustedProvenanceReplayCancelled:
             return
         except Exception as exc:
             if self._handle_missing_source_file(
@@ -1722,7 +1673,7 @@ class _ProvenanceEditController:
                     row.scope,
                     spec._prefix_before_ref(start_ref),
                 )
-            except _TrustedScriptReplayCancelled:
+            except _TrustedProvenanceReplayCancelled:
                 raise
             except Exception as exc:
                 raise _ProvenanceReplayFailure(
@@ -1939,14 +1890,108 @@ class _ProvenanceEditController:
         candidate: ToolProvenanceSpec,
         *,
         where: str = "validating the provenance change",
+        retain_active_filter: bool = True,
     ) -> None:
         with (
             self._manager._extensions.execution.capture_replay_sources()
         ) as publication:
-            edit = self._validated_edit(node, scope, candidate, where=where)
-            publication.require_current_for_publication()
-            self._apply_validated_edit(edit)
-            publication.publish()
+            current = (
+                node.displayed_source_spec
+                if scope == "source"
+                else node.displayed_provenance_spec
+            )
+            current_identities = {
+                entry.document_identity()
+                for entry in self._provenance_code_entries(
+                    current,
+                    node=node,
+                    scope=scope,
+                )
+            }
+            entries = self._provenance_code_entries(
+                candidate,
+                node=node,
+                scope=scope,
+            )
+            edited_entries = tuple(
+                entry
+                for entry in entries
+                if entry.document_identity() not in current_identities
+            )
+            if scope == "source" and node.parent_uid is not None:
+                parent = self._manager._parent_node(node)
+                displayed_candidate = compose_display_provenance(
+                    parent.displayed_provenance_spec,
+                    candidate,
+                    parent_data=parent.current_source_data(),
+                )
+                current_display_entries = self._provenance_code_entries(
+                    node.displayed_provenance_spec,
+                    node=node,
+                    scope="display",
+                )
+                current_display_identities = {
+                    entry.document_identity() for entry in current_display_entries
+                }
+                edited_execution_identities = {
+                    entry.execution_identity() for entry in edited_entries
+                }
+                edited_entries = (
+                    *edited_entries,
+                    *(
+                        entry
+                        for entry in self._provenance_code_entries(
+                            displayed_candidate,
+                            node=node,
+                            scope="display",
+                        )
+                        if entry.document_identity() not in current_display_identities
+                        and entry.execution_identity() in edited_execution_identities
+                    ),
+                )
+            with self._manager._workspace_controller.local_code_edit(
+                entries,
+                edited_entries=edited_entries,
+                focus_on_block=True,
+            ) as authorization:
+                if entries and authorization is None:
+                    raise _TrustedProvenanceReplayCancelled
+                edit = self._validated_edit(
+                    node,
+                    scope,
+                    candidate,
+                    where=where,
+                    authorization=authorization,
+                    retain_active_filter=retain_active_filter,
+                )
+                publication.require_current_for_publication()
+                self._apply_validated_edit(edit)
+                publication.publish()
+
+    def _provenance_code_entries(
+        self,
+        spec: ToolProvenanceSpec | None,
+        *,
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        scope: typing.Literal["display", "source"],
+    ) -> tuple[typing.Any, ...]:
+        node_path = (
+            self._manager._workspace_controller.saving._workspace_node_path_for_node(
+                node
+            )
+        )
+        segment = "source/provenance" if scope == "source" else "provenance"
+        return provenance_code_trust_entries(
+            spec,
+            location_prefix=f"{node_path}/{segment}",
+        )
+
+    @staticmethod
+    def _capability_authorizer(authorization: object | None):
+        def authorize(_entries: tuple[typing.Any, ...]) -> object | None:
+            return authorization
+
+        return authorize
 
     def _validated_edit(
         self,
@@ -1955,15 +2000,23 @@ class _ProvenanceEditController:
         candidate: ToolProvenanceSpec,
         *,
         where: str,
+        authorization: object | None = None,
+        retain_active_filter: bool = True,
     ) -> _ValidatedProvenanceEdit:
-        base_candidate, filter_operation = self._split_active_filter(node, candidate)
+        if retain_active_filter:
+            base_candidate, filter_operation = self._split_active_filter(
+                node, candidate
+            )
+        else:
+            base_candidate, filter_operation = candidate, None
         try:
             source_data, base_candidate = self._replay_candidate_result(
                 node,
                 scope,
                 base_candidate,
+                authorization=authorization,
             )
-        except _TrustedScriptReplayCancelled:
+        except _TrustedProvenanceReplayCancelled:
             raise
         except Exception as exc:
             replay_target = (
@@ -2119,6 +2172,8 @@ class _ProvenanceEditController:
         node: _ImageToolWrapper | _ManagedWindowNode,
         scope: typing.Literal["display", "source"],
         spec: ToolProvenanceSpec,
+        *,
+        authorization: object | None = None,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
         if spec.kind == "file":
             return self._replay_file_candidate(spec), spec
@@ -2130,15 +2185,23 @@ class _ProvenanceEditController:
                 )
                 for operation in spec.operations
             ):
-                return self._replay_live_script_candidate(node, scope, spec), spec
+                return (
+                    self._replay_live_script_candidate(
+                        node,
+                        scope,
+                        spec,
+                        authorization=authorization,
+                    ),
+                    spec,
+                )
             if scope == "source" and node.parent_uid is not None:
                 parent = self._manager._parent_node(node)
                 return (
-                    spec.apply(
+                    self._manager._apply_provenance(
+                        spec,
                         parent.current_source_data(),
-                        extension_executor=(
-                            self._manager._extensions.execution.run_operation
-                        ),
+                        reason="apply this provenance order",
+                        authorization=authorization,
                     ),
                     spec,
                 )
@@ -2146,41 +2209,38 @@ class _ProvenanceEditController:
             if parent_data is None:
                 raise RuntimeError("Live provenance needs a parent source to replay")
             return (
-                spec.apply(
+                self._manager._apply_provenance(
+                    spec,
                     parent_data,
-                    extension_executor=(
-                        self._manager._extensions.execution.run_operation
-                    ),
+                    reason="apply this provenance order",
+                    authorization=authorization,
                 ),
                 spec,
             )
         if spec.kind == "script":
-            external_input_names = self._script_replay_source_input_names(spec)
+            external_input_names = script_replay_source_input_names(spec)
             if external_input_names:
                 source_data = node.resolved_replay_source_data()
                 if source_data is None:
                     raise RuntimeError("Script provenance needs its replay source")
                 replay_inputs = dict.fromkeys(external_input_names, source_data)
-                trusted_user_code = script_provenance_requires_trust(
-                    spec,
-                    external_input_names=set(replay_inputs),
-                )
-                if trusted_user_code:
-                    self._manager._ensure_script_provenance_trusted(
-                        spec,
-                        reason="apply this provenance order",
-                        external_input_names=set(replay_inputs),
-                    )
                 return (
                     replay_script_provenance(
                         spec,
                         replay_inputs,
-                        trusted_user_code=trusted_user_code,
                         extension_executor=(
                             self._manager._extensions.execution.run_operation
                         ),
                         extension_loader_executor=(
                             self._manager._extensions.replay_loader
+                        ),
+                        authorize=(
+                            functools.partial(
+                                self._manager._authorize_provenance_execution,
+                                reason="apply this provenance order",
+                            )
+                            if authorization is None
+                            else self._capability_authorizer(authorization)
                         ),
                     ),
                     spec,
@@ -2188,6 +2248,7 @@ class _ProvenanceEditController:
             result = self._manager._rebuild_script_provenance(
                 spec,
                 target_node_uid=node.uid,
+                authorization=authorization,
             )
             return result.data, result.provenance_spec
         raise RuntimeError("Unsupported provenance kind")
@@ -2197,6 +2258,8 @@ class _ProvenanceEditController:
         node: _ImageToolWrapper | _ManagedWindowNode,
         scope: typing.Literal["display", "source"],
         spec: ToolProvenanceSpec,
+        *,
+        authorization: object | None = None,
     ) -> xr.DataArray:
         if scope == "source" and node.parent_uid is not None:
             parent = self._manager._parent_node(node)
@@ -2212,42 +2275,30 @@ class _ProvenanceEditController:
             ),
             parent_data,
         )
-        for operation in spec.operations:
-            if not isinstance(
-                operation,
-                ScriptCodeOperation,
-            ):
-                if isinstance(operation, ExtensionRoutineOperation):
-                    data = self._manager._extensions.execution.run_operation(
-                        operation, data
-                    )
-                else:
-                    data = operation._apply_schema_v2(data, parent_data=parent_data)
-                continue
-            step_spec = self._live_script_step_spec(operation)
-            replay_inputs = {
+        replay_spec = script(
+            *spec.operations,
+            start_label="Replay live provenance",
+            seed_code="derived = data",
+            active_name="derived",
+        )
+        return replay_script_provenance(
+            replay_spec,
+            {
                 "data": data,
                 "derived": data,
                 "parent_data": parent_data,
-            }
-            trusted_user_code = script_provenance_requires_trust(
-                step_spec,
-                external_input_names=set(replay_inputs),
-            )
-            if trusted_user_code:
-                self._manager._ensure_script_provenance_trusted(
-                    step_spec,
-                    reason="apply this provenance step",
-                    external_input_names=set(replay_inputs),
+            },
+            authorize=(
+                functools.partial(
+                    self._manager._authorize_provenance_execution,
+                    reason="apply this provenance order",
                 )
-            data = replay_script_provenance(
-                step_spec,
-                replay_inputs,
-                trusted_user_code=trusted_user_code,
-                extension_executor=(self._manager._extensions.execution.run_operation),
-                extension_loader_executor=self._manager._extensions.replay_loader,
-            )
-        return data
+                if authorization is None
+                else self._capability_authorizer(authorization)
+            ),
+            extension_executor=self._manager._extensions.execution.run_operation,
+            extension_loader_executor=self._manager._extensions.replay_loader,
+        )
 
     @staticmethod
     def _live_script_step_spec(
@@ -2278,6 +2329,10 @@ class _ProvenanceEditController:
                         self._manager._extensions.execution.run_operation
                     ),
                     extension_loader_executor=(self._manager._extensions.replay_loader),
+                    authorize=functools.partial(
+                        self._manager._authorize_provenance_execution,
+                        reason="reload this file provenance",
+                    ),
                 )
             except Exception as exc:
                 if warning_details := _replay_warning_details(replay_warnings):

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_controller.py
@@ -573,11 +573,20 @@ class _ProvenanceEditController:
         ) as publication:
             current_data = node.current_public_data()
             replay_source_data = node.resolved_replay_source_data()
+            script_context_names = ("data", "derived")
+            current_output_name = getattr(
+                node.displayed_provenance_spec,
+                "active_name",
+                None,
+            )
+            current_output_names = (
+                (current_output_name,) if isinstance(current_output_name, str) else ()
+            )
             if local.kind == "script":
                 spec = compose_full_provenance(
                     node.displayed_provenance_spec,
                     local,
-                    script_context_names=("data", "derived"),
+                    script_context_names=script_context_names,
                 )
             else:
                 spec = compose_full_provenance(
@@ -613,7 +622,15 @@ class _ProvenanceEditController:
                     raise _TrustedProvenanceReplayCancelled
                 try:
                     if local.kind == "script":
-                        input_names = script_replay_source_input_names(local)
+                        input_names = tuple(
+                            dict.fromkeys(
+                                (
+                                    *script_context_names,
+                                    *current_output_names,
+                                    *script_replay_source_input_names(local),
+                                )
+                            )
+                        )
                         data = replay_script_provenance(
                             local,
                             dict.fromkeys(input_names, current_data),

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -71,8 +71,8 @@ class _ScriptRebuildError(RuntimeError):
         self.details = details
 
 
-class _TrustedScriptReplayCancelled(RuntimeError):
-    """Raised when the user declines to execute trusted replay code."""
+class _TrustedProvenanceReplayCancelled(RuntimeError):
+    """Raised when document trust blocks recorded Python code."""
 
 
 def _manager_settings() -> QtCore.QSettings:
@@ -813,6 +813,8 @@ def _workspace_file_manager_action_text() -> str:
 class _WorkspacePropertiesState:
     is_modified: bool
     top_level_window_count: int
+    code_trust_text: str = "Trusted local document"
+    code_trust_review_available: bool = False
 
 
 def _workspace_file_type_text(path: pathlib.Path | None) -> str:
@@ -857,6 +859,7 @@ class _WorkspacePropertiesDialog(QtWidgets.QDialog):
         workspace_path: str | os.PathLike[str] | None,
         *,
         state: _WorkspacePropertiesState,
+        review_code_callback: Callable[[], None] | None = None,
         parent: QtWidgets.QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -876,6 +879,7 @@ class _WorkspacePropertiesDialog(QtWidgets.QDialog):
         self.value_labels: dict[str, QtWidgets.QLabel] = {}
         self.copy_path_button: QtWidgets.QAbstractButton | None = None
         self.reveal_button: QtWidgets.QAbstractButton | None = None
+        self.review_code_button: QtWidgets.QAbstractButton | None = None
 
         layout = QtWidgets.QVBoxLayout(self)
 
@@ -984,6 +988,13 @@ class _WorkspacePropertiesDialog(QtWidgets.QDialog):
         row = self._add_detail(
             details_layout,
             row,
+            "code_trust",
+            "Stored code",
+            state.code_trust_text,
+        )
+        row = self._add_detail(
+            details_layout,
+            row,
             "unsaved_changes",
             "Unsaved changes",
             "Yes" if state.is_modified else "No",
@@ -997,6 +1008,19 @@ class _WorkspacePropertiesDialog(QtWidgets.QDialog):
         )
 
         self.button_box = QtWidgets.QDialogButtonBox(self)
+        if state.code_trust_review_available and review_code_callback is not None:
+            self.review_code_button = typing.cast(
+                "QtWidgets.QAbstractButton",
+                self.button_box.addButton(
+                    "Review and Trust…",
+                    QtWidgets.QDialogButtonBox.ButtonRole.ActionRole,
+                ),
+            )
+            self.review_code_button.setObjectName(
+                "manager_workspace_review_code_button"
+            )
+            self.review_code_button.clicked.connect(self.accept)
+            self.review_code_button.clicked.connect(review_code_callback)
         if self._workspace_path is not None:
             self.copy_path_button = typing.cast(
                 "QtWidgets.QAbstractButton",

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -24,8 +24,36 @@ import erlab.interactive.imagetool.manager._workspace._saving as workspace_savin
 import erlab.interactive.imagetool.manager._workspace._state as workspace_state
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
+import erlab.interactive.imagetool.manager._workspace._trust as workspace_trust
 import erlab.interactive.imagetool.slicer
 import erlab.interactive.imagetool.viewer_linking
+from erlab.interactive._code_trust import (
+    approve_document_trust,
+    bind_document_trust_manifest,
+    commit_local_edit_trust,
+    create_manifest,
+    document_trust_description,
+    document_trust_has_trusted_lineage,
+    document_trust_is_trusted,
+    document_trust_needs_review,
+    execution_capability_allows,
+    external_document_trust,
+    issue_complete_execution_capability,
+    issue_execution_capability,
+    issue_local_edit_capability,
+    manifest_has_code,
+    merge_document_trust,
+    relocate_document_trust,
+    relocate_manifest_entries,
+    trusted_location_document_trust,
+    untrusted_document_trust,
+)
+from erlab.interactive._code_trust._application import (
+    load_document_trust,
+    load_imported_document_trust,
+    save_document_trust,
+)
+from erlab.interactive._code_trust._ui import confirm_code_trust
 from erlab.interactive.imagetool.manager import _desktop
 from erlab.interactive.imagetool.manager._widgets import (
     _RECENT_WORKSPACES_SETTINGS_KEY,
@@ -45,11 +73,18 @@ if typing.TYPE_CHECKING:
     import h5py
     import xarray as xr
 
+    from erlab.interactive._code_trust._api import _DocumentTrust
+    from erlab.interactive._code_trust._core import CodeTrustEntry, CodeTrustEntrySource
+    from erlab.interactive.imagetool._mainwindow import ImageTool
     from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
     from erlab.interactive.imagetool.manager._workspace._state import (
         _WorkspaceStateSnapshot,
     )
-    from erlab.interactive.imagetool.manager._wrapper import _ManagedWindowNode
+    from erlab.interactive.imagetool.manager._wrapper import (
+        _ImageToolWrapper,
+        _ManagedWindowNode,
+    )
+    from erlab.interactive.utils import ToolWindow
 else:
     import lazy_loader as _lazy
 
@@ -74,6 +109,7 @@ def _show_itws_workspace_warning(parent: QtWidgets.QWidget) -> None:
 class _WorkspaceController:
     def __init__(self, manager: ImageToolManager) -> None:
         self._manager = manager
+        self._local_edit_capability: object | None = None
         self._loader_state = workspace_format.WorkspaceLoaderState()
         self.loading = workspace_loading._WorkspaceLoader(manager, self)
         self.saving = workspace_saving._WorkspaceSaver(manager, self)
@@ -99,6 +135,390 @@ class _WorkspaceController:
             workspace_saving._WorkspaceGcResultReceiver | None
         ) = None
         self._workspace_gc_requested = False
+
+    def _loaded_workspace_code_trust(
+        self,
+        path: str | os.PathLike[str],
+        manifest: Mapping[str, typing.Any],
+        *,
+        selected_paths: set[str] | None,
+    ) -> _DocumentTrust:
+        if workspace_trust.workspace_path_is_trusted(path):
+            return trusted_location_document_trust()
+        try:
+            imported_manifest = workspace_trust.workspace_code_trust_manifest(
+                manifest, selected_paths=selected_paths
+            )
+        except (TypeError, ValueError):
+            logger.warning(
+                "Workspace Python content could not be inspected",
+                exc_info=True,
+            )
+            return untrusted_document_trust()
+        if selected_paths is None:
+            return load_document_trust(imported_manifest)
+        try:
+            code_manifest = workspace_trust.workspace_code_trust_manifest(manifest)
+        except (TypeError, ValueError):
+            # An unavailable unselected tool must not prevent a safe selected import.
+            return load_document_trust(imported_manifest)
+        return load_imported_document_trust(code_manifest, imported_manifest)
+
+    def _legacy_workspace_code_trust(
+        self, path: str | os.PathLike[str]
+    ) -> _DocumentTrust:
+        if workspace_trust.workspace_path_is_trusted(path):
+            return trusted_location_document_trust()
+        return untrusted_document_trust()
+
+    def _load_with_code_trust(
+        self,
+        incoming: _DocumentTrust,
+        *,
+        replace: bool,
+        load: Callable[[], bool],
+    ) -> bool:
+        """Apply incoming trust while payloads load, and roll it back on failure."""
+        previous = self._manager._workspace_state.code_trust
+        if (
+            not replace
+            and document_trust_needs_review(previous)
+            and document_trust_has_trusted_lineage(incoming)
+        ):
+            # Imported node paths can be rebased after this merge. Do not let a
+            # signed pre-rebase location authorize an equal existing location.
+            incoming = untrusted_document_trust(incoming.manifest)
+        self._merge_workspace_code_trust(incoming, replace=replace)
+        try:
+            loaded = load()
+        except Exception:
+            self._set_workspace_code_trust(previous)
+            raise
+        if not loaded:
+            self._set_workspace_code_trust(previous)
+        return loaded
+
+    def _set_workspace_code_trust(self, trust: _DocumentTrust) -> None:
+        """Set one manager-owned decision and notify executable features."""
+        state = self._manager._workspace_state
+        previous = state.code_trust
+        if previous == trust:
+            return
+        state.code_trust = trust
+        self._refresh_code_trust_ui()
+        self._notify_code_trust_changed()
+
+    def _merge_workspace_code_trust(
+        self, incoming: _DocumentTrust, *, replace: bool = False
+    ) -> None:
+        self._set_workspace_code_trust(
+            merge_document_trust(
+                self._manager._workspace_state.code_trust,
+                incoming,
+                replace=replace,
+            )
+        )
+
+    def adopt_external_code(self, entries: CodeTrustEntrySource) -> None:
+        """Merge executable content imported from outside the manager document."""
+        resolved_entries = tuple(entries() if callable(entries) else entries)
+        if not resolved_entries:
+            return
+        self._merge_workspace_code_trust(
+            external_document_trust(
+                create_manifest(
+                    workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN,
+                    workspace_trust.WORKSPACE_CODE_TRUST_POLICY_VERSION,
+                    resolved_entries,
+                )
+            )
+        )
+
+    def _notify_code_trust_changed(self) -> None:
+        for node in self._manager._tool_graph.nodes.values():
+            if node.tool_window is not None:
+                try:
+                    node.tool_window._code_trust_changed()
+                except Exception:
+                    logger.exception(
+                        "Could not update %s after the workspace trust changed",
+                        node.uid,
+                    )
+
+    def _record_saved_workspace_code_trust(
+        self,
+        manifest: Mapping[str, typing.Any],
+        *,
+        trusted_lineage: bool,
+        current_document: bool = True,
+    ) -> None:
+        state = self._manager._workspace_state
+        try:
+            code_manifest = workspace_trust.workspace_code_trust_manifest(manifest)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Saved workspace Python content could not be inspected",
+                exc_info=True,
+            )
+            self._manager._status_bar.showMessage(
+                "Workspace saved, but its Python content could not be inspected",
+                5000,
+            )
+            if current_document:
+                self._set_workspace_code_trust(untrusted_document_trust())
+            return
+        saved_trust, signature_stored = save_document_trust(
+            state.code_trust,
+            code_manifest,
+            saved_trusted_lineage=trusted_lineage,
+        )
+        if not signature_stored:
+            self._manager._status_bar.showMessage(
+                "Workspace saved, but code trust could not be stored", 5000
+            )
+        if current_document:
+            self._set_workspace_code_trust(saved_trust)
+
+    def review_and_approve_workspace_code_trust(self) -> None:
+        """Review the current executable bundle and approve it as one unit."""
+        try:
+            manifest = workspace_trust.current_workspace_code_trust_manifest(
+                self._manager
+            )
+        except (TypeError, ValueError):
+            QtWidgets.QMessageBox.warning(
+                self._manager,
+                "Stored Code Cannot Be Reviewed",
+                "ERLab cannot inspect the saved executable content of one or more "
+                "tools. Install the missing tool extension or remove the affected "
+                "tool before you trust this workspace.",
+            )
+            return
+        if manifest_has_code(manifest) and not confirm_code_trust(
+            self._manager,
+            manifest,
+            document_name="Workspace",
+            object_name="manager_code_trust_review_dialog",
+            window_title="Review Workspace Code",
+        ):
+            return
+        self._set_workspace_code_trust(
+            approve_document_trust(self._manager._workspace_state.code_trust, manifest)
+        )
+
+    def issue_code_execution_capability(
+        self,
+        entries: CodeTrustEntrySource,
+        *,
+        focus_on_block: bool = False,
+        allow_partial: bool = False,
+    ) -> object | None:
+        """Issue a capability for one exact workspace execution inventory.
+
+        Graph replay can request a partial capability because it checks each entry at
+        its execution boundary. All other callers require the complete inventory.
+        """
+        resolved_entries = tuple(entries() if callable(entries) else entries)
+        if self._local_edit_capability is not None and (
+            execution_capability_allows(
+                self._local_edit_capability,
+                resolved_entries,
+            )
+            or (
+                allow_partial
+                and any(
+                    execution_capability_allows(
+                        self._local_edit_capability,
+                        (entry,),
+                    )
+                    for entry in resolved_entries
+                )
+            )
+        ):
+            return self._local_edit_capability
+        issuer = (
+            issue_execution_capability
+            if allow_partial
+            else issue_complete_execution_capability
+        )
+        trust, capability = issuer(
+            self._manager._workspace_state.code_trust,
+            resolved_entries,
+        )
+        self._set_workspace_code_trust(trust)
+        if capability is None and focus_on_block:
+            self._manager.code_trust_banner.setFocus()
+        return capability
+
+    @contextlib.contextmanager
+    def local_code_edit(
+        self,
+        execution_entries: CodeTrustEntrySource,
+        *,
+        edited_entries: CodeTrustEntrySource,
+        focus_on_block: bool = False,
+    ) -> Iterator[object | None]:
+        """Authorize one explicit local edit and commit lineage on success."""
+        state = self._manager._workspace_state
+        previous = state.code_trust
+        resolved_execution_entries = tuple(
+            execution_entries() if callable(execution_entries) else execution_entries
+        )
+        resolved_edited_entries = tuple(
+            edited_entries() if callable(edited_entries) else edited_entries
+        )
+        prospective, capability = issue_local_edit_capability(
+            previous,
+            resolved_execution_entries,
+            edited_entries=resolved_edited_entries,
+        )
+        if not execution_capability_allows(capability, resolved_edited_entries):
+            capability = None
+        previous_manifest = previous.manifest
+        if prospective != previous and (
+            previous_manifest is None
+            or previous_manifest.domain != workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN
+            or previous_manifest.policy_version
+            != workspace_trust.WORKSPACE_CODE_TRUST_POLICY_VERSION
+        ):
+            previous_manifest = workspace_trust.current_workspace_code_trust_manifest(
+                self._manager
+            )
+        if capability is None and focus_on_block:
+            self._manager.code_trust_banner.setFocus()
+        previous_capability = self._local_edit_capability
+        self._local_edit_capability = capability
+        try:
+            yield capability
+        finally:
+            self._local_edit_capability = previous_capability
+        if prospective != previous and state.code_trust == previous:
+            try:
+                manifest = workspace_trust.current_workspace_code_trust_manifest(
+                    self._manager
+                )
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Edited workspace Python content could not be inspected",
+                    exc_info=True,
+                )
+                return
+            committed = commit_local_edit_trust(
+                previous,
+                capability,
+                () if previous_manifest is None else previous_manifest.entries,
+                manifest.entries,
+                edited_entries=resolved_edited_entries,
+                document_manifest=manifest,
+            )
+            if committed != previous:
+                self._set_workspace_code_trust(committed)
+
+    def _refresh_code_trust_ui(self) -> None:
+        trust = self._manager._workspace_state.code_trust
+        banner = getattr(self._manager, "code_trust_banner", None)
+        if banner is None:
+            return
+        banner.setVisible(not document_trust_is_trusted(trust))
+
+    def _bind_current_workspace_manifest_if_review_needed(self) -> None:
+        """Bind the full inventory after a node changes a paused workspace."""
+        trust = self._manager._workspace_state.code_trust
+        if not document_trust_needs_review(trust):
+            return
+        try:
+            manifest = workspace_trust.current_workspace_code_trust_manifest(
+                self._manager
+            )
+        except (TypeError, ValueError):
+            return
+        self._set_workspace_code_trust(bind_document_trust_manifest(trust, manifest))
+
+    @staticmethod
+    def _locate_tool_code_trust_entries(
+        entries: Iterable[CodeTrustEntry], *, location_getter: Callable[[], str]
+    ) -> tuple[CodeTrustEntry, ...]:
+        """Map feature-relative tool entries to exact workspace locations."""
+        return relocate_manifest_entries(
+            create_manifest("erlab.workspace-tool-location", 1, entries),
+            location_prefix=location_getter(),
+        )
+
+    def _configure_tool_code_trust(
+        self,
+        tool: ToolWindow,
+        *,
+        location_getter: Callable[[], str] | None = None,
+    ) -> None:
+        """Connect one materialized tool to the manager-owned trust decision."""
+        incoming_trust = tool._document_trust
+        current_trust = self._manager._workspace_state.code_trust
+        if incoming_trust == current_trust:
+            incoming_trust = None
+        elif location_getter is not None:
+            manifest = tool._current_code_trust_manifest()
+            if manifest is not None:
+                incoming_trust = relocate_document_trust(
+                    incoming_trust,
+                    manifest,
+                    location_prefix=location_getter(),
+                )
+        if incoming_trust is not None:
+            self._merge_workspace_code_trust(incoming_trust)
+        tool._set_code_trust_host(
+            self.issue_code_execution_capability,
+            local_edit_context=self.local_code_edit,
+            state_getter=lambda: self._manager._workspace_state.code_trust,
+            entry_locator=(
+                None
+                if location_getter is None
+                else functools.partial(
+                    self._locate_tool_code_trust_entries,
+                    location_getter=location_getter,
+                )
+            ),
+        )
+
+    def _locate_imagetool_code_trust_entries(
+        self,
+        entries: Iterable[CodeTrustEntry],
+        *,
+        node_getter: Callable[[], _ImageToolWrapper | _ManagedWindowNode],
+    ) -> tuple[CodeTrustEntry, ...]:
+        """Map runtime provenance entries to one ImageTool document location."""
+        node = node_getter()
+        location_prefix = (
+            f"{self.saving._workspace_node_path_for_node(node)}/provenance"
+        )
+        return relocate_manifest_entries(
+            create_manifest("erlab.workspace-imagetool-location", 1, entries),
+            location_prefix=location_prefix,
+            remove_location_prefix="runtime/",
+        )
+
+    def _configure_imagetool_code_trust(
+        self,
+        tool: ImageTool,
+        *,
+        node_getter: (
+            Callable[[], _ImageToolWrapper | _ManagedWindowNode] | None
+        ) = None,
+    ) -> None:
+        """Connect one ImageTool to the manager-owned trust decision."""
+
+        def issue(entries: Iterable[CodeTrustEntry]) -> object | None:
+            if node_getter is not None:
+                entries = self._locate_imagetool_code_trust_entries(
+                    entries,
+                    node_getter=node_getter,
+                )
+            return self.issue_code_execution_capability(
+                entries,
+                focus_on_block=True,
+                allow_partial=True,
+            )
+
+        tool.slicer_area._set_stored_code_authorizer(issue)
 
     def _tool_data_reference_matches_current_snapshot(
         self, reference: Mapping[str, typing.Any]
@@ -465,13 +885,17 @@ class _WorkspaceController:
         _WorkspacePropertiesDialog(
             self._manager.workspace_path,
             state=self._workspace_properties_state(),
+            review_code_callback=self.review_and_approve_workspace_code_trust,
             parent=self._manager,
         ).exec()
 
     def _workspace_properties_state(self) -> _WorkspacePropertiesState:
+        trust = self._manager._workspace_state.code_trust
         return _WorkspacePropertiesState(
             is_modified=self._manager.is_workspace_modified,
             top_level_window_count=self._manager.ntools,
+            code_trust_text=document_trust_description(trust),
+            code_trust_review_available=document_trust_needs_review(trust),
         )
 
     @property
@@ -1008,6 +1432,14 @@ class _WorkspaceController:
                             replace_ds,
                             source_parent_data=source_parent_data,
                             reference_resolver=reference_resolver,
+                            document_trust=self._manager._workspace_state.code_trust,
+                            entry_locator=functools.partial(
+                                self._locate_tool_code_trust_entries,
+                                location_getter=functools.partial(
+                                    self.saving._workspace_node_path_for_node,
+                                    node,
+                                ),
+                            ),
                             variable_names=rebind_names,
                         )
                         for name in rebind_names:
@@ -1431,7 +1863,11 @@ class _WorkspaceController:
         return dirty_changed
 
     def _mark_node_added(self, uid: str) -> bool:
-        return self._mark_workspace_dirty(uid=uid, added=True, structure="Added window")
+        changed = self._mark_workspace_dirty(
+            uid=uid, added=True, structure="Added window"
+        )
+        self._bind_current_workspace_manifest_if_review_needed()
+        return changed
 
     def _mark_node_data_dirty(self, uid: str) -> bool:
         changed = self._mark_workspace_dirty(uid=uid, data=True)
@@ -2112,6 +2548,11 @@ class _WorkspaceController:
                 else "Workspace saved"
             )
         self._manager._status_bar.showMessage(message, 5000)
+        self._record_saved_workspace_code_trust(
+            snapshot.generation_plan.manifest,
+            trusted_lineage=snapshot.trusted_lineage,
+            current_document=not post_save_events and not has_new_dirty_generation,
+        )
         if restore_focus:
             self._restore_focus_after_workspace_save(origin)
         self._record_recent_workspace(workspace_path)
@@ -2494,6 +2935,13 @@ class _WorkspaceController:
                     else "Workspace saved"
                 )
             self._manager._status_bar.showMessage(message, 5000)
+            self._record_saved_workspace_code_trust(
+                snapshot.generation_plan.manifest,
+                trusted_lineage=snapshot.trusted_lineage,
+                current_document=(
+                    not post_save_events and not has_new_dirty_generation
+                ),
+            )
             self._restore_focus_after_workspace_save(origin)
             self._schedule_workspace_gc()
             if on_finished is not None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import functools
 import hashlib
 import json
 import logging
@@ -869,6 +870,7 @@ class _WorkspaceLoader:
             self._controller._set_node_window_modified(uid, uid in dirty_uids)
         self._controller._update_workspace_window_title()
         self._controller._refresh_manager_record()
+        self._controller._refresh_code_trust_ui()
 
     def _load_workspace_imagetool_dataset(
         self,
@@ -990,7 +992,6 @@ class _WorkspaceLoader:
                 ds = ds.copy(deep=False)
                 ds.attrs["itool_name"] = ""
             ds = self._dataset_without_missing_workspace_colormap(ds, node_path)
-
             if pending_workspace_memory_payload is not None:
                 pending_ds = self._workspace_dataset_with_reserved_uid(
                     ds, reserved_uids
@@ -1105,6 +1106,21 @@ class _WorkspaceLoader:
             )
             return target
 
+        ds = self._tool_dataset_without_saved_input_provenance(ds)
+        uid = self._manager._next_node_uid(self._workspace_saved_uid_from_dataset(ds))
+        if parent_target is None:
+            location_prefix = f"figures/{uid}"
+        else:
+            parent_node = self._manager._node_for_target(parent_target)
+            location_prefix = (
+                f"{self._controller.saving._workspace_node_path_for_node(parent_node)}"
+                f"/childtools/{uid}"
+            )
+        entry_locator = functools.partial(
+            self._controller._locate_tool_code_trust_entries,
+            location_getter=lambda: location_prefix,
+        )
+
         reference_datasets: dict[tuple[pathlib.Path, str], xr.Dataset] = {}
         try:
             with _workspace_load_stage(profiler, "tool reference restore"):
@@ -1125,6 +1141,8 @@ class _WorkspaceLoader:
                         _tool_data_reference_resolver=tool_data_reference_resolver,
                         _materialize_tool_data_references=True,
                         _defer_restore_work=True,
+                        _code_trust=self._manager._workspace_state.code_trust,
+                        _code_trust_entry_locator=entry_locator,
                     )
                 )
             with _workspace_load_stage(profiler, "tool manager registration"):
@@ -1180,6 +1198,17 @@ class _WorkspaceLoader:
             raise
         self._record_workspace_loaded_node_target(ds, target, loaded_targets_by_uid)
         return target
+
+    @staticmethod
+    def _tool_dataset_without_saved_input_provenance(ds: xr.Dataset) -> xr.Dataset:
+        """Remove the legacy duplicate input-provenance snapshot before restore."""
+        attr_name = erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
+        if attr_name not in ds.attrs:
+            return ds
+        restored = ds.copy(deep=False)
+        restored.attrs = dict(ds.attrs)
+        restored.attrs.pop(attr_name, None)
+        return restored
 
     @staticmethod
     def _workspace_saved_uid_from_dataset(ds: xr.Dataset) -> str | None:
@@ -2577,6 +2606,9 @@ class _WorkspaceLoader:
                         )
                         and manifest is not None
                     ):
+                        current_manifest = typing.cast(
+                            "Mapping[str, typing.Any]", manifest
+                        )
                         load_store = None
                         owns_load_store = False
                         store_adopted = False
@@ -2592,7 +2624,7 @@ class _WorkspaceLoader:
                             if select:
                                 with profiler.stage("selection dialog setup"):
                                     dialog = _ChooseFromWorkspaceManifestDialog(
-                                        self._manager, manifest
+                                        self._manager, current_manifest
                                     )
                                 if (
                                     dialog.exec()
@@ -2602,17 +2634,28 @@ class _WorkspaceLoader:
                                 selected_paths = dialog.selected_paths()
                             incoming_extension_state = self._prepare_extension_scripts(
                                 access.path,
-                                manifest,
+                                current_manifest,
                                 selected_paths=selected_paths,
                             )
-                            loaded = self._from_h5py_workspace_file(
-                                access.path,
-                                manifest,
+                            incoming_trust = (
+                                self._controller._loaded_workspace_code_trust(
+                                    access.path,
+                                    current_manifest,
+                                    selected_paths=selected_paths,
+                                )
+                            )
+                            loaded = self._controller._load_with_code_trust(
+                                incoming_trust,
                                 replace=replace,
-                                mark_dirty=mark_dirty,
-                                selected_paths=selected_paths,
-                                profiler=profiler,
-                                incoming_extension_state=incoming_extension_state,
+                                load=lambda: self._from_h5py_workspace_file(
+                                    access.path,
+                                    current_manifest,
+                                    replace=replace,
+                                    mark_dirty=mark_dirty,
+                                    selected_paths=selected_paths,
+                                    profiler=profiler,
+                                    incoming_extension_state=(incoming_extension_state),
+                                ),
                             )
                             if loaded and associate:
                                 self._controller._associate_loaded_workspace_file(
@@ -2671,13 +2714,20 @@ class _WorkspaceLoader:
                                 tree.attrs
                             )
                         )
-                    loaded = self._from_datatree(
-                        tree,
+                    incoming_trust = self._controller._legacy_workspace_code_trust(
+                        access.path
+                    )
+                    loaded = self._controller._load_with_code_trust(
+                        incoming_trust,
                         replace=replace,
-                        mark_dirty=mark_dirty,
-                        select=select,
-                        workspace_file_path=access.path,
-                        profiler=profiler,
+                        load=lambda: self._from_datatree(
+                            tree,
+                            replace=replace,
+                            mark_dirty=mark_dirty,
+                            select=select,
+                            workspace_file_path=access.path,
+                            profiler=profiler,
+                        ),
                     )
                     if replace:
                         self._manager._workspace_state.save_as_only = False

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -8,6 +8,7 @@ import collections
 import collections.abc
 import contextlib
 import copy
+import functools
 import html
 import json
 import logging
@@ -34,6 +35,9 @@ from erlab.interactive.imagetool._provenance._model import (
 )
 from erlab.interactive.imagetool._provenance._operations import (
     ImageToolSelectionSourceBinding,
+)
+from erlab.interactive.imagetool._provenance._trust import (
+    provenance_operation_requires_code_trust,
 )
 from erlab.interactive.imagetool.manager._node_change import _ManagedNodeChange
 from erlab.interactive.imagetool.manager._widgets import _curve_preview_data
@@ -228,6 +232,11 @@ class _PendingWorkspacePayloads:
         if not isinstance(filter_payload, dict):
             raise TypeError("Invalid pending filter operation")
         operation = parse_tool_provenance_operation(filter_payload)
+        if provenance_operation_requires_code_trust(operation):
+            raise TypeError(
+                "Operations that can execute stored Python cannot be used as display "
+                "filters"
+            )
         source_shape = tuple(data.sizes[dim] for dim in data.dims)
         filtered = operation.apply(data)
         if filtered.ndim != data.ndim or set(filtered.dims) != set(data.dims):
@@ -1008,7 +1017,7 @@ class _PendingWorkspacePayloads:
                 ds = ds.copy(deep=False)
                 pending_attrs = node.pending_workspace_payload_attrs
                 if pending_attrs is not None:
-                    ds.attrs.update(pending_attrs)
+                    ds.attrs = dict(pending_attrs)
                 ds.attrs["itool_name"] = "" if name is None else name
                 ds = self._loader._dataset_without_missing_workspace_colormap(
                     ds, payload_path
@@ -1072,7 +1081,8 @@ class _PendingWorkspacePayloads:
             pending_attrs = node.pending_workspace_payload_attrs
             if pending_attrs is not None:
                 ds = ds.copy(deep=False)
-                ds.attrs.update(pending_attrs)
+                ds.attrs = dict(pending_attrs)
+            ds = self._loader._tool_dataset_without_saved_input_provenance(ds)
 
             source_parent_data, tool_data_reference_resolver = (
                 self._loader._workspace_tool_restore_references(
@@ -1086,6 +1096,12 @@ class _PendingWorkspacePayloads:
             )
 
             with self._controller._workspace_load_context():
+                entry_locator = functools.partial(
+                    self._controller._locate_tool_code_trust_entries,
+                    location_getter=lambda: (
+                        self._controller.saving._workspace_node_path_for_node(node)
+                    ),
+                )
                 tool: erlab.interactive.utils.ToolWindow = (
                     erlab.interactive.utils.ToolWindow.from_dataset(
                         ds,
@@ -1093,10 +1109,13 @@ class _PendingWorkspacePayloads:
                         _tool_data_reference_resolver=tool_data_reference_resolver,
                         _materialize_tool_data_references=True,
                         _defer_restore_work=True,
+                        _code_trust=self._manager._workspace_state.code_trust,
+                        _code_trust_entry_locator=entry_locator,
                     )
                 )
                 if node.parent_uid is None:
                     self._loader._require_workspace_root_tool_is_figure(tool)
+                    tool.set_input_provenance_spec(None)
                     node.window = tool
                     if not tool._tool_display_name:
                         tool._tool_display_name = node.name
@@ -1104,9 +1123,6 @@ class _PendingWorkspacePayloads:
                     self._manager._figure_collection.sync(select_uid=None)
                 else:
                     parent = self._manager._node_for_target(node.parent_uid)
-                    node.window = tool
-                    if not tool._tool_display_name:
-                        tool._tool_display_name = parent.name
                     parent_uid = parent.uid
 
                     def _source_parent_fetcher() -> xr.DataArray:
@@ -1119,10 +1135,14 @@ class _PendingWorkspacePayloads:
                             parent_uid
                         ).displayed_provenance_spec
 
+                    tool.set_input_provenance_spec(None)
                     tool.set_source_parent_fetcher(_source_parent_fetcher)
                     tool.set_input_provenance_parent_fetcher(
                         _input_provenance_parent_fetcher
                     )
+                    node.window = tool
+                    if not tool._tool_display_name:
+                        tool._tool_display_name = parent.name
                     self._manager._tool_graph.add_child_reference(
                         parent.uid, node.uid, tool
                     )

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -22,6 +22,7 @@ import erlab.interactive.imagetool.manager._workspace._format as workspace_forma
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 from erlab.interactive import _qt_state
+from erlab.interactive._code_trust import document_trust_has_trusted_lineage
 from erlab.interactive.imagetool._load_source import _serialize_loader_kwargs
 from erlab.interactive.imagetool.manager._widgets import (
     _strip_workspace_modified_placeholder,
@@ -61,6 +62,7 @@ class _WorkspaceSaveSnapshot:
     generation: int
     generation_plan: workspace_storage._WorkspaceGenerationPlan
     compression_mode: WorkspaceCompressionMode
+    trusted_lineage: bool
     serialized_tool_data_references: tuple[
         tuple[str, str, dict[str, dict[str, typing.Any]]], ...
     ] = ()
@@ -328,10 +330,12 @@ class _WorkspaceSaver:
                 persistence.replay_source_data,
                 blob_name,
             )
-        if provenance_spec is not None:
+        if kind == "imagetool" and provenance_spec is not None:
             ds.attrs["manager_node_provenance_spec"] = json.dumps(
                 provenance_spec.model_dump(mode="json")
             )
+        else:
+            ds.attrs.pop("manager_node_provenance_spec", None)
         if isinstance(node, _ImageToolWrapper) and node.source_input_ndim is not None:
             ds.attrs["manager_node_source_input_ndim"] = int(node.source_input_ndim)
         if isinstance(node, _ImageToolWrapper) and node.watched:
@@ -418,6 +422,10 @@ class _WorkspaceSaver:
                 ),
             ):
                 ds = tool.to_dataset()
+            ds.attrs.pop(
+                erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR,
+                None,
+            )
             ds.attrs["tool_title"] = _strip_workspace_modified_placeholder(
                 ds.attrs.get("tool_title", "")
             )
@@ -467,14 +475,25 @@ class _WorkspaceSaver:
         return tree
 
     def _workspace_node_path(self, uid: str) -> str:
-        node = self._manager._tool_graph.nodes[uid]
+        return self._workspace_node_path_for_node(self._manager._tool_graph.nodes[uid])
+
+    def _workspace_node_path_for_node(
+        self, node: _ImageToolWrapper | _ManagedWindowNode
+    ) -> str:
+        """Return the path for a node before or after graph registration."""
         if isinstance(node, _ImageToolWrapper):
             return str(node.index)
-        if self._manager._is_figure_node(node):
-            return f"figures/{uid}"
+        if (
+            self._manager._tool_graph.nodes.get(node.uid) is node
+            and self._manager._is_figure_node(node)
+        ) or (
+            node.tool_window is not None
+            and node.tool_window.manager_collection == "figures"
+        ):
+            return f"figures/{node.uid}"
         if node.parent_uid is None:
-            raise KeyError(f"Node {uid!r} has no parent")
-        return f"{self._workspace_node_path(node.parent_uid)}/childtools/{uid}"
+            raise KeyError(f"Node {node.uid!r} has no parent")
+        return f"{self._workspace_node_path(node.parent_uid)}/childtools/{node.uid}"
 
     def _workspace_payload_path(self, uid: str) -> str:
         node = self._manager._tool_graph.nodes[uid]
@@ -793,6 +812,10 @@ class _WorkspaceSaver:
                 snapshot,
                 manifest=committed_generation.manifest,
             )
+            self._controller._record_saved_workspace_code_trust(
+                committed_generation.manifest,
+                trusted_lineage=snapshot.trusted_lineage,
+            )
         finally:
             if snapshot is not None:
                 snapshot.close()
@@ -941,7 +964,30 @@ class _WorkspaceSaver:
         else:
             attrs.pop(erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR, None)
             attrs.pop(erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR, None)
+        attrs.pop(erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR, None)
+        attrs.pop("manager_node_provenance_spec", None)
         return attrs
+
+    @staticmethod
+    def _tool_payload_has_saved_input_provenance(
+        node: _ImageToolWrapper | _ManagedWindowNode,
+        previous: Mapping[str, typing.Any] | None,
+    ) -> bool:
+        """Return whether a reusable tool payload has legacy input provenance."""
+        attr_name = erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
+        pending_attrs = node.pending_workspace_payload_attrs
+        if pending_attrs is not None and attr_name in pending_attrs:
+            return True
+        if previous is None:
+            return False
+        payload_attrs = previous.get("payload_attrs")
+        if payload_attrs is None:
+            return False
+        try:
+            attrs = workspace_format._restore_workspace_manifest_attrs(payload_attrs)
+        except Exception:
+            return True
+        return attr_name in attrs
 
     def _pending_workspace_payload_attrs_for_save(
         self, node: _ImageToolWrapper | _ManagedWindowNode
@@ -1135,11 +1181,15 @@ class _WorkspaceSaver:
             previous_object_id = (
                 previous.get("payload_object_id") if previous is not None else None
             )
+            has_saved_input_provenance = kind == "tool" and (
+                self._tool_payload_has_saved_input_provenance(node, previous)
+            )
             can_reuse_object = (
                 isinstance(previous_object_id, str)
                 and bool(previous_object_id)
                 and previous_object_id not in extension_object_ids
                 and uid not in dirty_data
+                and not has_saved_input_provenance
             )
 
             dataset: xr.Dataset | None = None
@@ -1147,7 +1197,10 @@ class _WorkspaceSaver:
                 previous.get("payload_attrs") if previous is not None else None
             )
             needs_current_attrs = (
-                attrs_payload is None or uid in dirty_state or uid in dirty_data
+                attrs_payload is None
+                or uid in dirty_state
+                or uid in dirty_data
+                or has_saved_input_provenance
             )
             if needs_current_attrs:
                 pending_attrs = (
@@ -1197,7 +1250,10 @@ class _WorkspaceSaver:
                     and uid not in self._manager._workspace_state.dirty_data
                     and (
                         kind != "tool"
-                        or self._pending_workspace_tool_references_available(node)
+                        or (
+                            not has_saved_input_provenance
+                            and self._pending_workspace_tool_references_available(node)
+                        )
                     )
                 )
                 if use_pending:
@@ -1345,6 +1401,11 @@ class _WorkspaceSaver:
                 legacy_reader_rebindings=legacy_reader_rebindings,
             ),
             compression_mode=self._workspace_compression_mode(),
+            trusted_lineage=(
+                document_trust_has_trusted_lineage(
+                    self._manager._workspace_state.code_trust
+                )
+            ),
             serialized_tool_data_references=(
                 self._serialized_tool_data_references(serialized_datasets)
             ),

--- a/src/erlab/interactive/imagetool/manager/_workspace/_state.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_state.py
@@ -17,6 +17,7 @@ import uuid
 from dataclasses import dataclass
 
 from erlab.extensions._models import _script_name_key
+from erlab.interactive._code_trust import new_document_trust
 from erlab.interactive.imagetool.manager._workspace._format import (
     _current_workspace_schema_version,
     _WorkspaceEmbeddedScriptEntry,
@@ -28,6 +29,7 @@ if typing.TYPE_CHECKING:
 
     from qtpy import QtCore
 
+    from erlab.interactive._code_trust._api import _DocumentTrust
     from erlab.interactive.imagetool.manager._extensions._models import (
         _WorkspaceScriptRequirement,
     )
@@ -321,6 +323,7 @@ class _WorkspaceStateSnapshot(typing.TypedDict):
     save_as_only: bool
     degraded_reasons: tuple[str, ...]
     extension_scripts: _WorkspaceScriptState
+    code_trust: _DocumentTrust
 
 
 class _ManagerWorkspaceState:
@@ -348,6 +351,7 @@ class _ManagerWorkspaceState:
         self.dirty_events: list[_WorkspaceDirtyEvent] = []
         self.save_in_progress: bool = False
         self.schema_version: int = _current_workspace_schema_version()
+        self.code_trust = new_document_trust()
         self.lock: QtCore.QLockFile | None = None
         self.closing_document: bool = False
         self.save_as_only: bool = False
@@ -496,6 +500,7 @@ class _ManagerWorkspaceState:
             "save_as_only": self.save_as_only,
             "degraded_reasons": self.degraded_reasons,
             "extension_scripts": self.extension_scripts.copy(),
+            "code_trust": self.code_trust,
         }
 
     def restore(self, snapshot: _WorkspaceStateSnapshot) -> set[str]:
@@ -520,4 +525,5 @@ class _ManagerWorkspaceState:
         self.save_as_only = snapshot["save_as_only"]
         self.degraded_reasons = snapshot["degraded_reasons"]
         self.extension_scripts.replace(snapshot["extension_scripts"])
+        self.code_trust = snapshot["code_trust"]
         return self.dirty_added | self.dirty_data | self.dirty_state

--- a/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
@@ -69,7 +69,7 @@ def _decoded_json_mapping(value: typing.Any) -> Mapping[str, typing.Any] | None:
         return None
     try:
         payload = json.loads(value)
-    except (TypeError, ValueError):
+    except ValueError:
         return None
     return payload if isinstance(payload, dict) else None
 

--- a/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
@@ -1,0 +1,238 @@
+"""Workspace adapter for durable executable-code trust."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import typing
+from collections.abc import Mapping
+
+import erlab
+import erlab.interactive.imagetool.manager._workspace._format as workspace_format
+from erlab.interactive._code_trust import (
+    create_manifest,
+    document_path_is_trusted,
+    relocate_manifest_entries,
+)
+from erlab.interactive._code_trust._payloads import CODE_PAYLOAD_ENTRIES_ATTR
+from erlab.interactive._saved_tools import resolve_saved_tool_class
+from erlab.interactive.imagetool._provenance._trust import provenance_code_trust_entries
+
+if typing.TYPE_CHECKING:
+    import os
+
+    from erlab.interactive.imagetool.manager._mainwindow import ImageToolManager
+    from erlab.interactive.utils import ToolWindow
+
+WORKSPACE_CODE_TRUST_DOMAIN = "erlab.workspace"
+WORKSPACE_CODE_TRUST_POLICY_VERSION = 7
+_MANIFEST_ID = (WORKSPACE_CODE_TRUST_DOMAIN, WORKSPACE_CODE_TRUST_POLICY_VERSION)
+_MANAGER_LIVE_SOURCE_SPEC_ATTR = "manager_node_live_source_spec"
+_MANAGER_PROVENANCE_SPEC_ATTR = "manager_node_provenance_spec"
+_ITOOL_PROVENANCE_SPEC_ATTR = "itool_provenance_spec"
+_TOOL_SOURCE_SPEC_ATTR = "tool_source_spec"
+_PROVENANCE_ATTRS = (_MANAGER_PROVENANCE_SPEC_ATTR, _ITOOL_PROVENANCE_SPEC_ATTR)
+_SOURCE_ATTRS = {
+    _MANAGER_LIVE_SOURCE_SPEC_ATTR: "source",
+    _TOOL_SOURCE_SPEC_ATTR: "tool-source",
+}
+_ALL_SOURCE_ATTRS = tuple(_SOURCE_ATTRS.items())
+_CODE_TRUST_ATTRS = frozenset(
+    (
+        *_PROVENANCE_ATTRS,
+        *_SOURCE_ATTRS,
+        CODE_PAYLOAD_ENTRIES_ATTR,
+        "tool_cls_qualname",
+        "tool_state",
+    )
+)
+
+
+def workspace_path_is_trusted(path: str | os.PathLike[str]) -> bool:
+    """Return whether an ``.itws`` path matches the user trusted-folder policy."""
+    document = pathlib.Path(path)
+    if document.suffix.lower() != ".itws":
+        return False
+    security = erlab.interactive.options.model.security
+    return document_path_is_trusted(
+        WORKSPACE_CODE_TRUST_DOMAIN,
+        document,
+        (
+            (WORKSPACE_CODE_TRUST_DOMAIN, folder)
+            for folder in security.trusted_workspace_folders
+        ),
+    )
+
+
+def _decoded_json_mapping(value: typing.Any) -> Mapping[str, typing.Any] | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        payload = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _entry_attrs(entry: Mapping[str, typing.Any]) -> dict[str, typing.Any]:
+    payload = entry.get("payload_attrs")
+    if isinstance(payload, dict):
+        return {key: payload[key] for key in _CODE_TRUST_ATTRS if key in payload}
+    if not isinstance(payload, list):
+        raise TypeError("Workspace node manifest must contain payload attributes")
+    attrs: dict[str, typing.Any] = {}
+    for item in payload:
+        if not isinstance(item, list) or len(item) != 2:
+            raise TypeError("Workspace manifest attribute entry is invalid")
+        encoded_key, encoded_value = item
+        if not isinstance(encoded_key, Mapping) or encoded_key.get("kind") != "str":
+            continue
+        key = encoded_key.get("value")
+        if key not in _CODE_TRUST_ATTRS:
+            continue
+        if (
+            not isinstance(encoded_value, Mapping)
+            or encoded_value.get("kind") != "str"
+            or not isinstance(encoded_value.get("value"), str)
+        ):
+            raise TypeError(f"Workspace code trust attribute {key!r} must be a string")
+        attrs[typing.cast("str", key)] = encoded_value["value"]
+    return attrs
+
+
+def _tool_code_trust_from_attrs(
+    attrs: Mapping[str, typing.Any],
+):
+    identifier = attrs.get("tool_cls_qualname")
+    if identifier is None:
+        return None
+    if not isinstance(identifier, str):
+        raise TypeError("Workspace tool class identifier must be a string")
+    tool_state = attrs.get("tool_state")
+    if not isinstance(tool_state, str):
+        raise TypeError("Workspace tool state must be JSON text")
+    try:
+        tool_cls = typing.cast("type[ToolWindow]", resolve_saved_tool_class(identifier))
+        status = tool_cls.StateModel.model_validate_json(tool_state)
+        manifest_attrs = dict(attrs)
+        manifest_attrs.pop(_TOOL_SOURCE_SPEC_ATTR, None)
+        return tool_cls._code_trust_manifest_from_saved_metadata(status, manifest_attrs)
+    except Exception as exc:
+        raise TypeError("Workspace tool trust metadata could not be inspected") from exc
+
+
+def _node_code_trust_entries(
+    path: str,
+    attrs: Mapping[str, typing.Any],
+    tool_manifest,
+    *,
+    provenance_specs=(),
+    source_specs=(),
+    saved_provenance_attrs=_PROVENANCE_ATTRS,
+    saved_source_attrs=_ALL_SOURCE_ATTRS,
+):
+    """Return deduplicated provenance and relocated tool entries for one node."""
+    entries = []
+    located_specs = [
+        *((f"{path}/provenance", spec) for spec in provenance_specs),
+        *(
+            (f"{path}/provenance", _decoded_json_mapping(attrs.get(attr)))
+            for attr in saved_provenance_attrs
+        ),
+        *source_specs,
+    ]
+    located_specs.extend(
+        (
+            f"{path}/{segment}/provenance",
+            _decoded_json_mapping(attrs.get(attr)),
+        )
+        for attr, segment in saved_source_attrs
+    )
+    for location, provenance_spec in located_specs:
+        if provenance_spec is None:
+            continue
+        for entry in provenance_code_trust_entries(
+            provenance_spec,
+            location_prefix=location,
+        ):
+            if entry not in entries:
+                entries.append(entry)
+    if tool_manifest is not None:
+        entries.extend(relocate_manifest_entries(tool_manifest, location_prefix=path))
+    return entries
+
+
+def workspace_code_trust_manifest(
+    workspace_manifest: Mapping[str, typing.Any],
+    *,
+    selected_paths: set[str] | None = None,
+):
+    """Build the signed executable manifest from workspace metadata only."""
+    entries = []
+    for node_entry in workspace_format._iter_workspace_manifest_node_entries(
+        workspace_manifest
+    ):
+        path = node_entry.get("path")
+        if not isinstance(path, str) or (
+            selected_paths is not None and path not in selected_paths
+        ):
+            continue
+        attrs = _entry_attrs(node_entry)
+        is_imagetool = (
+            node_entry.get("kind") == "imagetool" and "tool_cls_qualname" not in attrs
+        )
+        if not is_imagetool:
+            attrs.pop(_MANAGER_PROVENANCE_SPEC_ATTR, None)
+        tool_manifest = _tool_code_trust_from_attrs(attrs)
+        entries += _node_code_trust_entries(
+            path,
+            attrs,
+            tool_manifest,
+            saved_provenance_attrs=(
+                _PROVENANCE_ATTRS if is_imagetool else (_ITOOL_PROVENANCE_SPEC_ATTR,)
+            ),
+        )
+    return create_manifest(*_MANIFEST_ID, entries)
+
+
+def current_workspace_code_trust_manifest(
+    manager: ImageToolManager,
+):
+    """Build a review manifest from current metadata without reading data arrays."""
+    entries = []
+    node_path = manager._workspace_controller.saving._workspace_node_path
+    for uid in sorted(manager._tool_graph.nodes, key=node_path):
+        node = manager._tool_graph.nodes[uid]
+        path = node_path(uid)
+        tool = node.tool_window
+        tool_manifest = None if tool is None else tool._current_code_trust_manifest()
+        attrs = node.pending_workspace_payload_attrs or {}
+        if tool is None:
+            tool_manifest = _tool_code_trust_from_attrs(attrs)
+        source_spec = node.source_spec
+        source_attr, source_segment = (
+            (_MANAGER_LIVE_SOURCE_SPEC_ATTR, "source")
+            if node.is_imagetool
+            else (_TOOL_SOURCE_SPEC_ATTR, "tool-source")
+        )
+        include_source = node.is_imagetool or tool is None or tool_manifest is None
+        entries += _node_code_trust_entries(
+            path,
+            attrs,
+            tool_manifest,
+            provenance_specs=(
+                (node.passive_displayed_provenance_spec,) if node.is_imagetool else ()
+            ),
+            saved_provenance_attrs=_PROVENANCE_ATTRS if node.is_imagetool else (),
+            source_specs=(
+                ((f"{path}/{source_segment}/provenance", source_spec),)
+                if include_source
+                else ()
+            ),
+            saved_source_attrs=(
+                ((source_attr, source_segment),)
+                if tool is None and source_spec is None
+                else ()
+            ),
+        )
+    return create_manifest(*_MANIFEST_ID, entries)

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -23,7 +23,6 @@ __all__ = ["_ImageToolWrapper", "_ManagedWindowNode"]
 import contextlib
 import datetime
 import functools
-import importlib
 import json
 import keyword
 import logging
@@ -51,6 +50,7 @@ from erlab.interactive.imagetool._load_source import (
     _LoadFunc,
     _LoadSourceDetails,
     _parse_serialized_file_data_selection,
+    _registered_local_callable_loader,
 )
 from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool.manager._node_change import _ManagedNodeChange
@@ -637,6 +637,10 @@ class _ManagedWindowNode(QtCore.QObject):
             self._window_kind = "imagetool"
             self._imagetool = value
             self._tool_window = None
+            self.manager._workspace_controller._configure_imagetool_code_trust(
+                value,
+                node_getter=lambda: self,
+            )
             self.manager._install_workspace_save_shortcut(value)
             self.manager._register_interaction_window(value)
             if self._provenance_spec is not None or self._source_spec is not None:
@@ -676,6 +680,14 @@ class _ManagedWindowNode(QtCore.QObject):
         self._tool_window = tool
         self._tool_provenance_revision_key = (tool, tool.provenance_revision)
         self._imagetool = None
+        self.manager._workspace_controller._configure_tool_code_trust(
+            tool,
+            location_getter=lambda: (
+                self.manager._workspace_controller.saving._workspace_node_path_for_node(
+                    self,
+                )
+            ),
+        )
         self.manager._install_workspace_save_shortcut(tool)
         self.manager._register_interaction_window(tool)
         tool.installEventFilter(self)
@@ -860,6 +872,8 @@ class _ManagedWindowNode(QtCore.QObject):
             old.slicer_area.sigDisplayedProvenanceChanged.disconnect(
                 self._handle_imagetool_provenance_changed
             )
+        old.slicer_area._set_stored_code_authorizer(None)
+        old.slicer_area._in_manager = False
         old._set_managed_reveal_callback(None)
         if close:
             old.close()
@@ -1348,19 +1362,10 @@ class _ManagedWindowNode(QtCore.QObject):
             restored_kwargs = _deserialize_loader_kwargs(kwargs)
         except Exception:
             return None
-        if ":" in fn:
-            try:
-                mod_name, qual = fn.split(":", maxsplit=1)
-                func_obj: typing.Any = importlib.import_module(mod_name)
-                for attr in qual.split("."):
-                    func_obj = getattr(func_obj, attr)
-            except Exception:
-                return None
-            if not callable(func_obj):
-                return None
-            return func_obj, restored_kwargs, selection
         if fn in erlab.io.loaders:
             return fn, restored_kwargs, selection
+        if func_obj := _registered_local_callable_loader(fn):
+            return func_obj, restored_kwargs, selection
         return None
 
     def load_source_code(self, *, assign: str = "data") -> str | None:
@@ -2795,11 +2800,10 @@ class _ManagedWindowNode(QtCore.QObject):
                         return False
                     parent_data = self.parent_source_data()
                     source_spec = self._materialized_source_spec(parent_data)
-                    resolved = source_spec.apply(
+                    resolved = self.manager._apply_provenance(
+                        source_spec,
                         parent_data,
-                        extension_executor=(
-                            self.manager._extensions.execution.run_operation
-                        ),
+                        reason="refresh this ImageTool from its parent",
                     )
                     provenance_spec = compose_display_provenance(
                         self.manager._parent_node(self).displayed_provenance_spec,
@@ -2856,11 +2860,10 @@ class _ManagedWindowNode(QtCore.QObject):
                     if not self.has_source_binding:
                         return False
                     source_spec = self._materialized_source_spec(parent_data)
-                    resolved = source_spec.apply(
+                    resolved = self.manager._apply_provenance(
+                        source_spec,
                         parent_data,
-                        extension_executor=(
-                            self.manager._extensions.execution.run_operation
-                        ),
+                        reason="refresh this ImageTool from its parent",
                     )
                     provenance_spec = compose_display_provenance(
                         self.manager._parent_node(self).displayed_provenance_spec,

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import collections
 import contextlib
 import copy
-import importlib
 import logging
 import os
 import pathlib
@@ -34,16 +33,18 @@ from erlab.interactive.imagetool._load_source import (
     _extension_loader_identity,
     _LoadFunc,
     _parse_serialized_file_data_selection,
+    _register_local_callable_loader,
+    _registered_local_callable_loader,
     _serialize_loader_kwargs,
 )
 from erlab.interactive.imagetool._provenance._execution import (
     _select_replay_input,
     _semantic_file_data_selection,
+    can_reload_with_trusted_code,
     can_reload_without_trust,
     file_load_source_status,
     replay_file_provenance,
     replay_script_provenance,
-    script_provenance_requires_trust,
 )
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
@@ -54,6 +55,10 @@ from erlab.interactive.imagetool._provenance._model import (
     has_file_load_source,
     parse_tool_provenance_operation,
     require_live_source_spec,
+)
+from erlab.interactive.imagetool._provenance._trust import (
+    provenance_operation_requires_code_trust,
+    provenance_requires_code_trust,
 )
 from erlab.interactive.imagetool._viewer_dialogs import (
     _AssociatedCoordsDialog,
@@ -343,6 +348,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
         self._axes_signals_connected = False
         self._axes_signal_connected_indices: set[int] = set()
         self._workspace_load_profiler = _workspace_load_profiler
+        self._stored_code_authorizer: (
+            Callable[[tuple[typing.Any, ...]], object | None] | None
+        ) = None
 
         self._linking_proxy: SlicerLinkProxy | None = None
 
@@ -784,13 +792,16 @@ class ImageSlicerArea(QtWidgets.QWidget):
         load_func = self._load_func
         if load_func is not None:
             fn = load_func[0]
-            func_name = f"{fn.__module__}:{fn.__qualname__}" if callable(fn) else fn
-            selection = load_func[2].model_dump(mode="json")
-            load_func = (
-                func_name,
-                _serialize_loader_kwargs(load_func[1]),
-                selection,
-            )
+            func_name = _register_local_callable_loader(fn) if callable(fn) else fn
+            if func_name is None:
+                load_func = None
+            else:
+                selection = load_func[2].model_dump(mode="json")
+                load_func = (
+                    func_name,
+                    _serialize_loader_kwargs(load_func[1]),
+                    selection,
+                )
         state: ImageSlicerState = {
             "color": self.colormap_properties,
             "slice": self.array_slicer.state,
@@ -888,47 +899,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
             if file_path is not None:
                 self._file_path = pathlib.Path(file_path)
 
-            load_func = state.get("load_func", None)
-            if load_func is not None:
-                fn: str = load_func[0]
-                try:
-                    selection = _parse_serialized_file_data_selection(load_func[2])
-                    restored_kwargs = _deserialize_loader_kwargs(load_func[1])
-                except Exception:
-                    self._load_func = None
-                    selection = None
-                    restored_kwargs = None
-                if ":" in fn:
-                    try:
-                        mod_name, qual = fn.split(":")
-                        mod = importlib.import_module(mod_name)
-                        func_obj = mod
-                        for attr in qual.split("."):
-                            func_obj = getattr(func_obj, attr)
-                        if selection is not None:
-                            self._load_func = (
-                                typing.cast("Callable", func_obj),
-                                typing.cast("dict[str, typing.Any]", restored_kwargs),
-                                selection,
-                            )
-                    except Exception:
-                        self._load_func = None
-                elif (
-                    fn in erlab.io.loaders
-                    and selection is not None
-                    and restored_kwargs is not None
-                ):
-                    self._load_func = (
-                        fn,
-                        restored_kwargs,
-                        selection,
-                    )
-                else:
-                    self._load_func = None
+            self._restore_serialized_load_func(state.get("load_func"))
 
             if file_path is not None and not self._state_refresh_deferred():
                 self.sigDataChanged.emit()
-                logger.debug("Restored file path")
+            logger.debug("Restored file path")
 
         with self._workspace_load_stage("imagetool state restore: filter"):
             self._restore_filter_operation_from_state(
@@ -959,6 +934,31 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 ax.set_cursor_colors(self.cursor_colors)
             self.sigCursorColorsChanged.emit()
             logger.debug("Reapplied saved cursor colors")
+
+    def _restore_serialized_load_func(
+        self,
+        load_func: typing.Any,
+    ) -> bool:
+        """Restore one saved loader reference."""
+        self._load_func = None
+        if not isinstance(load_func, list | tuple) or len(load_func) != 3:
+            return False
+        target, serialized_kwargs, selection_payload = load_func
+        try:
+            selection = _parse_serialized_file_data_selection(selection_payload)
+            restored_kwargs = _deserialize_loader_kwargs(serialized_kwargs)
+        except Exception:
+            return False
+
+        if isinstance(target, str) and target in erlab.io.loaders:
+            self._load_func = (target, restored_kwargs, selection)
+            return True
+        if isinstance(target, str):
+            func = _registered_local_callable_loader(target)
+            if func is not None:
+                self._load_func = (func, restored_kwargs, selection)
+                return True
+        return False
 
     @property
     def splitter_sizes(self) -> list[list[int]]:
@@ -1399,6 +1399,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
         operation: ToolProvenanceOperation,
         dims: tuple[Hashable, ...],
     ) -> xr.DataArray:
+        if provenance_operation_requires_code_trust(operation):
+            raise TypeError(
+                "Operations that can execute stored Python cannot be used as display "
+                "filters"
+            )
         return self._normalize_filter_result_for_source_dims(
             data,
             operation.apply(data),
@@ -2499,6 +2504,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 isinstance(value, str) and value for value in extension_identity[:3]
             ):
                 func = func_instance.name
+            elif callable(func):
+                _register_local_callable_loader(func)
             self._load_func = (func, load_func[1], selection)
         else:
             self._load_func = None
@@ -2681,25 +2688,37 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
                 self.refresh_colormap()
 
+    def _set_stored_code_authorizer(
+        self,
+        authorize: Callable[[tuple[typing.Any, ...]], object | None] | None,
+    ) -> None:
+        """Set the document host callback for stored provenance execution."""
+        self._stored_code_authorizer = authorize
+
     @property
     def reloadable(self) -> bool:
         """Check if the displayed data can be reloaded.
 
         Managed child ImageTools reload through the manager when they can refresh
         from a reloadable ancestor. Direct file-backed windows reload from their
-        stored loader. Detached file-rooted provenance reloads by replaying its
-        self-contained code. Managed script-derived ImageTools reload through the
-        manager from their recorded inputs.
+        stored loader. Standalone ImageTools replay only provenance that does not
+        contain stored code. Managed ImageTools can ask their document host to
+        authorize stored code.
 
         Returns
         -------
         bool
             `True` if the data can be reloaded, `False` otherwise.
         """
-        if (
-            self._managed_source_chain_reload_target() is not None
-            or self._direct_reloadable()
-            or self._provenance_reloadable()
+        provenance_spec = self.provenance_spec
+        stored_code_without_host = (
+            provenance_spec is not None
+            and provenance_requires_code_trust(provenance_spec)
+            and self._stored_code_authorizer is None
+        )
+        if self._managed_source_chain_reload_target() is not None or (
+            not stored_code_without_host
+            and (self._direct_reloadable() or self._provenance_reloadable())
         ):
             return True
         manager = self._manager_instance if self._in_manager else None
@@ -2773,11 +2792,18 @@ class ImageSlicerArea(QtWidgets.QWidget):
     def _provenance_reloadable(self) -> bool:
         """Return whether replay provenance can rebuild the displayed data from file."""
         manager = self._manager_instance if self._in_manager else None
+        extension_status_resolver = (
+            None if manager is None else manager._extensions.capability_status
+        )
         return can_reload_without_trust(
             self.provenance_spec,
-            extension_status_resolver=(
-                None if manager is None else manager._extensions.capability_status
-            ),
+            extension_status_resolver=extension_status_resolver,
+        ) or (
+            self._stored_code_authorizer is not None
+            and can_reload_with_trusted_code(
+                self.provenance_spec,
+                extension_status_resolver=extension_status_resolver,
+            )
         )
 
     def _direct_reload_unavailable_reason(self) -> str | None:
@@ -2903,14 +2929,30 @@ class ImageSlicerArea(QtWidgets.QWidget):
             extension_status_resolver=extension_status_resolver,
         ):
             return None
-        if provenance_spec.kind == "script":
-            if script_provenance_requires_trust(provenance_spec):
-                return (
-                    "This data includes recorded script code that needs trust "
-                    "confirmation before replay. Reload it in ImageTool Manager, "
-                    "or recreate it from reloadable inputs to enable standalone "
-                    "reload."
+        if provenance_requires_code_trust(provenance_spec):
+            if (
+                self._stored_code_authorizer is not None
+                and can_reload_with_trusted_code(
+                    provenance_spec,
+                    extension_status_resolver=extension_status_resolver,
                 )
+            ):
+                return None
+            if can_reload_with_trusted_code(
+                provenance_spec,
+                extension_status_resolver=extension_status_resolver,
+            ):
+                return (
+                    "This data includes recorded code that standalone ImageTool "
+                    "does not execute. Open it in ImageTool Manager to review the "
+                    "code and reload the data."
+                )
+            return (
+                "This data was created from recorded script steps that cannot "
+                "be reloaded automatically from the saved provenance. Reopen "
+                "or recreate it from reloadable inputs to enable reload."
+            )
+        if provenance_spec.kind == "script":
             return (
                 "This data was created from recorded script steps that cannot be "
                 "reloaded automatically from the saved provenance. Reopen or "
@@ -2920,6 +2962,13 @@ class ImageSlicerArea(QtWidgets.QWidget):
 
     def _local_reload_unavailable_reason(self) -> str | None:
         """Return why this slicer area cannot reload without manager routing."""
+        provenance_spec = self.provenance_spec
+        if (
+            provenance_spec is not None
+            and provenance_requires_code_trust(provenance_spec)
+            and self._stored_code_authorizer is None
+        ):
+            return self._provenance_reload_unavailable_reason()
         if self._direct_reloadable() or self._provenance_reloadable():
             return None
         reason = self._direct_reload_unavailable_reason()
@@ -2938,9 +2987,17 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """Return why Reload Data cannot run, or `None` when reload is available."""
         if self._managed_source_chain_reload_target() is not None:
             return None
+        manager = self._manager_instance if self._in_manager else None
+        provenance_spec = self.provenance_spec
+        if (
+            manager is None
+            and provenance_spec is not None
+            and provenance_requires_code_trust(provenance_spec)
+            and self._stored_code_authorizer is None
+        ):
+            return self._provenance_reload_unavailable_reason()
         if self._direct_reloadable() or self._provenance_reloadable():
             return None
-        manager = self._manager_instance if self._in_manager else None
         if manager is not None:
             target = manager.target_from_slicer_area(self)
             if target is not None:
@@ -2970,7 +3027,11 @@ class ImageSlicerArea(QtWidgets.QWidget):
             selection,
         )
 
-    def _fetch_for_provenance_reload(self) -> xr.DataArray:
+    def _fetch_for_provenance_reload(
+        self,
+        *,
+        authorize: Callable[[tuple[typing.Any, ...]], object | None] | None = None,
+    ) -> xr.DataArray:
         """Replay file-rooted provenance and return the active displayed data."""
         provenance_spec = self.provenance_spec
         if provenance_spec is None:
@@ -2986,10 +3047,18 @@ class ImageSlicerArea(QtWidgets.QWidget):
         )
         if load_source is not None and source_status == "missing-file":
             raise FileNotFoundError(pathlib.Path(load_source.path))
-        if not can_reload_without_trust(
-            provenance_spec,
-            extension_status_resolver=extension_status_resolver,
-        ):
+        reloadable = (
+            can_reload_without_trust(
+                provenance_spec,
+                extension_status_resolver=extension_status_resolver,
+            )
+            if authorize is None
+            else can_reload_with_trusted_code(
+                provenance_spec,
+                extension_status_resolver=extension_status_resolver,
+            )
+        )
+        if not reloadable:
             raise RuntimeError("Data cannot be reloaded from provenance")
         extension_executor = (
             None if manager is None else manager._extensions.execution.run_operation
@@ -3002,6 +3071,7 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 provenance_spec,
                 extension_executor=extension_executor,
                 extension_loader_executor=extension_loader_executor,
+                authorize=authorize,
             )
         if provenance_spec.kind == "script":
             return replay_script_provenance(
@@ -3009,12 +3079,34 @@ class ImageSlicerArea(QtWidgets.QWidget):
                 {},
                 extension_executor=extension_executor,
                 extension_loader_executor=extension_loader_executor,
+                authorize=authorize,
             )
         raise RuntimeError("Data cannot be reloaded from provenance")
 
-    def _fetch_reload_data(self) -> tuple[xr.DataArray, dict[str, typing.Any]]:
+    def _fetch_reload_data(
+        self,
+        *,
+        authorize: Callable[[tuple[typing.Any, ...]], object | None] | None = None,
+    ) -> tuple[xr.DataArray, dict[str, typing.Any]]:
         """Return reload data and replacement kwargs for the active reload source."""
         provenance_spec = self.provenance_spec
+        if (
+            provenance_spec is not None
+            and provenance_requires_code_trust(provenance_spec)
+            and authorize is None
+        ):
+            raise RuntimeError(
+                "Recorded code requires authorization from ImageTool Manager"
+            )
+        if (
+            provenance_spec is not None
+            and authorize is not None
+            and provenance_requires_code_trust(provenance_spec)
+        ):
+            return (
+                self._fetch_for_provenance_reload(authorize=authorize),
+                {},
+            )
         if (
             provenance_spec is not None
             and (provenance_spec.kind == "script" or bool(provenance_spec.steps))
@@ -3045,7 +3137,38 @@ class ImageSlicerArea(QtWidgets.QWidget):
             and manager._script_reload_from_slicer_area(self, execute=False)
         ):
             return manager._script_reload_from_slicer_area(self, execute=True)
-        if self._direct_reloadable() or self._provenance_reloadable():
+        provenance_spec = self.provenance_spec
+        if (
+            provenance_spec is not None
+            and provenance_requires_code_trust(provenance_spec)
+            and self._stored_code_authorizer is None
+        ):
+            if manager is not None:
+                return manager._script_reload_from_slicer_area(self, execute=True)
+            return False
+        authorization_blocked = False
+
+        def authorize(entries: tuple[typing.Any, ...]) -> object | None:
+            nonlocal authorization_blocked
+            if self._stored_code_authorizer is None:
+                authorization_blocked = True
+                return None
+            capability = self._stored_code_authorizer(entries)
+            authorization_blocked = capability is None
+            return capability
+
+        execution_authorizer = (
+            authorize
+            if provenance_spec is not None
+            and provenance_requires_code_trust(provenance_spec)
+            and self._stored_code_authorizer is not None
+            else None
+        )
+        if (
+            execution_authorizer is not None
+            or self._direct_reloadable()
+            or self._provenance_reloadable()
+        ):
             try:
                 replay_capture = (
                     contextlib.nullcontext(None)
@@ -3053,13 +3176,17 @@ class ImageSlicerArea(QtWidgets.QWidget):
                     else manager._extensions.execution.capture_replay_sources()
                 )
                 with replay_capture as publication:
-                    data, kwargs = self._fetch_reload_data()
+                    data, kwargs = self._fetch_reload_data(
+                        authorize=execution_authorizer
+                    )
                     if publication is not None:
                         publication.require_current_for_publication()
                     self._replace_reload_data(data, kwargs)
                     if publication is not None:
                         publication.publish()
             except Exception:
+                if authorization_blocked:
+                    return False
                 erlab.interactive.utils.MessageDialog.critical(
                     self, "Error", "An error occurred while reloading data."
                 )

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -43,7 +43,33 @@ import xarray as xr
 from qtpy import PYQT6, PYSIDE6, QtCore, QtGui, QtWidgets, uic
 
 import erlab
-from erlab.interactive import _qt_state
+from erlab.interactive import _qt_state, _saved_tools
+from erlab.interactive._code_trust import (
+    approve_document_trust,
+    commit_local_edit_trust,
+    create_manifest,
+    document_trust_is_trusted,
+    execution_capability_allows,
+    external_document_trust,
+    issue_complete_execution_capability,
+    issue_execution_capability,
+    issue_local_edit_capability,
+    manifest_has_code,
+    new_document_trust,
+    verify_document_payload_entries,
+)
+from erlab.interactive._code_trust._application import (
+    load_document_trust,
+    save_document_trust,
+)
+from erlab.interactive._code_trust._payloads import (
+    code_payload_entries_from_metadata,
+    store_code_payload_entries,
+)
+from erlab.interactive._code_trust._ui import (
+    confirm_code_trust,
+    create_code_trust_banner,
+)
 from erlab.interactive._file_loaders import BUILTIN_FILE_LOADER_SPECS
 from erlab.interactive._plot_state import TOOL_VIEW_STATE_ATTR, ToolPlotStateRegistry
 from erlab.interactive._widgets import _Separator
@@ -63,6 +89,12 @@ if typing.TYPE_CHECKING:
     import varname
     from pyqtgraph.GraphicsScene.mouseEvents import MouseDragEvent
 
+    from erlab.interactive._code_trust._api import _DocumentTrust
+    from erlab.interactive._code_trust._core import (
+        CodeTrustEntry,
+        CodeTrustEntrySource,
+        CodeTrustManifest,
+    )
     from erlab.interactive.imagetool._provenance._model import (
         ToolProvenanceOperation,
         ToolProvenanceSpec,
@@ -3351,6 +3383,8 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     # for every mutation. It prevents later history and semantic signals from counting
     # the same mutation again.
     _PROVENANCE_IS_MODEL_OWNED: typing.ClassVar[bool] = False
+    _CODE_TRUST_DOMAIN: typing.ClassVar[str | None] = None
+    _CODE_TRUST_POLICY_VERSION: typing.ClassVar[int] = 1
     __tool_display_name: str = ""
 
     StateModel: type[M]
@@ -3363,6 +3397,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     def __init_subclass__(cls, **kwargs: typing.Any) -> None:
         """Put each concrete status setter inside the mutation boundary."""
         super().__init_subclass__(**kwargs)
+        _saved_tools.register_saved_tool_class(cls)
         status_property = cls.__dict__.get("tool_status")
         if not isinstance(status_property, property) or status_property.fset is None:
             return
@@ -3409,7 +3444,21 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._source_status_layout.addWidget(self._source_status_button, 0)
         self._source_status_layout.addStretch(1)
         self._tool_root_layout.addWidget(self._source_status_bar, 0)
+
+        self._code_trust_banner = create_code_trust_banner(self._tool_root_widget)
+        self._code_trust_banner.review_requested.connect(self._review_code_trust)
+        self._code_trust_banner.hide()
+        self._tool_root_layout.addWidget(self._code_trust_banner, 0)
         QtWidgets.QMainWindow.setCentralWidget(self, self._tool_root_widget)
+
+        self._document_trust = new_document_trust()
+        self._code_trust_capability_issuer: Callable[..., object | None] | None = None
+        self._code_trust_local_edit_context: Callable[..., typing.Any] | None = None
+        self._code_trust_local_edit_capability: object | None = None
+        self._code_trust_state_getter: Callable[[], _DocumentTrust] | None = None
+        self._code_trust_entry_locator: (
+            Callable[[Iterable[CodeTrustEntry]], tuple[CodeTrustEntry, ...]] | None
+        ) = None
 
         self._source_spec: ToolProvenanceSpec | None = None
         self._source_binding: ImageToolSelectionSourceBinding | None = None
@@ -3823,10 +3872,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         already produced the data that a queued restore callback would produce. This
         prevents stale restore-time previews or caches from running later.
         """
-        if not self._flushing_restore_work:
-            task_key = self._restore_work_key(callback, key=key)
-            if task_key is not None:
-                self._deferred_restore_work.pop(task_key, None)
+        task_key = self._restore_work_key(callback, key=key)
+        if task_key is not None:
+            self._deferred_restore_work.pop(task_key, None)
 
     def _flush_restore_work(
         self,
@@ -3854,7 +3902,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             tasks = [(task_key, self._deferred_restore_work[task_key])]
         else:
             return False
-        for pending_key, (pending_callback, run_on_show) in tasks:
+        for pending_key, pending_work in tasks:
+            if self._deferred_restore_work.get(pending_key) is not pending_work:
+                continue
+            pending_callback, run_on_show = pending_work
             if pending_key in skip_keys:
                 continue
             if run_on_show_only and not run_on_show:
@@ -3864,7 +3915,8 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 pending_callback()
             finally:
                 self._flushing_restore_work = False
-            self._deferred_restore_work.pop(pending_key, None)
+            if self._deferred_restore_work.get(pending_key) is pending_work:
+                self._deferred_restore_work.pop(pending_key)
             flushed = True
         return flushed
 
@@ -5121,7 +5173,13 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     def _resolve_source_data(self, parent_data: xr.DataArray) -> xr.DataArray:
         """Apply the current source spec or selection state to ``parent_data``."""
-        return self._materialized_source_spec(parent_data).apply(parent_data)
+        source_spec = self._materialized_source_spec(parent_data)
+        capability = self._issue_code_execution_capability(
+            lambda: self._source_spec_code_trust_entries(source_spec)
+        )
+        if capability is None:
+            raise PermissionError("Tool source provenance contains untrusted code")
+        return source_spec.apply(parent_data, authorization=capability)
 
     def validate_update_data(self, new_data: xr.DataArray) -> xr.DataArray:
         """Validate or normalize source data before `update_data` consumes it.
@@ -5363,6 +5421,17 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Return the state model to serialize for this tool."""
         return self.tool_status
 
+    def _code_trust_payload_entries(self) -> Iterable[CodeTrustEntry]:
+        """Return executable opaque-payload entries for the current tool state."""
+        return ()
+
+    def _code_trust_payload_entries_from_dataset(
+        self, ds: xr.Dataset
+    ) -> Iterable[CodeTrustEntry]:
+        """Return executable opaque-payload entries already serialized in ``ds``."""
+        del ds
+        return self._code_trust_payload_entries()
+
     @classmethod
     def can_save_and_load(cls) -> bool:
         """Check if this tool can be saved and restored."""
@@ -5470,7 +5539,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             return None
         try:
             parent_data = self._source_parent_fetcher()
-            resolved = self._materialized_source_spec(parent_data).apply(parent_data)
+            resolved = self._resolve_source_data(parent_data)
             resolved = self.validate_update_data(resolved)
         except Exception:
             return None
@@ -5542,7 +5611,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._flush_restore_work_for_save()
         self._flush_pending_history_write()
         ds = self._saved_tool_data_dataset()
-        return self._append_persistence_payload(ds)
+        ds = self._append_persistence_payload(ds)
+        store_code_payload_entries(
+            ds.attrs,
+            self._code_trust_payload_entries_from_dataset(ds),
+        )
+        return ds
 
     @staticmethod
     def _saved_tool_data_references(
@@ -5568,15 +5642,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         return references
 
     @staticmethod
-    def _saved_source_spec_from_attrs(
-        ds: xr.Dataset,
+    def _saved_source_spec_from_metadata(
+        attrs: Mapping[str, typing.Any],
     ) -> ToolProvenanceSpec:
         from erlab.interactive.imagetool._provenance._model import (
             parse_tool_provenance_spec,
             require_live_source_spec,
         )
 
-        payload = ds.attrs.get(_TOOL_SOURCE_SPEC_ATTR)
+        payload = attrs.get(_TOOL_SOURCE_SPEC_ATTR)
         if not isinstance(payload, str):
             raise TypeError("Referenced tool data is missing source provenance")
         source_spec = parse_tool_provenance_spec(
@@ -5588,6 +5662,13 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         return live_source_spec
 
     @classmethod
+    def _saved_source_spec_from_attrs(
+        cls,
+        ds: xr.Dataset,
+    ) -> ToolProvenanceSpec:
+        return cls._saved_source_spec_from_metadata(ds.attrs)
+
+    @classmethod
     def _resolve_saved_tool_data_reference(
         cls,
         reference: Mapping[str, typing.Any],
@@ -5596,6 +5677,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         source_parent_data: xr.DataArray | None,
         reference_resolver: Callable[[Mapping[str, typing.Any]], xr.DataArray | None]
         | None,
+        document_trust: _DocumentTrust | None = None,
+        entry_locator: (
+            Callable[[Iterable[CodeTrustEntry]], tuple[CodeTrustEntry, ...]] | None
+        ) = None,
     ) -> xr.DataArray:
         kind = reference.get("kind")
         if kind == "parent_source":
@@ -5604,7 +5689,24 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     "Saved tool data references parent ImageTool data, but the "
                     "parent data is unavailable."
                 )
-            return cls._saved_source_spec_from_attrs(ds).apply(source_parent_data)
+            source_spec = cls._saved_source_spec_from_attrs(ds)
+            capability = None
+            if document_trust is not None:
+                entries = tuple(cls._source_spec_code_trust_entries(source_spec))
+                if entry_locator is not None:
+                    entries = entry_locator(entries)
+                _trust, capability = issue_complete_execution_capability(
+                    document_trust,
+                    entries,
+                )
+                if capability is None:
+                    raise _MissingSavedToolDataReferenceError(
+                        "Saved tool source provenance contains untrusted code"
+                    )
+            return source_spec.apply(
+                source_parent_data,
+                authorization=capability,
+            )
         if kind == "manager_node":
             if reference_resolver is None:
                 raise _MissingSavedToolDataReferenceError(
@@ -5640,6 +5742,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         source_parent_data: xr.DataArray | None,
         reference_resolver: Callable[[Mapping[str, typing.Any]], xr.DataArray | None]
         | None,
+        document_trust: _DocumentTrust | None = None,
+        entry_locator: (
+            Callable[[Iterable[CodeTrustEntry]], tuple[CodeTrustEntry, ...]] | None
+        ) = None,
         variable_names: Collection[str] | None = None,
         materialize_references: bool = False,
     ) -> dict[str, xr.DataArray]:
@@ -5655,6 +5761,8 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     ds,
                     source_parent_data=source_parent_data,
                     reference_resolver=reference_resolver,
+                    document_trust=document_trust,
+                    entry_locator=entry_locator,
                 )
                 if materialize_references:
                     resolved = resolved.copy(deep=False).load()
@@ -5689,18 +5797,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         qualname = ds.attrs.get("tool_cls_qualname")
         if not isinstance(qualname, str):
             raise TypeError("Saved tool dataset is missing a valid tool class")
-        try:
-            mod_name, qual = qualname.split(":", maxsplit=1)
-        except ValueError as exc:
-            raise TypeError("Saved tool dataset is missing a valid tool class") from exc
-        if not mod_name or not qual:
+        mod_name, separator, qual = qualname.partition(":")
+        if not separator or not mod_name or not qual or ":" in qual:
             raise TypeError("Saved tool dataset is missing a valid tool class")
 
-        mod = importlib.import_module(mod_name)
-        cls_obj: object = mod
-        for attr in qual.split("."):
-            cls_obj = getattr(cls_obj, attr)
-        if not isinstance(cls_obj, type) or not issubclass(cls_obj, ToolWindow):
+        try:
+            cls_obj = _saved_tools.resolve_saved_tool_class(qualname)
+        except LookupError as exc:
+            raise TypeError("Saved tool class is not registered") from exc
+        if not issubclass(cls_obj, ToolWindow):
             raise TypeError("Saved tool class is not a ToolWindow subclass")
         return cls_obj
 
@@ -5734,6 +5839,13 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             kwargs.pop("_materialize_tool_data_references", False)
         )
         defer_restore_work = bool(kwargs.pop("_defer_restore_work", False))
+        document_trust = typing.cast(
+            "_DocumentTrust | None", kwargs.pop("_code_trust", None)
+        )
+        entry_locator = typing.cast(
+            "Callable[[Iterable[CodeTrustEntry]], tuple[CodeTrustEntry, ...]] | None",
+            kwargs.pop("_code_trust_entry_locator", None),
+        )
         ds = _serialization.restore_private_coords(ds, _SAVED_TOOL_DATA_NAME)
 
         saved_version = ds.attrs.get("erlab_version", "0.0.0")
@@ -5747,11 +5859,24 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         cls_obj = typing.cast(
             "type[typing.Self]", cls._saved_tool_class_from_dataset(ds)
         )
+        saved_status = cls_obj.StateModel.model_validate_json(ds.attrs["tool_state"])
+        saved_code_payload_entries = (
+            ()
+            if cls_obj._CODE_TRUST_DOMAIN is None
+            else code_payload_entries_from_metadata(ds.attrs)
+        )
+        if document_trust is None:
+            manifest = cls_obj._code_trust_manifest_from_saved_metadata(
+                saved_status, ds.attrs
+            )
+            document_trust = external_document_trust(manifest)
         data_items = cls_obj._tool_data_items_from_dataset(
             ds,
             source_parent_data=source_parent_data,
             reference_resolver=reference_resolver,
             materialize_references=materialize_data_references,
+            document_trust=document_trust,
+            entry_locator=entry_locator,
         )
 
         # Instantiate the class and set the status
@@ -5767,14 +5892,28 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             _TOOL_WINDOW_RESTORE_DEFER.reset(token)
         previous_restoring = False
         previous_defer_restore = False
+        tool._code_trust_entry_locator = entry_locator
         tool._restoring_from_dataset = True
         tool._defer_restored_tool_work = defer_restore_work
         restore_succeeded = False
         try:
+            actual_code_payload_entries = (
+                ()
+                if cls_obj._CODE_TRUST_DOMAIN is None
+                else tuple(tool._code_trust_payload_entries_from_dataset(ds))
+            )
+            if entry_locator is not None:
+                saved_code_payload_entries = entry_locator(saved_code_payload_entries)
+                actual_code_payload_entries = entry_locator(actual_code_payload_entries)
+            verified_document_trust = verify_document_payload_entries(
+                document_trust,
+                saved_code_payload_entries,
+                actual_code_payload_entries,
+            )
+            document_trust = verified_document_trust
+            tool.set_document_trust(document_trust, notify=False)
             with tool._history_suppressed():
-                tool.tool_status = cls_obj.StateModel.model_validate_json(
-                    ds.attrs["tool_state"]
-                )
+                tool.tool_status = saved_status
             tool._tool_display_name = ds.attrs.get("tool_display_name", "")
             source_spec = None
             if _TOOL_SOURCE_SPEC_ATTR in ds.attrs:
@@ -5883,9 +6022,25 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """
         from erlab.interactive.imagetool import _serialization
 
-        _serialization.encode_private_coords(
-            self.to_dataset(), _SAVED_TOOL_DATA_NAME
-        ).to_netcdf(filename, engine="h5netcdf", invalid_netcdf=True)
+        dataset = self.to_dataset()
+        saved_status = self.StateModel.model_validate_json(dataset.attrs["tool_state"])
+        manifest = self._code_trust_manifest_from_saved_metadata(
+            saved_status, dataset.attrs
+        )
+        _serialization.encode_private_coords(dataset, _SAVED_TOOL_DATA_NAME).to_netcdf(
+            filename, engine="h5netcdf", invalid_netcdf=True
+        )
+        if manifest is not None:
+            saved_trust, signature_stored = save_document_trust(
+                self._current_document_trust(),
+                manifest,
+            )
+            if self._code_trust_state_getter is None:
+                self.set_document_trust(saved_trust, notify=False)
+            if not signature_stored:
+                logger.warning(
+                    "Tool file was saved, but durable code trust could not be stored",
+                )
 
     @classmethod
     def from_file(cls, filename: str | os.PathLike, **kwargs) -> typing.Self:
@@ -5898,7 +6053,20 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         **kwargs
             Additional keyword arguments passed to the constructor.
         """
-        return cls.from_dataset(xr.load_dataset(filename, engine="h5netcdf"), **kwargs)
+        with xr.open_dataset(filename, engine="h5netcdf") as opened:
+            cls_obj = cls._saved_tool_class_from_dataset(opened)
+            status = cls_obj.StateModel.model_validate_json(opened.attrs["tool_state"])
+            manifest = cls_obj._code_trust_manifest_from_saved_metadata(
+                status, opened.attrs
+            )
+            document_trust = (
+                external_document_trust(None)
+                if manifest is None
+                else load_document_trust(manifest)
+            )
+            dataset = opened.load()
+        kwargs["_code_trust"] = document_trust
+        return cls.from_dataset(dataset, **kwargs)
 
     def duplicate(self, **kwargs) -> typing.Self:
         """Create a duplicate of the current tool window.
@@ -5917,7 +6085,312 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             The duplicated tool window.
 
         """
+        kwargs["_code_trust"] = self._current_document_trust()
         return self.from_dataset(self.to_dataset(), **kwargs)
+
+    @classmethod
+    def _code_trust_manifest_from_saved_metadata(
+        cls,
+        status: M,
+        attrs: Mapping[str, typing.Any],
+    ) -> CodeTrustManifest | None:
+        """Return executable content from saved state and opaque-payload metadata."""
+        if cls._CODE_TRUST_DOMAIN is None:
+            return None
+        source_spec = (
+            cls._saved_source_spec_from_metadata(attrs)
+            if _TOOL_SOURCE_SPEC_ATTR in attrs
+            else None
+        )
+        return create_manifest(
+            cls._CODE_TRUST_DOMAIN,
+            cls._CODE_TRUST_POLICY_VERSION,
+            (
+                *cls._code_trust_entries_from_status(status),
+                *code_payload_entries_from_metadata(attrs),
+                *cls._source_spec_code_trust_entries(source_spec),
+            ),
+        )
+
+    def _current_code_trust_manifest(self) -> CodeTrustManifest | None:
+        """Return executable content for the current in-memory document."""
+        if self._CODE_TRUST_DOMAIN is None:
+            return None
+        return create_manifest(
+            self._CODE_TRUST_DOMAIN,
+            self._CODE_TRUST_POLICY_VERSION,
+            (
+                *self._code_trust_entries_from_status(self._saved_tool_status()),
+                *self._code_trust_payload_entries(),
+                *self._source_spec_code_trust_entries(self._source_spec),
+            ),
+        )
+
+    @staticmethod
+    def _source_spec_code_trust_entries(
+        source_spec: ToolProvenanceSpec | None,
+    ) -> Iterable[CodeTrustEntry]:
+        if source_spec is None:
+            return ()
+        from erlab.interactive.imagetool._provenance._trust import (
+            provenance_code_trust_entries,
+        )
+
+        return provenance_code_trust_entries(
+            source_spec,
+            location_prefix="tool-source/provenance",
+        )
+
+    @classmethod
+    def _code_trust_entries_from_status(cls, status: M) -> Iterable[CodeTrustEntry]:
+        """Return feature entries included in the document trust manifest."""
+        return ()
+
+    def _current_document_trust(self) -> _DocumentTrust:
+        """Return trust from the current document host."""
+        if self._code_trust_state_getter is not None:
+            return self._code_trust_state_getter()
+        return self._document_trust
+
+    def _set_code_trust_host(
+        self,
+        issue_capability: Callable[..., object | None],
+        *,
+        local_edit_context: Callable[..., typing.Any],
+        state_getter: Callable[[], _DocumentTrust],
+        entry_locator: (
+            Callable[[Iterable[CodeTrustEntry]], tuple[CodeTrustEntry, ...]] | None
+        ) = None,
+    ) -> None:
+        """Use one document host for all managed code-trust decisions."""
+        previous_trust = self._current_document_trust()
+        self._code_trust_capability_issuer = issue_capability
+        self._code_trust_local_edit_context = local_edit_context
+        self._code_trust_state_getter = state_getter
+        self._code_trust_entry_locator = entry_locator
+        self._code_trust_banner.hide()
+        if self._current_document_trust() != previous_trust:
+            self._code_trust_changed()
+
+    @contextlib.contextmanager
+    def _local_code_edit(
+        self,
+        execution_entries: CodeTrustEntrySource,
+        *,
+        edited_entries: CodeTrustEntrySource,
+        focus_on_block: bool = False,
+    ) -> Iterator[object | None]:
+        """Authorize one explicit local edit and commit lineage on success."""
+        resolved_execution_entries = tuple(
+            execution_entries() if callable(execution_entries) else execution_entries
+        )
+        resolved_edited_entries = tuple(
+            edited_entries() if callable(edited_entries) else edited_entries
+        )
+        if self._code_trust_local_edit_context is not None:
+            if self._code_trust_entry_locator is not None:
+                resolved_execution_entries = self._code_trust_entry_locator(
+                    resolved_execution_entries
+                )
+                resolved_edited_entries = self._code_trust_entry_locator(
+                    resolved_edited_entries
+                )
+            with self._code_trust_local_edit_context(
+                resolved_execution_entries,
+                edited_entries=resolved_edited_entries,
+                focus_on_block=focus_on_block,
+            ) as capability:
+                yield capability
+            return
+
+        previous = self._document_trust
+        prospective, capability = issue_local_edit_capability(
+            previous,
+            resolved_execution_entries,
+            edited_entries=resolved_edited_entries,
+        )
+        previous_manifest = (
+            self._current_code_trust_manifest() if prospective != previous else None
+        )
+        if capability is None and focus_on_block:
+            self._code_trust_banner.setFocus()
+        previous_capability = self._code_trust_local_edit_capability
+        self._code_trust_local_edit_capability = capability
+        try:
+            yield capability
+        finally:
+            self._code_trust_local_edit_capability = previous_capability
+        if prospective != previous and self._document_trust == previous:
+            manifest = self._current_code_trust_manifest()
+            committed = commit_local_edit_trust(
+                previous,
+                capability,
+                () if previous_manifest is None else previous_manifest.entries,
+                () if manifest is None else manifest.entries,
+                edited_entries=resolved_edited_entries,
+            )
+            if committed != previous:
+                self.set_document_trust(committed)
+
+    def _authorize_code_execution(
+        self,
+        entries: CodeTrustEntrySource,
+        *,
+        focus_on_block: bool = False,
+    ) -> bool:
+        """Authorize executable entries with the current document decision."""
+        return (
+            self._issue_code_execution_capability(
+                entries, focus_on_block=focus_on_block
+            )
+            is not None
+        )
+
+    def _apply_local_code_inventory_change(
+        self,
+        previous_entries: CodeTrustEntrySource,
+        candidate_entries: CodeTrustEntrySource,
+        evaluation_entries: CodeTrustEntrySource,
+        change: Callable[[], None],
+        *,
+        focus_on_block: bool = False,
+    ) -> bool:
+        """Authorize evaluation, then apply and commit a code inventory change."""
+        resolved_previous = tuple(
+            previous_entries() if callable(previous_entries) else previous_entries
+        )
+        resolved_candidate = tuple(
+            candidate_entries() if callable(candidate_entries) else candidate_entries
+        )
+        resolved_evaluation = tuple(
+            evaluation_entries() if callable(evaluation_entries) else evaluation_entries
+        )
+        previous_identities = tuple(
+            entry.document_identity() for entry in resolved_previous
+        )
+        previous_identity_set = frozenset(previous_identities)
+        edited_entries = tuple(
+            entry
+            for entry in resolved_candidate
+            if entry.document_identity() not in previous_identity_set
+        )
+        with self._local_code_edit(
+            resolved_candidate,
+            edited_entries=edited_entries,
+            focus_on_block=focus_on_block,
+        ) as capability:
+            if not execution_capability_allows(capability, resolved_evaluation):
+                if focus_on_block:
+                    self._code_trust_banner.setFocus()
+                return False
+            change()
+        return True
+
+    def _review_code_candidate(
+        self,
+        entries: CodeTrustEntrySource,
+        *,
+        document_name: str,
+        object_name: str,
+        window_title: str,
+    ) -> object | None:
+        """Review external code and return a capability for only that candidate."""
+        resolved_entries = tuple(entries() if callable(entries) else entries)
+        if not resolved_entries:
+            return None
+        if self._CODE_TRUST_DOMAIN is None:
+            raise RuntimeError("Code candidate review requires a trust domain")
+        manifest = create_manifest(
+            self._CODE_TRUST_DOMAIN,
+            self._CODE_TRUST_POLICY_VERSION,
+            resolved_entries,
+        )
+        candidate_trust = approve_document_trust(
+            external_document_trust(manifest), manifest
+        )
+        _trust, capability = issue_execution_capability(
+            candidate_trust, resolved_entries
+        )
+        if not confirm_code_trust(
+            self,
+            manifest,
+            document_name=document_name,
+            object_name=object_name,
+            window_title=window_title,
+        ):
+            return None
+        return capability
+
+    def _issue_code_execution_capability(
+        self,
+        entries: CodeTrustEntrySource,
+        *,
+        focus_on_block: bool = False,
+    ) -> object | None:
+        """Issue a capability that allows the complete execution request."""
+        resolved_entries = tuple(entries() if callable(entries) else entries)
+        if self._code_trust_local_edit_capability is not None and (
+            execution_capability_allows(
+                self._code_trust_local_edit_capability,
+                resolved_entries,
+            )
+        ):
+            return self._code_trust_local_edit_capability
+        document_entries = resolved_entries
+        if self._code_trust_entry_locator is not None:
+            document_entries = self._code_trust_entry_locator(resolved_entries)
+        if self._code_trust_capability_issuer is not None:
+            capability = self._code_trust_capability_issuer(
+                document_entries, focus_on_block=focus_on_block
+            )
+        else:
+            trust, capability = issue_complete_execution_capability(
+                self._document_trust,
+                document_entries,
+            )
+            self.set_document_trust(trust, notify=False)
+        if execution_capability_allows(capability, document_entries):
+            return capability
+        if focus_on_block:
+            self._code_trust_banner.setFocus()
+        return None
+
+    def set_document_trust(
+        self,
+        trust: _DocumentTrust,
+        *,
+        notify: bool = True,
+    ) -> _DocumentTrust:
+        """Set standalone document trust and notify the feature when it changes."""
+        changed = trust != self._document_trust
+        self._document_trust = trust
+        if self._code_trust_state_getter is None:
+            self._code_trust_banner.setVisible(not document_trust_is_trusted(trust))
+        if changed and notify:
+            self._code_trust_changed()
+        return trust
+
+    def _code_trust_changed(self) -> None:
+        """React after document trust changes."""
+
+    def _review_code_trust(self) -> None:
+        manifest = self._current_code_trust_manifest()
+        if manifest is None:
+            return
+        if not manifest_has_code(manifest):
+            self.set_document_trust(
+                approve_document_trust(self._document_trust, manifest)
+            )
+            return
+        if not confirm_code_trust(
+            self,
+            manifest,
+            document_name="Document",
+            object_name="tool_code_trust_review_dialog",
+            window_title="Review Stored Code",
+        ):
+            return
+        self.set_document_trust(approve_document_trust(self._document_trust, manifest))
 
     def showEvent(self, event: QtGui.QShowEvent | None) -> None:
         self._flush_restore_work(run_on_show_only=True)

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -4493,7 +4493,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 )
 
         operations = tuple(
-            operation.model_copy(update={"framework_owned": True})
+            operation.model_copy(update={"uses_implicit_framework_imports": True})
             if isinstance(operation, ScriptCodeOperation)
             else operation
             for operation in operations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import logging
 import os
 import pathlib
 import re
+import shutil
 import sys
 import tempfile
 import threading
@@ -83,6 +84,9 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _TEST_OPTIONS_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH"
 _TEST_OPTIONS_MANAGED_ENV_VAR = "ERLAB_INTERACTIVE_OPTIONS_PATH_TEST_MANAGED"
 _TEST_INTERACTIVE_OPTIONS_PATHS: list[pathlib.Path] = []
+_TEST_CODE_TRUST_ENV_VAR = "ERLAB_CODE_TRUST_DIRECTORY"
+_TEST_CODE_TRUST_MANAGED_ENV_VAR = "ERLAB_CODE_TRUST_DIRECTORY_TEST_MANAGED"
+_TEST_CODE_TRUST_PATHS: list[pathlib.Path] = []
 _TEST_MANAGER_SETTINGS_ENV_VAR = "ERLAB_IMAGETOOL_MANAGER_SETTINGS_PATH"
 _TEST_MANAGER_SETTINGS_MANAGED_ENV_VAR = (
     "ERLAB_IMAGETOOL_MANAGER_SETTINGS_PATH_TEST_MANAGED"
@@ -111,6 +115,17 @@ def pytest_configure(config: pytest.Config) -> None:
         os.environ[_TEST_OPTIONS_ENV_VAR] = str(settings_path)
         os.environ[_TEST_OPTIONS_MANAGED_ENV_VAR] = "1"
         _TEST_INTERACTIVE_OPTIONS_PATHS.append(settings_path)
+
+    if (
+        _TEST_CODE_TRUST_ENV_VAR not in os.environ
+        or os.environ.get(_TEST_CODE_TRUST_MANAGED_ENV_VAR) == "1"
+    ):
+        trust_path = pathlib.Path(tempfile.gettempdir()) / (
+            f"erlabpy-test-code-trust-{worker_id}-{os.getpid()}-{uuid.uuid4().hex}"
+        )
+        os.environ[_TEST_CODE_TRUST_ENV_VAR] = str(trust_path)
+        os.environ[_TEST_CODE_TRUST_MANAGED_ENV_VAR] = "1"
+        _TEST_CODE_TRUST_PATHS.append(trust_path)
 
     if (
         _TEST_MANAGER_SETTINGS_ENV_VAR not in os.environ
@@ -309,6 +324,8 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             settings_path.unlink()
     for catalog_directory in _TEST_EXTENSION_CATALOG_DIRECTORIES:
         catalog_directory.cleanup()
+    for trust_path in _TEST_CODE_TRUST_PATHS:
+        shutil.rmtree(trust_path, ignore_errors=True)
 
     if _XDIST_WORKER_ERRORS:
         session.exitstatus = pytest.ExitCode.TESTS_FAILED

--- a/tests/interactive/imagetool/manager/figurecomposer/_common.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/_common.py
@@ -285,7 +285,6 @@ def _custom_order_step(label: str) -> FigureOperationState:
     return FigureOperationState.custom(
         label=label,
         code=f"fig.__dict__['_order'] = fig.__dict__.get('_order', []) + [{label!r}]",
-        trusted=True,
     )
 
 

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -351,7 +351,7 @@ def test_figure_document_renames_source_references_atomically() -> None:
             operations=(
                 FigureOperationState.plot_array(label="array", source="selected"),
                 FigureOperationState.custom(
-                    label="python", code="result = data + selected", trusted=True
+                    label="python", code="result = data + selected"
                 ),
             ),
             primary_source="data",
@@ -374,7 +374,7 @@ def test_figure_document_renames_source_references_atomically() -> None:
         update={
             "operations": (
                 FigureOperationState.custom(
-                    label="ambiguous", code="renamed = renamed + 1", trusted=True
+                    label="ambiguous", code="renamed = renamed + 1"
                 ),
             )
         }
@@ -714,7 +714,7 @@ def test_figure_document_pastes_operations_and_sources_atomically() -> None:
     )
     preserved_result = preserved.paste_operations(
         0,
-        (FigureOperationState.custom(label="code", code="pass", trusted=True),),
+        (FigureOperationState.custom(label="code", code="pass"),),
         (metadata_source,),
         {"metadata_only": data},
         {},
@@ -895,9 +895,7 @@ def test_operation_metadata_covers_every_operation_kind() -> None:
             "method_plot_yerr": FigureMethodPlotValueState(source="third"),
         }
     )
-    custom = FigureOperationState.custom(
-        label="custom", code="result = second + first", trusted=False
-    )
+    custom = FigureOperationState.custom(label="custom", code="result = second + first")
     operations = (
         FigureOperationState(kind=FigureOperationKind.SET_PALETTE, label="palette"),
         plot_array,
@@ -984,7 +982,10 @@ def test_operation_metadata_covers_every_operation_kind() -> None:
     )
     assert document.operation_source_names(custom) == ("first", "second")
     assert document.direct_sources_used_by_recipe() == {"first", "second"}
-    assert document.direct_sources_used_by_recipe(executable_only=True) == set()
+    assert document.direct_sources_used_by_recipe(executable_only=True) == {
+        "first",
+        "second",
+    }
 
 
 def test_figure_composer_operation_modules_use_editor_signal_contract() -> None:
@@ -1546,7 +1547,6 @@ def test_figure_composer_generated_code_skips_disabled_operations(qtbot) -> None
                 FigureOperationState.custom(
                     label="disabled Python",
                     code="raise RuntimeError('must not run')",
-                    trusted=True,
                 ).model_copy(update={"enabled": False}),
             ),
             primary_source="data",

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -12,6 +12,10 @@ import erlab.interactive._figurecomposer._codegen as figurecomposer_codegen
 import erlab.interactive._figurecomposer._rendering as figurecomposer_rendering
 import erlab.interactive._figurecomposer._tool as figurecomposer_tool_module
 import erlab.interactive._stylesheets
+from erlab.interactive._code_trust import (
+    document_trust_has_trusted_lineage,
+    new_document_trust,
+)
 from erlab.interactive._figurecomposer import (
     FigureComposerTool,
     FigureGridSpecAxesState,
@@ -29,9 +33,6 @@ from erlab.interactive._figurecomposer._model import (
 )
 from erlab.interactive._figurecomposer._operations import (
     _custom_code as figurecomposer_custom_code_operation,
-)
-from erlab.interactive._figurecomposer._ui import (
-    _operation_panel as figurecomposer_operation_panel,
 )
 
 from ._common import (
@@ -59,7 +60,6 @@ def test_figure_composer_custom_code_helpers_cover_codegen_paths(qtbot) -> None:
             "arr = xr.DataArray(values)\n"
             "eplt.clean_labels(ax)"
         ),
-        trusted=True,
     )
     assert (
         figurecomposer_custom_code_operation._section_summary(
@@ -110,11 +110,8 @@ def test_figure_composer_custom_code_helpers_cover_codegen_paths(qtbot) -> None:
         == frozenset()
     )
     assert figurecomposer_custom_code_operation._custom_axes_alias_lines(tool) == []
-    assert (
-        figurecomposer_custom_code_operation._code_lines(
-            tool, operation.model_copy(update={"trusted": False})
-        )
-        == []
+    assert operation.code in "\n".join(
+        figurecomposer_custom_code_operation._code_lines(tool, operation)
     )
     assert (
         figurecomposer_custom_code_operation._required_imports(
@@ -480,7 +477,6 @@ def test_figure_composer_custom_code_read_write_source_is_dependency(
     operation = FigureOperationState.custom(
         label="read-write source",
         code=code,
-        trusted=True,
     )
     tool = FigureComposerTool(
         data,
@@ -512,7 +508,6 @@ def test_figure_composer_source_rename_refactors_custom_python(qtbot) -> None:
                 FigureOperationState.custom(
                     label="summary",
                     code=code,
-                    trusted=True,
                 ),
             ),
             primary_source="data",
@@ -547,7 +542,6 @@ def test_figure_composer_source_rename_rejects_ambiguous_python(
     operation = FigureOperationState.custom(
         label="summary",
         code=code,
-        trusted=True,
     )
     tool = FigureComposerTool(
         data,
@@ -573,7 +567,6 @@ def test_figure_composer_custom_code_editor_is_multiline_and_debounced(
     operation = FigureOperationState.custom(
         label="code",
         code="ax.set_title('old')",
-        trusted=True,
     )
     tool = FigureComposerTool(
         data,
@@ -633,7 +626,6 @@ def test_figure_composer_custom_code_editor_skips_render_until_valid_python(
     operation = FigureOperationState.custom(
         label="code",
         code="ax.set_title('old')",
-        trusted=True,
     )
     tool = FigureComposerTool(
         data,
@@ -694,12 +686,10 @@ def test_figure_composer_custom_code_pending_edit_survives_step_switch(
     first_operation = FigureOperationState.custom(
         label="first",
         code="ax.set_title('old')",
-        trusted=True,
     )
     second_operation = FigureOperationState.custom(
         label="second",
         code="ax.set_xlabel('other')",
-        trusted=True,
     )
     tool = FigureComposerTool(
         data,
@@ -740,7 +730,6 @@ def test_figure_composer_custom_code_pending_edit_flushes_on_close(qtbot) -> Non
     operation = FigureOperationState.custom(
         label="code",
         code="ax.set_title('old')",
-        trusted=True,
     )
     tool = FigureComposerTool(
         data,
@@ -789,7 +778,6 @@ def test_figure_composer_custom_code_uses_public_nonuniform_dims(qtbot) -> None:
             "assert 'sample_temp' in data.dims\n"
             "assert 'sample_temp_idx' not in data.dims"
         ),
-        trusted=True,
     )
     tool = FigureComposerTool(
         internal,
@@ -840,7 +828,6 @@ def test_figure_composer_recipe_codegen_and_loaded_custom_code_trust(qtbot) -> N
                 FigureOperationState.custom(
                     label="custom",
                     code="ax.set_title('trusted')",
-                    trusted=True,
                 ),
             ),
             primary_source=status.primary_source,
@@ -850,7 +837,9 @@ def test_figure_composer_recipe_codegen_and_loaded_custom_code_trust(qtbot) -> N
 
     loaded = erlab.interactive.utils.ToolWindow.from_dataset(custom_tool.to_dataset())
     qtbot.addWidget(loaded)
-    assert loaded.tool_status.operations[0].trusted is False
+    assert not document_trust_has_trusted_lineage(loaded._document_trust)
+    assert "trusted" not in loaded.tool_status.operations[0].model_dump()
+    assert "set_title" in loaded.generated_code()
 
 
 def test_figure_composer_custom_code_codegen_namespace(qtbot) -> None:
@@ -871,7 +860,6 @@ def test_figure_composer_custom_code_codegen_namespace(qtbot) -> None:
                         "ax.set_title(str(np.array([1])[0]))\n"
                         "fig.__dict__['_eplt_name'] = eplt.__name__"
                     ),
-                    trusted=True,
                 ),
             ),
             primary_source="data",
@@ -906,7 +894,6 @@ def test_figure_composer_custom_code_codegen_nested_class_import(qtbot) -> None:
                         "    return Result\n"
                         "fig.custom_total = build().total"
                     ),
-                    trusted=True,
                 ),
             ),
             primary_source="data",
@@ -950,7 +937,6 @@ def test_figure_composer_custom_code_sources_drive_usage_and_full_replay(
                         "import statistics\n"
                         "fig.source_mean = statistics.fmean([float(custom_source)])"
                     ),
-                    trusted=True,
                 ),
                 FigureOperationState.line(label="line", source="custom_source"),
             ),
@@ -1000,7 +986,6 @@ def test_figure_composer_source_name_map_does_not_rewrite_custom_locals(
                 FigureOperationState.custom(
                     label="custom",
                     code=("data_0 = 1\nfig.__dict__['custom_data_0'] = data_0"),
-                    trusted=True,
                 ),
             ),
             primary_source="data_0",
@@ -1040,7 +1025,6 @@ def test_figure_composer_source_name_map_assigns_custom_aliases_simultaneously(
                         "fig.__dict__['custom_values'] = "
                         "(float(a.values[0]), float(b.values[0]))"
                     ),
-                    trusted=True,
                 ),
             ),
             primary_source="a",
@@ -1169,7 +1153,6 @@ def test_figure_composer_source_alias_editor_rejects_ambiguous_python(qtbot) -> 
                 FigureOperationState.custom(
                     label="summary",
                     code="data = data.mean()",
-                    trusted=True,
                 ),
             ),
             primary_source="data",
@@ -1233,7 +1216,6 @@ def test_figure_composer_custom_code_codegen_gridspec_axes_alias(qtbot) -> None:
                         "axs['main-axis'].set_xlabel('energy')\n"
                         "fig.custom_total = float(np.sum())"
                     ),
-                    trusted=True,
                 ),
             ),
             primary_source="data",
@@ -1253,7 +1235,7 @@ def test_figure_composer_custom_code_codegen_gridspec_axes_alias(qtbot) -> None:
     assert namespace["fig"].custom_total == 3.0
 
 
-def test_figure_composer_untrusted_custom_code_reports_render_error(qtbot) -> None:
+def test_figure_composer_untrusted_custom_code_is_paused(qtbot) -> None:
     data = xr.DataArray(
         np.arange(4.0),
         dims=("x",),
@@ -1263,9 +1245,8 @@ def test_figure_composer_untrusted_custom_code_reports_render_error(qtbot) -> No
     operation = FigureOperationState.custom(
         label="custom",
         code="ax.set_title('loaded')",
-        trusted=False,
     )
-    tool = FigureComposerTool(
+    local_tool = FigureComposerTool(
         data,
         recipe=FigureRecipeState(
             sources=(FigureSourceState(name="data", label="data"),),
@@ -1273,35 +1254,25 @@ def test_figure_composer_untrusted_custom_code_reports_render_error(qtbot) -> No
             primary_source="data",
         ),
     )
+    tool = erlab.interactive.utils.ToolWindow.from_dataset(local_tool.to_dataset())
+    assert isinstance(tool, FigureComposerTool)
     qtbot.addWidget(tool)
     tool.show_figure_window(activate=False)
 
     item = tool.operation_panel.operation_list.topLevelItem(0)
     assert item is not None
-    assert _operation_status_codes(tool, 0) == ("render_error",)
-    assert "Custom code is not trusted" in item.toolTip(
-        figurecomposer_operation_panel._OPERATION_LIST_STATUS_COLUMN
-    )
+    assert _operation_status_codes(tool, 0) == ()
+    assert not document_trust_has_trusted_lineage(tool._document_trust)
+    assert not tool._code_trust_banner.isHidden()
+    assert tool.figure.axes[0].get_title() == ""
     assert _operation_source_status_label(tool).isHidden()
 
-    tool.operation_panel.operation_list.setCurrentItem(
-        tool.operation_panel.operation_list.topLevelItem(0)
-    )
-    tool.operation_editor.select_section("code")
-    trusted_check = tool.operation_editor.stack.currentWidget().findChild(
-        QtWidgets.QCheckBox, "figureComposerCustomCodeTrustedCheck"
-    )
-    assert trusted_check is not None
-    assert not trusted_check.isChecked()
+    tool.set_document_trust(new_document_trust())
 
-    trusted_check.setChecked(True)
-
-    assert tool.tool_status.operations[0].trusted is True
-    qtbot.waitUntil(lambda: not tool._operation_render_errors, timeout=1000)
+    qtbot.waitUntil(lambda: tool.figure.axes[0].get_title() == "loaded", timeout=1000)
     item = tool.operation_panel.operation_list.topLevelItem(0)
     assert item is not None
     assert _operation_status_codes(tool, 0) == ()
-    assert "Custom code is not trusted" not in item.toolTip(
-        figurecomposer_operation_panel._OPERATION_LIST_STATUS_COLUMN
-    )
+    assert tool._code_trust_banner.isHidden()
+    assert tool.figure.axes[0].get_title() == "loaded"
     assert _operation_source_status_label(tool).isHidden()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_live_style.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_live_style.py
@@ -108,7 +108,6 @@ def test_figure_composer_live_colormap_falls_back_for_earlier_custom_step(
     custom = FigureOperationState.custom(
         label="mutate",
         code="data.values[:] += 1.0",
-        trusted=True,
     )
     tool = _visible_image_tool(
         qtbot,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_creation.py
@@ -1367,7 +1367,6 @@ def test_manager_custom_figure_code_uses_readable_source_aliases(
                     "operation": FigureOperationState.custom(
                         label="summary",
                         code=code,
-                        trusted=True,
                     )
                 }
             else:
@@ -1393,7 +1392,6 @@ def test_manager_custom_figure_code_uses_readable_source_aliases(
                 "operation": FigureOperationState.custom(
                     label="ambiguous",
                     code=ambiguous_code,
-                    trusted=True,
                 )
             },
             {"custom_code": ambiguous_code},

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -1626,6 +1626,7 @@ def test_manager_figure_workspace_reference_helper_edges(
                 objects=(),
             ),
             compression_mode="none",
+            trusted_lineage=True,
             serialized_tool_data_references=(
                 ("missing", "missing-token", {}),
                 (root_node.uid, root_node.snapshot_token, {}),

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -761,8 +761,6 @@ def test_figure_composer_method_helper_edge_contracts(
     assert tool.tool_status.operations[1].method_kwargs == {}
     method_editor._update_current_method_kwarg(tool.operation_editor, "pad", 0.3)
     assert tool.tool_status.operations[1].method_kwargs == {"pad": 0.3}
-    method_editor._operation_trust_update_callback(tool.operation_editor)(True)
-    assert tool.tool_status.operations[1].trusted is True
     method_editor._method_float_pair_args_update_callback(tool.operation_editor)("0, 1")
     assert tool.tool_status.operations[1].method_args == (0.0, 1.0)
     method_editor._update_current_method_family(
@@ -1919,10 +1917,10 @@ def test_figure_composer_loaded_method_canonicalizes_control_aliases(
 
     if name == "suptitle":
         loaded = method_state._loaded_operation(
-            operation.model_copy(update={"method_transform": "custom", "trusted": True})
+            operation.model_copy(update={"method_transform": "custom"})
         )
         assert loaded.method_kwargs == expected
-        assert not loaded.trusted
+        assert "trusted" not in loaded.model_dump()
 
 
 def test_figure_composer_loaded_method_preserves_semantic_none() -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
@@ -16,6 +16,10 @@ import erlab.interactive._figurecomposer._rendering as figurecomposer_rendering
 import erlab.interactive._figurecomposer._ui._tick_params as figurecomposer_tick_params
 import erlab.interactive._stylesheets
 import erlab.plotting as eplt
+from erlab.interactive._code_trust import (
+    document_trust_has_trusted_lineage,
+    new_document_trust,
+)
 from erlab.interactive._figurecomposer import (
     FigureAxesSelectionState,
     FigureComposerTool,
@@ -780,15 +784,10 @@ def test_figure_composer_method_custom_transform_errors() -> None:
             "method_transform_expression": "ax.transAxes",
         }
     )
-    empty = untrusted.model_copy(
-        update={"trusted": True, "method_transform_expression": ""}
-    )
-    not_transform = untrusted.model_copy(
-        update={"trusted": True, "method_transform_expression": "1"}
-    )
+    empty = untrusted.model_copy(update={"method_transform_expression": ""})
+    not_transform = untrusted.model_copy(update={"method_transform_expression": "1"})
 
-    with pytest.raises(ValueError, match="not trusted"):
-        method_execution._method_transform_code(untrusted, spec)
+    assert method_execution._method_transform_code(untrusted, spec) is not None
     with pytest.raises(ValueError, match="empty"):
         method_execution._method_transform_code(empty, spec)
     with pytest.raises(ValueError, match="empty"):
@@ -828,7 +827,6 @@ def test_figure_composer_loaded_custom_method_transform_requires_trust(qtbot) ->
                         "method_args": ((0.0, 1.0),),
                         "method_transform": "custom",
                         "method_transform_expression": "ax.transAxes",
-                        "trusted": True,
                     }
                 ),
             ),
@@ -843,12 +841,18 @@ def test_figure_composer_loaded_custom_method_transform_requires_trust(qtbot) ->
     operation = loaded.tool_status.operations[0]
     assert operation.method_transform == "custom"
     assert operation.method_transform_expression == "ax.transAxes"
-    assert operation.trusted is False
+    assert not document_trust_has_trusted_lineage(loaded._document_trust)
+    assert "trusted" not in operation.model_dump()
 
     figurecomposer_rendering._render_into_figure(
         loaded, loaded.figure, sync_visible=False
     )
-    assert "not trusted" in loaded._operation_render_errors[operation.operation_id]
+    assert loaded._operation_render_errors == {}
+    assert len(loaded.figure.axes[0].lines) == 0
+
+    loaded.set_document_trust(new_document_trust())
+
+    assert len(loaded.figure.axes[0].lines) == 1
 
 
 def test_figure_composer_figure_method_has_no_axes_target(qtbot) -> None:
@@ -1437,7 +1441,6 @@ def test_figure_composer_draw_error_follows_later_artist_mutation(qtbot) -> None
     mutation_operation = FigureOperationState.custom(
         label="invalid dashes",
         code="axs[0, 0].lines[0].set_dashes([1, -1])",
-        trusted=True,
     )
     tool = FigureComposerTool(
         data,
@@ -1466,7 +1469,6 @@ def test_figure_composer_draw_error_marks_axes_mutation(qtbot) -> None:
     mutation_operation = FigureOperationState.custom(
         label="invalid aspect",
         code="axs[0, 0].set_aspect('equal', adjustable='datalim')",
-        trusted=True,
     )
     tool = FigureComposerTool(
         data,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method_plot_data.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method_plot_data.py
@@ -133,7 +133,6 @@ def test_figure_composer_axes_plot_method_render_and_codegen(qtbot) -> None:
                         "method_args": ((0.0, 0.25, 1.0),),
                         "method_transform": "custom",
                         "method_transform_expression": "ax.transAxes",
-                        "trusted": True,
                     }
                 ),
             ),
@@ -226,9 +225,8 @@ def test_figure_composer_axes_plot_method_render_and_codegen(qtbot) -> None:
         QtWidgets.QCheckBox, "figureComposerMethodTransformTrustedCheck"
     )
     assert custom_transform_edit is not None
-    assert custom_transform_trusted is not None
+    assert custom_transform_trusted is None
     assert custom_transform_edit.text() == "ax.transAxes"
-    assert custom_transform_trusted.isChecked()
 
     fig = tool.figure
     figurecomposer_rendering._render_into_figure(tool, fig, sync_visible=False)

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices_cache.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices_cache.py
@@ -146,7 +146,6 @@ def test_custom_code_disables_plot_slices_selection_cache(qtbot) -> None:
     custom = FigureOperationState.custom(
         label="mutate",
         code="data.values[:] += 1.0",
-        trusted=True,
     )
     second = _slice_operation("after", axes=((0, 1),))
     tool = _slices_tool(data, first, custom, second)
@@ -174,7 +173,6 @@ def test_custom_code_only_render_invalidates_previous_selection(qtbot) -> None:
     custom = FigureOperationState.custom(
         label="mutate",
         code="data.values[:] += 1.0",
-        trusted=True,
     )
     original_recipe = tool.tool_status
     tool._document.replace_recipe(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -1972,7 +1972,7 @@ def test_figure_composer_source_selection_helper_edges(qtbot) -> None:
     ).sources == ("data",)
     assert (
         FigureComposerTool._operation_without_map_selections(
-            FigureOperationState.custom(label="custom", code="pass", trusted=True),
+            FigureOperationState.custom(label="custom", code="pass"),
             None,
         ).map_selections
         == ()
@@ -3571,7 +3571,7 @@ def test_figure_composer_source_inspector_tracks_source_tab_selection(qtbot) -> 
         ),
         operations=(
             FigureOperationState.line(label="first line", source="first"),
-            FigureOperationState.custom(label="custom", code="pass", trusted=True),
+            FigureOperationState.custom(label="custom", code="pass"),
         ),
         primary_source="first",
     )
@@ -3916,7 +3916,6 @@ def test_figure_composer_provenance_replays_transitive_selected_source_chain(
             FigureOperationState.custom(
                 label="reserve source name",
                 code="sample_map = -1",
-                trusted=True,
             ),
             FigureOperationState.line(label="profile", source="selected_v"),
         ),
@@ -5061,7 +5060,7 @@ def test_figure_composer_legacy_source_selection_defensive_paths(qtbot) -> None:
     assert converted_sources.map_selections == ()
     assert (
         FigureComposerTool._legacy_selection_fallback_source(
-            FigureOperationState.custom(label="custom", code="pass", trusted=True),
+            FigureOperationState.custom(label="custom", code="pass"),
             "base",
         )
         is None

--- a/tests/interactive/imagetool/manager/figurecomposer/test_trust.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_trust.py
@@ -1,0 +1,575 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+from qtpy import QtWidgets
+
+import erlab.interactive._figurecomposer._rendering as figurecomposer_rendering
+import erlab.interactive.utils
+from erlab.interactive._code_trust import (
+    create_manifest,
+    document_trust_has_trusted_lineage,
+    document_trust_is_trusted,
+    external_document_trust,
+    new_document_trust,
+    untrusted_document_trust,
+)
+from erlab.interactive._code_trust._api import _document_trust_after_save
+from erlab.interactive._code_trust._application import (
+    load_document_trust,
+    reset_saved_code_trust,
+)
+from erlab.interactive._figurecomposer import FigureComposerTool, FigureSourceState
+from erlab.interactive._figurecomposer._model._state import (
+    FigureMethodFamily,
+    FigureOperationState,
+    FigureRecipeState,
+)
+from erlab.interactive._figurecomposer._trust import (
+    figure_code_trust_entries,
+    figure_operation_execution_entries,
+)
+
+
+def _custom_recipe(code: str = "pass") -> FigureRecipeState:
+    return FigureRecipeState(
+        operations=(FigureOperationState.custom(label="custom", code=code),)
+    )
+
+
+def _custom_tool(qtbot, code: str = "pass") -> FigureComposerTool:
+    tool = FigureComposerTool(
+        xr.DataArray(np.arange(2.0), dims="x"), recipe=_custom_recipe(code)
+    )
+    qtbot.addWidget(tool)
+    return tool
+
+
+def _manifest_bytes(recipe: FigureRecipeState) -> bytes:
+    return create_manifest(
+        "erlab.workspace",
+        1,
+        figure_code_trust_entries(recipe, location_prefix="figures/0"),
+    ).canonical_bytes()
+
+
+def test_figure_code_trust_entries_capture_code_and_execution_context() -> None:
+    custom = FigureOperationState.custom(label="custom", code="ax.plot([1, 2])")
+    method = FigureOperationState.method(
+        family=FigureMethodFamily.AXES,
+        name="text",
+    ).model_copy(
+        update={
+            "enabled": False,
+            "method_transform": "data",
+            "method_transform_expression": "ax.transAxes",
+        }
+    )
+
+    entries = figure_code_trust_entries(
+        FigureRecipeState(operations=(custom, method)), location_prefix="figures/0"
+    )
+
+    assert [entry.feature for entry in entries] == [
+        "erlab.figure-composer.custom-code",
+        "erlab.figure-composer.custom-transform",
+    ]
+    assert entries[0].code == "ax.plot([1, 2])"
+    assert entries[0].location == "figures/0/operations/0"
+    assert entries[1].context["enabled"] is False
+    assert entries[1].context["transform"] == "data"
+
+
+def test_figure_code_trust_entries_ignore_empty_code() -> None:
+    assert not figure_code_trust_entries(
+        _custom_recipe(""), location_prefix="figures/0"
+    )
+
+
+def test_figure_code_trust_entries_ignore_source_provenance_containers() -> None:
+    recipe = FigureRecipeState(
+        sources=(
+            FigureSourceState(
+                name="data",
+                label="data",
+                provenance_spec={"kind": "script"},
+            ),
+        )
+    )
+
+    entries = figure_code_trust_entries(recipe, location_prefix="figure")
+
+    assert entries == ()
+
+
+def test_figure_operation_execution_entries_only_include_executed_code() -> None:
+    custom = FigureOperationState.custom(label="custom", code="pass")
+    preset_transform = FigureOperationState.method(
+        family=FigureMethodFamily.AXES, name="plot"
+    ).model_copy(update={"method_transform_expression": "ax.transAxes"})
+    custom_transform = preset_transform.model_copy(
+        update={"method_transform": "custom"}
+    )
+
+    recipe = FigureRecipeState(operations=(custom, preset_transform, custom_transform))
+
+    assert figure_operation_execution_entries(recipe, 0, location_prefix="figure")
+    assert not figure_operation_execution_entries(recipe, 1, location_prefix="figure")
+    assert figure_operation_execution_entries(recipe, 2, location_prefix="figure")
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        FigureOperationState.method(
+            family=FigureMethodFamily.AXES,
+            name="set_title",
+        ).model_copy(
+            update={
+                "method_transform": "custom",
+                "method_transform_expression": "ax.transAxes",
+            }
+        ),
+        FigureOperationState.custom(label="custom", code="").model_copy(
+            update={
+                "method_transform": "custom",
+                "method_transform_expression": "ax.transAxes",
+            }
+        ),
+    ],
+)
+def test_figure_code_trust_ignores_unreachable_transform_expression(
+    operation: FigureOperationState,
+) -> None:
+    recipe = FigureRecipeState(operations=(operation,))
+
+    assert not figure_code_trust_entries(recipe, location_prefix="figure")
+    assert not figure_operation_execution_entries(recipe, 0, location_prefix="figure")
+
+
+def test_invalid_operation_does_not_request_code_authorization(
+    qtbot, monkeypatch
+) -> None:
+    tool = FigureComposerTool(
+        xr.DataArray(np.arange(3.0), dims="x", name="data"),
+        recipe=FigureRecipeState(
+            operations=(
+                FigureOperationState.custom(label="custom", code="raise RuntimeError"),
+            )
+        ),
+    )
+    qtbot.addWidget(tool)
+    monkeypatch.setattr(
+        tool.operation_editor,
+        "has_input_error",
+        lambda _operation: True,
+    )
+    monkeypatch.setattr(
+        tool,
+        "_authorize_code_execution",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid operation requested code authorization"
+        ),
+    )
+    monkeypatch.setattr(
+        tool,
+        "_issue_code_execution_capability",
+        lambda *_args, **_kwargs: pytest.fail(
+            "invalid operation requested an execution capability"
+        ),
+    )
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getSaveFileName",
+        lambda *_args, **_kwargs: ("", ""),
+    )
+
+    figurecomposer_rendering._render_into_figure(
+        tool,
+        tool.figure,
+        sync_visible=False,
+    )
+    tool.export_figure()
+
+
+def test_figure_render_keeps_capability_at_execution_boundary(
+    qtbot, monkeypatch
+) -> None:
+    tool = _custom_tool(qtbot, "ax.set_title('guarded')")
+    original_execute = figurecomposer_rendering.execute_with_capability
+    guarded_calls: list[object] = []
+
+    def execute_with_capability(capability, entries, execute):
+        assert capability is not None
+        guarded_calls.append(capability)
+        return original_execute(capability, entries, execute)
+
+    monkeypatch.setattr(
+        figurecomposer_rendering,
+        "execute_with_capability",
+        execute_with_capability,
+    )
+
+    figurecomposer_rendering._render_into_figure(
+        tool,
+        tool.figure,
+        sync_visible=False,
+    )
+
+    assert guarded_calls
+    assert tool.figure.axes[0].get_title() == "guarded"
+
+
+def test_figure_operation_discards_legacy_trusted_field() -> None:
+    operation = FigureOperationState.model_validate(
+        {
+            "kind": "custom",
+            "label": "custom",
+            "code": "pass",
+            "trusted": True,
+        }
+    )
+
+    assert "trusted" not in operation.model_dump()
+
+
+def test_figure_manifest_tracks_execution_controls_but_not_review_labels() -> None:
+    first = FigureOperationState.custom(label="First label", code="ax.plot([1])")
+    second = FigureOperationState.custom(label="Second", code="ax.plot([2])")
+
+    def canonical(*operations: FigureOperationState) -> bytes:
+        return _manifest_bytes(FigureRecipeState(operations=operations))
+
+    baseline = canonical(first, second)
+    assert baseline == canonical(first.model_copy(update={"label": "Renamed"}), second)
+    assert baseline != canonical(
+        first.model_copy(update={"code": "ax.plot([3])"}), second
+    )
+    assert baseline != canonical(second, first)
+    assert baseline != canonical(first.model_copy(update={"enabled": False}), second)
+    assert baseline != canonical(
+        first.model_copy(update={"sources": ("alternate",)}), second
+    )
+
+
+def test_figure_manifest_ignores_safe_rendering_pipeline_state() -> None:
+    setup_title = FigureOperationState.method(
+        family=FigureMethodFamily.AXES,
+        name="set_title",
+        args=("safe title",),
+    )
+    custom = FigureOperationState.custom(
+        label="custom",
+        code="result = ax.get_title()",
+    )
+
+    recipe = FigureRecipeState(operations=(setup_title, custom))
+    baseline = _manifest_bytes(recipe)
+
+    assert baseline == _manifest_bytes(
+        recipe.model_copy(
+            update={
+                "operations": (
+                    setup_title.model_copy(update={"method_args": ("changed",)}),
+                    custom,
+                )
+            }
+        )
+    )
+    assert baseline == _manifest_bytes(
+        recipe.model_copy(
+            update={"setup": recipe.setup.model_copy(update={"figsize": (8.0, 4.0)})}
+        )
+    )
+    assert baseline == _manifest_bytes(
+        recipe.model_copy(
+            update={
+                "operations": (
+                    setup_title.model_copy(update={"label": "Renamed"}),
+                    custom,
+                )
+            }
+        )
+    )
+    assert baseline == _manifest_bytes(
+        recipe.model_copy(
+            update={"export": recipe.export.model_copy(update={"dpi": 300.0})}
+        )
+    )
+
+
+def test_figure_manifest_tracks_custom_code_namespace() -> None:
+    operation = FigureOperationState.custom(label="custom", code="data.plot(ax=ax)")
+    source = FigureSourceState(name="data", label="First label")
+
+    recipe = FigureRecipeState(sources=(source,), operations=(operation,))
+    baseline = _manifest_bytes(recipe)
+
+    assert baseline == _manifest_bytes(
+        recipe.model_copy(
+            update={"sources": (source.model_copy(update={"label": "Renamed"}),)}
+        )
+    )
+    assert baseline != _manifest_bytes(
+        recipe.model_copy(
+            update={"sources": (source.model_copy(update={"name": "other"}),)}
+        )
+    )
+    assert baseline != _manifest_bytes(
+        recipe.model_copy(
+            update={"setup": recipe.setup.model_copy(update={"ncols": 2})}
+        )
+    )
+
+
+def test_figure_manifest_tracks_custom_transform_mode() -> None:
+    operation = FigureOperationState.method(
+        family=FigureMethodFamily.AXES, name="text"
+    ).model_copy(
+        update={
+            "method_transform": "custom",
+            "method_transform_expression": "ax.transAxes",
+        }
+    )
+    changed = operation.model_copy(update={"method_transform": "data"})
+
+    assert figure_code_trust_entries(
+        FigureRecipeState(operations=(operation,)), location_prefix="figures/0"
+    ) != figure_code_trust_entries(
+        FigureRecipeState(operations=(changed,)), location_prefix="figures/0"
+    )
+
+
+@pytest.mark.parametrize("initial_reason", ["signature", "no_code", "untrusted"])
+def test_local_figure_code_edit_never_requires_review(
+    qtbot,
+    initial_reason: str,
+) -> None:
+    tool = FigureComposerTool(
+        xr.DataArray(np.arange(3.0), dims="x", name="data"),
+        recipe=(
+            FigureRecipeState()
+            if initial_reason == "no_code"
+            else _custom_recipe("ax.set_title('before')")
+        ),
+    )
+    qtbot.addWidget(tool)
+    manifest = tool._current_code_trust_manifest()
+    assert manifest is not None
+    if initial_reason == "signature":
+        trust = _document_trust_after_save(
+            new_document_trust(),
+            manifest,
+            saved_trusted_lineage=True,
+            signature_stored=True,
+        )
+    elif initial_reason == "no_code":
+        trust = external_document_trust(manifest)
+    else:
+        trust = untrusted_document_trust(manifest)
+    tool.set_document_trust(trust)
+
+    tool.tool_status = tool.tool_status.model_copy(
+        update={
+            "operations": (
+                FigureOperationState.custom(
+                    label="custom",
+                    code="ax.set_title('locally edited')",
+                ),
+            )
+        }
+    )
+
+    assert document_trust_has_trusted_lineage(tool._document_trust)
+    assert tool.figure.axes[0].get_title() == "locally edited"
+
+
+def test_local_figure_edit_authorizes_only_edited_identity(qtbot) -> None:
+    external_first = FigureOperationState.custom(
+        label="first", code="ax.set_title('external first')"
+    )
+    external_second = FigureOperationState.custom(
+        label="second", code="ax.set_title('external second')"
+    )
+    tool = FigureComposerTool(
+        xr.DataArray(np.arange(3.0), dims="x", name="data"),
+        recipe=FigureRecipeState(operations=(external_first, external_second)),
+    )
+    qtbot.addWidget(tool)
+    manifest = tool._current_code_trust_manifest()
+    assert manifest is not None
+    tool.set_document_trust(untrusted_document_trust(manifest), notify=False)
+
+    local_first = FigureOperationState.custom(
+        label="first", code="ax.set_title('local first')"
+    )
+    tool.tool_status = tool.tool_status.model_copy(
+        update={"operations": (local_first, external_second)}
+    )
+
+    assert not document_trust_is_trusted(tool._document_trust)
+    qtbot.waitUntil(
+        lambda: (
+            bool(tool.figure.axes) and tool.figure.axes[0].get_title() == "local first"
+        ),
+        timeout=1000,
+    )
+    assert not tool._authorize_code_execution(
+        figure_operation_execution_entries(
+            tool.tool_status, 1, location_prefix="figure"
+        )
+    )
+
+    local_second = FigureOperationState.custom(
+        label="second", code="ax.set_title('local second')"
+    )
+    tool.tool_status = tool.tool_status.model_copy(
+        update={"operations": (local_first, local_second)}
+    )
+
+    assert document_trust_has_trusted_lineage(tool._document_trust)
+    qtbot.waitUntil(
+        lambda: (
+            bool(tool.figure.axes) and tool.figure.axes[0].get_title() == "local second"
+        ),
+        timeout=1000,
+    )
+
+
+def test_local_figure_reorder_changes_saved_signature_to_local_lineage(qtbot) -> None:
+    recipe = FigureRecipeState(
+        operations=(
+            FigureOperationState.custom(label="first", code="ax.set_title('first')"),
+            FigureOperationState.custom(label="second", code="ax.set_title('second')"),
+        )
+    )
+    tool = FigureComposerTool(xr.DataArray(np.arange(3.0), dims="x"), recipe=recipe)
+    qtbot.addWidget(tool)
+    manifest = tool._current_code_trust_manifest()
+    assert manifest is not None
+    signed = _document_trust_after_save(
+        new_document_trust(),
+        manifest,
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+    tool.set_document_trust(signed)
+
+    tool.tool_status = tool.tool_status.model_copy(
+        update={"operations": tuple(reversed(tool.tool_status.operations))}
+    )
+
+    assert tool._document_trust != signed
+    assert document_trust_has_trusted_lineage(tool._document_trust)
+
+
+def test_figure_file_trust_is_durable_and_untrusted_saves_do_not_sign(
+    qtbot, tmp_path
+) -> None:
+    reset_saved_code_trust(domain="erlab.figure-composer-file")
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    recipe = FigureRecipeState(
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(
+            FigureOperationState.custom(label="custom", code="ax.set_title('ok')"),
+        ),
+        primary_source="data",
+    )
+    tool = FigureComposerTool(data, recipe=recipe)
+    qtbot.addWidget(tool)
+    trusted_file = tmp_path / "trusted-figure.h5"
+    tool.to_file(trusted_file)
+
+    restored = erlab.interactive.utils.ToolWindow.from_file(trusted_file)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, FigureComposerTool)
+    assert document_trust_has_trusted_lineage(restored._document_trust)
+
+    reset_saved_code_trust(domain="erlab.figure-composer-file")
+    untrusted = erlab.interactive.utils.ToolWindow.from_file(trusted_file)
+    qtbot.addWidget(untrusted)
+    assert isinstance(untrusted, FigureComposerTool)
+    assert not document_trust_has_trusted_lineage(untrusted._document_trust)
+    duplicate = untrusted.duplicate()
+    qtbot.addWidget(duplicate)
+    assert not document_trust_has_trusted_lineage(duplicate._document_trust)
+
+    untrusted_file = tmp_path / "untrusted-figure.h5"
+    untrusted.to_file(untrusted_file)
+    manifest = untrusted._current_code_trust_manifest()
+    assert manifest is not None
+    assert not document_trust_is_trusted(load_document_trust(manifest))
+
+
+def test_failed_figure_file_save_does_not_sign(qtbot, tmp_path) -> None:
+    reset_saved_code_trust(domain="erlab.figure-composer-file")
+    tool = _custom_tool(qtbot)
+    manifest = tool._current_code_trust_manifest()
+    assert manifest is not None
+
+    with pytest.raises(FileNotFoundError):
+        tool.to_file(tmp_path / "missing" / "figure.h5")
+
+    assert not document_trust_is_trusted(load_document_trust(manifest))
+
+
+def test_tool_file_is_not_written_when_trust_manifest_build_fails(
+    qtbot, tmp_path, monkeypatch
+) -> None:
+    tool = _custom_tool(qtbot)
+    target = tmp_path / "figure.h5"
+
+    def fail_manifest_build(_cls, _status, _attrs):
+        raise RuntimeError("manifest failed")
+
+    monkeypatch.setattr(
+        FigureComposerTool,
+        "_code_trust_manifest_from_saved_metadata",
+        classmethod(fail_manifest_build),
+    )
+
+    with pytest.raises(RuntimeError, match="manifest failed"):
+        tool.to_file(target)
+
+    assert not target.exists()
+
+
+def test_save_refreshes_banner_after_removing_all_executable_code(
+    qtbot, tmp_path
+) -> None:
+    reset_saved_code_trust(domain="erlab.figure-composer-file")
+    source_path = tmp_path / "source.h5"
+    tool = _custom_tool(qtbot)
+    tool.to_file(source_path)
+
+    reset_saved_code_trust(domain="erlab.figure-composer-file")
+    restored = erlab.interactive.utils.ToolWindow.from_file(source_path)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, FigureComposerTool)
+    assert not document_trust_has_trusted_lineage(restored._document_trust)
+    assert not restored._code_trust_banner.isHidden()
+
+    restored.tool_status = restored.tool_status.model_copy(update={"operations": ()})
+    restored.to_file(tmp_path / "without-code.h5")
+
+    assert document_trust_has_trusted_lineage(restored._document_trust)
+    assert restored._code_trust_banner.isHidden()
+
+
+def test_review_clears_trust_warning_after_all_code_is_removed(
+    qtbot, monkeypatch
+) -> None:
+    tool = _custom_tool(qtbot)
+    tool.set_document_trust(untrusted_document_trust())
+    tool.tool_status = tool.tool_status.model_copy(update={"operations": ()})
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "exec",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected dialog")),
+    )
+
+    tool._review_code_trust()
+
+    assert document_trust_has_trusted_lineage(tool._document_trust)
+    assert tool._code_trust_banner.isHidden()

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -1834,7 +1834,6 @@ def test_figure_composer_tool_edge_state_contracts(qtbot, monkeypatch) -> None:
     custom_operation = FigureOperationState.custom(
         label="custom",
         code="pass",
-        trusted=True,
     )
     tool.add_operation(custom_operation)
     tool._target_current_operation_all_axes()
@@ -2122,9 +2121,7 @@ def test_figure_composer_axes_selection_guards_recipe_updates(
     assert len(render_calls) == 1
     qtbot.waitUntil(lambda: len(render_calls) == 2, timeout=1000)
 
-    tool.add_operation(
-        FigureOperationState.custom(label="code", code="pass", trusted=True)
-    )
+    tool.add_operation(FigureOperationState.custom(label="code", code="pass"))
     tool.operation_panel.operation_list.setCurrentItem(
         tool.operation_panel.operation_list.topLevelItem(1)
     )
@@ -2388,9 +2385,7 @@ def test_figure_composer_gridspec_axes_selection_guards_recipe_updates(
     assert tool._preview_render_update_pending
     qtbot.waitUntil(lambda: len(render_calls) == 1, timeout=1000)
 
-    tool.add_operation(
-        FigureOperationState.custom(label="code", code="pass", trusted=True)
-    )
+    tool.add_operation(FigureOperationState.custom(label="code", code="pass"))
     tool.operation_panel.operation_list.setCurrentItem(
         tool.operation_panel.operation_list.topLevelItem(1)
     )
@@ -2762,7 +2757,6 @@ def test_figure_composer_reports_and_clears_render_errors(qtbot) -> None:
     operation = FigureOperationState.custom(
         label="custom",
         code="raise RuntimeError('boom')",
-        trusted=True,
     )
     tool = FigureComposerTool(
         data,
@@ -3778,7 +3772,7 @@ def test_figure_composer_operation_table_presents_targets_and_selects_rows(
                     sources=("data",),
                     axes=FigureAxesSelectionState(expression="axs[:, 0]"),
                 ),
-                FigureOperationState.custom(label="custom", code="pass", trusted=True),
+                FigureOperationState.custom(label="custom", code="pass"),
             ),
             primary_source="data",
         ),
@@ -4454,7 +4448,6 @@ def test_figure_composer_duplicates_and_reorders_steps(qtbot) -> None:
                         "fig.__dict__['_order'] = "
                         "fig.__dict__.get('_order', []) + ['first']"
                     ),
-                    trusted=True,
                 ),
                 FigureOperationState.custom(
                     label="second",
@@ -4462,7 +4455,6 @@ def test_figure_composer_duplicates_and_reorders_steps(qtbot) -> None:
                         "fig.__dict__['_order'] = "
                         "fig.__dict__.get('_order', []) + ['second']"
                     ),
-                    trusted=True,
                 ),
                 FigureOperationState.custom(
                     label="third",
@@ -4470,7 +4462,6 @@ def test_figure_composer_duplicates_and_reorders_steps(qtbot) -> None:
                         "fig.__dict__['_order'] = "
                         "fig.__dict__.get('_order', []) + ['third']"
                     ),
-                    trusted=True,
                 ),
             ),
             primary_source="data",
@@ -4579,7 +4570,6 @@ def test_figure_composer_batch_duplicates_reorders_and_removes_steps(qtbot) -> N
             code=(
                 f"fig.__dict__['_order'] = fig.__dict__.get('_order', []) + [{label!r}]"
             ),
-            trusted=True,
         )
 
     tool = FigureComposerTool(

--- a/tests/interactive/imagetool/manager/provenance/_common.py
+++ b/tests/interactive/imagetool/manager/provenance/_common.py
@@ -15,8 +15,10 @@ import erlab
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._details_panel as manager_details_panel
 import erlab.interactive.utils
+from erlab.interactive._code_trust import issue_execution_capability, new_document_trust
 from erlab.interactive._fit2d import Fit2DTool
 from erlab.interactive.imagetool import itool
+from erlab.interactive.imagetool._load_source import _register_local_callable_loader
 from erlab.interactive.imagetool._provenance._model import (
     FileLoadSource,
     FileReplayCall,
@@ -29,6 +31,26 @@ from erlab.interactive.imagetool.dialogs import SelectionDialog
 from erlab.interactive.imagetool.manager._provenance_edit import (
     _controller as provenance_edit_controller,
 )
+
+_register_local_callable_loader(xr.load_dataarray)
+
+
+def _authorize_execution(entries: tuple[typing.Any, ...]) -> object:
+    _trust, capability = issue_execution_capability(new_document_trust(), entries)
+    if capability is None:  # pragma: no cover - local trust always issues one.
+        raise RuntimeError("Could not issue test execution capability")
+    return capability
+
+
+@contextlib.contextmanager
+def _authorize_local_edit(
+    entries: tuple[typing.Any, ...],
+    *,
+    edited_entries: tuple[typing.Any, ...],
+    **_kwargs: typing.Any,
+):
+    del edited_entries
+    yield _authorize_execution(entries)
 
 
 def _manager_provenance_file_spec(path: pathlib.Path):
@@ -255,7 +277,19 @@ def _fake_edit_controller(
             data=xr.DataArray([1.0], dims=("x",)),
             provenance_spec=spec,
         ),
-        _ensure_script_provenance_trusted=lambda *_args, **_kwargs: None,
+        _apply_provenance=lambda spec, data, **kwargs: spec.apply(
+            data,
+            authorization=kwargs.get("authorization"),
+        ),
+        _authorize_provenance_execution=(
+            lambda entries, **_kwargs: _authorize_execution(entries)
+        ),
+        _workspace_controller=types.SimpleNamespace(
+            local_code_edit=_authorize_local_edit,
+            saving=types.SimpleNamespace(
+                _workspace_node_path_for_node=lambda current: f"nodes/{current.uid}"
+            ),
+        ),
         _update_info=lambda **_kwargs: None,
     )
     return provenance_edit_controller._ProvenanceEditController(

--- a/tests/interactive/imagetool/manager/provenance/test_clipboard.py
+++ b/tests/interactive/imagetool/manager/provenance/test_clipboard.py
@@ -64,6 +64,7 @@ from tests.interactive.imagetool.manager.helpers import (
 
 from ._common import (
     _add_file_replay_tool,
+    _authorize_execution,
     _fake_edit_controller,
     _fake_edit_node,
     _manager_replay_file_spec,
@@ -1244,7 +1245,9 @@ def test_manager_delete_invalid_script_step_rolls_back(
         seed_code="derived = data",
         active_name="result",
     )
-    displayed = replay_script_provenance(spec, {"data": data})
+    displayed = replay_script_provenance(
+        spec, {"data": data}, authorize=_authorize_execution
+    )
 
     with manager_context() as manager:
         tool = itool(displayed, manager=False, execute=False)
@@ -1300,7 +1303,9 @@ def test_manager_copy_paste_structured_provenance_steps(
         seed_code="derived = data",
         active_name="derived",
     )
-    dest_data = replay_script_provenance(dest_spec, {"data": dest_base})
+    dest_data = replay_script_provenance(
+        dest_spec, {"data": dest_base}, authorize=_authorize_execution
+    )
 
     with manager_context() as manager:
         source_tool = itool(source_data, manager=False, execute=False)
@@ -2015,7 +2020,9 @@ def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
         seed_code="derived = data",
         active_name="result",
     )
-    script_data = replay_script_provenance(script_spec, {"data": data})
+    script_data = replay_script_provenance(
+        script_spec, {"data": data}, authorize=_authorize_execution
+    )
 
     with manager_context() as manager:
         parent_tool = itool(data, manager=False, execute=False)
@@ -2060,6 +2067,7 @@ def test_manager_copy_paste_script_provenance_steps_detaches_and_rolls_back(
         expected = replay_script_provenance(
             script_spec,
             {"data": child_data},
+            authorize=_authorize_execution,
         )
         xr.testing.assert_identical(child_tool.slicer_area._data, expected)
         assert child_node.source_spec is None
@@ -2145,7 +2153,9 @@ def test_manager_paste_script_steps_replays_from_current_output_name(
         seed_code="derived = data",
         active_name="result",
     )
-    dest_data = replay_script_provenance(dest_base_spec, {"data": data})
+    dest_data = replay_script_provenance(
+        dest_base_spec, {"data": data}, authorize=_authorize_execution
+    )
     copied_operation = ScriptCodeOperation(
         label="Offset copied result",
         code="result = derived + 2.0",
@@ -2156,7 +2166,9 @@ def test_manager_paste_script_steps_replays_from_current_output_name(
         seed_code="derived = data",
         active_name="result",
     )
-    source_data = replay_script_provenance(source_spec, {"data": data})
+    source_data = replay_script_provenance(
+        source_spec, {"data": data}, authorize=_authorize_execution
+    )
 
     with manager_context() as manager:
         dest_tool = itool(dest_data, manager=False, execute=False)

--- a/tests/interactive/imagetool/manager/provenance/test_clipboard.py
+++ b/tests/interactive/imagetool/manager/provenance/test_clipboard.py
@@ -901,6 +901,9 @@ def test_manager_paste_steps_validation_error_branches(
             (ScriptCodeOperation(label="script", code="derived = data"),),
         )
 
+    parent = _fake_edit_node(full_data(), uid="parent")
+    parent.current_source_data = lambda: xr.DataArray([1.0], dims=("x",))
+    controller = _fake_edit_controller(node, parent=parent)
     monkeypatch.setattr(
         controller,
         "_replay_candidate_result",

--- a/tests/interactive/imagetool/manager/provenance/test_derivation_ui.py
+++ b/tests/interactive/imagetool/manager/provenance/test_derivation_ui.py
@@ -45,6 +45,9 @@ from erlab.interactive.imagetool._provenance._operations import (
     RenameOperation,
     ScriptCodeOperation,
 )
+from erlab.interactive.imagetool._provenance._trust import (
+    script_replay_source_input_names,
+)
 from erlab.interactive.imagetool.manager._provenance_edit import (
     _controller as manager_provenance_controller,
 )
@@ -58,7 +61,9 @@ from erlab.interactive.imagetool.manager._provenance_edit._reorder import (
     _ProvenanceReorderListModel,
     _ProvenanceReorderListView,
 )
-from erlab.interactive.imagetool.manager._widgets import _TrustedScriptReplayCancelled
+from erlab.interactive.imagetool.manager._widgets import (
+    _TrustedProvenanceReplayCancelled,
+)
 from tests.interactive.imagetool.manager.helpers import (
     select_metadata_items,
     select_metadata_rows,
@@ -67,6 +72,7 @@ from tests.interactive.imagetool.manager.helpers import (
 
 from ._common import (
     _add_file_replay_tool,
+    _authorize_execution,
     _manager_replay_file_spec,
     _provenance_paste_test_data,
     _set_aggregate,
@@ -909,14 +915,13 @@ def test_manager_provenance_reorder_requires_available_replay(
 
         root.set_detached_provenance(detached_script, replay_source_data=data)
         manager._update_info()
-        assert manager._provenance_edit_controller._script_replay_source_input_names(
-            detached_script
-        ) == ("data",)
+        assert script_replay_source_input_names(detached_script) == ("data",)
         assert manager._provenance_edit_controller.can_reorder_steps()[0]
 
         root.set_detached_provenance(trusted_script, replay_source_data=None)
         manager._update_info()
-        assert manager._provenance_edit_controller.can_reorder_steps()[0]
+        available, reason = manager._provenance_edit_controller.can_reorder_steps()
+        assert available, reason
         menu = manager._build_metadata_derivation_menu()
         assert menu is not None
         assert manager._metadata_reorder_steps_action.isEnabled()
@@ -948,6 +953,9 @@ def test_manager_provenance_reorder_controller_tracks_dependencies_and_targets(
                     )
                 ),
             ),
+        ),
+        _authorize_provenance_execution=lambda entries, **_kwargs: _authorize_execution(
+            entries
         ),
     )
     controller = _ProvenanceEditController(typing.cast("typing.Any", manager))
@@ -1130,7 +1138,9 @@ def test_manager_detached_watched_provenance_reorder_uses_retained_source(
         seed_code=seed_code,
         active_name="derived",
     )
-    displayed = replay_script_provenance(spec, {"my_data": source})
+    displayed = replay_script_provenance(
+        spec, {"my_data": source}, authorize=_authorize_execution
+    )
 
     with manager_context() as manager:
         tool = typing.cast(
@@ -1347,7 +1357,7 @@ def test_manager_provenance_reorder_cancelled_replay_restores_dialog(
     )
 
     def cancel_replay(*_args, **_kwargs) -> None:
-        raise _TrustedScriptReplayCancelled
+        raise _TrustedProvenanceReplayCancelled
 
     monkeypatch.setattr(controller, "_validate_and_replace", cancel_replay)
 
@@ -2023,7 +2033,7 @@ def test_manager_provenance_script_structured_row_can_revert(
             ),
         ),
     )
-    initial = replay_script_provenance(spec, {})
+    initial = replay_script_provenance(spec, {}, authorize=_authorize_execution)
 
     with manager_context() as manager:
         manager.show()

--- a/tests/interactive/imagetool/manager/provenance/test_editor_foundations.py
+++ b/tests/interactive/imagetool/manager/provenance/test_editor_foundations.py
@@ -1,5 +1,4 @@
 import contextlib
-import enum
 import gc
 import pathlib
 import types
@@ -1379,7 +1378,10 @@ def test_manager_selection_provenance_edit_restores_from_high_dimensional_source
     manager._rebuild_script_provenance = lambda *_args, **_kwargs: pytest.fail(
         "selection edit should not rebuild script provenance"
     )
-    manager._ensure_script_provenance_trusted = lambda *_args, **_kwargs: None
+    manager._authorize_provenance_execution = lambda *_args, **_kwargs: False
+    manager._apply_provenance = lambda provenance, data, **_kwargs: provenance.apply(
+        data
+    )
     manager._update_info = lambda **_kwargs: None
     controller = provenance_edit_controller._ProvenanceEditController(
         typing.cast("typing.Any", manager)
@@ -1522,134 +1524,75 @@ def test_manager_derivation_cache_key_rejects_lineage_cycles() -> None:
         _ = nodes["first"]._derivation_display_rows_lineage_generation
 
 
-def test_manager_trusted_script_replay_prompt_is_session_scoped(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manager = types.SimpleNamespace(_trusted_script_replay_keys=set())
+def test_manager_script_replay_uses_workspace_document_trust() -> None:
+    trust_checks: list[typing.Any] = []
+    capability = object()
+    workspace_controller = types.SimpleNamespace(
+        issue_code_execution_capability=lambda entries, **_kwargs: (
+            trust_checks.append(entries) or capability
+        ),
+    )
+    manager = types.SimpleNamespace(_workspace_controller=workspace_controller)
     controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
-    spec = _trust_required_script_spec()
-    prompts: list[str] = []
-    monkeypatch.setattr(
-        controller,
-        "_prompt_trusted_script_replay",
-        lambda _spec, *, reason: prompts.append(reason) or True,
+    entries = (object(),)
+
+    assert (
+        controller._authorize_provenance_execution(entries, reason="reload")
+        is capability
     )
+    assert len(trust_checks) == 1
+    assert trust_checks[0] is entries
 
-    controller._ensure_script_provenance_trusted(spec, reason="reload this result")
-    controller._ensure_script_provenance_trusted(spec, reason="reload this result")
-    changed_spec = spec.model_copy(
-        update={
-            "operations": (
-                ScriptCodeOperation(
-                    label="User code",
-                    code=(
-                        "import os\n"
-                        "derived = data_0 + int(os.path.exists(os.devnull)) + 1"
-                    ),
-                ),
-            ),
-        }
+
+def test_manager_script_replay_stops_when_workspace_code_is_untrusted() -> None:
+    manager = types.SimpleNamespace(
+        _workspace_controller=types.SimpleNamespace(
+            issue_code_execution_capability=lambda _entries, **_kwargs: None,
+        )
     )
-    controller._ensure_script_provenance_trusted(changed_spec, reason="reload")
-
-    assert prompts == ["reload this result", "reload"]
-
-
-def test_manager_trusted_script_replay_prompt_cancel(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manager = types.SimpleNamespace(_trusted_script_replay_keys=set())
     controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
-    monkeypatch.setattr(
-        controller,
-        "_prompt_trusted_script_replay",
-        lambda _spec, *, reason: False,
+    entries = (object(),)
+
+    with pytest.raises(manager_widgets._TrustedProvenanceReplayCancelled):
+        controller._authorize_provenance_execution(entries, reason="reload this result")
+    assert (
+        controller._authorize_provenance_execution(
+            entries,
+            reason="reload this result",
+            raise_on_block=False,
+        )
+        is None
     )
 
-    with pytest.raises(manager_widgets._TrustedScriptReplayCancelled):
-        controller._ensure_script_provenance_trusted(
-            _trust_required_script_spec(),
+
+def test_manager_provenance_authorization_forwards_exact_entries() -> None:
+    trust_checks: list[typing.Any] = []
+    trust_options: list[dict[str, typing.Any]] = []
+    capability = object()
+
+    def issue_code_execution_capability(entries, **kwargs) -> object:
+        trust_checks.append(entries)
+        trust_options.append(kwargs)
+        return capability
+
+    manager = types.SimpleNamespace(
+        _workspace_controller=types.SimpleNamespace(
+            issue_code_execution_capability=issue_code_execution_capability,
+        )
+    )
+    controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
+    entries = (object(),)
+
+    assert (
+        controller._authorize_provenance_execution(
+            entries,
             reason="reload this result",
         )
-
-
-def test_manager_trusted_script_replay_safe_and_prompt_paths(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manager = types.SimpleNamespace(_trusted_script_replay_keys=set())
-    controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
-    safe_spec = script(
-        ScriptCodeOperation(label="Offset", code="derived = data + 1"),
-        start_label="Run safe script",
-        seed_code="derived = data",
-        active_name="derived",
+        is capability
     )
-    monkeypatch.setattr(
-        controller,
-        "_prompt_trusted_script_replay",
-        lambda *_args, **_kwargs: pytest.fail("safe replay should not prompt"),
-    )
-
-    controller._ensure_script_provenance_trusted(safe_spec, reason="reload")
-    prompt_controller = manager_lineage._LineageController(
-        typing.cast("typing.Any", manager)
-    )
-    detailed_texts: list[str] = []
-
-    class _FakeMessageBox:
-        class Icon(enum.IntEnum):
-            Warning = 1
-
-        class ButtonRole(enum.IntEnum):
-            AcceptRole = 1
-
-        class StandardButton(enum.IntEnum):
-            Cancel = 1
-
-        def __init__(self, _parent: typing.Any = None) -> None:
-            self._run_button = object()
-            self._cancel_button = object()
-
-        def setObjectName(self, _name: str) -> None:
-            pass
-
-        def setIcon(self, _icon: enum.IntEnum) -> None:
-            pass
-
-        def setWindowTitle(self, _title: str) -> None:
-            pass
-
-        def setText(self, _text: str) -> None:
-            pass
-
-        def setInformativeText(self, _text: str) -> None:
-            pass
-
-        def setDetailedText(self, text: str) -> None:
-            detailed_texts.append(text)
-
-        def addButton(
-            self, button: str | enum.IntEnum, _role: enum.IntEnum | None = None
-        ) -> object:
-            if button == "Run Code":
-                return self._run_button
-            return self._cancel_button
-
-        def setDefaultButton(self, _button: typing.Any) -> None:
-            pass
-
-        def exec(self) -> None:
-            pass
-
-        def clickedButton(self) -> object:
-            return self._run_button
-
-    monkeypatch.setattr(manager_lineage.QtWidgets, "QMessageBox", _FakeMessageBox)
-    assert prompt_controller._prompt_trusted_script_replay(
-        safe_spec,
-        reason="reload this result",
-    )
-    assert detailed_texts == ["derived = data + 1"]
+    assert len(trust_checks) == 1
+    assert trust_checks[0] is entries
+    assert trust_options == [{"focus_on_block": True, "allow_partial": True}]
 
 
 def test_manager_provenance_lightweight_helper_edges() -> None:
@@ -1713,40 +1656,35 @@ def test_manager_provenance_lightweight_helper_edges() -> None:
         is None
     )
 
-    forwarded: list[
-        tuple[
-            ToolProvenanceSpec,
-            str,
-            set[str] | None,
-        ]
-    ] = []
-    spec = script(
-        start_label="Run script",
-        active_name="derived",
-    )
+    forwarded: list[tuple[tuple[object, ...], str, bool]] = []
+    entries = (object(),)
+    capability = object()
 
-    def ensure_script_provenance_trusted(
-        spec_arg: ToolProvenanceSpec,
+    def authorize_script_provenance_execution(
+        entries_arg: tuple[object, ...],
         *,
         reason: str,
-        external_input_names: set[str] | None = None,
-    ) -> None:
-        forwarded.append((spec_arg, reason, external_input_names))
+        raise_on_block: bool = True,
+    ) -> object:
+        forwarded.append((entries_arg, reason, raise_on_block))
+        return capability
 
     manager = types.SimpleNamespace(
         _lineage_controller=types.SimpleNamespace(
-            _ensure_script_provenance_trusted=ensure_script_provenance_trusted
+            _authorize_provenance_execution=(authorize_script_provenance_execution)
         )
     )
 
-    manager_mainwindow.ImageToolManager._ensure_script_provenance_trusted(
-        typing.cast("typing.Any", manager),
-        spec,
-        reason="reload this result",
-        external_input_names={"data_0"},
+    assert (
+        manager_mainwindow.ImageToolManager._authorize_provenance_execution(
+            typing.cast("typing.Any", manager),
+            entries,
+            reason="reload this result",
+        )
+        is capability
     )
 
-    assert forwarded == [(spec, "reload this result", {"data_0"})]
+    assert forwarded == [(entries, "reload this result", True)]
 
 
 def test_manager_trust_required_script_can_reload_and_rebuilds_trusted(
@@ -1768,12 +1706,13 @@ def test_manager_trust_required_script_can_reload_and_rebuilds_trusted(
             ),
         ),
         _script_input_can_reload=lambda *_args, **_kwargs: True,
-        _ensure_script_provenance_trusted=lambda _spec, *, reason: ensured.append(
-            reason
-        ),
         _resolve_live_script_input_for_reload=lambda *_args, **_kwargs: None,
     )
     controller = manager_lineage._LineageController(typing.cast("typing.Any", manager))
+    capability = object()
+    controller._authorize_provenance_execution = (  # type: ignore[method-assign]
+        lambda _entries, *, reason, **_kwargs: ensured.append(reason) or capability
+    )
     node = types.SimpleNamespace(
         is_imagetool=True,
         imagetool=object(),
@@ -1785,7 +1724,7 @@ def test_manager_trust_required_script_can_reload_and_rebuilds_trusted(
         spec_arg: ToolProvenanceSpec,
         **kwargs: typing.Any,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
-        trusted_flags.append(bool(kwargs["trusted_user_code"]))
+        trusted_flags.append(kwargs["authorize"]((object(),)) is capability)
         return xr.DataArray([2.0], dims=("x",)), spec_arg
 
     monkeypatch.setattr(
@@ -2054,7 +1993,7 @@ def test_manager_edit_script_code_trust_cancel_does_not_show_error(
             return "import os\nderived = data_0 + int(os.path.exists(os.devnull))"
 
     def cancel_validate(*_args: typing.Any, **_kwargs: typing.Any) -> None:
-        raise manager_widgets._TrustedScriptReplayCancelled
+        raise manager_widgets._TrustedProvenanceReplayCancelled
 
     monkeypatch.setattr(provenance_edit_controller, "_ScriptCodeEditDialog", FakeDialog)
     monkeypatch.setattr(controller, "_validate_and_replace", cancel_validate)

--- a/tests/interactive/imagetool/manager/provenance/test_file_relinking.py
+++ b/tests/interactive/imagetool/manager/provenance/test_file_relinking.py
@@ -3410,7 +3410,9 @@ def test_manager_provenance_file_replay_validation_prechecks_missing_path(
     monkeypatch.setattr(
         provenance_edit_controller,
         "replay_file_provenance",
-        lambda _spec: pytest.fail("missing files should fail before loader replay"),
+        lambda _spec, **_kwargs: pytest.fail(
+            "missing files should fail before loader replay"
+        ),
     )
 
     with pytest.raises(FileNotFoundError, match="no longer accessible"):
@@ -3434,6 +3436,7 @@ def test_manager_provenance_file_replay_validation_captures_loader_warnings(
         *,
         extension_executor: typing.Any = None,
         extension_loader_executor: typing.Any = None,
+        **_kwargs: typing.Any,
     ) -> xr.DataArray:
         assert extension_executor is not None
         assert extension_loader_executor is not None

--- a/tests/interactive/imagetool/manager/provenance/test_operation_editing.py
+++ b/tests/interactive/imagetool/manager/provenance/test_operation_editing.py
@@ -386,6 +386,7 @@ def test_manager_terminal_current_data_edit_accept_still_replays_for_validation(
         _node: typing.Any,
         _scope: typing.Literal["display", "source"],
         candidate: ToolProvenanceSpec,
+        **_kwargs: typing.Any,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
         replayed.append(candidate)
         return current, candidate
@@ -556,6 +557,9 @@ def test_manager_extension_operation_uses_extension_executor_for_filter_and_repl
 
     controller._manager._extensions = types.SimpleNamespace(
         execution=types.SimpleNamespace(run_operation=run_operation),
+        replay_loader=lambda *_args, **_kwargs: pytest.fail(
+            "routine provenance must not use extension loader execution"
+        ),
         unavailable_reason_for_node=lambda _uid: "extension unavailable",
     )
 
@@ -608,7 +612,7 @@ def test_manager_extension_operation_edit_raises_when_descriptor_is_unavailable(
         )
 
 
-def test_manager_paste_detached_trusted_script_propagates_cancel() -> None:
+def test_manager_paste_detached_untrusted_script_propagates_cancel() -> None:
     data = xr.DataArray([1.0], dims=("x",))
     local = script(
         ScriptCodeOperation(
@@ -623,10 +627,11 @@ def test_manager_paste_detached_trusted_script_propagates_cancel() -> None:
     node.resolved_replay_source_data = lambda: data
     controller = _fake_edit_controller(node)
 
-    def cancel(*_args, **_kwargs) -> None:
-        raise manager_widgets._TrustedScriptReplayCancelled
+    @contextlib.contextmanager
+    def block_local_edit(*_args, **_kwargs):
+        yield None
 
-    controller._manager._ensure_script_provenance_trusted = cancel
+    controller._manager._workspace_controller.local_code_edit = block_local_edit
     controller._manager._extensions = types.SimpleNamespace(
         execution=types.SimpleNamespace(
             capture_replay_sources=lambda: contextlib.nullcontext(object()),
@@ -635,7 +640,7 @@ def test_manager_paste_detached_trusted_script_propagates_cancel() -> None:
         replay_loader=lambda *_args, **_kwargs: None,
     )
 
-    with pytest.raises(manager_widgets._TrustedScriptReplayCancelled):
+    with pytest.raises(manager_widgets._TrustedProvenanceReplayCancelled):
         controller._paste_detached_steps(node, local, where="pasting")
 
 
@@ -928,6 +933,7 @@ def test_manager_affine_coord_edit_accept_still_replays_for_validation(
         _node: typing.Any,
         _scope: typing.Literal["display", "source"],
         candidate: ToolProvenanceSpec,
+        **_kwargs: typing.Any,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
         replayed.append(candidate)
         return current, candidate
@@ -1126,6 +1132,7 @@ def test_manager_affine_coord_edit_falls_back_to_replay(
         _node: typing.Any,
         _scope: typing.Literal["display", "source"],
         candidate: ToolProvenanceSpec,
+        **_kwargs: typing.Any,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
         replayed.append(candidate)
         return replay_data, candidate
@@ -1210,6 +1217,7 @@ def test_manager_terminal_current_data_edit_falls_back_to_replay(
         _node: typing.Any,
         _scope: typing.Literal["display", "source"],
         candidate: ToolProvenanceSpec,
+        **_kwargs: typing.Any,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
         replayed.append(candidate)
         return replay_data, candidate
@@ -1294,6 +1302,7 @@ def test_manager_provenance_native_operation_editor_cancel_and_replay_failures(
         _node: typing.Any,
         _scope: typing.Literal["display", "source"],
         candidate: ToolProvenanceSpec,
+        **_kwargs: typing.Any,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
         replayed_specs.append(candidate)
         return data, candidate
@@ -1325,14 +1334,14 @@ def test_manager_provenance_native_operation_editor_cancel_and_replay_failures(
         *_args: object,
         **_kwargs: object,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
-        raise manager_widgets._TrustedScriptReplayCancelled
+        raise manager_widgets._TrustedProvenanceReplayCancelled
 
     monkeypatch.setattr(
         controller,
         "_replay_candidate_result",
         _raise_replay_cancelled,
     )
-    with pytest.raises(manager_widgets._TrustedScriptReplayCancelled):
+    with pytest.raises(manager_widgets._TrustedProvenanceReplayCancelled):
         controller._edited_native_operations(
             typing.cast("typing.Any", _fake_edit_node(spec)),
             row,
@@ -1431,6 +1440,7 @@ def test_manager_provenance_validation_preserves_active_filter_with_one_replay(
         _node: typing.Any,
         _scope: typing.Literal["display", "source"],
         spec: ToolProvenanceSpec,
+        **_kwargs: typing.Any,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
         replayed_specs.append(spec)
         return data, spec
@@ -1485,11 +1495,15 @@ def test_manager_provenance_validation_rejects_highdim_reorder_result(
         active_name="derived",
     )
     reordered = original.model_copy(update={"steps": tuple(reversed(original.steps))})
-    controller = _fake_edit_controller()
     node = types.SimpleNamespace(
+        uid="node",
         imagetool=None,
+        displayed_provenance_spec=original,
+        displayed_source_spec=None,
+        parent_uid=None,
         resolved_replay_source_data=lambda: source,
     )
+    controller = _fake_edit_controller(node)
     applied_edits: list[typing.Any] = []
     monkeypatch.setattr(controller, "_apply_validated_edit", applied_edits.append)
 
@@ -1543,6 +1557,7 @@ def test_manager_provenance_validation_reports_active_filter_validation_failure(
         _node: typing.Any,
         _scope: typing.Literal["display", "source"],
         spec: ToolProvenanceSpec,
+        **_kwargs: typing.Any,
     ) -> tuple[xr.DataArray, ToolProvenanceSpec]:
         nonlocal calls
         calls += 1

--- a/tests/interactive/imagetool/manager/test_app.py
+++ b/tests/interactive/imagetool/manager/test_app.py
@@ -1199,8 +1199,10 @@ def test_manager_workspace_properties_action_uses_current_state(
             workspace_path: str | None,
             *,
             state: _WorkspacePropertiesState,
+            review_code_callback: Callable[[], None] | None = None,
             parent: QtWidgets.QWidget | None = None,
         ) -> None:
+            _ = review_code_callback
             dialog_calls.append((workspace_path, state, parent))
 
         def exec(self) -> int:

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -20,6 +20,7 @@ import erlab.interactive.imagetool.manager._lineage as manager_lineage
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.utils
+from erlab.interactive._code_trust import issue_execution_capability, new_document_trust
 from erlab.interactive.imagetool import _kspace_conversion, itool
 from erlab.interactive.imagetool._provenance import _execution
 from erlab.interactive.imagetool._provenance._execution import replay_script_provenance
@@ -62,6 +63,14 @@ from .helpers import (
     select_child_tool,
     select_tools,
 )
+
+
+def _authorize_execution(entries: tuple[typing.Any, ...]) -> object:
+    _trust, capability = issue_execution_capability(new_document_trust(), entries)
+    if capability is None:  # pragma: no cover - local trust always issues one.
+        raise RuntimeError("Could not issue test execution capability")
+    return capability
+
 
 if typing.TYPE_CHECKING:
     from erlab.interactive.imagetool.manager._modelview import (
@@ -1324,7 +1333,11 @@ def test_manager_console_reserved_result_name_replays_without_shadowing() -> Non
         "data_0",
     ]
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"data_0": data0, "data_1": data1}),
+        replay_script_provenance(
+            spec,
+            {"data_0": data0, "data_1": data1},
+            authorize=_authorize_execution,
+        ),
         combined.data,
     )
 
@@ -2557,7 +2570,11 @@ def test_manager_console_captures_self_contained_function_source(
         assert "def add_scale(data):" in shifted_code
         assert "def offset_data(data):" in shifted_code
         xr.testing.assert_identical(
-            replay_script_provenance(shifted_spec, {"data_0": data}),
+            replay_script_provenance(
+                shifted_spec,
+                {"data_0": data},
+                authorize=_authorize_execution,
+            ),
             data + 2.0,
         )
         manager.console._console_widget.execute("piped = tools[0].pipe(offset_data)")

--- a/tests/interactive/imagetool/manager/test_console.py
+++ b/tests/interactive/imagetool/manager/test_console.py
@@ -3349,7 +3349,7 @@ def test_manager_reload_script_derived_target_honors_trust_cancel() -> None:
     node = types.SimpleNamespace(uid="node", provenance_spec=spec)
 
     def rebuild(*_args, **_kwargs):
-        raise manager_widgets._TrustedScriptReplayCancelled
+        raise manager_widgets._TrustedProvenanceReplayCancelled
 
     manager = types.SimpleNamespace(
         _node_for_target=lambda _target: node,

--- a/tests/interactive/imagetool/manager/test_extensions.py
+++ b/tests/interactive/imagetool/manager/test_extensions.py
@@ -31,6 +31,7 @@ from erlab.interactive.imagetool._load_source import (
     _resolve_load_func,
 )
 from erlab.interactive.imagetool._provenance._execution import (
+    can_reload_with_trusted_code,
     can_reload_without_trust,
     file_load_source_status,
     replay_file_provenance,
@@ -3987,9 +3988,11 @@ def test_extension_routine_reloadability_requires_ready_exact_source() -> None:
         )
         return "ready"
 
-    assert can_reload_without_trust(spec, extension_status_resolver=ready)
+    assert not can_reload_without_trust(spec, extension_status_resolver=ready)
+    assert calls == []
+    assert can_reload_with_trusted_code(spec, extension_status_resolver=ready)
     assert calls == [("lab.py", source_hash, "routine", "normalize")]
-    assert not can_reload_without_trust(
+    assert not can_reload_with_trusted_code(
         spec,
         extension_status_resolver=lambda *_args: "disabled",
     )
@@ -7621,8 +7624,8 @@ def test_workspace_script_remap_updates_node_provenance_owners(
             source_state="stale",
         )
         input_tool = _ExtensionInputTool(xr.DataArray([3.0]))
-        input_tool.set_input_provenance_spec(old_spec)
         tool_uid = manager.add_childtool(input_tool, 0, show=False)
+        input_tool.set_input_provenance_spec(old_spec)
         manager._workspace_state.mark_clean()
 
         manager._extensions._remap_workspace_script(
@@ -8929,9 +8932,19 @@ def test_provenance_edit_records_replay_source_after_replacement(
             "_check_replay_capture",
             lambda _capture: events.append("check"),
         )
+        monkeypatch.setattr(
+            controller,
+            "_provenance_code_entries",
+            lambda *_args, **_kwargs: (),
+        )
+        node = types.SimpleNamespace(
+            displayed_provenance_spec=None,
+            displayed_source_spec=None,
+            parent_uid=None,
+        )
 
         controller._validate_and_replace(
-            typing.cast("typing.Any", object()),
+            typing.cast("typing.Any", node),
             "display",
             full_data(),
         )
@@ -8946,7 +8959,7 @@ def test_provenance_edit_records_replay_source_after_replacement(
         monkeypatch.setattr(controller, "_apply_validated_edit", fail_replacement)
         with pytest.raises(RuntimeError, match="replacement failed"):
             controller._validate_and_replace(
-                typing.cast("typing.Any", object()),
+                typing.cast("typing.Any", node),
                 "display",
                 full_data(),
             )

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -43,6 +43,8 @@ from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool
 from erlab.interactive.imagetool import _kspace_conversion, itool
 from erlab.interactive.imagetool._load_source import _LoadSourceDetails
+from erlab.interactive.imagetool._provenance import _model as provenance_model
+from erlab.interactive.imagetool._provenance._code import _FIT_DATASET_MARKER
 from erlab.interactive.imagetool._provenance._execution import replay_file_provenance
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
@@ -851,6 +853,24 @@ def test_acquisition_context_values_are_serialization_stable() -> None:
     assert not AcquisitionContextState(enabled=True).enabled
     with pytest.raises(ValueError, match="unique by kind"):
         AcquisitionContextState(fields=(field, field))
+
+
+def test_acquisition_context_rejects_opaque_fit_results_without_decoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def reject_decode(_value: typing.Any) -> typing.NoReturn:
+        raise AssertionError("acquisition context decoded an opaque fit result")
+
+    monkeypatch.setattr(provenance_model, "_decode_fit_dataset", reject_decode)
+
+    with pytest.raises(ValueError, match="requires code authorization"):
+        AcquisitionContextField.model_validate(
+            {
+                "kind": "attribute",
+                "name": "payload",
+                "value": {_FIT_DATASET_MARKER: "serialized-result"},
+            }
+        )
 
 
 def test_acquisition_context_field_dialog_validates_and_restores(
@@ -5173,6 +5193,26 @@ def test_workspace_properties_dialog_without_associated_file(qtbot) -> None:
     )
     dialog._copy_path()
     dialog._reveal_path()
+
+
+def test_workspace_properties_dialog_offers_code_review(qtbot) -> None:
+    reviews: list[None] = []
+    dialog = _WorkspacePropertiesDialog(
+        None,
+        state=_WorkspacePropertiesState(
+            is_modified=False,
+            top_level_window_count=0,
+            code_trust_review_available=True,
+        ),
+        review_code_callback=lambda: reviews.append(None),
+    )
+    qtbot.addWidget(dialog)
+
+    assert dialog.review_code_button is not None
+    dialog.review_code_button.click()
+
+    assert reviews == [None]
+    assert dialog.result() == QtWidgets.QDialog.DialogCode.Accepted
 
 
 def test_workspace_properties_dialog_file_detail_branches(

--- a/tests/interactive/imagetool/manager/test_wrapper.py
+++ b/tests/interactive/imagetool/manager/test_wrapper.py
@@ -561,6 +561,35 @@ def test_added_time_helpers_use_aware_datetimes(caplog) -> None:
     )
 
 
+def test_take_window_clears_and_reattach_restores_manager_execution_host(
+    qtbot,
+    test_data,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        tool = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+        index = manager.add_imagetool(tool, show=False)
+        wrapper = manager._tool_graph.root_wrappers[index]
+
+        assert tool.slicer_area._stored_code_authorizer is not None
+        assert tool.slicer_area._in_manager
+
+        detached = wrapper.take_window()
+
+        assert detached is tool
+        assert tool.slicer_area._stored_code_authorizer is None
+        assert not tool.slicer_area._in_manager
+
+        wrapper.window = tool
+
+        assert tool.slicer_area._stored_code_authorizer is not None
+        assert tool.slicer_area._in_manager
+
+
 def test_wrapper_source_data_replaced_uses_parent_fallback_and_skips_missing_child(
     qtbot,
     monkeypatch,

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -35,6 +35,7 @@ from erlab.interactive.imagetool._load_source import _serialize_loader_kwargs
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     ToolProvenanceSpec,
+    compose_display_provenance,
     full_data,
     script,
 )
@@ -43,6 +44,7 @@ from erlab.interactive.imagetool._provenance._operations import (
     GaussianFilterOperation,
     ImageToolSelectionSourceBinding,
     RenameOperation,
+    ScriptCodeOperation,
 )
 from erlab.interactive.imagetool.manager import ImageToolManager
 from erlab.interactive.imagetool.manager._dialogs import (
@@ -65,6 +67,26 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _WorkspaceSweepFigureTool,
     _WorkspaceSweepToolState,
 )
+
+
+class _ManagedInputAuthorityTool(_AddedTimeChildTool):
+    tool_name = "managed-input-authority"
+    COPY_PROVENANCE: typing.ClassVar = (
+        erlab.interactive.utils.ToolScriptProvenanceDefinition(
+            start_label="Start from the managed tool input",
+            label="Create the tool result",
+            expression_method="_copy_expression",
+            assign="result",
+        )
+    )
+
+    def _copy_expression(
+        self, *, input_name: str | None, data: xr.DataArray | None
+    ) -> str | None:
+        del data
+        if input_name is None:
+            return None
+        return f"{input_name}.rename('tool-result')"
 
 
 def _workspace_sweep_json(value: typing.Any) -> typing.Any:
@@ -1047,6 +1069,161 @@ def _workspace_sweep_data(name: str, *, offset: float = 0.0) -> xr.DataArray:
         attrs={"sample": name, "acquisition": {"pass": int(offset)}},
         name=name,
     )
+
+
+def _injected_input_provenance() -> ToolProvenanceSpec:
+    return script(
+        ScriptCodeOperation(
+            label="Injected input",
+            code="derived = data.pipe(attacker)",
+        ),
+        start_label="Run injected input code",
+        seed_code="derived = data",
+        active_name="derived",
+    )
+
+
+def test_managed_tool_rebuilds_input_provenance_from_parent(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    data = xr.DataArray(np.arange(6.0), dims=("x",), name="source")
+    parent_provenance = full_data(RenameOperation(name="parent-result"))
+    source_spec = full_data(RenameOperation(name="tool-input"))
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = erlab.interactive.imagetool.ImageTool(data, _in_manager=True)
+        manager.add_imagetool(
+            root,
+            show=False,
+            provenance_spec=parent_provenance,
+        )
+        child = _ManagedInputAuthorityTool(source_spec.apply(data))
+        child.set_source_binding(source_spec)
+        child.set_input_provenance_spec(_injected_input_provenance())
+        child_uid = manager.add_childtool(child, 0, show=False)
+
+        expected = compose_display_provenance(
+            manager._tool_graph.root_wrappers[0].displayed_provenance_spec,
+            source_spec,
+            parent_data=data,
+        )
+        assert child._effective_input_provenance_spec() == expected
+        current = child.current_provenance_spec()
+        assert current is not None
+        assert "attacker" not in current.display_code()
+
+        figure = _WorkspaceSweepFigureTool(data)
+        figure.set_input_provenance_spec(_injected_input_provenance())
+        figure_uid = manager.add_figuretool(figure, show=False)
+        assert figure._effective_input_provenance_spec() is None
+
+        fname = tmp_path / "managed-input-authority.itws"
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        node_path = f"0/childtools/{child_uid}"
+        attrs = _current_workspace_payload_attrs(fname, node_path)
+        assert erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
+        with h5py.File(fname, "r") as h5_file:
+            payload = h5_file[_current_workspace_payload_path(fname, node_path)]
+            assert (
+                erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
+                not in payload.attrs
+            )
+        figure_path = f"figures/{figure_uid}"
+        figure_attrs = _current_workspace_payload_attrs(fname, figure_path)
+        assert (
+            erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR not in figure_attrs
+        )
+
+
+def test_legacy_tool_input_provenance_is_not_raw_copied(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    monkeypatch.setattr(
+        QtWidgets.QDialog,
+        "exec",
+        lambda dialog: pytest.fail(
+            f"Unexpected dialog: {type(dialog).__name__} {dialog.windowTitle()!r}"
+        ),
+    )
+    data = xr.DataArray(np.arange(6.0), dims=("x",), name="source")
+    parent_provenance = full_data(RenameOperation(name="parent-result"))
+    source_spec = full_data(RenameOperation(name="tool-input"))
+    fname = tmp_path / "legacy-managed-input.itws"
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        root = erlab.interactive.imagetool.ImageTool(data, _in_manager=True)
+        manager.add_imagetool(
+            root,
+            show=False,
+            provenance_spec=parent_provenance,
+        )
+        child = _ManagedInputAuthorityTool(source_spec.apply(data))
+        child.set_source_binding(source_spec)
+        child_uid = manager.add_childtool(child, 0, show=False)
+        manager._workspace_controller.saving._save_workspace_document(fname)
+
+    node_path = f"0/childtools/{child_uid}"
+    encoded_injection = json.dumps(_injected_input_provenance().model_dump(mode="json"))
+    with _edit_current_workspace_payload_attrs(fname, node_path) as attrs:
+        attrs[erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
+            encoded_injection
+        )
+    with h5py.File(fname, "a") as h5_file:
+        payload = h5_file[_current_workspace_payload_path(fname, node_path)]
+        payload.attrs[erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
+            encoded_injection
+        )
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        assert manager._workspace_controller.loading._load_workspace_file(
+            fname,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+        child_node = manager._child_node(child_uid)
+        assert child_node.pending_workspace_tool_payload is not None
+        assert erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR in (
+            child_node.pending_workspace_payload_attrs or {}
+        )
+
+        manager._workspace_controller.saving._save_workspace_document(fname)
+
+        assert child_node.pending_workspace_tool_payload is None
+        restored = typing.cast("_ManagedInputAuthorityTool", child_node.tool_window)
+        expected = compose_display_provenance(
+            manager._tool_graph.root_wrappers[0].displayed_provenance_spec,
+            restored.source_spec,
+            parent_data=manager._tool_graph.root_wrappers[0].current_source_data(),
+        )
+        assert restored._effective_input_provenance_spec() == expected
+        current = restored.current_provenance_spec()
+        assert current is not None
+        assert "attacker" not in current.display_code()
+
+        attrs = _current_workspace_payload_attrs(fname, node_path)
+        assert erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
+        with h5py.File(fname, "r") as h5_file:
+            payload = h5_file[_current_workspace_payload_path(fname, node_path)]
+            assert (
+                erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
+                not in payload.attrs
+            )
+        manager._workspace_controller._drain_workspace_deferred_events()
+        manager._workspace_controller._mark_workspace_clean()
 
 
 def _configure_workspace_sweep_imagetool(
@@ -2238,6 +2415,9 @@ def test_manager_workspace_roundtrip_restores_full_serializable_state(
         tool_payload = _workspace_sweep_h5_attr_payload(
             fname, "0/childtools/sweep-child-tool/tool"
         )
+        figure_payload = _workspace_sweep_h5_attr_payload(
+            fname, f"figures/{figure_uid}/tool"
+        )
         assert tool_payload["tool_state"] == child_window.tool_status.model_dump(
             mode="json"
         )
@@ -2247,6 +2427,7 @@ def test_manager_workspace_roundtrip_restores_full_serializable_state(
             mode="json"
         )
         assert "tool_source_binding" not in tool_payload
+        assert "manager_node_provenance_spec" not in figure_payload
         with h5py.File(fname, "r") as h5_file:
             tool_group = h5_file[
                 _current_workspace_payload_path(fname, "0/childtools/sweep-child-tool")

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -14,6 +14,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool._load_source as imagetool_load_source
 import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._console as manager_console
@@ -26,9 +27,11 @@ import erlab.interactive.imagetool.manager._workspace._pending as workspace_pend
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 from erlab.interactive.imagetool import itool
+from erlab.interactive.imagetool._load_source import _register_local_callable_loader
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
+    ScriptInput,
     ToolProvenanceOperation,
     compose_display_provenance,
     full_data,
@@ -39,6 +42,7 @@ from erlab.interactive.imagetool._provenance._operations import (
     AverageOperation,
     BoxcarFilterOperation,
     GaussianFilterOperation,
+    ScriptCodeOperation,
     SortCoordOrderOperation,
     SqueezeOperation,
 )
@@ -1574,6 +1578,9 @@ def test_wrapper_pending_workspace_branch_helpers(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    monkeypatch.setattr(imagetool_load_source, "_LOCAL_CALLABLE_LOADERS", {})
+    for loader in (xr.load_dataarray, xr.load_dataset, xr.load_datatree):
+        _register_local_callable_loader(loader)
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
         data = xr.DataArray(np.arange(9, dtype=float).reshape(3, 3), dims=("x", "y"))
@@ -1606,22 +1613,25 @@ def test_wrapper_pending_workspace_branch_helpers(
         assert wrapper._load_func_from_serialized_state(["bad", {}, None]) is None
         assert (
             wrapper._load_func_from_serialized_state(
-                ["math:missing", {}, serialized_selection]
+                ["attacker.module:missing", {}, serialized_selection]
             )
             is None
         )
         assert (
             wrapper._load_func_from_serialized_state(
-                ["math:pi", {}, serialized_selection]
+                ["attacker.module:callable", {}, serialized_selection]
             )
             is None
         )
-        assert (
-            wrapper._load_func_from_serialized_state(
-                ["math:sqrt", {}, serialized_selection]
-            )[0].__name__
-            == "sqrt"
-        )
+        assert wrapper._load_func_from_serialized_state(
+            ["xarray:load_dataarray", {}, serialized_selection]
+        ) == (xr.load_dataarray, {}, dataarray_selection)
+        assert wrapper._load_func_from_serialized_state(
+            ["xarray:load_dataset", {}, serialized_selection]
+        ) == (xr.load_dataset, {}, dataarray_selection)
+        assert wrapper._load_func_from_serialized_state(
+            ["xarray:load_datatree", {}, serialized_selection]
+        ) == (xr.load_datatree, {}, dataarray_selection)
         assert wrapper._load_func_from_serialized_state(
             ["da30", {}, serialized_selection]
         ) == ("da30", {}, dataarray_selection)
@@ -1784,29 +1794,93 @@ def test_pending_workspace_reload_reason_branches(
             == "missing file"
         )
 
-        script_spec = types.SimpleNamespace(kind="script")
-        monkeypatch.setattr(
-            manager_lineage,
-            "script_provenance_requires_trust",
-            lambda _spec: True,
+        opaque_script = script(
+            ScriptCodeOperation(label="Opaque", code=None, copyable=False),
+            start_label="Run script",
+            seed_code="derived = data",
+            active_name="derived",
+            script_inputs=(ScriptInput(name="data", label="Input"),),
         )
-        trust_reason = controller._pending_imagetool_reload_unavailable_reason(
+        opaque_reason = controller._pending_imagetool_reload_unavailable_reason(
             types.SimpleNamespace(
-                provenance_spec=script_spec,
+                provenance_spec=opaque_script,
+                uid="pending",
                 _load_source_details=lambda: None,
             )
         )
-        assert trust_reason is not None
-        assert "trust confirmation" in trust_reason
+        assert opaque_reason is not None
 
+        raw_script = script(
+            ScriptCodeOperation(
+                label="Transform",
+                code="derived = data + 1",
+            ),
+            start_label="Run script",
+            seed_code="derived = data",
+            active_name="derived",
+        )
+        raw_reason = controller._pending_imagetool_reload_unavailable_reason(
+            types.SimpleNamespace(
+                provenance_spec=raw_script,
+                uid="pending",
+                _load_source_details=lambda: None,
+            )
+        )
+        assert raw_reason is not None
+        assert "no recorded inputs" in raw_reason
+
+        script_input = object()
+        script_spec = types.SimpleNamespace(
+            kind="script",
+            script_inputs=(script_input,),
+        )
+        replayable = True
+        monkeypatch.setattr(
+            controller,
+            "_script_provenance_runnable",
+            lambda _spec: replayable,
+        )
         monkeypatch.setattr(
             manager_lineage,
-            "script_provenance_requires_trust",
-            lambda _spec: False,
+            "provenance_code_trust_entries",
+            lambda *_args, **_kwargs: pytest.fail(
+                "passive reload status built code-trust entries"
+            ),
         )
+        unavailable_reason: str | None = None
+        monkeypatch.setattr(
+            manager,
+            "_script_input_unavailable_reason",
+            lambda *_args, **_kwargs: unavailable_reason,
+        )
+        unavailable_reason = "missing input"
+        assert (
+            controller._pending_imagetool_reload_unavailable_reason(
+                types.SimpleNamespace(
+                    provenance_spec=script_spec,
+                    uid="pending",
+                    _load_source_details=lambda: None,
+                )
+            )
+            == unavailable_reason
+        )
+        unavailable_reason = None
+        assert (
+            controller._pending_imagetool_reload_unavailable_reason(
+                types.SimpleNamespace(
+                    provenance_spec=script_spec,
+                    uid="pending",
+                    _load_source_details=lambda: None,
+                )
+            )
+            is None
+        )
+
+        replayable = False
         replay_reason = controller._pending_imagetool_reload_unavailable_reason(
             types.SimpleNamespace(
                 provenance_spec=script_spec,
+                uid="pending",
                 _load_source_details=lambda: None,
             )
         )

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -1395,7 +1395,7 @@ def test_hidden_toolwindow_with_missing_saved_class_is_skipped(
         assert child_uid not in manager._tool_graph.nodes
         assert skipped
         assert skipped[0][0] == f"0/childtools/{child_uid}"
-        assert isinstance(skipped[0][1], ModuleNotFoundError)
+        assert isinstance(skipped[0][1], TypeError)
 
 
 def test_pending_toolwindow_source_metadata_decodes_saved_state(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -27,6 +27,7 @@ import erlab.interactive.imagetool.manager._workspace._state as workspace_state
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.viewer as imagetool_viewer
+from erlab.interactive._code_trust import new_document_trust
 from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.imagetool import itool
@@ -641,6 +642,7 @@ def test_workspace_save_snapshot_selects_and_preserves_extension_objects(
                 dirty_added=set(),
                 dirty_state=set(),
                 path=source_path.resolve(),
+                code_trust=new_document_trust(),
             ),
             _tool_graph=types.SimpleNamespace(nodes={}),
         )
@@ -716,6 +718,7 @@ def test_committed_generation_merges_embedded_source_into_live_state(
             legacy_reader_rebindings=(("/legacy/imagetool", "payload"),),
         ),
         compression_mode="none",
+        trusted_lineage=True,
         embedded_script_sources=(("embedded.py", embedded_hash, embedded_source),),
     )
 
@@ -1627,6 +1630,7 @@ def _workspace_save_test_snapshot(
             objects=(),
         ),
         compression_mode="none",
+        trusted_lineage=True,
     )
 
 
@@ -1660,6 +1664,7 @@ def test_workspace_save_worker_reports_missing_backing_source(tmp_path) -> None:
             ),
         ),
         compression_mode="none",
+        trusted_lineage=True,
     )
     worker = workspace_saving._WorkspaceSaveWorker(target, snapshot)
     results: list[tuple[float, workspace_saving._WorkspaceSaveError | None]] = []
@@ -1706,6 +1711,7 @@ def test_workspace_save_worker_classifies_publication_errors(
             objects=(),
         ),
         compression_mode="none",
+        trusted_lineage=True,
     )
     monkeypatch.setattr(
         workspace_storage,
@@ -1742,6 +1748,7 @@ def test_workspace_save_worker_closes_readers_only_after_contention(
             objects=(),
         ),
         compression_mode="none",
+        trusted_lineage=True,
     )
     close_calls: list[None] = []
 
@@ -1804,6 +1811,7 @@ def test_pending_workspace_tool_attrs_update_source_metadata() -> None:
         "tool_display_name": "old",
         "tool_title": "prefix old",
         erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR: "stale",
+        erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR: "legacy",
     }
     saver._pending_workspace_node_attrs = types.MethodType(
         lambda _self, _node, _attrs, *, kind: dict(pending_base),
@@ -1827,6 +1835,7 @@ def test_pending_workspace_tool_attrs_update_source_metadata() -> None:
     assert erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR not in attrs
     assert attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] == "valid"
     assert attrs[erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR] is True
+    assert erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
 
     node.name = "plain"
     node.source_spec = None
@@ -2676,10 +2685,16 @@ def test_manager_background_workspace_save_failure_restores_state(
 
     with manager_context() as manager:
         operation_errors: list[tuple[str, str]] = []
+        trust_records: list[dict[str, typing.Any]] = []
         monkeypatch.setattr(
             manager,
             "_show_operation_error",
             lambda title, text: operation_errors.append((title, text)),
+        )
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_record_saved_workspace_code_trust",
+            lambda manifest, **_kwargs: trust_records.append(manifest),
         )
         _fname = _bind_dirty_workspace_for_save_test(manager, tmp_path)
         errors: list[workspace_saving._WorkspaceSaveError] = []
@@ -2707,6 +2722,7 @@ def test_manager_background_workspace_save_failure_restores_state(
         assert manager.import_workspace_action.isEnabled()
         assert manager.is_workspace_modified
         assert not operation_errors
+        assert not trust_records
         manager._workspace_controller._mark_workspace_clean()
         manager._workspace_state.path = None
 
@@ -5072,6 +5088,7 @@ def test_workspace_save_and_save_as_error_continuation_branches(
                 objects=(),
             ),
             compression_mode="none",
+            trusted_lineage=True,
         )
 
     with manager_context() as manager:
@@ -5214,6 +5231,7 @@ def test_workspace_save_completion_ignores_inactive_document(
                 objects=(),
             ),
             compression_mode="none",
+            trusted_lineage=True,
         )
         monkeypatch.setattr(
             controller.saving, "_workspace_save_snapshot", lambda _path: snapshot
@@ -5277,6 +5295,7 @@ def test_workspace_save_as_completion_ignores_inactive_document(
                     objects=(),
                 ),
                 compression_mode="none",
+                trusted_lineage=True,
             ),
         )
 

--- a/tests/interactive/imagetool/manager/workspace/test_trust.py
+++ b/tests/interactive/imagetool/manager/workspace/test_trust.py
@@ -248,6 +248,45 @@ def test_workspace_code_trust_manifest_uses_metadata_and_not_workspace_id() -> N
     assert first.canonical_bytes() != changed_code.canonical_bytes()
 
 
+def test_workspace_trust_adapter_rejects_invalid_metadata() -> None:
+    assert not workspace_trust.workspace_path_is_trusted("workspace.txt")
+    assert workspace_trust._decoded_json_mapping("{") is None
+    assert workspace_trust._decoded_json_mapping("[]") is None
+
+    with pytest.raises(TypeError, match="attribute entry is invalid"):
+        workspace_trust._entry_attrs({"payload_attrs": [["only-one-item"]]})
+    with pytest.raises(TypeError, match="identifier must be a string"):
+        workspace_trust._tool_code_trust_from_attrs({"tool_cls_qualname": 1})
+    with pytest.raises(TypeError, match="state must be JSON text"):
+        workspace_trust._tool_code_trust_from_attrs(
+            {"tool_cls_qualname": "test:Tool", "tool_state": 1}
+        )
+
+
+def test_workspace_trust_adapter_filters_saved_attributes() -> None:
+    assert workspace_trust._entry_attrs(
+        {
+            "payload_attrs": {
+                "tool_state": "{}",
+                "ignored": "not security metadata",
+            }
+        }
+    ) == {"tool_state": "{}"}
+    assert (
+        workspace_trust._entry_attrs(
+            {
+                "payload_attrs": [
+                    [
+                        {"kind": "int", "value": 1},
+                        {"kind": "str", "value": "ignored"},
+                    ]
+                ]
+            }
+        )
+        == {}
+    )
+
+
 @pytest.mark.parametrize(
     "identifier",
     [
@@ -284,6 +323,10 @@ def test_saved_tool_class_registry_accepts_canonical_figure_id() -> None:
     )
 
     assert ToolWindow._saved_tool_class_from_dataset(dataset) is FigureComposerTool
+
+
+def test_saved_tool_builtin_loader_resolves_nested_attributes() -> None:
+    assert _saved_tools._load_builtin_tool("json", "JSONDecoder") is json.JSONDecoder
 
 
 def test_saved_tool_class_registry_discovers_installed_extensions(
@@ -339,6 +382,40 @@ def test_saved_tool_entry_point_does_not_replace_builtin(
         is FigureComposerTool
     )
     assert loaded == []
+
+
+def test_saved_tool_registry_ignores_module_only_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _saved_tools.importlib.metadata,
+        "entry_points",
+        lambda *, group: [SimpleNamespace(attr=None)],
+    )
+    monkeypatch.setattr(_saved_tools, "_ENTRY_POINTS_DISCOVERED", False)
+
+    _saved_tools._discover_saved_tool_entry_points()
+
+
+def test_saved_tool_loader_must_return_a_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identifier = "test.saved_tools:NotAClass"
+    monkeypatch.setattr(
+        _saved_tools,
+        "_SAVED_TOOL_CLASSES",
+        dict(_saved_tools._SAVED_TOOL_CLASSES),
+    )
+    monkeypatch.setattr(
+        _saved_tools,
+        "_SAVED_TOOL_LOADERS",
+        dict(_saved_tools._SAVED_TOOL_LOADERS),
+    )
+    monkeypatch.setattr(_saved_tools, "_ENTRY_POINTS_DISCOVERED", True)
+    _saved_tools._register_saved_tool_loader(identifier, object)
+
+    with pytest.raises(TypeError, match="is not a class"):
+        _saved_tools.resolve_saved_tool_class(identifier)
 
 
 def test_saved_tool_entry_point_must_load_its_declared_class(

--- a/tests/interactive/imagetool/manager/workspace/test_trust.py
+++ b/tests/interactive/imagetool/manager/workspace/test_trust.py
@@ -1,0 +1,1924 @@
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import sys
+import typing
+from types import SimpleNamespace
+
+import numpy as np
+import pydantic
+import pytest
+import xarray as xr
+from qtpy import QtWidgets
+
+import erlab.interactive.imagetool.manager._workspace._format as workspace_format
+import erlab.interactive.imagetool.manager._workspace._trust as workspace_trust
+import erlab.interactive.utils as interactive_utils
+from erlab.interactive import _saved_tools
+from erlab.interactive._code_trust import (
+    create_entry,
+    create_manifest,
+    document_trust_has_trusted_lineage,
+    document_trust_is_trusted,
+    execution_capability_allows,
+    new_document_trust,
+    trusted_location_document_trust,
+    untrusted_document_trust,
+)
+from erlab.interactive._code_trust._api import _document_trust_after_save
+from erlab.interactive._code_trust._application import (
+    load_document_trust,
+    load_imported_document_trust,
+    reset_saved_code_trust,
+    save_document_trust,
+)
+from erlab.interactive._code_trust._core import CodeTrustReason
+from erlab.interactive._code_trust._payloads import store_code_payload_entries
+from erlab.interactive._figurecomposer import FigureComposerTool, FigureSourceState
+from erlab.interactive._figurecomposer import _rendering as figure_rendering
+from erlab.interactive._figurecomposer._model._state import (
+    FigureOperationState,
+    FigureRecipeState,
+)
+from erlab.interactive.imagetool._mainwindow import ImageTool
+from erlab.interactive.imagetool._provenance._model import (
+    FileDataSelection,
+    ReplayStep,
+    ScriptInput,
+    full_data,
+    script,
+)
+from erlab.interactive.imagetool._provenance._operations import (
+    AverageOperation,
+    ModelFitOperation,
+    ScriptCodeOperation,
+    _ModelFitParameterSpec,
+)
+from erlab.interactive.imagetool._provenance._trust import provenance_code_trust_entries
+from erlab.interactive.imagetool.manager._widgets import (
+    _TrustedProvenanceReplayCancelled,
+)
+from erlab.interactive.imagetool.manager._workspace._trust import (
+    current_workspace_code_trust_manifest,
+    workspace_code_trust_manifest,
+)
+from erlab.interactive.utils import ToolWindow
+from tests.interactive.imagetool.manager.workspace._support import (
+    _current_workspace_payload_attrs,
+    _current_workspace_payload_path,
+)
+
+if typing.TYPE_CHECKING:
+    import pathlib
+
+
+def _trust_uses_saved_signature(trust) -> bool:
+    return trust.reason == CodeTrustReason.SIGNATURE
+
+
+class _TrustProbeState(pydantic.BaseModel):
+    value: int = 0
+
+
+class _TrustProbeTool(ToolWindow):
+    StateModel = _TrustProbeState
+
+    def __init__(self, data: xr.DataArray) -> None:
+        super().__init__()
+        self._data = data
+        self._status = _TrustProbeState()
+
+    @property
+    def tool_data(self) -> xr.DataArray:
+        return self._data
+
+    @property
+    def tool_status(self) -> _TrustProbeState:
+        return self._status
+
+    @tool_status.setter
+    def tool_status(self, status: _TrustProbeState) -> None:
+        self._status = status
+
+
+def _workspace_manifest(
+    code: str,
+    *,
+    workspace_id: str = "workspace",
+    tool_identifier: str = _saved_tools.FIGURE_COMPOSER_TOOL_ID,
+) -> dict:
+    recipe = FigureRecipeState(
+        operations=(FigureOperationState.custom(label="custom", code=code),)
+    )
+    attrs = workspace_format._workspace_manifest_attrs(
+        {
+            "tool_cls_qualname": tool_identifier,
+            "tool_state": recipe.model_dump_json(),
+        }
+    )
+    return {
+        "workspace_id": workspace_id,
+        "root_order": [],
+        "nodes": [
+            {
+                "kind": "tool",
+                "path": "figures/0",
+                "payload_attrs": attrs,
+            }
+        ],
+    }
+
+
+def _workspace_manifest_from_attrs(
+    attrs: dict[str, typing.Any], *, kind: str = "imagetool", path: str = "0"
+) -> dict:
+    return {
+        "nodes": [
+            {
+                "kind": kind,
+                "path": path,
+                "payload_attrs": workspace_format._workspace_manifest_attrs(attrs),
+            }
+        ]
+    }
+
+
+def _loaded_workspace_trust(
+    manager,
+    workspace_path: pathlib.Path,
+    manifest: dict,
+    *,
+    selected_paths: set[str] | None = None,
+):
+    return manager._workspace_controller._loaded_workspace_code_trust(
+        workspace_path, manifest, selected_paths=selected_paths
+    )
+
+
+def _load_workspace(manager, workspace_path: pathlib.Path, *, replace: bool = True):
+    return manager._workspace_controller.loading._load_workspace_file(
+        workspace_path,
+        replace=replace,
+        associate=False,
+        mark_dirty=not replace,
+        select=False,
+    )
+
+
+@pytest.fixture
+def external_workspace(tmp_path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    workspace_path = tmp_path / "external.itws"
+    workspace_path.touch()
+    monkeypatch.setattr(workspace_trust, "workspace_path_is_trusted", lambda _: False)
+    return workspace_path
+
+
+def _serialized_imagetool_state(
+    *,
+    path: str = "scan.h5",
+    target: str = "os:remove",
+) -> dict:
+    return {
+        "file_path": path,
+        "load_func": [
+            target,
+            {},
+            FileDataSelection(kind="dataarray").model_dump(mode="json"),
+        ],
+    }
+
+
+def _restore_imagetool(
+    qtbot,
+    *,
+    state: dict[str, typing.Any] | None = None,
+    attrs: dict[str, typing.Any] | None = None,
+    trust=None,
+) -> ImageTool:
+    source = ImageTool(xr.DataArray(np.ones((2, 2)), dims=("x", "y")))
+    qtbot.addWidget(source)
+    dataset = source.to_dataset()
+    if state:
+        saved_state = json.loads(dataset.attrs["itool_state"])
+        saved_state.update(state)
+        dataset.attrs["itool_state"] = json.dumps(saved_state)
+    if attrs:
+        dataset.attrs.update(attrs)
+    kwargs = {} if trust is None else {"_code_trust": trust}
+    restored = ImageTool.from_dataset(dataset, **kwargs)
+    qtbot.addWidget(restored)
+    return restored
+
+
+def _model_fit_operation() -> ModelFitOperation:
+    return ModelFitOperation(
+        fit_dim="x",
+        model="PolynomialModel",
+        model_kwargs={"degree": 1},
+        parameters={
+            "c0": _ModelFitParameterSpec(value=0.0),
+            "c1": _ModelFitParameterSpec(expr="2 * c0"),
+        },
+        method="leastsq",
+        parameter="c0",
+    )
+
+
+def _model_fit_source_spec():
+    return full_data(_model_fit_operation())
+
+
+def _script_source(code: str = "derived = data + 1"):
+    return full_data(ScriptCodeOperation(label="Stored code", code=code))
+
+
+def test_workspace_code_trust_manifest_uses_metadata_and_not_workspace_id() -> None:
+    first = workspace_code_trust_manifest(
+        _workspace_manifest("ax.plot([1])", workspace_id="first")
+    )
+    same_code = workspace_code_trust_manifest(
+        _workspace_manifest("ax.plot([1])", workspace_id="attacker-copy")
+    )
+    changed_code = workspace_code_trust_manifest(
+        _workspace_manifest("ax.plot([2])", workspace_id="first")
+    )
+
+    assert first.canonical_bytes() == same_code.canonical_bytes()
+    assert first.canonical_bytes() != changed_code.canonical_bytes()
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "erlab.interactive._figurecomposer:FigureComposerTool",
+        "attacker.module:ToolWindow",
+    ],
+)
+def test_saved_tool_class_registry_rejects_file_selected_imports(
+    identifier: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = xr.Dataset(attrs={"tool_cls_qualname": identifier})
+
+    def fail_if_imported(_module_name: str):
+        raise AssertionError("document text selected a module import")
+
+    monkeypatch.setattr(_saved_tools.importlib, "import_module", fail_if_imported)
+
+    with pytest.raises(TypeError, match="not registered"):
+        ToolWindow._saved_tool_class_from_dataset(dataset)
+    with pytest.raises(TypeError, match="could not be inspected"):
+        workspace_code_trust_manifest(
+            _workspace_manifest(
+                "run_user_code()",
+                workspace_id="untrusted",
+                tool_identifier=identifier,
+            )
+        )
+
+
+def test_saved_tool_class_registry_accepts_canonical_figure_id() -> None:
+    dataset = xr.Dataset(
+        attrs={"tool_cls_qualname": _saved_tools.FIGURE_COMPOSER_TOOL_ID}
+    )
+
+    assert ToolWindow._saved_tool_class_from_dataset(dataset) is FigureComposerTool
+
+
+def test_saved_tool_class_registry_discovers_installed_extensions(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    module_name = "installed_erlab_tool_extension"
+    identifier = f"{module_name}:InstalledTool"
+    (tmp_path / f"{module_name}.py").write_text(
+        "from erlab.interactive.utils import ToolWindow\n"
+        "class InstalledTool(ToolWindow):\n    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    entry_point = importlib.metadata.EntryPoint(
+        name="installed-tool",
+        value=identifier,
+        group="erlab.interactive.tool_windows",
+    )
+    monkeypatch.setattr(
+        _saved_tools.importlib.metadata,
+        "entry_points",
+        lambda *, group: [entry_point],
+    )
+    monkeypatch.setattr(_saved_tools, "_ENTRY_POINTS_DISCOVERED", False)
+
+    dataset = xr.Dataset(attrs={"tool_cls_qualname": identifier})
+    restored_class = ToolWindow._saved_tool_class_from_dataset(dataset)
+
+    assert restored_class.__module__ == module_name
+    assert restored_class.__qualname__ == "InstalledTool"
+
+
+def test_saved_tool_entry_point_does_not_replace_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded: list[None] = []
+    entry_point = SimpleNamespace(
+        module="erlab.interactive._figurecomposer._tool",
+        attr="FigureComposerTool",
+        load=lambda: loaded.append(None),
+    )
+    monkeypatch.setattr(
+        _saved_tools.importlib.metadata,
+        "entry_points",
+        lambda *, group: [entry_point],
+    )
+    monkeypatch.setattr(_saved_tools, "_ENTRY_POINTS_DISCOVERED", False)
+
+    assert (
+        _saved_tools.resolve_saved_tool_class(_saved_tools.FIGURE_COMPOSER_TOOL_ID)
+        is FigureComposerTool
+    )
+    assert loaded == []
+
+
+def test_saved_tool_entry_point_must_load_its_declared_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identifier = "installed_erlab_tool_extension:DeclaredTool"
+    entry_point = SimpleNamespace(
+        module="installed_erlab_tool_extension",
+        attr="DeclaredTool",
+        load=lambda: FigureComposerTool,
+    )
+    monkeypatch.setattr(_saved_tools, "_SAVED_TOOL_CLASSES", {})
+    monkeypatch.setattr(
+        _saved_tools,
+        "_SAVED_TOOL_LOADERS",
+        dict(_saved_tools._SAVED_TOOL_LOADERS),
+    )
+    monkeypatch.setattr(
+        _saved_tools.importlib.metadata,
+        "entry_points",
+        lambda *, group: [entry_point],
+    )
+    monkeypatch.setattr(_saved_tools, "_ENTRY_POINTS_DISCOVERED", False)
+
+    with pytest.raises(TypeError, match=r"loaded .*FigureComposerTool"):
+        _saved_tools.resolve_saved_tool_class(identifier)
+
+
+def test_workspace_uses_the_registered_tool_trust_hook() -> None:
+    class FutureState(pydantic.BaseModel):
+        code: str
+
+    class FutureTool(ToolWindow):
+        StateModel = FutureState
+        _CODE_TRUST_DOMAIN = "test.future-tool"
+        _CODE_TRUST_POLICY_VERSION = 7
+
+        @classmethod
+        def _code_trust_entries_from_status(cls, status: FutureState):
+            return (
+                create_entry(
+                    "test.future-code",
+                    "tool/code",
+                    status.code,
+                ),
+            )
+
+    manifest = workspace_code_trust_manifest(
+        _workspace_manifest_from_attrs(
+            {
+                "tool_cls_qualname": FutureTool._qual_name(),
+                "tool_state": FutureState(code="run_user_code()").model_dump_json(),
+            },
+            kind="tool",
+            path="tools/0",
+        )
+    )
+
+    assert [entry.feature for entry in manifest.entries] == ["test.future-code"]
+    assert manifest.entries[0].location == "tools/0/tool/code"
+    assert manifest.entries[0].context == {}
+
+
+def test_workspace_manifest_includes_serialized_fit_callables(qtbot) -> None:
+    from erlab.interactive._fit1d import Fit1DTool
+
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = Fit1DTool(data)
+    qtbot.addWidget(tool)
+    tool._serialized_fit_result_blob = np.arange(8, dtype=np.uint8)
+    tool._pending_persisted_fit_is_current = False
+    saved = tool.to_dataset()
+    manifest = workspace_code_trust_manifest(
+        _workspace_manifest_from_attrs(saved.attrs, kind="tool", path="tools/0")
+    )
+
+    features = [entry.feature for entry in manifest.entries]
+    assert features[0] == "erlab.fit.serialized-model"
+    assert "erlab.fit.parameter-expression" in features
+    assert features[-1] == "erlab.fit.serialized-result"
+
+
+def test_signed_workspace_rejects_payload_metadata_added_outside_manifest(
+    qtbot, monkeypatch, tmp_path, manager_context
+) -> None:
+    from erlab.interactive._fit1d import Fit1DTool
+
+    reset_saved_code_trust(domain="erlab.workspace")
+    workspace_path = tmp_path / "injected-pending-payload.itws"
+    data = xr.DataArray(np.arange(5.0), dims="x", name="data")
+
+    with manager_context() as manager:
+        manager.add_imagetool(ImageTool(data), show=False)
+        fit_tool = Fit1DTool(data)
+        qtbot.addWidget(fit_tool)
+        fit_uid = manager.add_childtool(fit_tool, 0, show=False)
+        fit_tool.hide()
+
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+        assert _trust_uses_saved_signature(manager._workspace_state.code_trust)
+
+    injected_blob = np.arange(8, dtype=np.uint8)
+    injected_attrs: dict[str, typing.Any] = {}
+    store_code_payload_entries(
+        injected_attrs,
+        (Fit1DTool._fit_result_code_trust_entry(injected_blob),),
+    )
+    xr.Dataset(
+        {
+            Fit1DTool._PERSISTED_FIT_RESULT_VAR: xr.DataArray(
+                injected_blob,
+                dims=(Fit1DTool._PERSISTED_FIT_RESULT_DIM,),
+            )
+        },
+        attrs=injected_attrs,
+    ).to_netcdf(
+        workspace_path,
+        mode="a",
+        group=_current_workspace_payload_path(
+            workspace_path, f"0/childtools/{fit_uid}"
+        ).lstrip("/"),
+        engine="h5netcdf",
+    )
+
+    decode_calls: list[None] = []
+
+    def fail_if_decoded(_payload):
+        decode_calls.append(None)
+        raise AssertionError("unsigned pending payload was decoded")
+
+    monkeypatch.setattr(
+        interactive_utils,
+        "_deserialize_fit_dataset_blob",
+        fail_if_decoded,
+    )
+
+    with manager_context() as manager:
+        assert _load_workspace(manager, workspace_path)
+        assert _trust_uses_saved_signature(manager._workspace_state.code_trust)
+        node = manager._child_node(fit_uid)
+        assert node.pending_workspace_tool_payload is not None
+        assert node.materialize_pending_workspace_payload()
+
+        assert decode_calls == []
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert node.tool_window is not None
+        assert not document_trust_has_trusted_lineage(node.tool_window._document_trust)
+
+
+def test_signed_workspace_materializes_unchanged_fit_payload(
+    qtbot, tmp_path, manager_context
+) -> None:
+    from erlab.interactive._fit1d import Fit1DTool
+
+    reset_saved_code_trust(domain="erlab.workspace")
+    workspace_path = tmp_path / "signed-fit-payload.itws"
+    data = xr.DataArray(np.arange(5.0), dims="x", name="data")
+
+    with manager_context() as manager:
+        manager.add_imagetool(ImageTool(data), show=False)
+        fit_tool = Fit1DTool(data)
+        qtbot.addWidget(fit_tool)
+        fit_tool._serialized_fit_result_blob = np.arange(8, dtype=np.uint8)
+        fit_tool._pending_persisted_fit_is_current = False
+        fit_uid = manager.add_childtool(fit_tool, 0, show=False)
+        fit_tool.hide()
+
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+        assert _trust_uses_saved_signature(manager._workspace_state.code_trust)
+
+    with manager_context() as manager:
+        assert _load_workspace(manager, workspace_path)
+        signed = manager._workspace_state.code_trust
+        assert _trust_uses_saved_signature(signed)
+        node = manager._child_node(fit_uid)
+        assert node.pending_workspace_tool_payload is not None
+
+        assert node.materialize_pending_workspace_payload()
+
+        assert manager._workspace_state.code_trust == signed
+        assert node.tool_window is not None
+        assert node.tool_window._document_trust == signed
+
+
+def test_signed_workspace_materializes_child_parent_source_code(
+    qtbot, tmp_path, manager_context
+) -> None:
+    reset_saved_code_trust(domain="erlab.workspace")
+    workspace_path = tmp_path / "signed-child-parent-source.itws"
+    parent_data = xr.DataArray(
+        np.arange(10.0).reshape(2, 5),
+        dims=("y", "x"),
+        name="parent",
+    )
+    child_data = xr.DataArray(np.arange(2.0), dims="y", name="child")
+    source_spec = _model_fit_source_spec()
+
+    with manager_context() as manager:
+        manager.add_imagetool(ImageTool(parent_data), show=False)
+        child = _TrustProbeTool(child_data)
+        qtbot.addWidget(child)
+        child.set_source_binding(source_spec)
+        child_uid = manager.add_childtool(child, 0, show=True)
+
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+        references = json.loads(
+            _current_workspace_payload_attrs(
+                workspace_path, f"0/childtools/{child_uid}"
+            )["tool_data_references"]
+        )
+        assert references[interactive_utils._SAVED_TOOL_DATA_NAME] == {
+            "kind": "parent_source"
+        }
+        assert _trust_uses_saved_signature(manager._workspace_state.code_trust)
+
+    with manager_context() as manager:
+        assert _load_workspace(manager, workspace_path)
+        signed = manager._workspace_state.code_trust
+        assert _trust_uses_saved_signature(signed)
+        node = manager._child_node(child_uid)
+
+        assert manager._workspace_state.code_trust == signed
+        assert node.tool_window is not None
+        assert node.tool_window._document_trust == signed
+        assert node.tool_window.source_spec == source_spec
+        assert node.tool_window.tool_data.dims == ("y",)
+
+
+def test_workspace_code_trust_manifest_limits_selected_import_paths() -> None:
+    manifest = _workspace_manifest("ax.plot([1])")
+
+    selected = workspace_code_trust_manifest(manifest, selected_paths={"figures/0"})
+    excluded = workspace_code_trust_manifest(manifest, selected_paths={"other"})
+
+    assert selected.has_executable_code
+    assert not excluded.has_executable_code
+
+
+@pytest.mark.parametrize(
+    ("attribute", "location_segment"),
+    [
+        ("manager_node_live_source_spec", "/source/provenance/"),
+        ("tool_source_spec", "/tool-source/provenance/"),
+    ],
+)
+def test_workspace_manifest_includes_saved_live_source_code(
+    attribute: str,
+    location_segment: str,
+) -> None:
+    workspace_manifest = _workspace_manifest_from_attrs(
+        {attribute: _model_fit_source_spec().model_dump_json()},
+        kind="imagetool" if attribute.startswith("manager_") else "tool",
+        path="selected",
+    )
+
+    selected = workspace_code_trust_manifest(
+        workspace_manifest,
+        selected_paths={"selected"},
+    )
+    excluded = workspace_code_trust_manifest(
+        workspace_manifest,
+        selected_paths={"other"},
+    )
+
+    assert [entry.code for entry in selected.entries] == ["2 * c0"]
+    assert location_segment in selected.entries[0].location
+    assert not excluded.has_executable_code
+
+
+def test_imported_deferred_source_code_makes_combined_workspace_untrusted(
+    external_workspace,
+    manager_context,
+) -> None:
+    workspace_manifest = _workspace_manifest_from_attrs(
+        {
+            "manager_node_live_source_spec": (
+                _model_fit_source_spec().model_dump_json()
+            ),
+            "manager_node_source_state": "stale",
+        },
+        path="selected",
+    )
+
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        incoming = _loaded_workspace_trust(
+            manager,
+            external_workspace,
+            workspace_manifest,
+            selected_paths={"selected"},
+        )
+        assert not document_trust_is_trusted(incoming)
+        assert document_trust_is_trusted(manager._workspace_state.code_trust)
+
+        assert controller._load_with_code_trust(
+            incoming, replace=False, load=lambda: True
+        )
+
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+
+
+def test_workspace_trust_revocation_notifies_every_tool(
+    manager_context, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    def failing_callback() -> None:
+        calls.append("first")
+        raise RuntimeError("failed callback")
+
+    with manager_context() as manager, monkeypatch.context() as patcher:
+        patcher.setattr(
+            manager._tool_graph,
+            "nodes",
+            {
+                "first": SimpleNamespace(
+                    uid="first",
+                    tool_window=SimpleNamespace(_code_trust_changed=failing_callback),
+                ),
+                "second": SimpleNamespace(
+                    uid="second",
+                    tool_window=SimpleNamespace(
+                        _code_trust_changed=lambda: calls.append("second")
+                    ),
+                ),
+            },
+        )
+
+        manager._workspace_controller._set_workspace_code_trust(
+            untrusted_document_trust()
+        )
+
+    assert calls == ["first", "second"]
+
+
+def test_failed_workspace_load_restores_trust_notification(
+    manager_context, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        notifications: list[None] = []
+        monkeypatch.setattr(
+            controller,
+            "_notify_code_trust_changed",
+            lambda: notifications.append(None),
+        )
+
+        assert not controller._load_with_code_trust(
+            untrusted_document_trust(), replace=True, load=lambda: False
+        )
+
+        assert document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert len(notifications) == 2
+
+
+def test_selected_workspace_import_retains_complete_manifest_signature(
+    external_workspace, manager_context
+) -> None:
+    reset_saved_code_trust(domain=workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN)
+    manifest = _workspace_manifest(
+        "first_selected_import_marker()",
+        workspace_id="signed-import",
+    )
+    second = _workspace_manifest(
+        "second_selected_import_marker()",
+        workspace_id="signed-import",
+    )["nodes"][0]
+    second["path"] = "figures/1"
+    manifest["nodes"].append(second)
+    complete = workspace_code_trust_manifest(manifest)
+    selected = workspace_code_trust_manifest(
+        manifest,
+        selected_paths={"figures/0"},
+    )
+    assert complete.canonical_bytes() != selected.canonical_bytes()
+    _saved, signature_stored = save_document_trust(
+        new_document_trust(),
+        complete,
+    )
+    assert signature_stored
+
+    try:
+        with manager_context() as manager:
+            imported = _loaded_workspace_trust(
+                manager,
+                external_workspace,
+                manifest,
+                selected_paths={"figures/0"},
+            )
+        assert _trust_uses_saved_signature(imported)
+        forged = create_manifest(
+            workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN,
+            workspace_trust.WORKSPACE_CODE_TRUST_POLICY_VERSION,
+            (
+                create_entry(
+                    "test.forged-import",
+                    "figures/0/forged",
+                    "forged_import_marker()",
+                ),
+            ),
+        )
+        assert not _trust_uses_saved_signature(
+            load_imported_document_trust(complete, forged)
+        )
+    finally:
+        reset_saved_code_trust(domain=workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN)
+
+
+def test_signed_nonreplacing_import_into_untrusted_workspace_fails_closed_on_collision(
+    manager_context,
+) -> None:
+    existing_entry = create_entry(
+        "test.code",
+        "figures/n0/figure/operations/0",
+        "same_code()",
+    )
+    manifest = create_manifest(
+        workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN,
+        workspace_trust.WORKSPACE_CODE_TRUST_POLICY_VERSION,
+        (existing_entry,),
+    )
+    signed = _document_trust_after_save(
+        new_document_trust(),
+        manifest,
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+
+    with manager_context() as manager:
+        manager._workspace_state.code_trust = untrusted_document_trust(manifest)
+
+        assert manager._workspace_controller._load_with_code_trust(
+            signed,
+            replace=False,
+            load=lambda: True,
+        )
+
+        trust = manager._workspace_state.code_trust
+        assert not document_trust_is_trusted(trust)
+        assert not manager._workspace_controller.issue_code_execution_capability(
+            (existing_entry,)
+        )
+
+
+def test_selected_workspace_import_ignores_unavailable_unselected_tool(
+    external_workspace, manager_context
+) -> None:
+    manifest = _workspace_manifest(
+        "selected_import_marker()",
+        workspace_id="partial-import",
+    )
+    unavailable = _workspace_manifest(
+        "unavailable_import_marker()",
+        workspace_id="partial-import",
+        tool_identifier="unavailable.extension:Tool",
+    )["nodes"][0]
+    unavailable["path"] = "figures/1"
+    manifest["nodes"].append(unavailable)
+    with manager_context() as manager:
+        imported = _loaded_workspace_trust(
+            manager,
+            external_workspace,
+            manifest,
+            selected_paths={"figures/0"},
+        )
+
+    assert not document_trust_is_trusted(imported)
+
+
+@pytest.mark.parametrize("selected_paths", [None, {"figures/0"}])
+def test_workspace_with_unavailable_selected_tool_loads_untrusted(
+    selected_paths, external_workspace, manager_context
+) -> None:
+    manifest = _workspace_manifest(
+        "unavailable_import_marker()",
+        workspace_id="unavailable-tool",
+        tool_identifier="unavailable.extension:Tool",
+    )
+    with manager_context() as manager:
+        loaded_trust = _loaded_workspace_trust(
+            manager,
+            external_workspace,
+            manifest,
+            selected_paths=selected_paths,
+        )
+
+    assert not document_trust_is_trusted(loaded_trust)
+
+
+def test_workspace_tool_extension_failure_loads_untrusted(
+    external_workspace, monkeypatch, manager_context
+) -> None:
+    manifest = _workspace_manifest(
+        "extension_marker()",
+        workspace_id="broken-extension",
+    )
+    monkeypatch.setattr(
+        workspace_trust,
+        "resolve_saved_tool_class",
+        lambda _identifier: (_ for _ in ()).throw(RuntimeError("extension failed")),
+    )
+
+    with manager_context() as manager:
+        loaded_trust = _loaded_workspace_trust(manager, external_workspace, manifest)
+
+    assert not document_trust_is_trusted(loaded_trust)
+
+
+@pytest.mark.parametrize("current_document", [True, False])
+def test_uninspectable_saved_workspace_fails_closed_for_current_document(
+    current_document: bool, monkeypatch, manager_context
+) -> None:
+    save_calls: list[None] = []
+    monkeypatch.setattr(
+        workspace_trust,
+        "workspace_code_trust_manifest",
+        lambda _manifest: (_ for _ in ()).throw(TypeError("unavailable tool")),
+    )
+    monkeypatch.setattr(
+        "erlab.interactive.imagetool.manager._workspace._controller.save_document_trust",
+        lambda *_args, **_kwargs: save_calls.append(None),
+    )
+
+    with manager_context() as manager:
+        initial_trust = manager._workspace_state.code_trust
+        manager._workspace_controller._record_saved_workspace_code_trust(
+            {},
+            trusted_lineage=True,
+            current_document=current_document,
+        )
+
+        assert save_calls == []
+        if current_document:
+            assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        else:
+            assert manager._workspace_state.code_trust is initial_trust
+
+
+def test_workspace_review_without_remaining_code_clears_warning(
+    monkeypatch, manager_context
+) -> None:
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "exec",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected dialog")),
+    )
+    with manager_context() as manager:
+        manager._workspace_state.code_trust = untrusted_document_trust()
+        manager._workspace_controller._refresh_code_trust_ui()
+
+        manager._workspace_controller.review_and_approve_workspace_code_trust()
+
+        assert document_trust_is_trusted(manager._workspace_state.code_trust)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "derived = data + 1",
+        "import os\nderived = data + int(os.path.exists('/'))",
+        (
+            'builtins_dict = vars(erlab)["__builtins__"]\n'
+            'os = builtins_dict["__import__"]("os")\n'
+            "derived = data + int(os.path.exists(os.devnull))"
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "provenance_attr",
+    ["manager_node_provenance_spec", "itool_provenance_spec"],
+)
+def test_workspace_code_trust_manifest_includes_live_python_provenance(
+    code: str,
+    provenance_attr: str,
+) -> None:
+    provenance = _script_source(code)
+    manifest = workspace_code_trust_manifest(
+        _workspace_manifest_from_attrs(
+            {provenance_attr: provenance.model_dump_json()}, kind="imagetool"
+        )
+    )
+
+    assert manifest.has_executable_code
+    assert manifest.entries[0].feature == "erlab.provenance.script-code"
+
+
+def test_workspace_manifest_deduplicates_saved_imagetool_provenance() -> None:
+    provenance = _script_source()
+    serialized = provenance.model_dump_json()
+    manifest = workspace_code_trust_manifest(
+        _workspace_manifest_from_attrs(
+            {
+                "itool_provenance_spec": serialized,
+                "manager_node_provenance_spec": serialized,
+            }
+        )
+    )
+
+    assert len(manifest.entries) == 1
+
+
+def test_workspace_manifest_ignores_legacy_tool_manager_provenance() -> None:
+    recipe = FigureRecipeState(
+        operations=(FigureOperationState.custom(label="custom", code="ax.plot([1])"),)
+    )
+    manifest = workspace_code_trust_manifest(
+        _workspace_manifest_from_attrs(
+            {
+                "tool_cls_qualname": _saved_tools.FIGURE_COMPOSER_TOOL_ID,
+                "tool_state": recipe.model_dump_json(),
+                "manager_node_provenance_spec": _script_source().model_dump_json(),
+            },
+            kind="tool",
+            path="figures/0",
+        )
+    )
+
+    assert [entry.feature for entry in manifest.entries] == [
+        "erlab.figure-composer.custom-code"
+    ]
+    assert [entry.code for entry in manifest.entries] == ["ax.plot([1])"]
+
+
+def test_current_workspace_manifest_ignores_tool_displayed_provenance(
+    qtbot, manager_context
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            operations=(
+                FigureOperationState.custom(label="custom", code="ax.plot([1])"),
+            )
+        ),
+    )
+    qtbot.addWidget(tool)
+
+    with manager_context() as manager:
+        uid = manager.add_figuretool(tool, show=False)
+        manager._tool_graph.nodes[uid].set_pending_workspace_payload(
+            "tool",
+            "pending.itws",
+            "nodes/figures/0/payload",
+            payload_attrs={
+                "manager_node_provenance_spec": _script_source().model_dump_json()
+            },
+        )
+
+        manifest = current_workspace_code_trust_manifest(manager)
+
+    assert [entry.feature for entry in manifest.entries] == [
+        "erlab.figure-composer.custom-code"
+    ]
+    assert [entry.code for entry in manifest.entries] == ["ax.plot([1])"]
+
+
+def test_current_workspace_manifest_includes_distinct_pending_itool_provenance(
+    qtbot,
+    tmp_path,
+    manager_context,
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = ImageTool(data)
+    qtbot.addWidget(tool)
+    safe = full_data(AverageOperation(dims=("x",)))
+    executable = _script_source()
+    attrs = {
+        "manager_node_provenance_spec": safe.model_dump_json(),
+        "itool_provenance_spec": executable.model_dump_json(),
+    }
+
+    with manager_context() as manager:
+        manager.add_imagetool(tool, show=False)
+        node = manager._node_for_target(0)
+        node.set_pending_workspace_payload(
+            "imagetool",
+            tmp_path / "pending.itws",
+            "nodes/0/payload",
+            payload_attrs=attrs,
+        )
+
+        current = current_workspace_code_trust_manifest(manager)
+
+    loaded = workspace_code_trust_manifest(_workspace_manifest_from_attrs(attrs))
+    assert current.entries == loaded.entries
+    assert [entry.code for entry in current.entries] == ["derived = data + 1"]
+
+
+def test_workspace_code_trust_manifest_includes_model_fit_expressions() -> None:
+    provenance = _model_fit_source_spec()
+    manifest = workspace_code_trust_manifest(
+        _workspace_manifest_from_attrs(
+            {"manager_node_provenance_spec": provenance.model_dump_json()}
+        )
+    )
+
+    assert [entry.feature for entry in manifest.entries] == [
+        "erlab.provenance.model-fit-parameter-expression"
+    ]
+    assert manifest.entries[0].code == "2 * c0"
+
+
+def test_manager_provenance_apply_authorizes_model_fit_expression_before_execution(
+    manager_context,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4.0)})
+    operation = _model_fit_operation()
+    provenance = full_data(operation)
+    executions: list[None] = []
+    monkeypatch.setattr(
+        ModelFitOperation,
+        "apply",
+        lambda _operation, source: executions.append(None) or source,
+    )
+
+    with manager_context() as manager:
+        manager._workspace_state.code_trust = untrusted_document_trust()
+        with pytest.raises(_TrustedProvenanceReplayCancelled):
+            manager._apply_provenance(
+                provenance,
+                data,
+                reason="test provenance authorization",
+            )
+        assert executions == []
+
+        manager._workspace_state.code_trust = new_document_trust()
+        result = manager._apply_provenance(
+            provenance,
+            data,
+            reason="test provenance authorization",
+        )
+
+    xr.testing.assert_identical(result, data)
+    assert executions == [None]
+
+
+def test_provenance_manifest_ignores_safe_pipeline_and_review_state() -> None:
+    def manifest(
+        *,
+        average_dim: str = "x",
+        start_label: str = "Calculate result",
+        code_label: str = "Run code",
+        input_label: str = "Displayed input",
+        node_uid: str = "node-a",
+        snapshot_id: str = "snapshot-a",
+    ) -> bytes:
+        provenance = script(
+            ScriptCodeOperation(
+                label=code_label,
+                code=("import os\nderived = data + int(os.path.exists(os.devnull))"),
+            ),
+            start_label=start_label,
+            active_name="derived",
+            steps=(
+                ReplayStep(
+                    operation=AverageOperation(dims=(average_dim,)),
+                    input_policy="current",
+                ),
+            ),
+            script_inputs=(
+                ScriptInput(
+                    name="data",
+                    label=input_label,
+                    node_uid=node_uid,
+                    node_snapshot_token=snapshot_id,
+                    provenance_spec=full_data().model_dump(mode="json"),
+                ),
+            ),
+        )
+        return create_manifest(
+            "test.provenance",
+            1,
+            provenance_code_trust_entries(
+                provenance,
+                location_prefix="provenance",
+            ),
+        ).canonical_bytes()
+
+    baseline = manifest()
+
+    assert baseline == manifest(average_dim="y")
+    assert baseline == manifest(node_uid="node-b")
+    assert baseline == manifest(snapshot_id="snapshot-b")
+    assert baseline == manifest(start_label="Renamed result")
+    assert baseline == manifest(code_label="Renamed code step")
+    assert baseline == manifest(input_label="Renamed input")
+
+
+def test_workspace_manifest_ignores_file_loader_metadata() -> None:
+    def manifest_for(serialized_state: dict):
+        return workspace_code_trust_manifest(
+            _workspace_manifest_from_attrs(
+                {"itool_state": json.dumps(serialized_state)}
+            )
+        )
+
+    first = manifest_for(_serialized_imagetool_state())
+    changed = manifest_for(_serialized_imagetool_state(target="pathlib:Path.unlink"))
+
+    assert not first.has_executable_code
+    assert first.canonical_bytes() == changed.canonical_bytes()
+
+
+def test_workspace_code_trust_manifest_does_not_decode_unrelated_arrays(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _workspace_manifest("ax.plot([1])")
+    attrs = manifest["nodes"][0]["payload_attrs"]
+    attrs.extend(workspace_format._workspace_manifest_attrs({"preview": np.arange(4)}))
+
+    def fail_if_decoded(*_args, **_kwargs):
+        raise AssertionError("unrelated array metadata was decoded")
+
+    monkeypatch.setattr(workspace_format, "_workspace_decode_array", fail_if_decoded)
+
+    assert workspace_code_trust_manifest(manifest).has_executable_code
+
+
+def test_workspace_code_trust_manifest_rejects_array_in_code_attribute_without_decoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _workspace_manifest("ax.plot([1])")
+    manifest["nodes"][0]["payload_attrs"] = workspace_format._workspace_manifest_attrs(
+        {
+            "tool_cls_qualname": (
+                "erlab.interactive._figurecomposer._tool:FigureComposerTool"
+            ),
+            "tool_state": np.arange(4),
+        }
+    )
+
+    def fail_if_decoded(*_args, **_kwargs):
+        raise AssertionError("array metadata was decoded")
+
+    monkeypatch.setattr(workspace_format, "_workspace_decode_array", fail_if_decoded)
+
+    with pytest.raises(TypeError, match="must be a string"):
+        workspace_code_trust_manifest(manifest)
+
+
+def test_workspace_code_trust_manifest_fails_closed_without_payload_attrs() -> None:
+    with pytest.raises(TypeError, match="payload attributes"):
+        workspace_code_trust_manifest(
+            {"nodes": [{"kind": "tool", "path": "figures/0"}]}
+        )
+
+
+def test_trusted_workspace_location_is_checked_before_manifest_building(
+    monkeypatch, manager_context
+) -> None:
+    monkeypatch.setattr(
+        workspace_trust, "workspace_path_is_trusted", lambda _path: True
+    )
+
+    def fail_if_built(*_args, **_kwargs):
+        raise AssertionError("trusted-location load built the code manifest")
+
+    monkeypatch.setattr(workspace_trust, "workspace_code_trust_manifest", fail_if_built)
+    with manager_context() as manager:
+        trust = manager._workspace_controller._loaded_workspace_code_trust(
+            "trusted.itws", {"nodes": []}, selected_paths=None
+        )
+
+    assert document_trust_is_trusted(trust)
+
+
+def test_workspace_host_routes_materialized_tool_trust_to_one_state(
+    qtbot, manager_context
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    with manager_context() as manager:
+        manager.add_imagetool(ImageTool(data), show=False)
+        manager._workspace_state.code_trust = untrusted_document_trust()
+
+        tool = _TrustProbeTool(data)
+        qtbot.addWidget(tool)
+        manager.add_childtool(tool, 0, show=False)
+
+        assert not document_trust_has_trusted_lineage(tool._current_document_trust())
+
+        manager._workspace_state.code_trust = new_document_trust()
+        manager._workspace_controller._refresh_code_trust_ui()
+
+        assert document_trust_has_trusted_lineage(tool._current_document_trust())
+
+
+def test_workspace_host_preserves_identical_saved_signature(
+    qtbot, manager_context
+) -> None:
+    manifest = create_manifest(
+        workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN,
+        workspace_trust.WORKSPACE_CODE_TRUST_POLICY_VERSION,
+        (create_entry("test.code", "tools/0/code", "run_code()"),),
+    )
+    reset_saved_code_trust(domain=workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN)
+    try:
+        save_document_trust(new_document_trust(), manifest)
+        signed = load_document_trust(manifest)
+        assert _trust_uses_saved_signature(signed)
+
+        data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+        with manager_context() as manager:
+            manager._workspace_state.code_trust = signed
+            tool = _TrustProbeTool(data)
+            qtbot.addWidget(tool)
+            tool.set_document_trust(signed, notify=False)
+
+            manager._workspace_controller._configure_tool_code_trust(
+                tool, location_getter=lambda: "tools/0"
+            )
+
+            assert _trust_uses_saved_signature(manager._workspace_state.code_trust)
+    finally:
+        reset_saved_code_trust(domain=workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN)
+
+
+def test_workspace_local_code_edit_commits_only_after_success(
+    manager_context, monkeypatch
+) -> None:
+    saved_entry = create_entry("test.code", "tools/0/code", "saved()")
+    edited_entry = create_entry("test.code", "tools/0/code", "edited()")
+    signed = _document_trust_after_save(
+        new_document_trust(),
+        create_manifest(
+            workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN,
+            workspace_trust.WORKSPACE_CODE_TRUST_POLICY_VERSION,
+            (saved_entry,),
+        ),
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+
+    with manager_context() as manager:
+        manager._workspace_state.code_trust = signed
+        controller = manager._workspace_controller
+        scan_calls = 0
+        original_manifest_builder = (
+            workspace_trust.current_workspace_code_trust_manifest
+        )
+
+        def tracked_manifest_builder(manager):
+            nonlocal scan_calls
+            scan_calls += 1
+            return original_manifest_builder(manager)
+
+        monkeypatch.setattr(
+            workspace_trust,
+            "current_workspace_code_trust_manifest",
+            tracked_manifest_builder,
+        )
+        controller._mark_workspace_dirty(structure="test presentation edit")
+        assert manager._workspace_state.code_trust == signed
+
+        def fail_edit() -> None:
+            with controller.local_code_edit(
+                (edited_entry,),
+                edited_entries=(edited_entry,),
+            ) as capability:
+                assert manager._workspace_state.code_trust == signed
+                assert (
+                    controller.issue_code_execution_capability((edited_entry,))
+                    is capability
+                )
+                raise RuntimeError("validation failed")
+
+        with pytest.raises(RuntimeError, match="validation failed"):
+            fail_edit()
+
+        assert manager._workspace_state.code_trust == signed
+        assert scan_calls == 0
+
+        with controller.local_code_edit(
+            (edited_entry,),
+            edited_entries=(edited_entry,),
+        ):
+            assert manager._workspace_state.code_trust == signed
+
+        assert manager._workspace_state.code_trust != signed
+        assert scan_calls == 1
+        assert document_trust_has_trusted_lineage(
+            manager._workspace_state.code_trust
+        ), (
+            manager._workspace_state.code_trust.local_document_identities,
+            tuple(
+                entry.document_identity()
+                for entry in current_workspace_code_trust_manifest(manager).entries
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "trust",
+    [
+        pytest.param(new_document_trust(), id="local-lineage"),
+        pytest.param(trusted_location_document_trust(), id="trusted-location"),
+    ],
+)
+def test_trusted_workspace_local_code_edit_does_not_scan_manifest(
+    manager_context,
+    monkeypatch,
+    trust,
+) -> None:
+    edited_entry = create_entry("test.code", "tools/0/code", "edited()")
+
+    with manager_context() as manager:
+        manager._workspace_state.code_trust = trust
+        controller = manager._workspace_controller
+
+        def unexpected_manifest_scan(_manager):
+            raise AssertionError("trusted local edit scanned the workspace manifest")
+
+        monkeypatch.setattr(
+            workspace_trust,
+            "current_workspace_code_trust_manifest",
+            unexpected_manifest_scan,
+        )
+
+        with controller.local_code_edit(
+            (edited_entry,),
+            edited_entries=(edited_entry,),
+        ) as capability:
+            assert execution_capability_allows(capability, (edited_entry,))
+
+        assert manager._workspace_state.code_trust == trust
+
+
+def test_workspace_partial_capability_requires_explicit_graph_request(
+    manager_context,
+) -> None:
+    local_entry = create_entry("test.code", "tools/local/code", "local()")
+    external_entry = create_entry(
+        "test.code",
+        "tools/external/code",
+        "external()",
+    )
+
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        controller._set_workspace_code_trust(
+            untrusted_document_trust(
+                create_manifest(
+                    workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN,
+                    workspace_trust.WORKSPACE_CODE_TRUST_POLICY_VERSION,
+                    (external_entry,),
+                )
+            )
+        )
+
+        def check_open_transaction() -> None:
+            with controller.local_code_edit(
+                (local_entry, external_entry),
+                edited_entries=(local_entry,),
+            ) as partial_capability:
+                assert partial_capability is not None
+                assert (
+                    controller.issue_code_execution_capability(
+                        (local_entry, external_entry)
+                    )
+                    is None
+                )
+                assert (
+                    controller.issue_code_execution_capability(
+                        (local_entry, external_entry),
+                        allow_partial=True,
+                    )
+                    is partial_capability
+                )
+                assert execution_capability_allows(
+                    partial_capability,
+                    (local_entry,),
+                )
+                assert not execution_capability_allows(
+                    partial_capability,
+                    (external_entry,),
+                )
+                raise RuntimeError("stop test transaction")
+
+        with pytest.raises(RuntimeError, match="stop test transaction"):
+            check_open_transaction()
+
+
+def test_signed_workspace_runs_locally_edited_provenance_without_review(
+    qtbot,
+    manager_context,
+) -> None:
+    source = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    original = full_data(
+        ScriptCodeOperation(label="Offset", code="derived = derived + 1")
+    )
+    candidate = full_data(
+        ScriptCodeOperation(label="Offset", code="derived = derived + 2")
+    )
+    tool = ImageTool(source + 1)
+    qtbot.addWidget(tool)
+
+    with manager_context() as manager:
+        manager.add_imagetool(
+            tool,
+            show=False,
+            provenance_spec=original,
+            replay_source_data=source,
+        )
+        manifest = current_workspace_code_trust_manifest(manager)
+        signed = _document_trust_after_save(
+            new_document_trust(),
+            manifest,
+            saved_trusted_lineage=True,
+            signature_stored=True,
+        )
+        manager._workspace_controller._set_workspace_code_trust(signed)
+
+        node = manager._node_for_target(0)
+        manager._provenance_edit_controller._validate_and_replace(
+            node,
+            "display",
+            candidate,
+        )
+
+        xr.testing.assert_identical(node.current_public_data(), source + 2)
+        assert document_trust_has_trusted_lineage(manager._workspace_state.code_trust)
+        assert not _trust_uses_saved_signature(manager._workspace_state.code_trust)
+
+
+def test_local_provenance_edit_does_not_authorize_equal_code_at_another_node(
+    qtbot, manager_context
+) -> None:
+    source = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    shared = full_data(
+        ScriptCodeOperation(label="Shared", code="derived = derived + 1")
+    )
+    different = full_data(
+        ScriptCodeOperation(label="Different", code="derived = derived + 2")
+    )
+    first = ImageTool(source + 1)
+    second = ImageTool(source + 2)
+    qtbot.addWidget(first)
+    qtbot.addWidget(second)
+
+    with manager_context() as manager:
+        manager.add_imagetool(
+            first,
+            show=False,
+            provenance_spec=shared,
+            replay_source_data=source,
+        )
+        manager.add_imagetool(
+            second,
+            show=False,
+            provenance_spec=different,
+            replay_source_data=source,
+        )
+        manifest = current_workspace_code_trust_manifest(manager)
+        manager._workspace_controller._set_workspace_code_trust(
+            untrusted_document_trust(manifest)
+        )
+
+        second_node = manager._node_for_target(1)
+        manager._provenance_edit_controller._validate_and_replace(
+            second_node,
+            "display",
+            shared,
+        )
+
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert manager.code_trust_banner.isVisible()
+        xr.testing.assert_identical(second_node.current_public_data(), source + 1)
+        runtime_entries = provenance_code_trust_entries(
+            shared,
+            location_prefix="runtime",
+        )
+        assert second.slicer_area._stored_code_authorizer is not None
+        assert second.slicer_area._stored_code_authorizer(runtime_entries) is not None
+        assert first.slicer_area._stored_code_authorizer is not None
+        assert first.slicer_area._stored_code_authorizer(runtime_entries) is None
+
+        first_local = full_data(
+            ScriptCodeOperation(label="First local", code="derived = derived + 3")
+        )
+        first_node = manager._node_for_target(0)
+        manager._provenance_edit_controller._validate_and_replace(
+            first_node,
+            "display",
+            first_local,
+        )
+
+        assert document_trust_has_trusted_lineage(manager._workspace_state.code_trust)
+        xr.testing.assert_identical(first_node.current_public_data(), source + 3)
+
+
+def test_local_source_provenance_edit_owns_source_and_display_locations(
+    qtbot, manager_context
+) -> None:
+    source = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("y", "x"),
+        name="data",
+    )
+    shared = _model_fit_source_spec()
+    different_operation = _model_fit_operation().model_copy(
+        update={
+            "parameters": {
+                "c0": _ModelFitParameterSpec(value=0.0),
+                "c1": _ModelFitParameterSpec(expr="3 * c0"),
+            }
+        }
+    )
+    different = full_data(different_operation)
+    external = ImageTool(source)
+    parent = ImageTool(source)
+    child = ImageTool(source)
+    for tool in (external, parent, child):
+        qtbot.addWidget(tool)
+
+    with manager_context() as manager:
+        manager.add_imagetool(
+            external,
+            show=False,
+            provenance_spec=shared,
+            replay_source_data=source,
+        )
+        manager.add_imagetool(parent, show=False)
+        child_uid = manager.add_imagetool_child(
+            child,
+            1,
+            show=False,
+            source_spec=different,
+        )
+        manager._workspace_controller._set_workspace_code_trust(
+            untrusted_document_trust(current_workspace_code_trust_manifest(manager))
+        )
+
+        child_node = manager._child_node(child_uid)
+        manager._provenance_edit_controller._validate_and_replace(
+            child_node,
+            "source",
+            shared,
+        )
+
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        runtime_entries = provenance_code_trust_entries(
+            shared,
+            location_prefix="runtime",
+        )
+        assert child.slicer_area._stored_code_authorizer is not None
+        assert child.slicer_area._stored_code_authorizer(runtime_entries) is not None
+        assert external.slicer_area._stored_code_authorizer is not None
+        assert external.slicer_area._stored_code_authorizer(runtime_entries) is None
+
+
+def test_workspace_host_merges_added_tool_trust(qtbot, manager_context) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    recipe = FigureRecipeState(
+        operations=(
+            FigureOperationState.custom(label="custom", code="ax.set_title('code')"),
+        )
+    )
+    tool = FigureComposerTool(data, recipe=recipe)
+    qtbot.addWidget(tool)
+    tool.set_document_trust(untrusted_document_trust(), notify=False)
+
+    with manager_context() as manager:
+        manager.add_figuretool(tool, show=False)
+
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert not document_trust_has_trusted_lineage(tool._document_trust)
+        assert current_workspace_code_trust_manifest(manager).has_executable_code
+
+
+def test_local_figure_added_to_mixed_workspace_keeps_exact_local_ownership(
+    qtbot, manager_context
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    recipe = FigureRecipeState(
+        operations=(
+            FigureOperationState.custom(label="custom", code="ax.set_title('same')"),
+        )
+    )
+    external = FigureComposerTool(data, recipe=recipe)
+    local = FigureComposerTool(data, recipe=recipe)
+    qtbot.addWidget(external)
+    qtbot.addWidget(local)
+    external_manifest = external._current_code_trust_manifest()
+    assert external_manifest is not None
+    external.set_document_trust(
+        untrusted_document_trust(external_manifest), notify=False
+    )
+
+    with manager_context() as manager:
+        manager.add_figuretool(external, show=False)
+        manager.add_figuretool(local, show=False)
+
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert manager.code_trust_banner.isVisible()
+        figure_rendering._render_into_figure(
+            external, external.figure, sync_visible=False
+        )
+        figure_rendering._render_into_figure(local, local.figure, sync_visible=False)
+        assert external.figure.axes[0].get_title() == ""
+        assert local.figure.axes[0].get_title() == "same"
+
+
+def test_local_edit_does_not_authorize_equal_code_at_another_node_location(
+    qtbot, manager_context
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    first = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            operations=(
+                FigureOperationState.custom(
+                    label="first", code="ax.set_title('shared')"
+                ),
+            )
+        ),
+    )
+    second = FigureComposerTool(
+        data,
+        recipe=FigureRecipeState(
+            operations=(
+                FigureOperationState.custom(
+                    label="second", code="ax.set_title('external second')"
+                ),
+            )
+        ),
+    )
+    qtbot.addWidget(first)
+    qtbot.addWidget(second)
+    for tool in (first, second):
+        manifest = tool._current_code_trust_manifest()
+        assert manifest is not None
+        tool.set_document_trust(untrusted_document_trust(manifest), notify=False)
+
+    with manager_context() as manager:
+        manager.add_figuretool(first, show=False)
+        manager.add_figuretool(second, show=False)
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+
+        second.tool_status = second.tool_status.model_copy(
+            update={
+                "operations": (
+                    FigureOperationState.custom(
+                        label="second", code="ax.set_title('shared')"
+                    ),
+                )
+            }
+        )
+
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert manager.code_trust_banner.isVisible()
+        qtbot.waitUntil(
+            lambda: second.figure.axes[0].get_title() == "shared", timeout=1000
+        )
+        figure_rendering._render_into_figure(first, first.figure, sync_visible=False)
+        assert first.figure.axes[0].get_title() == ""
+        first_manifest = first._current_code_trust_manifest()
+        assert first_manifest is not None
+        assert (
+            manager._workspace_controller.issue_code_execution_capability(
+                first_manifest.entries
+            )
+            is None
+        )
+
+        first.tool_status = first.tool_status.model_copy(
+            update={
+                "operations": (
+                    FigureOperationState.custom(
+                        label="first", code="ax.set_title('local first')"
+                    ),
+                )
+            }
+        )
+
+        assert document_trust_has_trusted_lineage(manager._workspace_state.code_trust)
+        assert not manager.code_trust_banner.isVisible()
+        qtbot.waitUntil(
+            lambda: first.figure.axes[0].get_title() == "local first", timeout=1000
+        )
+        qtbot.waitUntil(
+            lambda: second.figure.axes[0].get_title() == "shared", timeout=1000
+        )
+
+
+def test_workspace_host_merges_added_imagetool_trust(qtbot, manager_context) -> None:
+    restored = _restore_imagetool(qtbot, state=_serialized_imagetool_state())
+
+    assert restored.slicer_area._load_func is None
+    with manager_context() as manager:
+        manager.add_imagetool(restored, show=False)
+
+        assert document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert restored.slicer_area._load_func is None
+        manifest = current_workspace_code_trust_manifest(manager)
+        assert not manifest.has_executable_code
+
+
+@pytest.mark.parametrize("attachment", ["root", "child"])
+def test_workspace_host_imports_standalone_executable_provenance_as_external(
+    qtbot, manager_context, attachment: str
+) -> None:
+    provenance = _script_source(
+        "import os\nderived = data + int(os.path.exists(os.devnull))"
+    )
+    restored = _restore_imagetool(
+        qtbot, attrs={"itool_provenance_spec": provenance.model_dump_json()}
+    )
+
+    with manager_context() as manager:
+        if attachment == "root":
+            target = manager.add_imagetool(restored, show=False)
+        else:
+            parent = ImageTool(xr.DataArray(np.arange(3.0), dims="x"))
+            qtbot.addWidget(parent)
+            manager.add_imagetool(parent, show=False)
+            target = manager.add_imagetool_child(restored, 0, show=False)
+
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert restored.provenance_spec == provenance
+        assert manager._node_for_target(target).displayed_provenance_spec == provenance
+        manifest = current_workspace_code_trust_manifest(manager)
+    assert [entry.feature for entry in manifest.entries] == [
+        "erlab.provenance.script-code"
+    ]
+
+
+def test_current_workspace_manifest_includes_imagetool_live_source_code(
+    qtbot,
+    manager_context,
+) -> None:
+    data = xr.DataArray(np.arange(4.0), dims="x", coords={"x": np.arange(4.0)})
+    root = ImageTool(data)
+    child = ImageTool(data)
+    qtbot.addWidget(root)
+    qtbot.addWidget(child)
+
+    with manager_context() as manager:
+        manager.add_imagetool(root, show=False)
+        manager.add_imagetool_child(
+            child,
+            0,
+            show=False,
+            source_spec=_model_fit_source_spec(),
+            source_state="stale",
+        )
+
+        assert document_trust_is_trusted(manager._workspace_state.code_trust)
+        manifest = current_workspace_code_trust_manifest(manager)
+
+    source_entries = [
+        entry for entry in manifest.entries if "/source/provenance/" in entry.location
+    ]
+    assert [entry.code for entry in source_entries] == ["2 * c0"]
+
+
+def test_workspace_host_retains_tool_payload_verification_failure(
+    qtbot, manager_context
+) -> None:
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    with manager_context() as manager:
+        manager.add_imagetool(ImageTool(data), show=False)
+        tool = _TrustProbeTool(data)
+        qtbot.addWidget(tool)
+        tool.set_document_trust(untrusted_document_trust(), notify=False)
+
+        manager._workspace_state.code_trust = trusted_location_document_trust()
+        manager.add_childtool(tool, 0, show=False)
+
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert not document_trust_is_trusted(tool._current_document_trust())
+        assert not document_trust_has_trusted_lineage(tool._document_trust)
+
+
+def test_workspace_approval_persists_and_restores_figure_execution(
+    qtbot, tmp_path, manager_context, monkeypatch
+) -> None:
+    reset_saved_code_trust(domain="erlab.workspace")
+    workspace_path = tmp_path / "code-trust.itws"
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    recipe = FigureRecipeState(
+        sources=(FigureSourceState(name="data", label="data"),),
+        operations=(
+            FigureOperationState.custom(label="custom", code="ax.set_title('trusted')"),
+        ),
+        primary_source="data",
+    )
+
+    with manager_context() as manager:
+        figure_uid = manager.add_figuretool(
+            FigureComposerTool(data, recipe=recipe), show=False
+        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+        assert _trust_uses_saved_signature(manager._workspace_state.code_trust)
+        assert _trust_uses_saved_signature(
+            load_document_trust(current_workspace_code_trust_manifest(manager))
+        )
+
+    reset_saved_code_trust(domain="erlab.workspace")
+    with manager_context() as manager:
+        manager.add_figuretool(FigureComposerTool(data), show=False)
+        assert _load_workspace(manager, workspace_path, replace=False)
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        untrusted_copy = tmp_path / "untrusted-copy.itws"
+        manager._workspace_controller.saving._save_workspace_document(untrusted_copy)
+        assert not _trust_uses_saved_signature(
+            load_document_trust(current_workspace_code_trust_manifest(manager))
+        )
+
+    with manager_context() as manager:
+        assert _load_workspace(manager, workspace_path)
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)
+        assert not manager.code_trust_banner.isHidden()
+        node = manager._child_node(figure_uid)
+        assert node.materialize_pending_workspace_payload()
+        tool = node.tool_window
+        assert isinstance(tool, FigureComposerTool)
+        figure_rendering._render_into_figure(tool, tool.figure, sync_visible=False)
+        assert tool.figure.axes[0].get_title() == ""
+
+        monkeypatch.setattr(
+            "erlab.interactive.imagetool.manager._workspace._controller."
+            "confirm_code_trust",
+            lambda *_args, **_kwargs: True,
+        )
+        manager._workspace_controller.review_and_approve_workspace_code_trust()
+        qtbot.waitUntil(
+            lambda: tool.figure.axes[0].get_title() == "trusted", timeout=1000
+        )
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+
+    with manager_context() as manager:
+        assert _load_workspace(manager, workspace_path)
+        assert _trust_uses_saved_signature(manager._workspace_state.code_trust)
+        signed = manager._workspace_state.code_trust
+        node = manager._child_node(figure_uid)
+        assert node.materialize_pending_workspace_payload()
+        assert manager._workspace_state.code_trust == signed
+
+
+def test_workspace_save_uses_snapshot_trust_without_overwriting_current_state(
+    tmp_path, manager_context
+) -> None:
+    reset_saved_code_trust(domain="erlab.workspace")
+    untrusted_snapshot = _workspace_manifest(
+        "ax.plot([1])", workspace_id="untrusted-snapshot"
+    )
+    trusted_snapshot = _workspace_manifest(
+        "ax.plot([2])", workspace_id="trusted-snapshot"
+    )
+
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        manager._workspace_state.code_trust = new_document_trust()
+
+        controller._record_saved_workspace_code_trust(
+            untrusted_snapshot,
+            trusted_lineage=False,
+            current_document=True,
+        )
+
+        untrusted_manifest = workspace_code_trust_manifest(untrusted_snapshot)
+        assert not _trust_uses_saved_signature(load_document_trust(untrusted_manifest))
+        assert document_trust_is_trusted(manager._workspace_state.code_trust)
+
+        manager._workspace_state.code_trust = untrusted_document_trust()
+        snapshot = controller.saving._workspace_generation_save_snapshot(
+            manager._workspace_state.dirty_generation,
+            fname=tmp_path / "snapshot.itws",
+        )
+        try:
+            assert not snapshot.trusted_lineage
+        finally:
+            snapshot.close()
+        controller._record_saved_workspace_code_trust(
+            trusted_snapshot,
+            trusted_lineage=True,
+            current_document=False,
+        )
+
+        assert _trust_uses_saved_signature(
+            load_document_trust(workspace_code_trust_manifest(trusted_snapshot))
+        )
+        assert not document_trust_is_trusted(manager._workspace_state.code_trust)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -50,6 +50,7 @@ from erlab.interactive.imagetool._figurecomposer_adapter import (
     _PlotOperationBuilder,
     build_figure_composer_operation,
 )
+from erlab.interactive.imagetool._load_source import _register_local_callable_loader
 from erlab.interactive.imagetool._provenance._execution import replay_file_provenance
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
@@ -78,6 +79,7 @@ from erlab.interactive.imagetool._provenance._operations import (
     InterpolationOperation,
     IselOperation,
     LeadingEdgeOperation,
+    ModelFitOperation,
     NormalizeOperation,
     QSelAggregationOperation,
     QSelOperation,
@@ -93,6 +95,7 @@ from erlab.interactive.imagetool._provenance._operations import (
     SymmetrizeOperation,
     ThinOperation,
     UniformInterpolationOperation,
+    _ModelFitParameterSpec,
 )
 from erlab.interactive.imagetool._viewer_dialogs import (
     _AssociatedCoordsDialog,
@@ -1222,7 +1225,7 @@ def test_itool_dataset_metadata_fields_roundtrip(qtbot, tmp_path: pathlib.Path) 
     assert saved_state["axis_inversions"] == {"alpha": True}
     assert saved_state["splitter_sizes"] == area.splitter_sizes
     assert saved_state["file_path"] == str(file_path)
-    assert saved_state["load_func"][0].endswith(":load_dataarray")
+    assert saved_state["load_func"][0].endswith(".load_dataarray")
     assert saved_state["load_func"][1:] == [
         {"engine": "h5netcdf"},
         {"kind": "dataarray", "value": None},
@@ -1474,6 +1477,52 @@ def test_itool_state_loader_string_selection_roundtrip_and_reload(
     win.close()
 
 
+def test_itool_state_builtin_callable_loader_restores_after_registry_reset(
+    qtbot,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    file_path = tmp_path / "scan.h5"
+    data = xr.DataArray(
+        np.arange(4.0).reshape((2, 2)),
+        dims=("x", "y"),
+        coords={"x": np.arange(2), "y": np.arange(2)},
+        name="signal",
+    )
+    data.to_netcdf(file_path, engine="h5netcdf")
+    win = ImageTool(
+        data,
+        file_path=file_path,
+        load_func=(
+            xr.load_dataarray,
+            {"engine": "h5netcdf"},
+            FileDataSelection(kind="dataarray"),
+        ),
+    )
+    qtbot.addWidget(win)
+    serialized = win.to_dataset()
+
+    monkeypatch.setattr(imagetool_load_source, "_LOCAL_CALLABLE_LOADERS", {})
+    restored = ImageTool.from_dataset(serialized)
+    qtbot.addWidget(restored)
+
+    assert restored.slicer_area._load_func == (
+        xr.load_dataarray,
+        {"engine": "h5netcdf"},
+        FileDataSelection(kind="dataarray"),
+    )
+    assert restored.slicer_area.reloadable
+
+    updated = data + 10.0
+    updated.to_netcdf(file_path, engine="h5netcdf")
+    with qtbot.wait_signal(restored.slicer_area.sigDataChanged):
+        restored.slicer_area.reload()
+    xarray.testing.assert_identical(restored.slicer_area.data, updated)
+
+    restored.close()
+    win.close()
+
+
 def test_itool_state_spreadsheet_metadata_source_roundtrip(
     qtbot,
     tmp_path: pathlib.Path,
@@ -1635,8 +1684,32 @@ def test_itool_restore_does_not_invoke_persisted_legacy_loader(
     qtbot.addWidget(restored)
 
     assert victim.read_text() == "preserve me"
+    assert restored.slicer_area._load_func is None
     restored.close()
     win.close()
+
+
+@pytest.mark.parametrize(
+    "load_func",
+    [
+        ["os:remove", 1, None],
+        ["os:remove", {}, {"invalid": True}],
+    ],
+)
+def test_itool_rejects_malformed_pending_loader_state(
+    qtbot,
+    tmp_path: pathlib.Path,
+    load_func: list[typing.Any],
+) -> None:
+    win = ImageTool(_TEST_DATA["2D"])
+    qtbot.addWidget(win)
+    file_path = tmp_path / "scan.h5"
+    file_path.touch()
+    win.slicer_area._file_path = file_path
+
+    assert not win.slicer_area._restore_serialized_load_func(load_func)
+    assert win.slicer_area._load_func is None
+    assert not win.slicer_area._direct_reloadable()
 
 
 def test_itool_legacy_dataset_selection_migrates_on_explicit_reload(
@@ -4218,6 +4291,7 @@ def test_itool_provenance_reload_rejects_incomplete_or_invalid_replay(
     monkeypatch,
     tmp_path: pathlib.Path,
 ) -> None:
+    _register_local_callable_loader(xr.load_dataarray)
     win = itool(xr.DataArray(np.arange(4.0), dims=("x",)), execute=False)
     qtbot.addWidget(win)
     unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
@@ -4355,7 +4429,7 @@ def test_itool_provenance_reload_rejects_incomplete_or_invalid_replay(
     assert not win.slicer_area.reloadable
     reason = win.slicer_area._provenance_reload_unavailable_reason()
     assert reason is not None
-    assert "trust" in reason.lower()
+    assert "ImageTool Manager" in reason
 
     win.set_provenance_spec(
         file_load(
@@ -4397,6 +4471,74 @@ def test_itool_provenance_reload_rejects_incomplete_or_invalid_replay(
 
     win.set_provenance_spec(None)
     with pytest.raises(RuntimeError, match="cannot be reloaded"):
+        win.slicer_area._fetch_reload_data()
+
+    win.close()
+
+
+def test_standalone_reload_never_executes_recorded_code(
+    qtbot,
+    tmp_path: pathlib.Path,
+) -> None:
+    _register_local_callable_loader(xr.load_dataarray)
+    source_file = tmp_path / "source.h5"
+    marker = tmp_path / "executed.txt"
+    xr.DataArray(np.arange(3.0), dims=("x",)).to_netcdf(
+        source_file,
+        engine="h5netcdf",
+    )
+    seed_code = (
+        "import xarray\n\n"
+        f"derived = xarray.load_dataarray({str(source_file)!r}, "
+        "engine='h5netcdf')"
+    )
+    provenance = script(
+        ScriptCodeOperation(
+            label="Write marker",
+            code=(
+                "import pathlib\n"
+                f"pathlib.Path({str(marker)!r}).write_text("
+                "'executed', encoding='utf-8')\n"
+                "derived = derived"
+            ),
+        ),
+        start_label="Load script-backed file",
+        seed_code=seed_code,
+        active_name="derived",
+        file_load_source=FileLoadSource(
+            path=source_file,
+            loader_label="Loader",
+            loader_text="xarray.load_dataarray",
+            kwargs_text='engine="h5netcdf"',
+            replay_call=FileReplayCall(
+                kind="callable",
+                target="xarray.load_dataarray",
+                kwargs={"engine": "h5netcdf"},
+                selected_index=0,
+            ),
+            load_code=seed_code,
+        ),
+    )
+    win = ImageTool(
+        xr.DataArray(np.full(3, -1.0), dims=("x",)),
+        file_path=source_file,
+        load_func=(
+            xr.load_dataarray,
+            {"engine": "h5netcdf"},
+            FileDataSelection(kind="dataarray"),
+        ),
+    )
+    qtbot.addWidget(win)
+    win.set_provenance_spec(provenance)
+    assert win.slicer_area._direct_reloadable()
+    assert not win.slicer_area.reloadable
+    reason = win.slicer_area._reload_unavailable_reason()
+    assert reason is not None
+    assert "ImageTool Manager" in reason
+    assert not win.slicer_area._reload()
+    assert not marker.exists()
+    np.testing.assert_array_equal(win.slicer_area.data.squeeze(), np.full(3, -1.0))
+    with pytest.raises(RuntimeError, match="requires authorization"):
         win.slicer_area._fetch_reload_data()
 
     win.close()
@@ -4490,6 +4632,7 @@ def test_itool_reload_unavailable_reason_metadata_branches(
     monkeypatch,
     tmp_path: pathlib.Path,
 ) -> None:
+    _register_local_callable_loader(xr.load_dataarray)
     win = itool(xr.DataArray(np.arange(4.0), dims=("x",)), execute=False)
     qtbot.addWidget(win)
     unavailable_reasons = _record_reload_unavailable_dialog(monkeypatch)
@@ -13968,6 +14111,35 @@ def test_itool_filter_dialog_reopens_with_current_settings(
     xarray.testing.assert_identical(win.slicer_area.data, expected)
 
     win.close()
+
+
+def test_itool_filter_rejects_model_fit_expression_before_execution(
+    qtbot, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4.0)})
+    operation = ModelFitOperation(
+        fit_dim="x",
+        model="PolynomialModel",
+        model_kwargs={"degree": 1},
+        parameters={
+            "c0": _ModelFitParameterSpec(value=0.0),
+            "c1": _ModelFitParameterSpec(expr="2 * c0"),
+        },
+        method="leastsq",
+        parameter="c0",
+    )
+    executions: list[None] = []
+    monkeypatch.setattr(
+        ModelFitOperation,
+        "apply",
+        lambda _operation, source: executions.append(None) or source,
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+
+    with pytest.raises(TypeError, match="cannot be used as display filters"):
+        win.slicer_area.apply_filter_operation(operation)
+    assert executions == []
 
 
 def test_normalize_filter_dialog_reopens_with_current_settings(qtbot) -> None:

--- a/tests/interactive/imagetool/test_module_split.py
+++ b/tests/interactive/imagetool/test_module_split.py
@@ -137,7 +137,7 @@ def test_figure_composer_semantics_do_not_load_qt_widgets() -> None:
             label="plot", source="data"
         )
         custom_operation = FigureOperationState.custom(
-            label="custom", code="result = data.mean()", trusted=True
+            label="custom", code="result = data.mean()"
         )
 
         assert document.operation_source_names(plot_operation) == ("data",)

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -6863,11 +6863,52 @@ def test_provenance_code_trust_entries_capture_live_unrestricted_code() -> None:
     )
 
 
+def test_implicit_framework_imports_do_not_bypass_code_trust() -> None:
+    saved = script(
+        ScriptCodeOperation(
+            label="Add",
+            code="derived = data_0 + 1",
+            uses_implicit_framework_imports=True,
+        ),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(ScriptInput(name="data_0", label="ImageTool 0"),),
+    ).model_dump(mode="json")
+    restored = parse_tool_provenance_spec(saved)
+    assert restored is not None
+
+    entries = provenance_code_trust_entries(
+        restored,
+        location_prefix="workspace/provenance",
+    )
+
+    assert [entry.code for entry in entries] == ["derived = data_0 + 1"]
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    with pytest.raises(TypeError, match="not trusted"):
+        replay_script_provenance(restored, {"data_0": data})
+    xr.testing.assert_identical(
+        replay_script_provenance(
+            restored,
+            {"data_0": data},
+            authorize=_authorize_execution,
+        ),
+        data + 1,
+    )
+
+
 @pytest.mark.parametrize("raw_script", [False, True])
+@pytest.mark.parametrize("implicit_imports", [False, True])
 def test_signed_script_replay_uses_the_exact_graph_inventory(
     raw_script: bool,
+    implicit_imports: bool,
 ) -> None:
-    live = full_data(ScriptCodeOperation(label="Add", code="derived = data + 1"))
+    live = full_data(
+        ScriptCodeOperation(
+            label="Add",
+            code="derived = data + 1",
+            uses_implicit_framework_imports=implicit_imports,
+        )
+    )
     replay_spec = script(
         *live.operations,
         start_label="Replay live provenance",

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -17,13 +17,24 @@ from pydantic import ValidationError
 
 import erlab
 import erlab.extensions._api as extension_api
+import erlab.interactive.imagetool._load_source as imagetool_load_source
+from erlab.interactive._code_trust import (
+    create_manifest,
+    issue_execution_capability,
+    new_document_trust,
+)
+from erlab.interactive._code_trust._api import _document_trust_after_save
 from erlab.interactive.imagetool._load_source import (
     _load_provenance_from_file_details,
     _load_source_details_from_file,
     _load_source_details_from_provenance,
+    _register_local_callable_loader,
+    _registered_local_callable_loader,
 )
 from erlab.interactive.imagetool._provenance import _code
+from erlab.interactive.imagetool._provenance import _model as provenance_model
 from erlab.interactive.imagetool._provenance._code import (
+    _FIT_DATASET_MARKER,
     _MAPPING_MARKER,
     _SCRIPT_REPLAY_ALLOWED_BUILTINS,
     _TUPLE_MARKER,
@@ -44,15 +55,15 @@ from erlab.interactive.imagetool._provenance._code import (
 from erlab.interactive.imagetool._provenance._execution import (
     _load_file_source_data,
     _parse_replay_input,
-    _resolve_importable_callable,
     _select_replay_input,
     can_reload_without_trust,
+    execute_replay_graph,
     file_load_source_status,
     replay_file_provenance,
     replay_script_provenance,
     script_provenance_replayable,
-    script_provenance_requires_trust,
 )
+from erlab.interactive.imagetool._provenance._graph import ReplayGraph, ReplayGraphError
 from erlab.interactive.imagetool._provenance._model import (
     _OPERATION_TYPES,
     ConsoleCall,
@@ -163,6 +174,27 @@ from erlab.interactive.imagetool._provenance._operations import (
     UniformInterpolationOperation,
     _ModelFitParameterSpec,
 )
+from erlab.interactive.imagetool._provenance._trust import (
+    provenance_code_trust_entries,
+    provenance_operation_code_trust_entries,
+    provenance_requires_code_trust,
+)
+
+
+def _authorize_execution(entries: tuple[typing.Any, ...]) -> object:
+    _trust, capability = issue_execution_capability(new_document_trust(), entries)
+    if capability is None:  # pragma: no cover - local trust always issues one.
+        raise RuntimeError("Could not issue test execution capability")
+    return capability
+
+
+def _single_input_script(code: str) -> ToolProvenanceSpec:
+    return script(
+        ScriptCodeOperation(label="Run code", code=code),
+        start_label="Run script",
+        active_name="derived",
+        script_inputs=(ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
 
 
 def _exec_generated_code(
@@ -417,6 +449,8 @@ def test_script_replay_keeps_unused_aliases_lazy() -> None:
         "import sys\n"
         "import numpy as np\n"
         "import xarray as xr\n"
+        "from erlab.interactive._code_trust import "
+        "issue_execution_capability, new_document_trust\n"
         "from erlab.interactive.imagetool._provenance._execution import "
         "replay_script_provenance\n"
         "from erlab.interactive.imagetool._provenance._model import "
@@ -434,7 +468,12 @@ def test_script_replay_keeps_unused_aliases_lazy() -> None:
         "        ScriptInput(name='data_1', label='B'),\n"
         "    ),\n"
         ")\n"
-        "replay_script_provenance(spec, {'data_0': data, 'data_1': data})\n"
+        "replay_script_provenance(\n"
+        "    spec, {'data_0': data, 'data_1': data},\n"
+        "    authorize=lambda entries: issue_execution_capability(\n"
+        "        new_document_trust(), entries\n"
+        "    )[1],\n"
+        ")\n"
         "loaded = sorted(\n"
         "    name for name in sys.modules\n"
         "    if name.startswith('erlab.analysis.')\n"
@@ -460,6 +499,7 @@ def _file_replay_source(
     replay_call: typing.Any = None,
 ) -> typing.Any:
     if replay_call is None:
+        _register_local_callable_loader(xr.load_dataarray)
         replay_call = FileReplayCall(
             kind="callable",
             target="xarray.load_dataarray",
@@ -1066,7 +1106,7 @@ def test_tool_provenance_migrates_legacy_parent_data_script_context() -> None:
     assert "script_context_bindings" not in spec.model_dump(mode="json")
     data = xr.DataArray([1.0, 2.0], dims=("x",))
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"data": data}),
+        replay_script_provenance(spec, {"data": data}, authorize=_authorize_execution),
         data + data,
     )
 
@@ -1090,6 +1130,7 @@ def test_tool_provenance_migrates_legacy_top_level_operation_context(
         data: xr.DataArray,
         *,
         parent_data: xr.DataArray,
+        authorization: object | None = None,
     ) -> xr.DataArray:
         seen_contexts.append((data, parent_data))
         return original_apply(self, data)
@@ -1463,7 +1504,7 @@ def test_generated_provenance_code_preserves_effect_order_across_aliases() -> No
     )
     previous_error_state = np.seterr(divide="warn")
     try:
-        expected = replay_script_provenance(spec, {}, trusted_user_code=True)
+        expected = replay_script_provenance(spec, {}, authorize=_authorize_execution)
         for code in (spec.derivation_code(), spec.display_code()):
             assert code is not None
             np.seterr(divide="warn")
@@ -1538,9 +1579,11 @@ def test_nonuniform_restore_statement_code_is_safe_to_reingest(
     )
 
     assert "lambda" not in code
-    assert not script_provenance_requires_trust(spec, external_input_names={"data"})
+    assert provenance_requires_code_trust(spec, external_input_names={"data"})
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"data": internal}),
+        replay_script_provenance(
+            spec, {"data": internal}, authorize=_authorize_execution
+        ),
         public,
     )
 
@@ -3707,7 +3750,13 @@ def test_tool_provenance_roundtrip_correct_with_edge_fit_dataset(
 
     reparsed_operation = parse_tool_provenance_operation(payload["operations"][0])
     assert isinstance(reparsed_operation, CorrectWithEdgeOperation)
-    decoded = reparsed_operation.decoded_edge_fit
+    entries = provenance_operation_code_trust_entries(
+        reparsed_operation,
+        location_prefix="operation",
+    )
+    with pytest.raises(PermissionError, match="not authorized"):
+        _ = reparsed_operation.decoded_edge_fit
+    decoded = reparsed_operation._decode_edge_fit(_authorize_execution(entries))
     xr.testing.assert_identical(
         decoded.drop_vars("modelfit_results"),
         gold_fit_res.drop_vars("modelfit_results"),
@@ -3721,7 +3770,7 @@ def test_tool_provenance_roundtrip_correct_with_edge_fit_dataset(
     assert reparsed_spec is not None
     assert reparsed_spec.derivation_code() is None
     xr.testing.assert_allclose(
-        reparsed_spec.apply(gold),
+        reparsed_spec.apply(gold, authorization=_authorize_execution(entries)),
         erlab.analysis.gold.correct_with_edge(gold, gold_fit_res, shift_coords=False),
     )
 
@@ -3801,6 +3850,7 @@ def test_tool_provenance_parse_restores_legacy_structured_script_steps() -> None
             "left": data.copy(deep=True),
             "right": data.copy(deep=True),
         },
+        authorize=_authorize_execution,
     )
     xr.testing.assert_identical(
         replayed,
@@ -3841,7 +3891,9 @@ def test_tool_provenance_parse_keeps_non_active_self_assignments_as_script() -> 
         "script_code",
         "script_code",
     ]
-    replayed = replay_script_provenance(parsed, {"data": data})
+    replayed = replay_script_provenance(
+        parsed, {"data": data}, authorize=_authorize_execution
+    )
     xr.testing.assert_identical(replayed, data)
 
 
@@ -3878,7 +3930,9 @@ def test_tool_provenance_parse_keeps_script_input_self_assignment_as_script() ->
         "script_code",
         "script_code",
     ]
-    replayed = replay_script_provenance(parsed, {"data_0": data})
+    replayed = replay_script_provenance(
+        parsed, {"data_0": data}, authorize=_authorize_execution
+    )
     xr.testing.assert_identical(replayed, data)
 
 
@@ -3907,7 +3961,9 @@ def test_tool_provenance_parse_restores_active_alias_structured_steps() -> None:
 
     assert parsed is not None
     assert [operation.op for operation in parsed.operations] == ["sortby"]
-    replayed = replay_script_provenance(parsed, {"data": data})
+    replayed = replay_script_provenance(
+        parsed, {"data": data}, authorize=_authorize_execution
+    )
     xr.testing.assert_identical(replayed, data.sortby("x"))
 
 
@@ -4039,7 +4095,9 @@ def test_tool_provenance_parse_restores_mixed_active_legacy_steps() -> None:
         "sortby",
         "qsel_aggregate",
     ]
-    replayed = replay_script_provenance(parsed, {"data": data})
+    replayed = replay_script_provenance(
+        parsed, {"data": data}, authorize=_authorize_execution
+    )
     xr.testing.assert_identical(
         replayed,
         data.sortby("x", ascending=False).qsel.mean("y"),
@@ -4186,6 +4244,7 @@ def test_tool_provenance_compose_full_preserves_structured_live_steps() -> None:
             "data_0": data.copy(deep=True),
             "data_1": data.copy(deep=True),
         },
+        authorize=_authorize_execution,
     )
     xr.testing.assert_identical(
         derived,
@@ -4212,10 +4271,13 @@ def test_tool_provenance_script_context_binding_replays_current_output() -> None
         start_label="Start from current ImageTool data",
         active_name="result",
     )
-    current = replay_script_provenance(parent, {"data": data})
+    current = replay_script_provenance(
+        parent, {"data": data}, authorize=_authorize_execution
+    )
     expected = replay_script_provenance(
         local,
         {"data": current, "derived": current},
+        authorize=_authorize_execution,
     )
 
     composed = compose_full_provenance(
@@ -4240,7 +4302,9 @@ def test_tool_provenance_script_context_binding_replays_current_output() -> None
         binding.model_dump(mode="json") for binding in composed.script_context_bindings
     ] == [{"operation_index": 1, "names": ["data", "derived"]}]
 
-    replayed = replay_script_provenance(composed, {"data": data})
+    replayed = replay_script_provenance(
+        composed, {"data": data}, authorize=_authorize_execution
+    )
     xr.testing.assert_identical(replayed, expected)
     code = typing.cast("str", composed.derivation_code())
     assert "Start from current ImageTool data" not in code
@@ -5315,6 +5379,7 @@ def test_embedded_only_extension_provenance_suppresses_recorded_load_code(
 def test_provenance_file_source_capabilities_cover_script_backed_files(
     tmp_path: pathlib.Path,
 ) -> None:
+    _register_local_callable_loader(xr.load_dataarray)
     path = tmp_path / "scan.h5"
     xr.DataArray(np.arange(3.0), dims=("x",)).to_netcdf(path, engine="h5netcdf")
     replay_call = FileReplayCall(
@@ -5344,10 +5409,13 @@ def test_provenance_file_source_capabilities_cover_script_backed_files(
     for spec in (file_spec, script_spec):
         assert has_file_load_source(spec)
         assert file_load_source_status(spec) == "loadable"
-        assert can_reload_without_trust(spec)
         operation_refs = tuple(iter_operation_refs(spec))
         assert [ref.operation_index for ref, _op in operation_refs] == [0]
         assert isinstance(operation_refs[0][1], AverageOperation)
+    assert can_reload_without_trust(file_spec)
+    assert not provenance_requires_code_trust(file_spec)
+    assert not can_reload_without_trust(script_spec)
+    assert provenance_requires_code_trust(script_spec)
 
     incomplete_file_spec = file_spec.model_copy(update={"file_load_source": None})
     assert file_load_source_status(incomplete_file_spec) == "no-file-load-source"
@@ -5400,6 +5468,7 @@ def test_provenance_file_source_capabilities_cover_script_backed_files(
             )
         }
     )
+
     assert file_load_source_status(missing_callable_spec) == "missing-loader"
     assert not can_reload_without_trust(missing_callable_spec)
 
@@ -5413,7 +5482,63 @@ def test_provenance_file_source_capabilities_cover_script_backed_files(
     )
     assert not has_file_load_source(plain_script)
     assert file_load_source_status(plain_script) == "no-file-load-source"
-    assert can_reload_without_trust(plain_script)
+    assert not can_reload_without_trust(plain_script)
+    assert provenance_requires_code_trust(plain_script)
+    assert provenance_code_trust_entries(
+        plain_script,
+        location_prefix="workspace/provenance",
+    )
+
+
+def test_nested_callable_file_provenance_uses_only_the_script_trust_boundary(
+    tmp_path: pathlib.Path,
+) -> None:
+    _register_local_callable_loader(np.loadtxt)
+    path = tmp_path / "source.dat"
+    path.write_text("1 2\n3 4\n", encoding="utf-8")
+    nested = file_load(
+        start_label="Load nested input",
+        seed_code="derived = xarray.DataArray(path)",
+        file_load_source=FileLoadSource(
+            path=str(path),
+            loader_label="loadtxt",
+            loader_text="numpy.loadtxt",
+            kwargs_text="(none)",
+            replay_call=FileReplayCall(
+                kind="callable",
+                target="numpy.loadtxt",
+                kwargs={},
+                selection=FileDataSelection(kind="dataarray"),
+            ),
+        ),
+    )
+    outer = script(
+        ScriptCodeOperation(label="Copy", code="derived = source.copy()"),
+        start_label="Use nested input",
+        active_name="derived",
+        script_inputs=(
+            ScriptInput(
+                name="source",
+                provenance_spec=nested.model_dump(mode="json"),
+            ),
+        ),
+    )
+
+    assert script_provenance_replayable(outer)
+    assert provenance_requires_code_trust(outer)
+    assert not can_reload_without_trust(outer)
+    assert {
+        entry.feature
+        for entry in provenance_code_trust_entries(
+            outer, location_prefix="workspace/provenance"
+        )
+    } == {
+        "erlab.provenance.script-code",
+    }
+    with pytest.raises(TypeError, match="not trusted"):
+        replay_script_provenance(outer, {})
+    result = replay_script_provenance(outer, {}, authorize=_authorize_execution)
+    xr.testing.assert_identical(result, xr.DataArray([[1.0, 2.0], [3.0, 4.0]]))
 
 
 def test_file_reload_checks_extension_routine_operations(
@@ -6652,6 +6777,7 @@ def test_replay_script_provenance_uses_resolved_inputs_without_mutating() -> Non
     result = replay_script_provenance(
         spec,
         {"data_0": left, "data_1": right},
+        authorize=_authorize_execution,
     )
 
     xr.testing.assert_identical(
@@ -6664,152 +6790,367 @@ def test_replay_script_provenance_uses_resolved_inputs_without_mutating() -> Non
     )
 
 
-def test_untrusted_script_replay_imports_use_executor_owned_modules() -> None:
-    data = xr.DataArray([1.0], dims=("x",))
-
-    def script_with_code(code: str) -> ToolProvenanceSpec:
-        return script(
-            ScriptCodeOperation(label="Import", code=code),
-            start_label="Run script",
-            active_name="derived",
-            script_inputs=(ScriptInput(name="data_0", label="ImageTool 0"),),
-        )
-
-    safe_import = script(
+def test_provenance_code_trust_entries_capture_unrestricted_graph() -> None:
+    unsafe = script(
         ScriptCodeOperation(
-            label="Use NumPy",
-            code="import numpy as np\nderived = data_0 + np.float64(1.0)",
+            label="Import",
+            code="import os\nderived = data_0 + int(os.path.exists('/'))",
+        ),
+        start_label="Run script",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(ScriptInput(name="data_0", label="ImageTool 0"),),
+    )
+    entries = provenance_code_trust_entries(
+        unsafe, location_prefix="nodes/0/provenance"
+    )
+
+    assert [entry.feature for entry in entries] == ["erlab.provenance.script-code"]
+    assert entries[0].location.endswith("/0")
+    assert "import os" in entries[0].code
+
+    safe = _single_input_script("derived = data_0 + 1")
+    assert provenance_requires_code_trust(safe)
+    assert provenance_code_trust_entries(safe, location_prefix="safe")
+
+
+def test_provenance_code_trust_omits_compiler_proven_input_relay() -> None:
+    relay = script(
+        start_label="Use live input",
+        seed_code="derived = data_0",
+        active_name="derived",
+        script_inputs=(
+            ScriptInput(name="data_0", label="Open ImageTool", node_uid="u"),
+        ),
+    )
+
+    assert provenance_code_trust_entries(relay, location_prefix="provenance") == ()
+
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    authorizations: list[tuple[typing.Any, ...]] = []
+
+    def authorize(entries: tuple[typing.Any, ...]) -> object:
+        authorizations.append(entries)
+        return _authorize_execution(entries)
+
+    xr.testing.assert_identical(
+        replay_script_provenance(relay, {"data_0": data}, authorize=authorize),
+        data,
+    )
+    assert authorizations == []
+
+
+def test_provenance_code_trust_entries_capture_live_unrestricted_code() -> None:
+    unsafe = full_data(
+        ScriptCodeOperation(
+            label="Import",
+            code="import os\nderived = data + int(os.path.exists('/'))",
+        )
+    )
+
+    entries = provenance_code_trust_entries(unsafe, location_prefix="nodes/0")
+
+    assert len(entries) == 1
+    assert entries[0].feature == "erlab.provenance.script-code"
+    assert entries[0].location == "nodes/0/operations/0"
+    assert entries[0].context == {
+        "active_name": "derived",
+        "binding_names": ["data", "derived", "parent_data"],
+    }
+    assert provenance_code_trust_entries(
+        full_data(ScriptCodeOperation(label="Add", code="derived = data + 1")),
+        location_prefix="safe",
+    )
+
+
+@pytest.mark.parametrize("raw_script", [False, True])
+def test_signed_script_replay_uses_the_exact_graph_inventory(
+    raw_script: bool,
+) -> None:
+    live = full_data(ScriptCodeOperation(label="Add", code="derived = data + 1"))
+    replay_spec = script(
+        *live.operations,
+        start_label="Replay live provenance",
+        seed_code="derived = data",
+        active_name="derived",
+    )
+    saved_spec = replay_spec if raw_script else live
+    saved_entries = provenance_code_trust_entries(
+        saved_spec, location_prefix="workspace/provenance"
+    )
+    signed = _document_trust_after_save(
+        new_document_trust(),
+        create_manifest("erlab.workspace", 1, saved_entries),
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+    data = xr.DataArray([1.0, 2.0], dims="x")
+    runtime_entries: tuple[typing.Any, ...] = ()
+
+    def authorize(entries: tuple[typing.Any, ...]) -> object | None:
+        nonlocal runtime_entries, signed
+        runtime_entries = entries
+        signed, capability = issue_execution_capability(signed, entries)
+        return capability
+
+    result = replay_script_provenance(
+        replay_spec,
+        (
+            {"data": data}
+            if raw_script
+            else {"data": data, "derived": data, "parent_data": data}
+        ),
+        authorize=authorize,
+    )
+
+    xr.testing.assert_identical(result, data + 1)
+    assert {entry.execution_identity() for entry in runtime_entries} == {
+        entry.execution_identity() for entry in saved_entries
+    }
+
+
+def test_provenance_code_trust_entries_capture_replay_context() -> None:
+    unsafe = script(
+        ScriptCodeOperation(
+            label="Import",
+            code="import os\nderived = data_0 + int(os.path.exists('/'))",
         ),
         start_label="Run script",
         active_name="derived",
         script_inputs=(ScriptInput(name="data_0", label="ImageTool 0"),),
     )
-    safe_erlab_import = script_with_code("import erlab\nderived = data_0.copy()")
-    safe_lmfit_import = script_with_code(
-        "import lmfit\nderived = data_0 + lmfit.Parameter('value', value=1.0).value"
+    changed_step = unsafe.steps[0].model_copy(
+        update={"context_names": ("selected_data",)}
     )
-    optional_approved_import = script_with_code(
-        "try:\n"
-        "    import xarray as xr\n"
-        "except ImportError:\n"
-        "    pass\n"
-        "derived = data_0 + xr.DataArray(1.0)"
+    changed = unsafe.model_copy(update={"steps": (changed_step,)})
+
+    assert provenance_code_trust_entries(
+        unsafe, location_prefix="nodes/0"
+    ) != provenance_code_trust_entries(changed, location_prefix="nodes/0")
+
+
+def test_provenance_code_trust_ignores_file_loader_arguments() -> None:
+    provenance = file_load(
+        start_label="Load data",
+        seed_code="data = custom_loader('scan.h5')",
+        file_load_source=FileLoadSource(
+            path="scan.h5",
+            loader_label="Custom loader",
+            loader_text="custom_loader",
+            kwargs_text="chunks=('x', 2)",
+            replay_call=FileReplayCall(
+                kind="callable",
+                target="custom_loader.load",
+                kwargs={"chunks": ("x", 2)},
+                selection=FileDataSelection(kind="dataarray"),
+            ),
+        ),
     )
-    nested_analysis_alias = script_with_code(
-        "def identity(value):\n"
-        "    _ = era\n"
-        "    return value\n"
-        "derived = identity(data_0)"
+
+    entries = provenance_code_trust_entries(
+        provenance,
+        location_prefix="nodes/0/provenance",
     )
-    optional_external_import = script_with_code(
-        "try:\n    import seaborn\nexcept ImportError:\n    pass\nderived = data_0"
+
+    assert entries == ()
+
+
+def test_provenance_code_trust_omits_declarative_operation_state() -> None:
+    def entries(values: list[float], *, shift_coords: bool = True):
+        return provenance_code_trust_entries(
+            full_data(
+                ScriptCodeOperation(label="Run", code="derived = data + 1"),
+                CorrectWithEdgeOperation(
+                    edge_fit=xr.Dataset({"edge": ("x", values)}),
+                    shift_coords=shift_coords,
+                ),
+            ),
+            location_prefix="nodes/0/provenance",
+        )
+
+    baseline = entries([1.0, 2.0])
+
+    assert baseline == entries([10.0, 20.0])
+    assert baseline == entries([1.0, 2.0], shift_coords=False)
+
+
+def test_opaque_fit_result_provenance_requires_trust() -> None:
+    operation = CorrectWithEdgeOperation(
+        edge_fit={_FIT_DATASET_MARKER: "serialized-result"}
     )
-    unsafe_from_import = script_with_code(
-        "from numpy import __builtins__ as exposed\n"
-        "derived = data_0 + exposed['eval']('40 + 2')"
+    provenance = full_data(operation)
+
+    entries = provenance_code_trust_entries(
+        provenance,
+        location_prefix="nodes/0/provenance",
     )
-    unsafe_dotted_import = script_with_code(
-        "import numpy.testing._private.utils as exposed\n"
-        "derived = data_0 + int(exposed.os.path.exists('/'))"
+
+    assert provenance_requires_code_trust(provenance)
+    assert not can_reload_without_trust(provenance)
+    assert len(entries) == 1
+    assert entries[0].feature == "erlab.provenance.lmfit-result"
+    assert entries[0].location == "nodes/0/provenance/operations/0/edge-fit"
+    assert len(entries[0].context["payload_sha256"]) == 64
+
+    changed = full_data(
+        operation.model_copy(
+            update={"edge_fit": {_FIT_DATASET_MARKER: "changed-result"}}
+        )
     )
-    unsafe_internal_import = script_with_code(
-        "import erlab.interactive.imagetool._provenance._code as exposed\n"
-        "derived = data_0 + exposed.np.float64(1.0)"
+    assert entries != provenance_code_trust_entries(
+        changed,
+        location_prefix="nodes/0/provenance",
     )
-    unsafe_dunder_alias = script_with_code(
-        "import numpy as __builtins__\nderived = data_0"
+
+
+def test_opaque_fit_result_decode_requires_explicit_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decoded = xr.Dataset({"edge": xr.DataArray([1.0], dims=("x",))})
+    payload = {_FIT_DATASET_MARKER: "serialized-result"}
+    calls: list[str] = []
+
+    def decode_fit_dataset(value: typing.Any) -> xr.Dataset:
+        calls.append(str(value))
+        return decoded
+
+    monkeypatch.setattr(provenance_model, "_decode_fit_dataset", decode_fit_dataset)
+
+    with pytest.raises(ValueError, match="requires code authorization"):
+        decode_provenance_value(payload)
+    assert calls == []
+
+    operation = CorrectWithEdgeOperation(edge_fit=payload)
+    assert calls == []
+    assert operation.derivation_entry().code is None
+    assert calls == []
+    with pytest.raises(PermissionError, match="not authorized"):
+        _ = operation.decoded_edge_fit
+    entries = provenance_operation_code_trust_entries(
+        operation,
+        location_prefix="operation",
     )
-    poisoned_import_policy = script_with_code(
+    xr.testing.assert_identical(
+        operation._decode_edge_fit(_authorize_execution(entries)),
+        decoded,
+    )
+    assert calls == ["serialized-result"]
+
+
+@pytest.mark.parametrize(
+    ("code", "offset"),
+    [
+        ("import numpy as np\nderived = data_0 + np.float64(1.0)", 1.0),
+        ("import erlab\nderived = data_0.copy()", 0.0),
+        (
+            "import lmfit\n"
+            "derived = data_0 + lmfit.Parameter('value', value=1.0).value",
+            1.0,
+        ),
+        (
+            "try:\n    import xarray as xr\nexcept ImportError:\n    pass\n"
+            "derived = data_0 + xr.DataArray(1.0)",
+            1.0,
+        ),
+        (
+            "def identity(value):\n    _ = era\n    return value\n"
+            "derived = identity(data_0)",
+            0.0,
+        ),
+    ],
+    ids=("numpy", "erlab", "lmfit", "optional-xarray", "analysis-alias"),
+)
+def test_trusted_script_replay_supports_standard_imports(
+    code: str, offset: float
+) -> None:
+    data = xr.DataArray([1.0], dims=("x",))
+    spec = _single_input_script(code)
+
+    assert script_provenance_replayable(spec)
+    assert provenance_requires_code_trust(spec)
+    with pytest.raises(TypeError, match="not trusted"):
+        replay_script_provenance(spec, {"data_0": data})
+    xr.testing.assert_identical(
+        replay_script_provenance(
+            spec,
+            {"data_0": data},
+            authorize=_authorize_execution,
+        ),
+        data + offset,
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "offset"),
+    [
+        (
+            "try:\n    import seaborn\nexcept ImportError:\n    pass\nderived = data_0",
+            0.0,
+        ),
+        (
+            "from numpy import __builtins__ as exposed\n"
+            "derived = data_0 + exposed['eval']('40 + 2')",
+            42.0,
+        ),
+        (
+            "import numpy.testing._private.utils as exposed\n"
+            "derived = data_0 + int(exposed.os.path.exists('/'))",
+            1.0,
+        ),
+        (
+            "import erlab.interactive.imagetool._provenance._code as exposed\n"
+            "derived = data_0 + exposed.np.float64(1.0)",
+            1.0,
+        ),
+        ("import numpy as __builtins__\nderived = data_0", 0.0),
+    ],
+    ids=("external", "from-import", "dotted", "internal", "dunder-alias"),
+)
+def test_explicit_trust_admits_unrestricted_imports(code: str, offset: float) -> None:
+    data = xr.DataArray([1.0], dims=("x",))
+    spec = _single_input_script(code)
+
+    assert not script_provenance_replayable(spec)
+    assert provenance_requires_code_trust(spec)
+    with pytest.raises(TypeError, match="not trusted"):
+        replay_script_provenance(spec, {"data_0": data})
+    xr.testing.assert_identical(
+        replay_script_provenance(
+            spec,
+            {"data_0": data},
+            authorize=_authorize_execution,
+        ),
+        data + offset,
+    )
+
+
+def test_trusted_script_cannot_replace_the_import_policy() -> None:
+    data = xr.DataArray([1.0], dims=("x",))
+    poison = _single_input_script(
         "framework = erlab.interactive.imagetool._provenance._code\n"
-        "framework._SCRIPT_REPLAY_PREBOUND_IMPORTS = {\n"
-        "    'numpy': framework,\n"
-        "}\n"
+        "framework._SCRIPT_REPLAY_PREBOUND_IMPORTS = {'numpy': framework}\n"
         "import numpy as imported_numpy\n"
         "derived = data_0 + imported_numpy.float64(1.0)"
     )
+    safe = _single_input_script(
+        "import numpy as np\nderived = data_0 + np.float64(1.0)"
+    )
 
-    assert script_provenance_replayable(safe_import)
-    assert not script_provenance_requires_trust(safe_import)
-    xr.testing.assert_identical(
-        replay_script_provenance(safe_import, {"data_0": data}),
-        data + 1.0,
-    )
-    xr.testing.assert_identical(
-        replay_script_provenance(safe_erlab_import, {"data_0": data}),
-        data,
-    )
-    assert script_provenance_replayable(safe_lmfit_import)
-    assert not script_provenance_requires_trust(safe_lmfit_import)
-    xr.testing.assert_identical(
-        replay_script_provenance(safe_lmfit_import, {"data_0": data}),
-        data + 1.0,
-    )
-    assert script_provenance_replayable(optional_approved_import)
-    assert not script_provenance_requires_trust(optional_approved_import)
-    xr.testing.assert_identical(
-        replay_script_provenance(optional_approved_import, {"data_0": data}),
-        data + 1.0,
-    )
-    assert script_provenance_replayable(nested_analysis_alias)
-    xr.testing.assert_identical(
-        replay_script_provenance(nested_analysis_alias, {"data_0": data}),
-        data,
-    )
     assert "__import__" not in _SCRIPT_REPLAY_ALLOWED_BUILTINS
     assert not hasattr(_code, "_SCRIPT_REPLAY_PREBOUND_IMPORTS")
-
     try:
-        xr.testing.assert_identical(
-            replay_script_provenance(
-                poisoned_import_policy,
-                {"data_0": data},
-            ),
-            data + 1.0,
-        )
-        xr.testing.assert_identical(
-            replay_script_provenance(safe_import, {"data_0": data}),
-            data + 1.0,
-        )
+        for spec in (poison, safe):
+            xr.testing.assert_identical(
+                replay_script_provenance(
+                    spec,
+                    {"data_0": data},
+                    authorize=_authorize_execution,
+                ),
+                data + 1.0,
+            )
     finally:
         if hasattr(_code, "_SCRIPT_REPLAY_PREBOUND_IMPORTS"):
             del _code._SCRIPT_REPLAY_PREBOUND_IMPORTS
-
-    for unsafe, message in (
-        (optional_external_import, "unsupported Import"),
-        (unsafe_from_import, "unsupported ImportFrom"),
-        (unsafe_dotted_import, "unsupported Import"),
-        (unsafe_internal_import, "unsupported Import"),
-        (unsafe_dunder_alias, "unsupported Import"),
-    ):
-        assert not script_provenance_replayable(unsafe)
-        assert script_provenance_requires_trust(unsafe)
-        with pytest.raises(TypeError, match=message):
-            replay_script_provenance(unsafe, {"data_0": data})
-
-    xr.testing.assert_identical(
-        replay_script_provenance(
-            optional_external_import,
-            {"data_0": data},
-            trusted_user_code=True,
-        ),
-        data,
-    )
-    xr.testing.assert_identical(
-        replay_script_provenance(
-            unsafe_from_import,
-            {"data_0": data},
-            trusted_user_code=True,
-        ),
-        data + 42.0,
-    )
-    xr.testing.assert_identical(
-        replay_script_provenance(
-            unsafe_dotted_import,
-            {"data_0": data},
-            trusted_user_code=True,
-        ),
-        data + 1.0,
-    )
 
 
 def test_replay_script_provenance_rejects_unsupported_or_incomplete_code() -> None:
@@ -6942,7 +7283,7 @@ def test_replay_script_provenance_rejects_unsupported_or_incomplete_code() -> No
     assert script_provenance_replayable(rename_input)
     assert script_provenance_replayable(captured_helper_global)
     assert script_provenance_replayable(redefined_helper)
-    with pytest.raises(TypeError, match="unsupported Import"):
+    with pytest.raises(TypeError, match="not trusted"):
         replay_script_provenance(unsupported, {"data_0": data})
     with pytest.raises(ValueError, match="non-replayable"):
         replay_script_provenance(incomplete, {"data_0": data})
@@ -6957,23 +7298,43 @@ def test_replay_script_provenance_rejects_unsupported_or_incomplete_code() -> No
     with pytest.raises(TypeError, match="unresolved name 'scale'"):
         replay_script_provenance(late_helper_global, {"data_0": data})
     xr.testing.assert_identical(
-        replay_script_provenance(active_input, {"data_0": data}),
+        replay_script_provenance(
+            active_input,
+            {"data_0": data},
+            authorize=_authorize_execution,
+        ),
         data.qsel.average("x"),
     )
     xr.testing.assert_identical(
-        replay_script_provenance(rename_input, {"data_0": data}),
+        replay_script_provenance(
+            rename_input,
+            {"data_0": data},
+            authorize=_authorize_execution,
+        ),
         data.rename("renamed"),
     )
     xr.testing.assert_identical(
-        replay_script_provenance(external_active_input, {"data_0": data}),
+        replay_script_provenance(
+            external_active_input,
+            {"data_0": data},
+            authorize=_authorize_execution,
+        ),
         data.qsel.average("x"),
     )
     xr.testing.assert_identical(
-        replay_script_provenance(captured_helper_global, {"data_0": data}),
+        replay_script_provenance(
+            captured_helper_global,
+            {"data_0": data},
+            authorize=_authorize_execution,
+        ),
         data + 2.0,
     )
     xr.testing.assert_identical(
-        replay_script_provenance(redefined_helper, {"data_0": data}),
+        replay_script_provenance(
+            redefined_helper,
+            {"data_0": data},
+            authorize=_authorize_execution,
+        ),
         data,
     )
 
@@ -6999,7 +7360,11 @@ def test_replay_script_provenance_accepts_console_module_aliases() -> None:
 
     assert script_provenance_replayable(spec)
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"data_0": data}),
+        replay_script_provenance(
+            spec,
+            {"data_0": data},
+            authorize=_authorize_execution,
+        ),
         erlab.analysis.transform.rotate(data, 0.0, axes=("x", "y"), reshape=False),
     )
 
@@ -7685,6 +8050,7 @@ def test_console_operations_match_branch_specific_calls() -> None:
 
 
 def test_file_replay_parses_supported_inputs_and_errors(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(imagetool_load_source, "_LOCAL_CALLABLE_LOADERS", {})
     image = xr.DataArray(
         np.arange(6).reshape((2, 3)),
         dims=("row", "col"),
@@ -7783,24 +8149,13 @@ def test_file_replay_parses_supported_inputs_and_errors(tmp_path, monkeypatch) -
             FileDataSelection(kind="sequence_index", value=2),
         )
 
-    assert _resolve_importable_callable("xarray.load_dataarray") is xr.load_dataarray
-    with pytest.raises(ValueError, match="must be dotted"):
-        _resolve_importable_callable("load")
-    with pytest.raises(ModuleNotFoundError):
-        _resolve_importable_callable("missing_erlab_replay_loader.load")
-    with pytest.raises(AttributeError):
-        _resolve_importable_callable("xarray.missing_loader.load")
-    with pytest.raises(TypeError, match="not callable"):
-        _resolve_importable_callable("math.pi")
-
-    broken_module = tmp_path / "broken_loader.py"
-    broken_module.write_text(
-        "import missing_erlab_replay_dependency\n",
-        encoding="utf-8",
+    assert (
+        _registered_local_callable_loader("xarray.load_dataarray") is xr.load_dataarray
     )
-    monkeypatch.syspath_prepend(str(tmp_path))
-    with pytest.raises(ModuleNotFoundError, match="missing_erlab_replay_dependency"):
-        _resolve_importable_callable("broken_loader.load")
+    assert (
+        _registered_local_callable_loader("xarray:load_dataarray") is xr.load_dataarray
+    )
+    assert _registered_local_callable_loader("missing.loader") is None
 
     source_file = tmp_path / "source.h5"
     image.to_netcdf(source_file, engine="h5netcdf")
@@ -7869,6 +8224,110 @@ def test_file_replay_parses_supported_inputs_and_errors(tmp_path, monkeypatch) -
         replay_file_provenance(typing.cast("typing.Any", None))
 
 
+def test_unregistered_callable_file_replay_does_not_import_target(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(imagetool_load_source, "_LOCAL_CALLABLE_LOADERS", {})
+    module_name = "unregistered_provenance_loader"
+    marker = tmp_path / "imported.txt"
+    (tmp_path / f"{module_name}.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('imported')\n"
+        "def load(path, **kwargs):\n    return path\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    load_source = _file_replay_source(
+        tmp_path / "source.dat",
+        replay_call=FileReplayCall(
+            kind="callable",
+            target=f"{module_name}.load",
+            selection=FileDataSelection(kind="dataarray"),
+        ),
+    )
+    pathlib.Path(load_source.path).touch()
+
+    spec = file_load(
+        start_label="Load source",
+        seed_code="derived = unavailable_loader('source.dat')",
+        file_load_source=load_source,
+    )
+    assert file_load_source_status(spec) == "missing-loader"
+    with pytest.raises(ValueError, match="not registered locally"):
+        _load_file_source_data(load_source)
+    assert module_name not in sys.modules
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    ("identifier", "loader"),
+    [
+        ("xarray.load_dataarray", xr.load_dataarray),
+        ("xarray.open_dataarray", xr.open_dataarray),
+        ("xarray.load_dataset", xr.load_dataset),
+        ("xarray.open_dataset", xr.open_dataset),
+        ("xarray.load_datatree", xr.load_datatree),
+        ("xarray.open_datatree", xr.open_datatree),
+    ],
+)
+def test_supported_callable_loader_resolution_survives_local_registry_reset(
+    identifier: str,
+    loader: collections.abc.Callable[..., typing.Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(imagetool_load_source, "_LOCAL_CALLABLE_LOADERS", {})
+
+    assert _registered_local_callable_loader(identifier) is loader
+    assert _registered_local_callable_loader(identifier.replace(".", ":", 1)) is loader
+
+
+def test_local_callable_loader_cannot_override_supported_identifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def spoofed_loader(*args: typing.Any, **kwargs: typing.Any) -> None:
+        del args, kwargs
+
+    spoofed_loader.__module__ = "xarray"
+    spoofed_loader.__qualname__ = "load_dataarray"
+    monkeypatch.setattr(imagetool_load_source, "_LOCAL_CALLABLE_LOADERS", {})
+
+    assert _register_local_callable_loader(spoofed_loader) == "xarray.load_dataarray"
+    assert (
+        _registered_local_callable_loader("xarray.load_dataarray") is xr.load_dataarray
+    )
+
+
+def test_supported_callable_file_loader_restores_after_local_registry_reset(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_file = tmp_path / "source.h5"
+    data = xr.DataArray([1.0, 2.0], dims=("x",), name="signal")
+    data.to_netcdf(source_file, engine="h5netcdf")
+    load_source = _file_replay_source(
+        source_file,
+        replay_call=FileReplayCall(
+            kind="callable",
+            target="xarray.load_dataarray",
+            kwargs={"engine": "h5netcdf"},
+            selection=FileDataSelection(kind="dataarray"),
+        ),
+    )
+    serialized = load_source.model_dump(mode="json")
+
+    monkeypatch.setattr(imagetool_load_source, "_LOCAL_CALLABLE_LOADERS", {})
+    restored = FileLoadSource.model_validate(serialized)
+
+    spec = file_load(
+        start_label="Load source",
+        seed_code="derived = xarray.load_dataarray('source.h5')",
+        file_load_source=restored,
+    )
+    assert file_load_source_status(spec) == "loadable"
+    xr.testing.assert_identical(_load_file_source_data(restored), data)
+
+
 def test_file_replay_uses_erlab_loader(example_loader, example_data_dir) -> None:
     del example_loader
     file_path = example_data_dir / "data_002.h5"
@@ -7895,6 +8354,7 @@ def test_file_replay_uses_erlab_loader(example_loader, example_data_dir) -> None
 def test_file_provenance_composes_structured_stages_and_replays_modified_source(
     tmp_path,
 ) -> None:
+    _register_local_callable_loader(xr.load_dataarray)
     path = tmp_path / "source.h5"
     data = xr.DataArray(
         np.arange(12).reshape((3, 4)),
@@ -8222,8 +8682,50 @@ def test_model_fit_operation_replays_fixed_and_expression_parameters() -> None:
         parameter="c2",
     )
 
-    expected = operation.apply(data)
+    entries = provenance_operation_code_trust_entries(
+        operation,
+        location_prefix="operation",
+    )
+    with pytest.raises(PermissionError, match="not authorized"):
+        operation.apply(data)
+    authorization = _authorize_execution(entries)
+    expected = operation.apply(data, authorization=authorization)
     np.testing.assert_allclose(expected, 2.0)
+
+    spec = full_data(operation)
+    entries = provenance_code_trust_entries(
+        spec,
+        location_prefix="nodes/0/provenance",
+    )
+    assert provenance_requires_code_trust(spec)
+    assert not can_reload_without_trust(spec)
+    assert len(entries) == 1
+    assert entries[0].feature == ("erlab.provenance.model-fit-parameter-expression")
+    assert entries[0].code == "2 * c2"
+    assert entries[0].context["parameter"] == "c1"
+
+    def replay_graph(*, legacy_trusted: bool = False) -> ReplayGraph:
+        graph = ReplayGraph(trusted_user_code=legacy_trusted)
+        input_key = graph.add_node("input", "live_input", payload={"data": data})
+        graph.output_key = graph.add_node(
+            "fit",
+            "operation",
+            parents=(input_key,),
+            payload={"operation": operation},
+        )
+        return graph
+
+    for graph in (replay_graph(), replay_graph(legacy_trusted=True)):
+        with pytest.raises(ReplayGraphError, match="not trusted"):
+            execute_replay_graph(graph)
+
+    xr.testing.assert_identical(
+        execute_replay_graph(
+            replay_graph(legacy_trusted=True),
+            authorize=_authorize_execution,
+        ),
+        expected,
+    )
 
     code = f"derived = {operation.expression_code('data')}"
     namespace = _exec_generated_code(

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -613,7 +613,7 @@ def test_replay_graph_omits_trivial_imports_for_one_framework_step() -> None:
     operation = ScriptCodeOperation(
         label="Copy data",
         code="result = xr.DataArray(np.asarray(data), dims=data.dims)",
-        framework_owned=True,
+        uses_implicit_framework_imports=True,
     )
     restored = ScriptCodeOperation.model_validate(operation.model_dump(mode="json"))
     spec = script(
@@ -627,7 +627,7 @@ def test_replay_graph_omits_trivial_imports_for_one_framework_step() -> None:
     code = typing.cast("str", spec.display_code())
     namespace = _exec_generated_code(code, {"data": data, "np": np, "xr": xr})
 
-    assert restored.framework_owned is True
+    assert restored.uses_implicit_framework_imports is True
     assert "import numpy" not in code
     assert "import xarray" not in code
     assert "result = data" not in code
@@ -681,12 +681,12 @@ def test_replay_graph_reserves_framework_names_for_script_outputs(
     )
 
 
-def test_replay_graph_reuses_user_owned_canonical_framework_import() -> None:
+def test_replay_graph_reuses_explicit_canonical_framework_import() -> None:
     spec = script(
         ScriptCodeOperation(
             label="Copy input",
             code="result = xr.DataArray(intermediate)",
-            framework_owned=True,
+            uses_implicit_framework_imports=True,
         ),
         start_label="Build data",
         seed_code="import xarray as xr\nintermediate = xr.DataArray([1.0])",
@@ -705,7 +705,7 @@ def test_replay_graph_restores_framework_import_after_user_alias_collision() -> 
         ScriptCodeOperation(
             label="Copy input",
             code="result = xr.DataArray(intermediate)",
-            framework_owned=True,
+            uses_implicit_framework_imports=True,
         ),
         start_label="Start from data",
         seed_code="import types as xr\nintermediate = data",
@@ -889,7 +889,7 @@ def test_replay_graph_partial_capability_reuses_cached_numeric_data() -> None:
             "active_name": "derived",
             "bindings": (("cached", external_key),),
             "codes": ("derived = cached + 1",),
-            "stored_code": ("derived = cached + 1",),
+            "document_codes": ("derived = cached + 1",),
             "hoist_imports": (False,),
         },
     )
@@ -2411,7 +2411,7 @@ def test_replay_graph_emit_reports_script_rewrite_syntax_errors(monkeypatch) -> 
             "codes": ("result = data_0",),
             "active_name": "result",
             "bindings": (("data_0", source_key),),
-            "framework_owned": (False,),
+            "uses_implicit_framework_imports": (False,),
         },
     )
 
@@ -2438,7 +2438,7 @@ def test_replay_graph_emit_reports_script_rewrite_syntax_errors(monkeypatch) -> 
             "codes": ("bad =",),
             "active_name": "derived",
             "bindings": (),
-            "framework_owned": (False,),
+            "uses_implicit_framework_imports": (False,),
         },
     )
     with pytest.raises(ReplayGraphError, match="Script replay code"):

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -13,6 +13,8 @@ import xarray as xr
 
 import erlab
 import erlab.extensions._api as extension_api
+from erlab.interactive._code_trust import issue_execution_capability, new_document_trust
+from erlab.interactive.imagetool._load_source import _register_local_callable_loader
 from erlab.interactive.imagetool._provenance import _graph
 from erlab.interactive.imagetool._provenance._code import (
     _SCRIPT_REPLAY_ALLOWED_BUILTINS,
@@ -23,13 +25,10 @@ from erlab.interactive.imagetool._provenance._code import (
 )
 from erlab.interactive.imagetool._provenance._execution import (
     _script_provenance_validates,
-    _script_trust_payload,
     execute_replay_graph,
     rebuild_script_provenance,
     replay_script_provenance,
     script_provenance_replayable,
-    script_provenance_requires_trust,
-    script_provenance_trust_key,
 )
 from erlab.interactive.imagetool._provenance._graph import (
     ReplayGraph,
@@ -90,6 +89,17 @@ from erlab.interactive.imagetool._provenance._operations import (
     SortCoordOrderOperation,
     SqueezeOperation,
 )
+from erlab.interactive.imagetool._provenance._trust import (
+    provenance_replay_graph_code_trust_entries,
+    provenance_requires_code_trust,
+)
+
+
+def _authorize_execution(entries: tuple[typing.Any, ...]) -> object:
+    _trust, capability = issue_execution_capability(new_document_trust(), entries)
+    if capability is None:  # pragma: no cover - local trust always issues one.
+        raise RuntimeError("Could not issue test execution capability")
+    return capability
 
 
 def _exec_generated_code(
@@ -154,6 +164,7 @@ def _file_replay_source(
     selected_index: int = 0,
     load_code: str | None = None,
 ):
+    _register_local_callable_loader(xr.load_dataarray)
     return FileLoadSource(
         path=str(path),
         loader_label="xarray.load_dataarray",
@@ -198,7 +209,7 @@ def test_script_compiler_assigns_final_output_after_pending_seed() -> None:
         external_input_names={"data"},
     )
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"data": data}),
+        replay_script_provenance(spec, {"data": data}, authorize=_authorize_execution),
         data.squeeze(),
     )
 
@@ -542,7 +553,6 @@ class Child(Base, metaclass=data_5):
     assert _single_assignment_output_name("derived =") is None
     assert _single_assignment_output_name("obj.value = data") is None
     assert _single_assignment_output_name("first = data\nsecond = data") is None
-    assert script_provenance_trust_key(None) is None
 
 
 @pytest.mark.parametrize("alias", ["derived", "source_data", "seed_result"])
@@ -595,7 +605,7 @@ def test_replay_graph_preserves_annotated_seed_alias() -> None:
     namespace = _exec_generated_code(code, {"watched": data})
 
     assert "source_data: object = watched" in code
-    assert namespace["__annotations__"] == {"source_data": object}
+    assert namespace["source_data"] is data
     xr.testing.assert_identical(namespace["result"], data + 1.0)
 
 
@@ -747,6 +757,7 @@ def test_replay_graph_script_context_binding_error_paths() -> None:
     rebound_graph = compile_replay_graph(
         rebound_input,
         external_inputs={"data_0": data},
+        trusted_user_code=True,
     )
     rebound_display_graph = compile_replay_graph(
         rebound_input,
@@ -754,7 +765,7 @@ def test_replay_graph_script_context_binding_error_paths() -> None:
         external_inputs={"data_0": data},
     )
     xr.testing.assert_identical(
-        execute_replay_graph(rebound_graph),
+        execute_replay_graph(rebound_graph, authorize=_authorize_execution),
         data + 1,
     )
     assert rebound_display_graph.output_key is not None
@@ -774,10 +785,11 @@ def test_replay_graph_script_context_binding_error_paths() -> None:
     active_graph = compile_replay_graph(
         active_relay,
         external_inputs={"data": data},
+        trusted_user_code=True,
     )
 
     xr.testing.assert_identical(
-        execute_replay_graph(active_graph),
+        execute_replay_graph(active_graph, authorize=_authorize_execution),
         data,
     )
     assert _remove_noop_assignments("derived =") == "derived ="
@@ -827,7 +839,7 @@ def test_replay_graph_manual_error_and_cache_paths() -> None:
         (("other = xr.DataArray([1.0], dims=('x',))",), "did not create"),
         (("derived = 1",), "did not produce"),
     ):
-        script_graph = ReplayGraph()
+        script_graph = ReplayGraph(trusted_user_code=True)
         script_key = script_graph.add_node(
             f"script-{message}",
             "script",
@@ -835,7 +847,7 @@ def test_replay_graph_manual_error_and_cache_paths() -> None:
         )
         script_graph.output_key = script_key
         with pytest.raises(ReplayGraphError, match=message):
-            execute_replay_graph(script_graph)
+            execute_replay_graph(script_graph, authorize=_authorize_execution)
 
     unknown_graph = ReplayGraph()
     unknown_key = unknown_graph.add_node("unknown", "unknown")
@@ -850,6 +862,62 @@ def test_replay_graph_manual_error_and_cache_paths() -> None:
         emit_replay_code(empty_graph, output_name="derived")
     with pytest.raises(ReplayGraphError, match="no output"):
         execute_replay_graph(empty_graph)
+
+
+def test_replay_graph_partial_capability_reuses_cached_numeric_data() -> None:
+    data = xr.DataArray(np.arange(3.0), dims=("x",))
+    graph = ReplayGraph()
+    input_key = graph.add_node("input", "live_input", payload={"data": data})
+    external_operation = types.SimpleNamespace(
+        op="model_fit",
+        parameters={
+            "dependent": types.SimpleNamespace(expr="2 * independent"),
+        },
+    )
+    external_key = graph.add_node(
+        "external-expression",
+        "operation",
+        parents=(input_key,),
+        payload={"operation": external_operation},
+    )
+    local_key = graph.add_node(
+        "local-script",
+        "script",
+        parents=(external_key,),
+        cacheable=False,
+        payload={
+            "active_name": "derived",
+            "bindings": (("cached", external_key),),
+            "codes": ("derived = cached + 1",),
+            "stored_code": ("derived = cached + 1",),
+            "hoist_imports": (False,),
+        },
+    )
+    graph.output_key = local_key
+    entries = provenance_replay_graph_code_trust_entries(
+        graph,
+        location_prefix="runtime",
+    )
+    local_entries = tuple(
+        entry for entry in entries if entry.feature == "erlab.provenance.script-code"
+    )
+    _trust, partial_capability = issue_execution_capability(
+        new_document_trust(),
+        local_entries,
+    )
+    assert partial_capability is not None
+
+    with pytest.raises(ReplayGraphError, match="not trusted"):
+        execute_replay_graph(graph, authorization=partial_capability)
+
+    xr.testing.assert_identical(
+        execute_replay_graph(
+            graph,
+            cache={external_key: data + 1},
+            authorization=partial_capability,
+        ),
+        data + 2,
+    )
 
 
 def test_script_input_parsing_does_not_affect_model_equality() -> None:
@@ -919,7 +987,9 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
             ),
         ),
     )
-    rebuilt, rebuilt_spec = rebuild_script_provenance(script_spec)
+    rebuilt, rebuilt_spec = rebuild_script_provenance(
+        script_spec, authorize=_authorize_execution
+    )
     xr.testing.assert_identical(rebuilt, data + 1.0)
     assert rebuilt_spec.script_inputs[0].node_uid is None
 
@@ -960,6 +1030,7 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
     live_rebuilt, live_rebuilt_spec = rebuild_script_provenance(
         live_spec,
         live_input_resolver=resolve_live,
+        authorize=_authorize_execution,
     )
     xr.testing.assert_identical(live_rebuilt, data * 2.0)
     assert live_calls == 1
@@ -1024,6 +1095,7 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
     mixed_role_result, mixed_role_rebuilt = rebuild_script_provenance(
         mixed_role_spec,
         live_input_resolver=resolve_role,
+        authorize=_authorize_execution,
     )
     xr.testing.assert_identical(mixed_role_result, source_data + displayed_data)
     rebuilt_displayed = mixed_role_rebuilt.script_inputs[1].parsed_provenance_spec()
@@ -1052,6 +1124,7 @@ def test_replay_graph_file_script_input_and_rebuild_edges(
     rebuilt_from_miss, _rebuilt_from_miss_spec = rebuild_script_provenance(
         duplicate_file_spec,
         live_input_resolver=miss_live,
+        authorize=_authorize_execution,
     )
     xr.testing.assert_identical(rebuilt_from_miss, data)
     assert miss_calls == 2
@@ -1335,7 +1408,7 @@ def test_replay_graph_preserves_shared_script_input_ownership(
         ),
     )
 
-    expected = replay_script_provenance(spec, {}, trusted_user_code=True)
+    expected = replay_script_provenance(spec, {}, authorize=_authorize_execution)
     code = typing.cast("str", spec.display_code())
 
     assert code.count("xr.load_dataarray") == 1
@@ -1384,7 +1457,7 @@ def test_replay_graph_isolates_mutation_across_shared_source_views(
         ),
     )
 
-    expected = replay_script_provenance(spec, {}, trusted_user_code=True)
+    expected = replay_script_provenance(spec, {}, authorize=_authorize_execution)
     code = typing.cast("str", spec.display_code())
 
     assert code.count("xr.load_dataarray") == 1
@@ -1422,7 +1495,7 @@ def test_replay_graph_preserves_shared_script_input_identity(
         ),
     )
 
-    expected = replay_script_provenance(spec, {}, trusted_user_code=True)
+    expected = replay_script_provenance(spec, {}, authorize=_authorize_execution)
     code = typing.cast("str", spec.display_code())
 
     assert code.count("xr.load_dataarray") == 1
@@ -1461,7 +1534,7 @@ def test_replay_graph_replays_script_with_preserved_file_steps(
     assert spec.kind == "script"
     assert any(isinstance(step.operation, AverageOperation) for step in spec.steps)
 
-    replayed = replay_script_provenance(spec, {})
+    replayed = replay_script_provenance(spec, {}, authorize=_authorize_execution)
 
     expected_input = AverageOperation(dims=("x",)).apply(source)
     xr.testing.assert_identical(replayed, expected_input - expected_input.mean())
@@ -1487,7 +1560,9 @@ def test_replay_graph_display_code_preserves_script_mutation_order() -> None:
         active_name="derived",
     )
 
-    replayed = replay_script_provenance(spec, {"data": data})
+    replayed = replay_script_provenance(
+        spec, {"data": data}, authorize=_authorize_execution
+    )
     code = typing.cast("str", spec.display_code())
     namespace = _exec_generated_code(code, {"data": data.copy(deep=True)})
 
@@ -1553,7 +1628,9 @@ def test_replay_graph_composes_local_script_stage_after_script_parent() -> None:
         "script_code",
     ]
 
-    replayed = replay_script_provenance(spec, {"data": source})
+    replayed = replay_script_provenance(
+        spec, {"data": source}, authorize=_authorize_execution
+    )
 
     expected = source.isel(x=slice(0, 2)).qsel.mean(("x",)) + 1
     xr.testing.assert_identical(replayed, expected)
@@ -1837,7 +1914,7 @@ def test_replay_graph_handles_structured_script_operations(
 
     graph = compile_replay_graph(spec)
     xr.testing.assert_identical(
-        execute_replay_graph(graph),
+        execute_replay_graph(graph, authorize=_authorize_execution),
         data.qsel.mean("alpha"),
     )
 
@@ -1892,7 +1969,11 @@ def test_replay_graph_preserves_script_inputs_after_structured_operation() -> No
         script_inputs=(ScriptInput(name="data_0", label="Input"),),
     )
 
-    graph = compile_replay_graph(spec, external_inputs={"data_0": data})
+    graph = compile_replay_graph(
+        spec,
+        external_inputs={"data_0": data},
+        trusted_user_code=True,
+    )
     script_nodes = [node for node in graph.nodes if node.kind == "script"]
 
     assert script_nodes
@@ -1902,7 +1983,7 @@ def test_replay_graph_preserves_script_inputs_after_structured_operation() -> No
         for input_name, _key in node.payload["bindings"]
     )
     xr.testing.assert_identical(
-        execute_replay_graph(graph),
+        execute_replay_graph(graph, authorize=_authorize_execution),
         data.qsel.average("x") + data.qsel.average("x"),
     )
 
@@ -1921,7 +2002,11 @@ def test_replay_graph_keeps_structured_operations_in_opaque_script() -> None:
         script_inputs=(ScriptInput(name="data_0", label="Input"),),
     )
 
-    graph = compile_replay_graph(spec, external_inputs={"data_0": data})
+    graph = compile_replay_graph(
+        spec,
+        external_inputs={"data_0": data},
+        trusted_user_code=True,
+    )
     script_nodes = [node for node in graph.nodes if node.kind == "script"]
 
     assert len(script_nodes) == 1
@@ -1931,7 +2016,7 @@ def test_replay_graph_keeps_structured_operations_in_opaque_script() -> None:
         for code in script_nodes[0].payload["codes"]
     )
     xr.testing.assert_identical(
-        execute_replay_graph(graph),
+        execute_replay_graph(graph, authorize=_authorize_execution),
         (data + 1).qsel.average("x")
         + (data + 1).qsel.average("x")
         + data.qsel.average("x"),
@@ -1960,7 +2045,9 @@ def test_replay_graph_omits_cosmetic_coordinate_sort_operation() -> None:
     assert spec.operations == ()
     assert "sort_coord_order" not in inlined_code
     xr.testing.assert_identical(
-        replay_script_provenance(spec, {"data_0": data}),
+        replay_script_provenance(
+            spec, {"data_0": data}, authorize=_authorize_execution
+        ),
         data + 1,
     )
 
@@ -2027,7 +2114,7 @@ def test_replay_graph_shares_structured_console_alias_prefixes(
     )
 
     code = typing.cast("str", spec.derivation_code())
-    graph = compile_replay_graph(spec)
+    graph = compile_replay_graph(spec, trusted_user_code=True)
 
     assert code.count("xr.load_dataarray") == 1
     assert code.count(".qsel.mean") == 1
@@ -2041,7 +2128,10 @@ def test_replay_graph_shares_structured_console_alias_prefixes(
     )
     expected = source.qsel.mean("k") - source.qsel.mean("k")
     xr.testing.assert_identical(_exec_generated_code(code)["derived"], expected)
-    xr.testing.assert_identical(execute_replay_graph(graph), expected)
+    xr.testing.assert_identical(
+        execute_replay_graph(graph, authorize=_authorize_execution),
+        expected,
+    )
 
 
 def test_replay_graph_display_normalizes_nested_derived_console_code(
@@ -2526,7 +2616,7 @@ def test_replay_graph_display_restores_dimensions_left_by_recorded_mapping(
         ),
     )
 
-    runtime_graph = compile_replay_graph(spec)
+    runtime_graph = compile_replay_graph(spec, trusted_user_code=True)
     display_graph = compile_replay_graph(spec, display=True)
     display_code = emit_replay_code(display_graph, output_name="derived")
     runtime_expected = source.swap_dims({"x_idx": "x", "y_idx": "y"}).drop_vars(
@@ -2538,7 +2628,7 @@ def test_replay_graph_display_restores_dimensions_left_by_recorded_mapping(
 
     assert "def _restore_image_tool_dimensions" not in display_code
     xr.testing.assert_identical(
-        execute_replay_graph(runtime_graph),
+        execute_replay_graph(runtime_graph, authorize=_authorize_execution),
         runtime_expected,
     )
     xr.testing.assert_identical(
@@ -2583,7 +2673,10 @@ def test_replay_graph_runtime_restores_script_seeded_internal_source_views(
     assert code.count("def _restore_image_tool_dimensions") == 1
     assert "erlab.utils.array._restore_nonuniform_dims" not in code
     assert "erlab.interactive.imagetool.slicer" not in code
-    xr.testing.assert_identical(execute_replay_graph(graph), source.qsel(x=0.2))
+    xr.testing.assert_identical(
+        execute_replay_graph(graph, authorize=_authorize_execution),
+        source.qsel(x=0.2),
+    )
     xr.testing.assert_identical(namespace["derived"], source.qsel(x=0.2))
 
 
@@ -3129,7 +3222,9 @@ def test_replay_graph_display_keeps_alias_before_import_rebinding() -> None:
         active_name="result",
     )
 
-    replayed = replay_script_provenance(spec, {"data": source})
+    replayed = replay_script_provenance(
+        spec, {"data": source}, authorize=_authorize_execution
+    )
     code = typing.cast("str", spec.display_code())
     generated = _exec_generated_code(code, {"data": source})["result"]
 
@@ -3294,7 +3389,11 @@ def test_replay_graph_structured_script_inputs_keep_execution_copy_boundary(
         script_inputs=(ScriptInput(name="data_0", label="Input"),),
     )
 
-    graph = compile_replay_graph(spec, external_inputs={"data_0": data})
+    graph = compile_replay_graph(
+        spec,
+        external_inputs={"data_0": data},
+        trusted_user_code=True,
+    )
     replayed = execute_replay_graph(graph)
 
     assert any(node.kind == "relay" for node in graph.nodes)
@@ -3317,10 +3416,14 @@ def test_replay_graph_disables_numbagg_only_during_execution() -> None:
         active_name="derived",
         script_inputs=(ScriptInput(name="data_0", label="Input"),),
     )
-    graph = compile_replay_graph(spec, external_inputs={"data_0": data})
+    graph = compile_replay_graph(
+        spec,
+        external_inputs={"data_0": data},
+        trusted_user_code=True,
+    )
 
     with xr.set_options(use_numbagg=True):
-        replayed = execute_replay_graph(graph)
+        replayed = execute_replay_graph(graph, authorize=_authorize_execution)
         assert xr.get_options()["use_numbagg"] is True
 
     assert replayed.attrs["use_numbagg_during_replay"] is False
@@ -4119,14 +4222,14 @@ def test_replay_graph_trusted_user_code_executes_blocked_constructs() -> None:
     )
 
     assert not script_provenance_replayable(spec)
-    assert script_provenance_requires_trust(spec)
+    assert provenance_requires_code_trust(spec)
     with pytest.raises(ReplayGraphError, match="unsupported Import"):
         compile_replay_graph(spec, external_inputs={"data": data})
 
     result = replay_script_provenance(
         spec,
         {"data": data},
-        trusted_user_code=True,
+        authorize=_authorize_execution,
     )
 
     xr.testing.assert_identical(result, data + 1)
@@ -4144,7 +4247,7 @@ def test_replay_graph_trusted_user_code_still_validates_result_type() -> None:
         replay_script_provenance(
             spec,
             {"data": data},
-            trusted_user_code=True,
+            authorize=_authorize_execution,
         )
 
 
@@ -4187,32 +4290,13 @@ def test_replay_graph_trusted_user_code_replays_nested_scripts(
     )
 
     assert script_provenance_replayable(spec)
-    assert script_provenance_requires_trust(spec)
-    trust_payload = _script_trust_payload(spec)
-    assert trust_payload is not None
-    assert trust_payload["inputs"][0]["name"] == "data_1"
-    assert trust_payload["inputs"][0]["payload"]["operations"][0]["code"].startswith(
-        "import os"
-    )
-    mixed_payload = _script_trust_payload(
-        spec.model_copy(
-            update={
-                "operations": (
-                    AverageOperation(dims=("x",)),
-                    *spec.operations,
-                )
-            }
-        )
-    )
-    assert mixed_payload is not None
-    assert len(mixed_payload["operations"]) == len(trust_payload["operations"])
-    assert script_provenance_trust_key(spec) is not None
-    with pytest.raises(ReplayGraphError, match="recorded operation"):
+    assert provenance_requires_code_trust(spec)
+    with pytest.raises(ReplayGraphError, match="not trusted"):
         rebuild_script_provenance(spec)
 
     result, rebuilt = rebuild_script_provenance(
         spec,
-        trusted_user_code=True,
+        authorize=_authorize_execution,
     )
 
     assert rebuilt.kind == "script"

--- a/tests/interactive/test_code_trust.py
+++ b/tests/interactive/test_code_trust.py
@@ -1,0 +1,1403 @@
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sqlite3
+import typing
+from contextlib import closing
+
+import pytest
+from qtpy import QtCore, QtWidgets
+
+import erlab.interactive._code_trust as code_trust
+import erlab.interactive._code_trust._application as _application
+from erlab.interactive._code_trust import (
+    approve_document_trust,
+    document_trust_has_trusted_lineage,
+    document_trust_is_trusted,
+    external_document_trust,
+    merge_document_trust,
+    new_document_trust,
+    trusted_location_document_trust,
+    untrusted_document_trust,
+)
+from erlab.interactive._code_trust._api import _document_trust_after_save
+from erlab.interactive._code_trust._core import CodeTrustEntry, CodeTrustManifest
+from erlab.interactive._code_trust._locations import (
+    document_path_is_trusted,
+    validate_trusted_location,
+)
+from erlab.interactive._code_trust._notary import CodeTrustError, CodeTrustNotary
+from erlab.interactive._code_trust._payloads import (
+    code_payload_entries_from_metadata,
+    store_code_payload_entries,
+)
+from erlab.interactive._code_trust._ui import confirm_code_trust
+
+
+def _entry(
+    code: str = "value = 1",
+    *,
+    feature: str = "test.code",
+    location: str = "window/0",
+    context: dict[str, object] | None = None,
+) -> CodeTrustEntry:
+    return CodeTrustEntry(
+        feature,
+        location,
+        code,
+        {"enabled": True, "order": [0, 1]} if context is None else context,
+    )
+
+
+def _manifest(
+    code: str = "value = 1", *, domain: str = "erlab.workspace", version: int = 1
+) -> CodeTrustManifest:
+    return CodeTrustManifest(domain, version, (_entry(code),))
+
+
+def _signed_trust(manifest: CodeTrustManifest | None = None):
+    return _document_trust_after_save(
+        new_document_trust(),
+        _manifest() if manifest is None else manifest,
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+
+
+def _trust_after_save(
+    trust,
+    manifest: CodeTrustManifest,
+    *,
+    trusted_lineage: bool,
+):
+    return _document_trust_after_save(
+        trust,
+        manifest,
+        saved_trusted_lineage=trusted_lineage,
+        signature_stored=True,
+    )
+
+
+def test_code_trust_package_exposes_only_the_functional_facade() -> None:
+    for implementation_type in (
+        "CodeTrustDecision",
+        "CodeTrustEntry",
+        "CodeTrustManifest",
+        "CodeTrustNotary",
+        "CodeTrustReason",
+        "_DocumentTrust",
+        "_ExecutionCapability",
+    ):
+        assert not hasattr(code_trust, implementation_type)
+    for obsolete_name in (
+        "document_trust_is_local_approval",
+        "document_trust_is_signed",
+        "mark_document_trust_edited",
+        "register_code_reference",
+        "register_code_reference_loader",
+        "resolve_code_reference",
+    ):
+        assert not hasattr(code_trust, obsolete_name)
+
+
+def test_code_trust_manifest_canonicalization_and_validation() -> None:
+    first = _manifest()
+    second = CodeTrustManifest(
+        "erlab.workspace",
+        1,
+        (_entry(context={"order": [0, 1], "enabled": True}),),
+    )
+
+    assert first.canonical_bytes() == second.canonical_bytes()
+    with pytest.raises(ValueError, match="non-finite"):
+        CodeTrustEntry("test", "here", "code", {"value": float("nan")})
+    with pytest.raises(TypeError, match="non-string"):
+        CodeTrustEntry("test", "here", "code", {1: "bad"})
+    with pytest.raises(TypeError, match="unsupported"):
+        CodeTrustEntry("test", "here", "code", {"values": (1, 2)})
+    with pytest.raises(ValueError, match="positive"):
+        CodeTrustManifest("test", 0, ())
+
+
+def test_code_trust_entry_snapshots_mutable_context() -> None:
+    context = {"enabled": True, "inputs": [{"name": "data"}]}
+    entry = code_trust.create_entry("test", "operation/0", "run()", context)
+    original = entry.payload()
+
+    context["enabled"] = False
+    context["inputs"][0]["name"] = "changed"
+
+    assert entry.payload() == original
+
+
+def test_manifest_review_includes_signed_execution_context() -> None:
+    manifest = _manifest()
+
+    review = code_trust.manifest_review_text(manifest)
+    serialized_context = json.dumps(
+        manifest.entries[0].payload()["context"],
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        indent=2,
+    )
+
+    assert manifest.entries[0].code in review
+    assert serialized_context in review
+
+
+@pytest.mark.parametrize("approve", [False, True])
+def test_code_trust_review_dialog_returns_selected_action(
+    qtbot, monkeypatch: pytest.MonkeyPatch, approve: bool
+) -> None:
+    parent = QtWidgets.QWidget()
+    qtbot.addWidget(parent)
+
+    def select_action(message: QtWidgets.QMessageBox) -> None:
+        if approve:
+            button = next(
+                candidate
+                for candidate in message.buttons()
+                if message.buttonRole(candidate)
+                == QtWidgets.QMessageBox.ButtonRole.AcceptRole
+            )
+        else:
+            button = message.button(QtWidgets.QMessageBox.StandardButton.Cancel)
+            assert button is not None
+        button.click()
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "exec", select_action)
+
+    assert (
+        confirm_code_trust(
+            parent,
+            _manifest(),
+            document_name="Document",
+            object_name="test_code_trust_review_dialog",
+            window_title="Review Stored Code",
+        )
+        is approve
+    )
+
+
+def test_relocated_entries_change_only_the_document_location() -> None:
+    entry = _manifest().entries[0]
+
+    relocated = code_trust.relocate_manifest_entries(
+        CodeTrustManifest("test.first", 1, (entry,)),
+        location_prefix="tools/0",
+    )
+
+    assert relocated[0].location == "tools/0/window/0"
+    assert relocated[0].feature == entry.feature
+    assert relocated[0].code == entry.code
+    assert relocated[0].context == entry.context
+    assert relocated[0].execution_identity() == entry.execution_identity()
+    assert relocated[0].document_identity() != entry.document_identity()
+
+
+def test_code_trust_lifecycle_is_centralized_behind_document_operations() -> None:
+    local = new_document_trust()
+    safe_external = external_document_trust(CodeTrustManifest("test", 1, ()))
+    signed = _signed_trust()
+
+    assert merge_document_trust(local, safe_external, replace=False) == local
+    assert merge_document_trust(signed, signed, replace=False) == signed
+    assert document_trust_is_trusted(safe_external)
+    assert not document_trust_has_trusted_lineage(safe_external)
+    assert not code_trust.authorize_document_execution(
+        safe_external, _manifest().entries
+    )[1]
+
+    untrusted = untrusted_document_trust(_manifest())
+    combined = merge_document_trust(local, untrusted, replace=False)
+    assert not document_trust_is_trusted(combined)
+    assert merge_document_trust(local, untrusted, replace=True) == untrusted
+
+    combined_trusted = merge_document_trust(
+        local,
+        trusted_location_document_trust(),
+        replace=False,
+    )
+    assert document_trust_is_trusted(combined_trusted)
+    assert document_trust_has_trusted_lineage(combined_trusted)
+
+    approved = approve_document_trust(untrusted)
+    assert document_trust_is_trusted(approved)
+    assert document_trust_has_trusted_lineage(approved)
+
+    empty_manifest = CodeTrustManifest("test", 1, ())
+    saved_empty_local = _trust_after_save(local, empty_manifest, trusted_lineage=True)
+    assert document_trust_has_trusted_lineage(saved_empty_local)
+    assert code_trust.authorize_document_execution(
+        saved_empty_local, _manifest().entries
+    )[1]
+    saved_empty_external = _trust_after_save(
+        untrusted, empty_manifest, trusted_lineage=False
+    )
+    assert document_trust_has_trusted_lineage(saved_empty_external)
+
+    saved_untrusted = _trust_after_save(
+        safe_external, _manifest(), trusted_lineage=False
+    )
+    assert code_trust.document_trust_needs_review(saved_untrusted)
+    assert not document_trust_has_trusted_lineage(saved_untrusted)
+
+    approved_during_save = _trust_after_save(
+        approved, _manifest(), trusted_lineage=False
+    )
+    assert approved_during_save == approved
+
+    revoked_during_save = _trust_after_save(
+        untrusted, _manifest(), trusted_lineage=True
+    )
+    assert revoked_during_save == untrusted
+
+    blocked, execution_allowed = code_trust.authorize_document_execution(
+        safe_external,
+        _manifest().entries,
+    )
+    assert not execution_allowed
+    assert code_trust.document_trust_needs_review(blocked)
+
+
+def test_binding_untrusted_manifest_updates_baseline_without_authorizing_external() -> (
+    None
+):
+    external_entry = _entry(code="external()", location="external")
+    local_entry = _entry(code="local()", location="local")
+    original_manifest = CodeTrustManifest("test", 1, (external_entry,))
+    current_manifest = CodeTrustManifest("test", 1, (external_entry, local_entry))
+    untrusted = untrusted_document_trust(original_manifest)
+    _, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (local_entry,),
+        edited_entries=(local_entry,),
+    )
+    mixed = code_trust.commit_local_edit_trust(
+        untrusted,
+        capability,
+        original_manifest.entries,
+        current_manifest.entries,
+        edited_entries=(local_entry,),
+    )
+
+    bound = code_trust.bind_document_trust_manifest(mixed, current_manifest)
+
+    assert bound.manifest == current_manifest
+    assert code_trust.document_trust_needs_review(bound)
+    assert code_trust.authorize_document_execution(bound, (local_entry,))[1]
+    assert not code_trust.authorize_document_execution(bound, (external_entry,))[1]
+    pruned = code_trust.bind_document_trust_manifest(bound, original_manifest)
+    assert not code_trust.authorize_document_execution(pruned, (local_entry,))[1]
+
+
+def test_binding_changed_signature_fails_closed() -> None:
+    original_manifest = _manifest("signed()")
+    changed_manifest = _manifest("changed()")
+    signed = _signed_trust(original_manifest)
+
+    assert code_trust.bind_document_trust_manifest(signed, original_manifest) == signed
+    changed = code_trust.bind_document_trust_manifest(signed, changed_manifest)
+
+    assert code_trust.document_trust_needs_review(changed)
+    assert not code_trust.authorize_document_execution(
+        changed, original_manifest.entries
+    )[1]
+    assert not code_trust.authorize_document_execution(
+        changed, changed_manifest.entries
+    )[1]
+
+    original_manifest.entries[0].context["enabled"] = False
+    mutated = code_trust.bind_document_trust_manifest(signed, original_manifest)
+    assert code_trust.document_trust_needs_review(mutated)
+
+
+def test_signed_document_authorizes_only_approved_execution_entries() -> None:
+    manifest = _manifest()
+    signed = _signed_trust(manifest)
+    approved = manifest.entries[0]
+    relocated = code_trust.create_entry(
+        approved.feature,
+        "embedded/tool/window/0",
+        approved.code,
+        approved.context,
+    )
+
+    unchanged, allowed = code_trust.authorize_document_execution(signed, (relocated,))
+
+    assert allowed
+    assert unchanged == signed
+    for changed in (
+        _entry(feature="test.other"),
+        _entry(code="value = 2"),
+        _entry(context={**approved.context, "enabled": False}),
+    ):
+        blocked, allowed = code_trust.authorize_document_execution(signed, (changed,))
+        assert not allowed
+        assert code_trust.document_trust_needs_review(blocked)
+
+
+def test_execution_capability_binds_the_exact_authorized_content() -> None:
+    manifest = _manifest()
+    signed = _signed_trust(manifest)
+    approved = manifest.entries[0]
+    relocated = code_trust.create_entry(
+        approved.feature,
+        "embedded/window/0",
+        approved.code,
+        approved.context,
+    )
+
+    unchanged, capability = code_trust.issue_execution_capability(
+        signed,
+        (relocated,),
+    )
+
+    assert unchanged == signed
+    assert capability is not None
+    assert code_trust.execution_capability_allows(capability, (approved,))
+    assert not code_trust.execution_capability_allows(True, (approved,))
+    changed = _entry(code="value = 2")
+    assert not code_trust.execution_capability_allows(capability, (changed,))
+
+    local, local_capability = code_trust.issue_execution_capability(
+        new_document_trust(),
+        (approved,),
+    )
+    assert document_trust_has_trusted_lineage(local)
+    assert local_capability is not None
+    assert not code_trust.execution_capability_allows(local_capability, (changed,))
+
+    blocked, blocked_capability = code_trust.issue_execution_capability(
+        untrusted_document_trust(manifest),
+        (approved,),
+    )
+    assert code_trust.document_trust_needs_review(blocked)
+    assert blocked_capability is None
+
+
+def test_execute_with_capability_keeps_the_check_at_the_execution_boundary() -> None:
+    approved = _entry()
+    changed = _entry(code="value = 2")
+    _trust, capability = code_trust.issue_execution_capability(
+        new_document_trust(),
+        (approved,),
+    )
+    calls: list[str] = []
+
+    executed, result = code_trust.execute_with_capability(
+        capability,
+        (approved,),
+        lambda: calls.append("approved") or 1,
+    )
+    blocked, blocked_result = code_trust.execute_with_capability(
+        capability,
+        (changed,),
+        lambda: calls.append("changed") or 2,
+    )
+
+    assert executed
+    assert result == 1
+    assert not blocked
+    assert blocked_result is None
+    assert calls == ["approved"]
+
+
+def test_local_edit_capability_transition_matrix() -> None:
+    edited_entry = _entry(code="value = 2")
+    signed = _signed_trust()
+    safe_external = external_document_trust(CodeTrustManifest("test", 1, ()))
+    local = new_document_trust()
+    trusted_location = trusted_location_document_trust()
+    untrusted = untrusted_document_trust(_manifest())
+
+    for trust, expected in (
+        (signed, approve_document_trust(signed)),
+        (safe_external, approve_document_trust(safe_external)),
+        (local, local),
+        (trusted_location, trusted_location),
+        (untrusted, approve_document_trust(untrusted)),
+    ):
+        prospective, capability = code_trust.issue_local_edit_capability(
+            trust,
+            (edited_entry,),
+            edited_entries=(edited_entry,),
+        )
+
+        assert prospective == expected
+        assert capability is not None
+        assert code_trust.execution_capability_allows(capability, (edited_entry,))
+
+
+def test_local_edit_capability_applies_stored_policy_to_unchanged_entries() -> None:
+    signed_entry = _entry()
+    edited_entry = _entry(code="value = 2")
+    unsigned_entry = _entry(code="external()")
+    signed = _signed_trust(CodeTrustManifest("test", 1, (signed_entry,)))
+
+    prospective, capability = code_trust.issue_local_edit_capability(
+        signed,
+        (signed_entry, edited_entry),
+        edited_entries=(edited_entry,),
+    )
+
+    assert prospective == approve_document_trust(signed)
+    assert capability is not None
+    assert code_trust.execution_capability_allows(
+        capability, (signed_entry, edited_entry)
+    )
+
+    for trust in (
+        signed,
+        external_document_trust(CodeTrustManifest("test", 1, ())),
+        untrusted_document_trust(_manifest()),
+    ):
+        prospective, capability = code_trust.issue_local_edit_capability(
+            trust,
+            (unsigned_entry, edited_entry),
+            edited_entries=(edited_entry,),
+        )
+
+        assert prospective == approve_document_trust(trust)
+        assert capability is not None
+        assert code_trust.execution_capability_allows(capability, (edited_entry,))
+        assert not code_trust.execution_capability_allows(capability, (unsigned_entry,))
+
+    for trust in (new_document_trust(), trusted_location_document_trust()):
+        unchanged, capability = code_trust.issue_local_edit_capability(
+            trust,
+            (unsigned_entry, edited_entry),
+            edited_entries=(edited_entry,),
+        )
+
+        assert unchanged == trust
+        assert capability is not None
+
+
+def test_local_edit_capability_does_not_promote_mixed_untrusted_content() -> None:
+    external_entry = _entry(code="external()")
+    edited_entry = _entry(code="local_edit()")
+    untrusted = untrusted_document_trust(
+        CodeTrustManifest("test", 1, (external_entry,))
+    )
+
+    prospective, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (external_entry, edited_entry),
+        edited_entries=(edited_entry,),
+    )
+
+    assert prospective == approve_document_trust(untrusted)
+    assert capability is not None
+    assert code_trust.execution_capability_allows(capability, (edited_entry,))
+    assert not code_trust.execution_capability_allows(capability, (external_entry,))
+
+    prospective, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (edited_entry,),
+        edited_entries=(edited_entry,),
+    )
+
+    assert prospective == approve_document_trust(untrusted)
+    assert capability is not None
+    assert code_trust.execution_capability_allows(capability, (edited_entry,))
+
+
+def test_local_edit_capability_rejects_ambiguous_untrusted_content() -> None:
+    edited_entry = _entry(code="same()", location="edited")
+    external_entry = _entry(code="same()", location="external")
+    untrusted = untrusted_document_trust(
+        CodeTrustManifest("test", 1, (external_entry,))
+    )
+
+    prospective, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (edited_entry, external_entry),
+        edited_entries=(edited_entry,),
+    )
+
+    assert prospective == approve_document_trust(untrusted)
+    assert not code_trust.execution_capability_allows(capability, (edited_entry,))
+    assert not code_trust.execution_capability_allows(capability, (external_entry,))
+
+
+def test_local_edit_capability_allows_single_untrusted_edit() -> None:
+    edited_entry = _entry(code="same()", location="edited")
+    external_entry = _entry(code="external()", location="external")
+    untrusted = untrusted_document_trust(
+        CodeTrustManifest("test", 1, (external_entry,))
+    )
+
+    prospective, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (edited_entry,),
+        edited_entries=(edited_entry,),
+    )
+
+    assert prospective == approve_document_trust(untrusted)
+    assert code_trust.execution_capability_allows(capability, (edited_entry,))
+
+
+def test_local_edit_commit_keeps_mixed_content_untrusted_but_runs_local_edit() -> None:
+    external_entry = _entry(code="external()", location="external")
+    edited_entry = _entry(code="local_edit()", location="edited")
+    untrusted = untrusted_document_trust(
+        CodeTrustManifest("test", 1, (external_entry,))
+    )
+    prospective, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (edited_entry,),
+        edited_entries=(edited_entry,),
+    )
+
+    assert prospective == approve_document_trust(untrusted)
+    mixed = code_trust.commit_local_edit_trust(
+        untrusted,
+        capability,
+        (external_entry,),
+        (external_entry, edited_entry),
+        edited_entries=(edited_entry,),
+    )
+
+    assert code_trust.document_trust_needs_review(mixed)
+    assert code_trust.authorize_document_execution(mixed, (edited_entry,))[1]
+    assert not code_trust.authorize_document_execution(mixed, (external_entry,))[1]
+    assert not code_trust.authorize_document_execution(
+        mixed, (external_entry, edited_entry)
+    )[1]
+    unchanged, mixed_capability = code_trust.issue_execution_capability(
+        mixed, (external_entry, edited_entry)
+    )
+    assert unchanged == mixed
+    assert mixed_capability is not None
+    assert code_trust.execution_capability_allows(mixed_capability, (edited_entry,))
+    assert not code_trust.execution_capability_allows(
+        mixed_capability, (external_entry,)
+    )
+    unchanged, complete_capability = code_trust.issue_complete_execution_capability(
+        mixed, (external_entry, edited_entry)
+    )
+    assert unchanged == mixed
+    assert complete_capability is None
+    _unchanged, local_capability = code_trust.issue_complete_execution_capability(
+        mixed, (edited_entry,)
+    )
+    assert code_trust.execution_capability_allows(local_capability, (edited_entry,))
+    assert (
+        code_trust.commit_local_edit_trust(
+            untrusted,
+            capability,
+            (external_entry,),
+            (edited_entry,),
+            edited_entries=(edited_entry,),
+        )
+        == prospective
+    )
+
+
+def test_cumulative_local_edits_promote_after_all_external_entries_are_replaced() -> (
+    None
+):
+    first_external = _entry(code="first_external()", location="first")
+    second_external = _entry(code="second_external()", location="second")
+    first_local = _entry(code="first_local()", location="first")
+    second_local = _entry(code="second_local()", location="second")
+    untrusted = untrusted_document_trust(
+        CodeTrustManifest("test", 1, (first_external, second_external))
+    )
+
+    _, first_capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (first_local,),
+        edited_entries=(first_local,),
+    )
+    mixed = code_trust.commit_local_edit_trust(
+        untrusted,
+        first_capability,
+        (first_external, second_external),
+        (first_local, second_external),
+        edited_entries=(first_local,),
+    )
+
+    assert code_trust.document_trust_needs_review(mixed)
+    assert code_trust.authorize_document_execution(mixed, (first_local,))[1]
+    _, second_capability = code_trust.issue_local_edit_capability(
+        mixed,
+        (first_local, second_local),
+        edited_entries=(second_local,),
+    )
+    assert second_capability is not None
+    promoted = code_trust.commit_local_edit_trust(
+        mixed,
+        second_capability,
+        (first_local, second_external),
+        (first_local, second_local),
+        edited_entries=(second_local,),
+    )
+
+    assert document_trust_has_trusted_lineage(promoted)
+    assert code_trust.authorize_document_execution(
+        promoted, (first_local, second_local)
+    )[1]
+
+
+def test_equal_code_at_two_locations_requires_two_local_edits() -> None:
+    external_a = _entry(code="same()", location="a")
+    external_b = _entry(code="same()", location="b")
+    untrusted = untrusted_document_trust(
+        CodeTrustManifest("test", 1, (external_a, external_b))
+    )
+
+    _, capability_b = code_trust.issue_local_edit_capability(
+        untrusted,
+        (external_b,),
+        edited_entries=(external_b,),
+    )
+    mixed = code_trust.commit_local_edit_trust(
+        untrusted,
+        capability_b,
+        (external_a, external_b),
+        (external_a, external_b),
+        edited_entries=(external_b,),
+    )
+
+    assert code_trust.document_trust_needs_review(mixed)
+    assert not code_trust.authorize_document_execution(mixed, (external_a,))[1]
+    assert code_trust.authorize_document_execution(mixed, (external_b,))[1]
+    _, combined_capability = code_trust.issue_execution_capability(
+        mixed, (external_a, external_b)
+    )
+    assert combined_capability is None
+
+    _, capability_a = code_trust.issue_local_edit_capability(
+        mixed,
+        (external_a,),
+        edited_entries=(external_a,),
+    )
+    promoted = code_trust.commit_local_edit_trust(
+        mixed,
+        capability_a,
+        (external_a, external_b),
+        (external_a, external_b),
+        edited_entries=(external_a,),
+    )
+
+    assert document_trust_has_trusted_lineage(promoted)
+
+
+def test_relocation_is_not_adopted_as_a_local_edit() -> None:
+    external = _entry(code="external()", location="a")
+    relocated = _entry(code="external()", location="b")
+    untrusted = untrusted_document_trust(CodeTrustManifest("test", 1, (external,)))
+    _, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (),
+        edited_entries=(),
+    )
+
+    committed = code_trust.commit_local_edit_trust(
+        untrusted,
+        capability,
+        (external,),
+        (relocated,),
+        edited_entries=(),
+    )
+
+    assert code_trust.document_trust_needs_review(committed)
+    assert not code_trust.authorize_document_execution(committed, (relocated,))[1]
+
+
+def test_relocating_changed_signed_source_manifest_fails_closed() -> None:
+    signed_manifest = CodeTrustManifest(
+        "test", 1, (_entry(code="signed()", location="feature"),)
+    )
+    changed_manifest = CodeTrustManifest(
+        "test", 1, (_entry(code="changed()", location="feature"),)
+    )
+
+    relocated = code_trust.relocate_document_trust(
+        _signed_trust(signed_manifest),
+        changed_manifest,
+        location_prefix="tools/0",
+    )
+
+    assert code_trust.document_trust_needs_review(relocated)
+    assert not code_trust.authorize_document_execution(
+        relocated, relocated.manifest.entries
+    )[1]
+
+
+def test_local_edit_commit_prunes_removed_local_identities() -> None:
+    external_entry = _entry(code="external()", location="external")
+    local_entry = _entry(code="local()", location="local")
+    untrusted = untrusted_document_trust(
+        CodeTrustManifest("test", 1, (external_entry,))
+    )
+    _, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (local_entry,),
+        edited_entries=(local_entry,),
+    )
+    mixed = code_trust.commit_local_edit_trust(
+        untrusted,
+        capability,
+        (external_entry,),
+        (external_entry, local_entry),
+        edited_entries=(local_entry,),
+    )
+
+    _, delete_capability = code_trust.issue_local_edit_capability(
+        mixed,
+        (),
+        edited_entries=(),
+    )
+    after_delete = code_trust.commit_local_edit_trust(
+        mixed,
+        delete_capability,
+        (external_entry, local_entry),
+        (external_entry,),
+        edited_entries=(),
+    )
+
+    assert code_trust.document_trust_needs_review(after_delete)
+    assert not code_trust.authorize_document_execution(after_delete, (local_entry,))[1]
+
+
+def test_cancelled_local_edit_does_not_change_partial_trust() -> None:
+    external_entry = _entry(code="external()", location="external")
+    local_entry = _entry(code="local()", location="local")
+    candidate = _entry(code="candidate()", location="candidate")
+    untrusted = untrusted_document_trust(
+        CodeTrustManifest("test", 1, (external_entry,))
+    )
+    _, local_capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (local_entry,),
+        edited_entries=(local_entry,),
+    )
+    mixed = code_trust.commit_local_edit_trust(
+        untrusted,
+        local_capability,
+        (external_entry,),
+        (external_entry, local_entry),
+        edited_entries=(local_entry,),
+    )
+
+    prospective, candidate_capability = code_trust.issue_local_edit_capability(
+        mixed,
+        (candidate,),
+        edited_entries=(candidate,),
+    )
+    cancelled = code_trust.commit_local_edit_trust(
+        mixed,
+        candidate_capability,
+        (external_entry, local_entry),
+        (external_entry, local_entry),
+        edited_entries=(candidate,),
+    )
+
+    assert prospective != mixed
+    assert cancelled == mixed
+    assert code_trust.authorize_document_execution(cancelled, (local_entry,))[1]
+    assert not code_trust.authorize_document_execution(cancelled, (candidate,))[1]
+
+
+def test_local_edit_commit_adopts_transaction_derived_identities() -> None:
+    external_entry = _entry(code="external()", location="external")
+    edited_entry = _entry(code="edited()", location="edited")
+    derived_entry = _entry(code="derived()", location="derived")
+    untrusted = untrusted_document_trust(
+        CodeTrustManifest("test", 1, (external_entry,))
+    )
+    _, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (edited_entry,),
+        edited_entries=(edited_entry,),
+    )
+
+    mixed = code_trust.commit_local_edit_trust(
+        untrusted,
+        capability,
+        (external_entry,),
+        (external_entry, edited_entry, derived_entry),
+        edited_entries=(edited_entry,),
+    )
+
+    assert code_trust.document_trust_needs_review(mixed)
+    assert code_trust.authorize_document_execution(
+        mixed, (edited_entry, derived_entry)
+    )[1]
+    assert not code_trust.authorize_document_execution(mixed, (external_entry,))[1]
+
+
+def test_local_edit_commit_stores_the_post_commit_manifest() -> None:
+    external_entry = _entry(code="external()", location="external")
+    local_entry = _entry(code="local()", location="local")
+    original_manifest = CodeTrustManifest("test", 1, (external_entry,))
+    current_manifest = CodeTrustManifest("test", 1, (external_entry, local_entry))
+    untrusted = untrusted_document_trust(original_manifest)
+    _, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (local_entry,),
+        edited_entries=(local_entry,),
+    )
+
+    committed = code_trust.commit_local_edit_trust(
+        untrusted,
+        capability,
+        original_manifest.entries,
+        current_manifest.entries,
+        edited_entries=(local_entry,),
+        document_manifest=current_manifest,
+    )
+
+    assert committed.manifest == current_manifest
+    assert code_trust.document_trust_needs_review(committed)
+    assert code_trust.authorize_document_execution(committed, (local_entry,))[1]
+    assert not code_trust.authorize_document_execution(committed, (external_entry,))[1]
+
+
+def test_non_replacing_import_preserves_only_exact_known_identities() -> None:
+    signed_entry = _entry(code="signed()", location="signed")
+    external_entry = _entry(code="external()", location="external")
+    signed = _signed_trust(CodeTrustManifest("test", 1, (signed_entry,)))
+    external = untrusted_document_trust(CodeTrustManifest("test", 1, (external_entry,)))
+
+    combined = merge_document_trust(signed, external, replace=False)
+
+    assert code_trust.document_trust_needs_review(combined)
+    assert code_trust.authorize_document_execution(combined, (signed_entry,))[1]
+    assert not code_trust.authorize_document_execution(combined, (external_entry,))[1]
+    replaced = merge_document_trust(combined, external, replace=True)
+    assert not code_trust.authorize_document_execution(replaced, (signed_entry,))[1]
+
+
+def test_local_edit_commit_rejects_an_edit_outside_the_validation_capability() -> None:
+    candidate = _entry(code="candidate()")
+    omitted_edit = _entry(code="omitted()")
+    external = external_document_trust(CodeTrustManifest("test", 1, ()))
+    prospective, capability = code_trust.issue_local_edit_capability(
+        external,
+        (candidate,),
+        edited_entries=(candidate, omitted_edit),
+    )
+
+    assert prospective == approve_document_trust(external)
+    assert (
+        code_trust.commit_local_edit_trust(
+            external,
+            capability,
+            (),
+            (candidate,),
+            edited_entries=(candidate, omitted_edit),
+        )
+        == external
+    )
+
+
+def test_local_edit_commit_accepts_entries_derived_during_validation() -> None:
+    saved_entry = _entry(code="saved_model()", location="model")
+    edited_entry = _entry(code="edited_model()", location="model")
+    derived_entry = _entry(code="p1_center - p0_center", location="parameters/p1")
+    signed = _signed_trust(CodeTrustManifest("test", 1, (saved_entry,)))
+    _, capability = code_trust.issue_local_edit_capability(
+        signed,
+        (edited_entry,),
+        edited_entries=(edited_entry,),
+    )
+
+    committed = code_trust.commit_local_edit_trust(
+        signed,
+        capability,
+        (saved_entry,),
+        (edited_entry, derived_entry),
+        edited_entries=(edited_entry,),
+    )
+
+    assert committed == approve_document_trust(signed)
+
+
+def test_local_edit_capability_is_bound_to_the_candidate_inventory() -> None:
+    candidate = _entry(code="local_edit()")
+    omitted_edit = _entry(code="not_in_candidate()")
+
+    prospective, capability = code_trust.issue_local_edit_capability(
+        new_document_trust(),
+        (candidate,),
+        edited_entries=(candidate, omitted_edit),
+    )
+
+    assert prospective == new_document_trust()
+    assert capability is not None
+    assert code_trust.execution_capability_allows(capability, (candidate,))
+    assert not code_trust.execution_capability_allows(capability, (omitted_edit,))
+    assert not code_trust.execution_capability_allows(
+        capability, (_entry(code="changed_after_authorization()"),)
+    )
+
+
+def test_local_edit_capability_handles_empty_and_deletion_edits() -> None:
+    retained = _entry(code="retained()")
+    removed = _entry(code="removed()")
+    signed = _signed_trust(CodeTrustManifest("test", 1, (retained, removed)))
+
+    prospective, capability = code_trust.issue_local_edit_capability(
+        signed,
+        (retained,),
+        edited_entries=(),
+    )
+
+    assert prospective == approve_document_trust(signed)
+    assert capability is not None
+    assert code_trust.execution_capability_allows(capability, (retained,))
+    assert not code_trust.execution_capability_allows(capability, (removed,))
+
+    safe_external = external_document_trust(CodeTrustManifest("test", 1, ()))
+    untrusted = untrusted_document_trust(_manifest())
+    for trust, expected in (
+        (signed, approve_document_trust(signed)),
+        (safe_external, approve_document_trust(safe_external)),
+        (untrusted, approve_document_trust(untrusted)),
+    ):
+        prospective, capability = code_trust.issue_local_edit_capability(
+            trust,
+            (),
+            edited_entries=(),
+        )
+
+        assert prospective == expected
+        assert capability is not None
+        assert code_trust.execution_capability_allows(capability, ())
+
+
+def test_signed_execution_identity_is_immutable_after_verification() -> None:
+    manifest = _manifest()
+    signed = _signed_trust(manifest)
+    original = _entry(location="runtime/window/0")
+    unchanged, capability = code_trust.issue_execution_capability(signed, (original,))
+
+    manifest.entries[0].context["enabled"] = False
+    original.context["enabled"] = False
+
+    assert unchanged == signed
+    assert capability is not None
+    assert not code_trust.authorize_document_execution(signed, (manifest.entries[0],))[
+        1
+    ]
+    assert not code_trust.execution_capability_allows(capability, (original,))
+    recreated = _entry(location="another/window/0")
+    assert code_trust.authorize_document_execution(signed, (recreated,))[1]
+    assert code_trust.execution_capability_allows(capability, (recreated,))
+
+
+def test_local_document_policy_does_not_build_entries_on_the_fast_path() -> None:
+    calls: list[None] = []
+
+    def entries():
+        calls.append(None)
+        return _manifest().entries
+
+    for trust in (
+        new_document_trust(),
+        approve_document_trust(untrusted_document_trust(_manifest())),
+        trusted_location_document_trust(),
+    ):
+        unchanged, allowed = code_trust.authorize_document_execution(trust, entries)
+        assert allowed
+        assert unchanged == trust
+    assert calls == []
+
+
+def test_opaque_code_payload_metadata_binds_exact_bytes() -> None:
+    entry = code_trust.create_payload_entry(
+        "test.serialized-callable",
+        "payload/result",
+        "Serialized callable",
+        b"original payload",
+    )
+    attrs: dict[str, object] = {}
+    store_code_payload_entries(attrs, (entry,))
+
+    assert code_payload_entries_from_metadata(attrs) == (entry,)
+
+    manifest = CodeTrustManifest("test.payload", 1, (entry,))
+    signed = _signed_trust(manifest)
+    assert (
+        code_trust.verify_document_payload_entries(signed, (entry,), (entry,)) == signed
+    )
+    changed_entry = code_trust.create_payload_entry(
+        "test.serialized-callable",
+        "payload/result",
+        "Serialized callable",
+        b"changed payload",
+    )
+    assert not document_trust_is_trusted(
+        code_trust.verify_document_payload_entries(
+            signed,
+            (entry,),
+            (changed_entry,),
+        )
+    )
+    assert not document_trust_is_trusted(
+        code_trust.verify_document_payload_entries(
+            new_document_trust(), (), (changed_entry,)
+        )
+    )
+    assert document_trust_is_trusted(
+        code_trust.verify_document_payload_entries(
+            trusted_location_document_trust(), (), (changed_entry,)
+        )
+    )
+
+
+def test_code_trust_notary_sign_check_remove_and_domain_separation(tmp_path) -> None:
+    notary = CodeTrustNotary(tmp_path)
+    manifest = _manifest()
+
+    assert not notary.check(manifest)
+    notary.sign(manifest)
+    assert notary.check(manifest)
+    assert not notary.check(_manifest(code="value = 2"))
+    assert not notary.check(_manifest(domain="erlab.figure-composer-file"))
+    assert not notary.check(_manifest(version=2))
+    notary.remove(manifest)
+    assert not notary.check(manifest)
+
+
+def test_code_trust_notary_reset_and_culling(tmp_path) -> None:
+    notary = CodeTrustNotary(tmp_path, cache_size=4)
+    manifests = tuple(_manifest(code=f"value = {index}") for index in range(5))
+    for manifest in manifests:
+        notary.sign(manifest)
+
+    assert not notary.check(manifests[0])
+    assert not notary.check(manifests[1])
+    assert all(notary.check(manifest) for manifest in manifests[2:])
+
+    notary.reset(domain="erlab.workspace")
+    assert not notary.check(manifests[2])
+
+
+def test_code_trust_notary_secret_and_database_tampering_fail_closed(tmp_path) -> None:
+    notary = CodeTrustNotary(tmp_path)
+    manifest = _manifest()
+    notary.sign(manifest)
+    secret_path = tmp_path / "code_trust_secret"
+    database_path = tmp_path / "code_signatures.db"
+
+    secret_path.write_bytes(os.urandom(1024))
+    assert not notary.check(manifest)
+
+    with closing(sqlite3.connect(database_path)) as connection:
+        connection.execute(
+            """
+            INSERT INTO signatures (domain, algorithm, signature, last_seen)
+            VALUES (?, ?, ?, ?)
+            """,
+            (manifest.domain, "sha256", "0" * 64, 0.0),
+        )
+        connection.commit()
+    assert not notary.check(manifest)
+
+
+def test_application_code_trust_storage_failure_is_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _manifest()
+
+    def unavailable_notary() -> typing.NoReturn:
+        raise RuntimeError("storage unavailable")
+
+    monkeypatch.setattr(
+        _application,
+        "_application_code_trust_notary",
+        unavailable_notary,
+    )
+
+    loaded = _application.load_document_trust(manifest)
+    assert not document_trust_is_trusted(loaded)
+
+    saved, signature_stored = _application.save_document_trust(
+        new_document_trust(),
+        manifest,
+    )
+    assert not signature_stored
+    assert document_trust_has_trusted_lineage(saved)
+    with pytest.raises(RuntimeError, match="storage unavailable"):
+        _application.reset_saved_code_trust()
+
+
+def test_application_does_not_sign_unregistered_manifest_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _entry(code="first()")
+    second = _entry(code="second()")
+    original = CodeTrustManifest("test", 1, (first, second))
+    changed_manifests = (
+        CodeTrustManifest("other", 1, (first, second)),
+        CodeTrustManifest("test", 2, (first, second)),
+        CodeTrustManifest(
+            "test", 1, (_entry(code="first()", location="other"), second)
+        ),
+        CodeTrustManifest("test", 1, (second, first)),
+        CodeTrustManifest("test", 1, (_entry(code="changed()"), second)),
+    )
+    signed_manifests: list[CodeTrustManifest] = []
+
+    class Notary:
+        def sign(self, manifest: CodeTrustManifest) -> None:
+            signed_manifests.append(manifest)
+
+    monkeypatch.setattr(_application, "_application_code_trust_notary", Notary)
+
+    for changed_manifest in changed_manifests:
+        saved, signature_stored = _application.save_document_trust(
+            _signed_trust(original),
+            changed_manifest,
+            saved_trusted_lineage=True,
+        )
+
+        assert signature_stored
+        assert not document_trust_is_trusted(saved)
+    assert signed_manifests == []
+
+    saved, signature_stored = _application.save_document_trust(
+        _signed_trust(original),
+        original,
+        saved_trusted_lineage=True,
+    )
+
+    assert signature_stored
+    assert document_trust_is_trusted(saved)
+    assert signed_manifests == [original]
+
+    mutable_manifest = _manifest()
+    mutable_trust = _signed_trust(mutable_manifest)
+    mutable_manifest.entries[0].context["enabled"] = False
+    saved, signature_stored = _application.save_document_trust(
+        mutable_trust,
+        mutable_manifest,
+        saved_trusted_lineage=True,
+    )
+
+    assert signature_stored
+    assert not document_trust_is_trusted(saved)
+    assert signed_manifests == [original]
+
+
+def test_untrusted_save_preserves_local_identities_only_in_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    external_entry = _entry(code="external()", location="external")
+    local_entry = _entry(code="local()", location="local")
+    original_manifest = CodeTrustManifest("test", 1, (external_entry,))
+    saved_manifest = CodeTrustManifest("test", 1, (external_entry, local_entry))
+    untrusted = untrusted_document_trust(original_manifest)
+    _, capability = code_trust.issue_local_edit_capability(
+        untrusted,
+        (local_entry,),
+        edited_entries=(local_entry,),
+    )
+    mixed = code_trust.commit_local_edit_trust(
+        untrusted,
+        capability,
+        original_manifest.entries,
+        saved_manifest.entries,
+        edited_entries=(local_entry,),
+    )
+    signed_manifests: list[CodeTrustManifest] = []
+
+    class Notary:
+        def sign(self, manifest: CodeTrustManifest) -> None:
+            signed_manifests.append(manifest)
+
+        def check(self, manifest: CodeTrustManifest) -> bool:
+            return False
+
+    monkeypatch.setattr(_application, "_application_code_trust_notary", Notary)
+
+    saved, _signature_stored = _application.save_document_trust(
+        mixed,
+        saved_manifest,
+        saved_trusted_lineage=False,
+    )
+
+    assert signed_manifests == []
+    assert code_trust.document_trust_needs_review(saved)
+    assert code_trust.authorize_document_execution(saved, (local_entry,))[1]
+    assert not code_trust.authorize_document_execution(saved, (external_entry,))[1]
+    reopened = _application.load_document_trust(saved_manifest)
+    assert code_trust.document_trust_needs_review(reopened)
+    assert not code_trust.authorize_document_execution(reopened, (local_entry,))[1]
+
+    pruned, _signature_stored = _application.save_document_trust(
+        saved,
+        original_manifest,
+        saved_trusted_lineage=False,
+    )
+    assert not code_trust.authorize_document_execution(pruned, (local_entry,))[1]
+
+
+def test_application_code_trust_directory_is_stable_across_qt_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+    qapp,
+) -> None:
+    monkeypatch.delenv("ERLAB_CODE_TRUST_DIRECTORY")
+    previous_application = qapp.applicationName()
+    previous_organization = qapp.organizationName()
+    previous_organization_domain = qapp.organizationDomain()
+    try:
+        qapp.setOrganizationName("")
+        qapp.setOrganizationDomain("")
+        qapp.setApplicationName("ImageTool Manager")
+        legacy_manager_directory = (
+            pathlib.Path(
+                QtCore.QStandardPaths.writableLocation(
+                    QtCore.QStandardPaths.StandardLocation.AppDataLocation
+                )
+            )
+            / "code-trust"
+        )
+        manager_directory = _application.application_code_trust_directory()
+
+        host_directories = []
+        for organization, organization_domain, application in (
+            ("First Host Organization", "first.example", "First Host"),
+            ("Second Host Organization", "second.example", "Second Host"),
+        ):
+            qapp.setOrganizationName(organization)
+            qapp.setOrganizationDomain(organization_domain)
+            qapp.setApplicationName(application)
+            host_directories.append(_application.application_code_trust_directory())
+    finally:
+        qapp.setOrganizationName(previous_organization)
+        qapp.setOrganizationDomain(previous_organization_domain)
+        qapp.setApplicationName(previous_application)
+
+    assert manager_directory == legacy_manager_directory
+    assert host_directories == [manager_directory, manager_directory]
+
+
+def test_application_code_trust_directory_honors_environment_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    configured = tmp_path / "custom-trust"
+    monkeypatch.setenv("ERLAB_CODE_TRUST_DIRECTORY", str(configured))
+
+    assert _application.application_code_trust_directory() == configured
+
+
+def test_code_trust_notary_missing_secret_invalidates_saved_signatures(
+    tmp_path,
+) -> None:
+    notary = CodeTrustNotary(tmp_path)
+    manifest = _manifest()
+    notary.sign(manifest)
+    secret_path = tmp_path / "code_trust_secret"
+
+    secret_path.unlink()
+
+    assert not notary.check(manifest)
+    assert len(secret_path.read_bytes()) == 1024
+
+
+def test_code_trust_notary_failed_secret_write_can_recover(
+    tmp_path, monkeypatch
+) -> None:
+    notary = CodeTrustNotary(tmp_path)
+    manifest = _manifest()
+
+    def fail_fsync(_descriptor: int) -> None:
+        raise OSError("write failed")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(os, "fsync", fail_fsync)
+        with pytest.raises(CodeTrustError, match="Could not create"):
+            notary.sign(manifest)
+
+    assert not (tmp_path / "code_trust_secret").exists()
+    assert not tuple(tmp_path.glob(".code_trust_secret-*"))
+
+    notary.sign(manifest)
+
+    assert notary.check(manifest)
+
+
+def test_code_trust_notary_replaces_corrupt_database_fail_closed(tmp_path) -> None:
+    notary = CodeTrustNotary(tmp_path)
+    manifest = _manifest()
+    notary.sign(manifest)
+    database_path = tmp_path / "code_signatures.db"
+    database_path.write_bytes(b"not a sqlite database")
+
+    assert not notary.check(manifest)
+    assert (
+        tmp_path / "code_signatures.db.bak"
+    ).read_bytes() == b"not a sqlite database"
+
+
+def test_code_trust_notary_does_not_replace_locked_database(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    notary = CodeTrustNotary(tmp_path)
+    manifest = _manifest()
+    notary.sign(manifest)
+    database_path = tmp_path / "code_signatures.db"
+    original_database = database_path.read_bytes()
+
+    def raise_locked(_connection: sqlite3.Connection) -> None:
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(notary, "_initialize_database", raise_locked)
+
+    with pytest.raises(CodeTrustError, match="Could not access"):
+        notary._connect()
+    assert database_path.read_bytes() == original_database
+    assert not (tmp_path / "code_signatures.db.bak").exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits only")
+def test_code_trust_notary_uses_private_permissions(tmp_path) -> None:
+    trust_directory = tmp_path / "trust"
+    notary = CodeTrustNotary(trust_directory)
+    notary.sign(_manifest())
+
+    assert (trust_directory / "code_trust_secret").stat().st_mode & 0o777 == 0o600
+    assert (trust_directory / "code_signatures.db").stat().st_mode & 0o777 == 0o600
+    assert trust_directory.stat().st_mode & 0o777 == 0o700
+
+
+def test_trusted_location_policy_resolves_descendants_and_symlinks(tmp_path) -> None:
+    trusted = tmp_path / "research"
+    outside = tmp_path / "outside"
+    trusted.mkdir()
+    outside.mkdir()
+    workspace = trusted / "nested" / "figure.itws"
+    workspace.parent.mkdir()
+    workspace.touch()
+    outside_workspace = outside / "outside.itws"
+    outside_workspace.touch()
+    (trusted / "escape").symlink_to(outside, target_is_directory=True)
+
+    locations = (("erlab.workspace", trusted),)
+
+    assert document_path_is_trusted("erlab.workspace", workspace, locations)
+    assert not document_path_is_trusted("other", workspace, locations)
+    assert not document_path_is_trusted(
+        "erlab.workspace",
+        trusted / "escape/outside.itws",
+        locations,
+    )
+
+
+def test_validate_trusted_location_rejects_filesystem_root(tmp_path) -> None:
+    folder = tmp_path / "research"
+    folder.mkdir()
+
+    assert validate_trusted_location(folder) == folder.resolve()
+    with pytest.raises(ValueError, match="filesystem root"):
+        validate_trusted_location(folder.anchor)

--- a/tests/interactive/test_code_trust.py
+++ b/tests/interactive/test_code_trust.py
@@ -6,12 +6,14 @@ import pathlib
 import sqlite3
 import typing
 from contextlib import closing
+from types import SimpleNamespace
 
 import pytest
 from qtpy import QtCore, QtWidgets
 
 import erlab.interactive._code_trust as code_trust
 import erlab.interactive._code_trust._application as _application
+import erlab.interactive._code_trust._notary as _notary
 from erlab.interactive._code_trust import (
     approve_document_trust,
     document_trust_has_trusted_lineage,
@@ -30,6 +32,7 @@ from erlab.interactive._code_trust._locations import (
 )
 from erlab.interactive._code_trust._notary import CodeTrustError, CodeTrustNotary
 from erlab.interactive._code_trust._payloads import (
+    CODE_PAYLOAD_ENTRIES_ATTR,
     code_payload_entries_from_metadata,
     store_code_payload_entries,
 )
@@ -119,6 +122,41 @@ def test_code_trust_manifest_canonicalization_and_validation() -> None:
         CodeTrustEntry("test", "here", "code", {"values": (1, 2)})
     with pytest.raises(ValueError, match="positive"):
         CodeTrustManifest("test", 0, ())
+
+
+@pytest.mark.parametrize(
+    ("args", "error", "message"),
+    [
+        ((1, "location", "code"), TypeError, "feature must be a string"),
+        ((" ", "location", "code"), ValueError, "feature must not be empty"),
+        (("feature", 1, "code"), TypeError, "location must be a string"),
+        (("feature", " ", "code"), ValueError, "location must not be empty"),
+        (("feature", "location", 1), TypeError, "code must be a string"),
+        (("feature", "location", "code", []), TypeError, "context must be a mapping"),
+    ],
+)
+def test_code_trust_entry_rejects_invalid_runtime_values(
+    args: tuple[typing.Any, ...], error: type[Exception], message: str
+) -> None:
+    with pytest.raises(error, match=message):
+        CodeTrustEntry(*args)
+
+
+@pytest.mark.parametrize(
+    ("args", "error", "message"),
+    [
+        ((1, 1, ()), TypeError, "domain must be a string"),
+        ((" ", 1, ()), ValueError, "domain must not be empty"),
+        (("test", True, ()), TypeError, "policy version must be an integer"),
+        (("test", 1, []), TypeError, "entries must be a tuple"),
+        (("test", 1, ("bad",)), TypeError, "entries must be CodeTrustEntry"),
+    ],
+)
+def test_code_trust_manifest_rejects_invalid_runtime_values(
+    args: tuple[typing.Any, ...], error: type[Exception], message: str
+) -> None:
+    with pytest.raises(error, match=message):
+        CodeTrustManifest(*args)
 
 
 def test_code_trust_entry_snapshots_mutable_context() -> None:
@@ -1053,6 +1091,69 @@ def test_opaque_code_payload_metadata_binds_exact_bytes() -> None:
     )
 
 
+def test_code_payload_metadata_validates_saved_values() -> None:
+    entry = code_trust.create_payload_entry(
+        "test.payload", "payload/0", "Serialized callable", b"payload"
+    )
+    attrs: dict[str, object] = {}
+    store_code_payload_entries(attrs, (entry,))
+    attrs[CODE_PAYLOAD_ENTRIES_ATTR] = str(attrs[CODE_PAYLOAD_ENTRIES_ATTR]).encode()
+
+    assert code_payload_entries_from_metadata(attrs) == (entry,)
+
+    invalid_metadata = (
+        (1, "must be JSON text"),
+        ("{", "invalid JSON"),
+        ("{}", "must be a JSON list"),
+        ("[{}]", "invalid fields"),
+        (
+            json.dumps(
+                [
+                    {
+                        "code": "Serialized callable",
+                        "context": [],
+                        "feature": "test.payload",
+                        "location": "payload/0",
+                    }
+                ]
+            ),
+            "context must be an object",
+        ),
+    )
+    for raw, message in invalid_metadata:
+        with pytest.raises(TypeError, match=message):
+            code_payload_entries_from_metadata({CODE_PAYLOAD_ENTRIES_ATTR: raw})
+
+
+def test_code_payload_metadata_rejects_invalid_entries() -> None:
+    with pytest.raises(ValueError, match="reserved"):
+        code_trust.create_payload_entry(
+            "test.payload",
+            "payload/0",
+            "Serialized callable",
+            b"payload",
+            {"payload_sha256": "0" * 64},
+        )
+
+    for digest in ("z" * 64, "0" * 62):
+        invalid = _entry(context={"payload_sha256": digest})
+        with pytest.raises(TypeError, match="invalid SHA-256"):
+            store_code_payload_entries({}, (invalid,))
+
+    entry = code_trust.create_payload_entry(
+        "test.payload", "payload/0", "Serialized callable", b"payload"
+    )
+    duplicate = code_trust.create_payload_entry(
+        "test.payload", "payload/0", "Another callable", b"other"
+    )
+    with pytest.raises(ValueError, match="unique locations"):
+        store_code_payload_entries({}, (entry, duplicate))
+
+    attrs = {CODE_PAYLOAD_ENTRIES_ATTR: "stale"}
+    store_code_payload_entries(attrs, ())
+    assert CODE_PAYLOAD_ENTRIES_ATTR not in attrs
+
+
 def test_code_trust_notary_sign_check_remove_and_domain_separation(tmp_path) -> None:
     notary = CodeTrustNotary(tmp_path)
     manifest = _manifest()
@@ -1067,11 +1168,100 @@ def test_code_trust_notary_sign_check_remove_and_domain_separation(tmp_path) -> 
     assert not notary.check(manifest)
 
 
+def test_code_trust_notary_rejects_invalid_configuration(tmp_path) -> None:
+    with pytest.raises(ValueError, match="cache size must be positive"):
+        CodeTrustNotary(tmp_path, cache_size=0)
+
+    notary = CodeTrustNotary(tmp_path)
+    (tmp_path / "code_trust_secret").write_bytes(b"short")
+    with pytest.raises(CodeTrustError, match="invalid size"):
+        notary._secret()
+
+
+def test_code_trust_notary_closes_connection_for_rejected_schema(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    notary = CodeTrustNotary(tmp_path)
+
+    class TrackingConnection:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    connection = TrackingConnection()
+
+    def reject_schema(_connection: object) -> None:
+        raise CodeTrustError("bad schema")
+
+    monkeypatch.setattr(_notary.sqlite3, "connect", lambda *_args: connection)
+    monkeypatch.setattr(notary, "_initialize_database", reject_schema)
+
+    with pytest.raises(CodeTrustError, match="bad schema"):
+        notary._connect()
+
+    assert connection.closed
+
+
+def test_code_trust_notary_empty_manifest_operations_are_noops(tmp_path) -> None:
+    notary = CodeTrustNotary(tmp_path)
+    manifest = CodeTrustManifest("erlab.workspace", 1, ())
+
+    assert notary.check(manifest)
+    notary.sign(manifest)
+    notary.remove(manifest)
+    assert not tuple(tmp_path.iterdir())
+
+
+def test_code_trust_notary_check_fails_closed_on_storage_error(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    notary = CodeTrustNotary(tmp_path)
+
+    def fail_signature(_manifest: CodeTrustManifest) -> str:
+        raise CodeTrustError("unavailable")
+
+    monkeypatch.setattr(notary, "_signature", fail_signature)
+
+    assert not notary.check(_manifest())
+
+
+class _FailingCodeTrustConnection:
+    def execute(self, *_args: object, **_kwargs: object) -> object:
+        raise sqlite3.OperationalError("unavailable")
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize(
+    ("operation", "message"),
+    [
+        (lambda notary, manifest: notary.sign(manifest), "store"),
+        (lambda notary, manifest: notary.remove(manifest), "remove"),
+        (lambda notary, _manifest: notary.reset(), "reset"),
+    ],
+)
+def test_code_trust_notary_wraps_database_mutation_failures(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: typing.Callable[[CodeTrustNotary, CodeTrustManifest], None],
+    message: str,
+) -> None:
+    notary = CodeTrustNotary(tmp_path)
+    monkeypatch.setattr(notary, "_connect", _FailingCodeTrustConnection)
+
+    with pytest.raises(CodeTrustError, match=message):
+        operation(notary, _manifest())
+
+
 def test_code_trust_notary_reset_and_culling(tmp_path) -> None:
     notary = CodeTrustNotary(tmp_path, cache_size=4)
     manifests = tuple(_manifest(code=f"value = {index}") for index in range(5))
     for manifest in manifests:
         notary.sign(manifest)
+    other_domain = _manifest(domain="erlab.figure-composer-file")
+    notary.sign(other_domain)
 
     assert not notary.check(manifests[0])
     assert not notary.check(manifests[1])
@@ -1079,6 +1269,10 @@ def test_code_trust_notary_reset_and_culling(tmp_path) -> None:
 
     notary.reset(domain="erlab.workspace")
     assert not notary.check(manifests[2])
+    assert notary.check(other_domain)
+
+    notary.reset()
+    assert not notary.check(other_domain)
 
 
 def test_code_trust_notary_secret_and_database_tampering_fail_closed(tmp_path) -> None:
@@ -1291,6 +1485,24 @@ def test_application_code_trust_directory_honors_environment_override(
     assert _application.application_code_trust_directory() == configured
 
 
+def test_application_code_trust_directory_requires_qt_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    standard_paths = SimpleNamespace(
+        StandardLocation=SimpleNamespace(GenericDataLocation=object()),
+        writableLocation=lambda _location: "",
+    )
+    monkeypatch.delenv("ERLAB_CODE_TRUST_DIRECTORY", raising=False)
+    monkeypatch.setattr(
+        _application,
+        "QtCore",
+        SimpleNamespace(QStandardPaths=standard_paths),
+    )
+
+    with pytest.raises(RuntimeError, match="Could not determine"):
+        _application.application_code_trust_directory()
+
+
 def test_code_trust_notary_missing_secret_invalidates_saved_signatures(
     tmp_path,
 ) -> None:
@@ -1401,3 +1613,18 @@ def test_validate_trusted_location_rejects_filesystem_root(tmp_path) -> None:
     assert validate_trusted_location(folder) == folder.resolve()
     with pytest.raises(ValueError, match="filesystem root"):
         validate_trusted_location(folder.anchor)
+
+
+def test_trusted_location_policy_rejects_files_and_unusable_paths(tmp_path) -> None:
+    not_a_folder = tmp_path / "not-a-folder"
+    not_a_folder.write_text("file")
+
+    with pytest.raises(ValueError, match="must be a folder"):
+        validate_trusted_location(not_a_folder)
+
+    missing_document = tmp_path / "missing.itws"
+    assert not document_path_is_trusted("test", missing_document, (("test", tmp_path),))
+
+    document = tmp_path / "document.itws"
+    document.touch()
+    assert not document_path_is_trusted("test", document, (("test", not_a_folder),))

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -320,7 +320,7 @@ def test_fit1d_persistence_helper_edges(qtbot, monkeypatch, gold) -> None:
     assert win._append_persistence_payload(empty) is empty
 
     blob = np.array([1, 2, 3], dtype=np.uint8)
-    win._pending_persisted_fit_result_blob = blob
+    win._serialized_fit_result_blob = blob
     win._pending_persisted_fit_is_current = True
     appended = win._append_persistence_payload(empty)
     np.testing.assert_array_equal(
@@ -365,6 +365,9 @@ def test_fit1d_persistence_helper_edges(qtbot, monkeypatch, gold) -> None:
     monkeypatch.setattr(win, "_update_fit_curve", lambda: calls.append("curve"))
     monkeypatch.setattr(win, "_mark_fit_fresh", lambda: calls.append("fresh"))
     monkeypatch.setattr(win, "_mark_fit_stale", lambda: calls.append("stale"))
+    payload_entry = win._fit_result_code_trust_entry(blob)
+    assert payload_entry is not None
+    win._saved_code_payload_entries = (payload_entry,)
 
     win._restore_persisted_fit_result_blob(blob, fit_is_current=True)
     win._restore_persisted_fit_result_blob(blob, fit_is_current=False)

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -1,4 +1,6 @@
+import contextlib
 import gc
+import json
 
 import lmfit
 import numpy as np
@@ -8,10 +10,27 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 from erlab.interactive import _fit1d as fit1d
+from erlab.interactive._code_trust import (
+    authorize_document_execution,
+    create_entry,
+    document_trust_has_trusted_lineage,
+    execution_capability_allows,
+    external_document_trust,
+    issue_local_edit_capability,
+    new_document_trust,
+    untrusted_document_trust,
+)
+from erlab.interactive._code_trust._api import _document_trust_after_save
 from erlab.interactive._fit1d import (
     Fit1DTool,
     _ParameterEditDelegate,
     _ParameterTableModel,
+)
+from erlab.interactive._fit_code_trust import (
+    lmfit_expression_model_code_entries,
+    lmfit_model_code_entry,
+    lmfit_parameter_expression_entries,
+    lmfit_result_code_entry,
 )
 from tests._qt_helpers import signal_receiver_count
 
@@ -22,8 +41,43 @@ def _make_1d_data() -> xr.DataArray:
     return xr.DataArray(data, dims=("x",), coords={"x": x}, name="spec")
 
 
+def _make_linear_fit1d_tool(
+    qtbot, *, expression: bool = False
+) -> tuple[Fit1DTool, xr.DataArray, lmfit.Model, lmfit.Parameters]:
+    data = _make_1d_data()
+    model = lmfit.models.LinearModel()
+    params = model.make_params(slope=1.0, intercept=2.0 if expression else 0.0)
+    if expression:
+        params["intercept"].expr = "2 * slope"
+    tool = erlab.interactive.ftool(data, model=model, params=params, execute=False)
+    qtbot.addWidget(tool)
+    if not isinstance(tool, Fit1DTool):  # pragma: no cover
+        raise TypeError("Expected Fit1DTool")
+    return tool, data, model, params
+
+
+def _set_signed_fit_trust(tool: Fit1DTool) -> None:
+    manifest = tool._current_code_trust_manifest()
+    assert manifest is not None
+    signed = _document_trust_after_save(
+        new_document_trust(),
+        manifest,
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+    tool.set_document_trust(signed, notify=False)
+
+
+def _trust_allows_local_code_edit(trust) -> bool:
+    entry = create_entry("test.local-edit", "test", "result = source")
+    return authorize_document_execution(trust, (entry,))[1]
+
+
 def _assert_fit_result_dataset_equivalent(
-    actual: xr.Dataset, expected: xr.Dataset
+    actual: xr.Dataset,
+    expected: xr.Dataset,
+    *,
+    require_model_type: bool = True,
 ) -> None:
     xr.testing.assert_identical(
         actual.drop_vars("modelfit_results"),
@@ -31,7 +85,8 @@ def _assert_fit_result_dataset_equivalent(
     )
     actual_result = actual.modelfit_results.compute().item()
     expected_result = expected.modelfit_results.compute().item()
-    assert type(actual_result.model) is type(expected_result.model)
+    if require_model_type:
+        assert type(actual_result.model) is type(expected_result.model)
     assert list(actual_result.params.keys()) == list(expected_result.params.keys())
     for name, expected_param in expected_result.params.items():
         actual_param = actual_result.params[name]
@@ -45,16 +100,29 @@ def _assert_fit_result_dataset_equivalent(
 
 
 def _fit_result_dataset(params: lmfit.Parameters, *, nfev: int = 1) -> xr.Dataset:
-    class _Result:
-        def __init__(self) -> None:
-            self.params = params.copy()
-            self.nfev = nfev
-            self.redchi = 1.0
-            self.rsquared = 0.9
-            self.aic = 1.0
-            self.bic = 2.0
+    params = params.copy()
+    param_args = ", ".join(("x", *params.keys()))
+    namespace = {"np": np}
+    exec(  # noqa: S102
+        f"def _model_func({param_args}):\n    return np.zeros_like(x, dtype=float)\n",
+        namespace,
+    )
+    model = lmfit.Model(namespace["_model_func"])
+    result = lmfit.model.ModelResult(
+        model,
+        params,
+        data=np.zeros(3),
+        fcn_args=(np.arange(3, dtype=float),),
+        max_nfev=nfev,
+    )
+    result.params = params.copy()
+    result.nfev = nfev
+    result.redchi = 1.0
+    result.rsquared = 0.9
+    result.aic = 1.0
+    result.bic = 2.0
 
-    return xr.Dataset({"modelfit_results": xr.DataArray(_Result(), dims=())})
+    return xr.Dataset({"modelfit_results": xr.DataArray(result, dims=())})
 
 
 @pytest.mark.parametrize(
@@ -194,6 +262,375 @@ def test_fit1d_tool_status_without_saved_params_uses_model_defaults(
 
     assert list(win_restored._params) == ["n0", "tau"]
     assert win_restored.tool_status.params
+
+
+def test_fit1d_saved_model_restore_waits_for_document_approval(
+    qtbot, monkeypatch
+) -> None:
+    data = _make_1d_data()
+    source = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(source)
+    saved = source.to_dataset()
+    saved_status = Fit1DTool.StateModel.model_validate_json(saved.attrs["tool_state"])
+
+    calls: list[str] = []
+    original_loads = lmfit.model.Model.loads
+
+    def tracked_loads(model, state, **kwargs):
+        calls.append(state)
+        return original_loads(model, state, **kwargs)
+
+    monkeypatch.setattr(lmfit.model.Model, "loads", tracked_loads)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, Fit1DTool)
+    assert calls == []
+    assert not document_trust_has_trusted_lineage(restored._document_trust)
+    assert restored._saved_tool_status() == saved_status
+
+    restored.set_document_trust(new_document_trust())
+
+    assert calls == [saved_status.model_state[1]]
+    assert restored.tool_status.model_name == saved_status.model_name
+
+
+@pytest.mark.parametrize("ndim", [1, 2])
+def test_signed_parameterless_model_restore_preserves_saved_identity(
+    qtbot, monkeypatch, ndim: int
+) -> None:
+    data = _make_1d_data()
+    if ndim == 2:
+        data = xr.concat([data, data + 1.0], dim="y")
+    source = erlab.interactive.ftool(
+        data,
+        model=lmfit.Model(lambda x: x, independent_vars=["x"]),
+        execute=False,
+    )
+    qtbot.addWidget(source)
+    assert not source._params
+    _set_signed_fit_trust(source)
+    signed_trust = source._document_trust
+    saved_model_state = source._serialized_model_state
+    saved_entries = source._fit_code_entries
+    saved = source.to_dataset()
+    dump_calls = 0
+    original_loads = lmfit.model.Model.loads
+
+    def tracked_loads(model, state, **kwargs):
+        loaded = original_loads(model, state, **kwargs)
+
+        def unexpected_dump(*_args, **_kwargs):
+            nonlocal dump_calls
+            dump_calls += 1
+            return lmfit.models.ExpressionModel("changed * x").dumps()
+
+        monkeypatch.setattr(loaded, "dumps", unexpected_dump)
+        return loaded
+
+    monkeypatch.setattr(lmfit.model.Model, "loads", tracked_loads)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _code_trust=signed_trust,
+    )
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, Fit1DTool)
+    assert dump_calls == 0
+    assert restored._serialized_model_state == saved_model_state
+    assert restored._fit_code_entries == saved_entries
+    assert restored._document_trust == signed_trust
+
+
+def test_fit1d_saved_model_class_does_not_import_document_target(
+    qtbot, monkeypatch, tmp_path
+) -> None:
+    module_name = "unregistered_saved_fit_model"
+    marker = tmp_path / "imported.txt"
+    (tmp_path / f"{module_name}.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('imported')\n"
+        "class SavedModel:\n    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    source = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(source)
+    saved = source.to_dataset()
+    status = Fit1DTool.StateModel.model_validate_json(saved.attrs["tool_state"])
+    saved.attrs["tool_state"] = status.model_copy(
+        update={
+            "model_state": (
+                f"{module_name}:SavedModel",
+                status.model_state[1],
+            )
+        }
+    ).model_dump_json()
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _code_trust=new_document_trust(),
+    )
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, Fit1DTool)
+    assert not marker.exists()
+    assert type(restored._model).__module__ != module_name
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_code"),
+    [
+        pytest.param(lmfit.models.ExponentialModel(), None, id="lmfit-library"),
+        pytest.param(erlab.analysis.fit.models.TLLModel(), None, id="erlab-library"),
+        pytest.param(
+            lmfit.models.ExpressionModel("amplitude * exp(-x / decay)"),
+            "amplitude * exp(-x / decay)",
+            id="expression",
+        ),
+        pytest.param(
+            lmfit.Model(lambda x, amplitude: amplitude * x),
+            "serialized-callable",
+            id="custom-callable",
+        ),
+        pytest.param(
+            erlab.analysis.fit.models.FermiEdgeModel(),
+            "serialized-callable",
+            id="embedded-library-callable",
+        ),
+    ],
+)
+def test_lmfit_code_trust_classifies_models_without_loading(
+    model: lmfit.Model, expected_code: str | None
+) -> None:
+    entry = lmfit_model_code_entry(
+        model.dumps(),
+        feature="test.lmfit-model",
+        location="model",
+    )
+
+    if expected_code is None:
+        assert entry is None
+    else:
+        assert entry is not None
+        assert expected_code in entry.code
+
+
+def test_expression_model_local_entry_matches_saved_model_identity() -> None:
+    expression = "amplitude * exp(-x / decay)"
+    model = lmfit.models.ExpressionModel(expression)
+    local_entries = lmfit_expression_model_code_entries(
+        expression,
+        "constant = 1",
+        feature="test.lmfit-model",
+        location="model",
+    )
+    saved_entry = lmfit_model_code_entry(
+        model.dumps(),
+        feature="test.lmfit-model",
+        location="model",
+    )
+
+    assert saved_entry is not None
+    assert local_entries[0] == saved_entry
+    assert local_entries[1].code == "constant = 1"
+
+
+def test_lmfit_code_trust_tracks_every_saved_parameter_expression() -> None:
+    entries = lmfit_parameter_expression_entries(
+        [
+            ("plain", None),
+            ("constrained", "2 * plain"),
+        ],
+        feature="test.lmfit-parameter",
+        location_prefix="parameters",
+    )
+
+    assert len(entries) == 1
+    assert entries[0].location == "parameters/constrained"
+    assert entries[0].code == "2 * plain"
+    assert entries[0].context == {"parameter": "constrained"}
+
+
+def test_lmfit_parameter_expression_locations_are_stable_and_escaped() -> None:
+    original = lmfit_parameter_expression_entries(
+        [("first/parameter", "scale * 2"), ("second", "scale * 3")],
+        feature="test.lmfit-parameter",
+        location_prefix="parameters",
+    )
+    inserted = lmfit_parameter_expression_entries(
+        [
+            ("added", "scale * 4"),
+            ("first/parameter", "scale * 2"),
+            ("second", "scale * 3"),
+        ],
+        feature="test.lmfit-parameter",
+        location_prefix="parameters",
+    )
+
+    assert original == inserted[1:]
+    assert [entry.location for entry in inserted] == [
+        "parameters/added",
+        "parameters/first%2Fparameter",
+        "parameters/second",
+    ]
+
+
+def _custom_lmfit_json(*, dill_value: str, numeric_value: float) -> str:
+    return json.dumps(
+        {
+            "chisqr": numeric_value,
+            "model": {
+                "__class__": "Callable",
+                "__name__": "custom_model",
+                "importer": "unavailable.user_module",
+                "pyversion": "3.14",
+                "value": dill_value,
+            },
+        }
+    )
+
+
+@pytest.mark.parametrize("payload_kind", ["model", "result"])
+def test_lmfit_entries_digest_only_executable_fragments(payload_kind: str) -> None:
+    def entry(*, dill_value: str, numeric_value: float):
+        serialized = _custom_lmfit_json(
+            dill_value=dill_value, numeric_value=numeric_value
+        )
+        if payload_kind == "model":
+            return lmfit_model_code_entry(
+                serialized,
+                feature="test.lmfit-model",
+                location="model",
+            )
+        payload = xr.Dataset(
+            {
+                "modelfit_results": xr.DataArray(serialized),
+                "numeric_result": xr.DataArray(numeric_value),
+            }
+        ).to_netcdf(path=None, engine="h5netcdf")
+        return lmfit_result_code_entry(
+            bytes(payload),
+            feature="test.lmfit-result",
+            location="fit-result",
+        )
+
+    original = entry(dill_value="dill-a", numeric_value=1.0)
+
+    assert original is not None
+    assert original == entry(dill_value="dill-a", numeric_value=2.0)
+    assert original != entry(dill_value="dill-b", numeric_value=1.0)
+
+
+def test_lmfit_code_trust_classifies_result_payload_without_loading_it() -> None:
+    x = np.linspace(0.0, 2.0, 11)
+    model = lmfit.models.ExponentialModel()
+    params = model.make_params(amplitude=1.0, decay=1.0)
+    result = model.fit(np.exp(-x), params, x=x)
+    payload = xr.Dataset({"modelfit_results": xr.DataArray(result.dumps())}).to_netcdf(
+        path=None, engine="h5netcdf"
+    )
+
+    entry = lmfit_result_code_entry(
+        bytes(payload),
+        feature="test.lmfit-result",
+        location="fit-result",
+    )
+
+    assert entry is None
+
+
+def test_fit1d_saved_library_model_and_result_restore_without_approval(qtbot) -> None:
+    x = np.linspace(0.0, 2.0, 25)
+    values = 1.2 * np.exp(-x / 0.8) + 0.005 * np.sin(5.0 * x)
+    data = xr.DataArray(values, dims=("x",), coords={"x": x})
+    model = lmfit.models.ExponentialModel()
+    source = erlab.interactive.ftool(
+        data,
+        model=model,
+        params=model.make_params(amplitude=1.0, decay=1.0),
+        execute=False,
+    )
+    qtbot.addWidget(source)
+    assert source._run_fit()
+    qtbot.waitUntil(lambda: source._last_result_ds is not None, timeout=10000)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(source.to_dataset())
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, Fit1DTool)
+    assert restored._pending_fit_status is None
+    assert restored._pending_persisted_fit_is_current is None
+    assert restored._model.func is lmfit.lineshapes.exponential
+    assert restored._last_result_ds is not None
+
+
+def test_fit1d_code_trust_tracks_parameter_expressions(qtbot) -> None:
+    tool = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(tool)
+    status = tool.tool_status
+    parameter_state = list(status.params[0])
+    parameter_state[3] = "other_parameter + 1"
+    changed_params = list(status.params)
+    changed_params[0] = tuple(parameter_state)
+    changed = status.model_copy(update={"params": changed_params})
+
+    baseline_entries = tuple(type(tool)._code_trust_entries_from_status(status))
+    changed_entries = tuple(type(tool)._code_trust_entries_from_status(changed))
+
+    assert baseline_entries != changed_entries
+    expression_entry = next(
+        entry
+        for entry in changed_entries
+        if entry.feature == tool._PARAMETER_CODE_TRUST_FEATURE
+    )
+    assert expression_entry.location == f"parameters/{parameter_state[0]}"
+    assert expression_entry.code == "other_parameter + 1"
+    assert expression_entry.context == {"parameter": parameter_state[0]}
+
+
+def test_fit1d_empty_model_state_does_not_bypass_expression_trust(
+    qtbot, monkeypatch
+) -> None:
+    source = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(source)
+    saved = source.to_dataset()
+    status = Fit1DTool.StateModel.model_validate_json(saved.attrs["tool_state"])
+    parameter_state = list(status.params[0])
+    parameter_state[3] = "1 + 1"
+    params = list(status.params)
+    params[0] = tuple(parameter_state)
+    modified_status = status.model_copy(
+        update={
+            "model_state": (status.model_state[0], ""),
+            "normalize_mean": not status.normalize_mean,
+            "params": params,
+        }
+    )
+    saved.attrs["tool_state"] = modified_status.model_dump_json()
+
+    calls: list[object] = []
+    original = Fit1DTool._deserialize_params
+
+    def tracked_deserialize(state, **kwargs):
+        calls.append(state)
+        return original(state, **kwargs)
+
+    monkeypatch.setattr(
+        Fit1DTool,
+        "_deserialize_params",
+        staticmethod(tracked_deserialize),
+    )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+
+    assert calls == []
+    assert not document_trust_has_trusted_lineage(restored._document_trust)
+    assert restored.normalize_check.isChecked() is modified_status.normalize_mean
+    assert tuple(type(restored)._code_trust_entries_from_status(modified_status))
 
 
 def test_fit1d_undo_redo(qtbot, exp_decay_model) -> None:
@@ -345,7 +782,9 @@ def test_fit1d_persistence_roundtrip_preserves_fit_result(
     expected_fit_ds = win._last_result_ds.copy(deep=True)
     expected_status = win.tool_status.model_dump()
 
-    win_restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    win_restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        win.to_dataset(), _code_trust=new_document_trust()
+    )
     qtbot.addWidget(win_restored)
     assert isinstance(win_restored, Fit1DTool)
 
@@ -383,7 +822,9 @@ def test_fit1d_persistence_roundtrip_preserves_stale_fit(
     expected_fit_ds = win._last_result_ds.copy(deep=True)
     expected_status = win.tool_status.model_dump()
 
-    win_restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    win_restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        win.to_dataset(), _code_trust=new_document_trust()
+    )
     qtbot.addWidget(win_restored)
     assert isinstance(win_restored, Fit1DTool)
 
@@ -393,6 +834,60 @@ def test_fit1d_persistence_roundtrip_preserves_stale_fit(
     assert win_restored._fit_is_current is False
     assert not win_restored.save_button.isEnabled()
     assert not win_restored.copy_button.isEnabled()
+
+
+def test_fit1d_persisted_result_digest_blocks_swapped_payload(
+    qtbot, monkeypatch
+) -> None:
+    t = np.linspace(0.0, 4.0, 25)
+    data = xr.DataArray(
+        3.0 * np.exp(-t / 2.0), dims=("t",), coords={"t": t}, name="decay"
+    )
+    model = lmfit.models.ExponentialModel()
+    source = erlab.interactive.ftool(
+        data,
+        model=model,
+        params=model.make_params(amplitude=2.0, decay=1.0),
+        execute=False,
+    )
+    qtbot.addWidget(source)
+    assert source._run_fit()
+    qtbot.waitUntil(lambda: source._last_result_ds is not None, timeout=10000)
+    qtbot.waitUntil(lambda: not source._fit_running(), timeout=10000)
+
+    tampered = source.to_dataset().copy(deep=True)
+    payload = np.asarray(tampered[source._PERSISTED_FIT_RESULT_VAR].values).copy()
+    payload[-1] ^= np.uint8(1)
+    tampered[source._PERSISTED_FIT_RESULT_VAR] = xr.DataArray(
+        payload,
+        dims=(source._PERSISTED_FIT_RESULT_DIM,),
+    )
+
+    decode_calls: list[None] = []
+
+    def fail_if_decoded(_payload):
+        decode_calls.append(None)
+        raise AssertionError("tampered fit result was decoded")
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_deserialize_fit_dataset_blob",
+        fail_if_decoded,
+    )
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        tampered,
+        _code_trust=new_document_trust(),
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+
+    assert decode_calls == []
+    assert not document_trust_has_trusted_lineage(restored._document_trust)
+
+    duplicate = restored.duplicate()
+    qtbot.addWidget(duplicate)
+    assert decode_calls == []
+    assert not document_trust_has_trusted_lineage(duplicate._document_trust)
 
 
 def test_fit1d_update_data_preserves_state_and_refit(
@@ -1573,6 +2068,330 @@ def test_fit1d_user_and_file_models(qtbot, tmp_path) -> None:
     code = win.copy_code()
     assert "load_model" in code
     assert str(model_path) in code
+
+
+def test_fit1d_model_file_reviews_exact_candidate_before_decode(
+    qtbot, tmp_path, monkeypatch
+) -> None:
+    tool, _data, _model, _params = _make_linear_fit1d_tool(qtbot, expression=True)
+    _set_signed_fit_trust(tool)
+    candidate = lmfit.models.ExpressionModel("amplitude * x + offset")
+    serialized = candidate.dumps()
+    model_path = tmp_path / "candidate.model"
+    model_path.write_text(serialized)
+    file_index = tool.model_combo.findData("__file")
+    events: list[str] = []
+    reviewed_manifests = []
+    review_options: list[dict[str, object]] = []
+    original_loads = lmfit.model.Model.loads
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (str(model_path), ""),
+    )
+
+    def confirm_candidate(_parent, manifest, **kwargs) -> bool:
+        events.append("review")
+        reviewed_manifests.append(manifest)
+        review_options.append(kwargs)
+        model_path.write_text(
+            lmfit.models.ExpressionModel("different * x + baseline").dumps()
+        )
+        return True
+
+    def tracked_loads(model, text, *args, **kwargs):
+        events.append("decode")
+        assert text == serialized
+        return original_loads(model, text, *args, **kwargs)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "confirm_code_trust", confirm_candidate
+    )
+    monkeypatch.setattr(lmfit.model.Model, "loads", tracked_loads)
+    with QtCore.QSignalBlocker(tool.model_combo):
+        tool.model_combo.setCurrentIndex(file_index)
+
+    tool._on_model_choice_changed(file_index)
+
+    assert events == ["review", "decode"]
+    assert len(reviewed_manifests) == 1
+    assert reviewed_manifests[0].entries == (
+        tool._model_code_trust_entry(("", serialized)),
+    )
+    assert review_options[0]["object_name"] == (
+        "fit_model_file_code_trust_review_dialog"
+    )
+    assert isinstance(tool._model, lmfit.models.ExpressionModel)
+    assert tool._model.expr == candidate.expr
+    assert tool._model_load_path == str(model_path)
+    assert _trust_allows_local_code_edit(tool._document_trust)
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected_reviews", "expected_decodes"),
+    [
+        pytest.param("cancel", 0, 0, id="file-dialog-cancel"),
+        pytest.param("deny", 1, 0, id="review-deny"),
+        pytest.param("entry-mutation", 1, 0, id="candidate-entry-mutation"),
+        pytest.param("failure", 1, 1, id="decode-failure"),
+    ],
+)
+def test_fit1d_model_file_cancel_deny_and_failure_preserve_state(
+    qtbot,
+    tmp_path,
+    monkeypatch,
+    outcome: str,
+    expected_reviews: int,
+    expected_decodes: int,
+) -> None:
+    tool, _data, old_model, _params = _make_linear_fit1d_tool(qtbot)
+    old_trust = tool._document_trust
+    old_model_state = tool._serialized_model_state
+    candidate = lmfit.models.ExpressionModel("amplitude * x + offset")
+    model_path = tmp_path / "candidate.model"
+    model_path.write_text(candidate.dumps())
+    file_index = tool.model_combo.findData("__file")
+    review_calls = 0
+    decode_calls = 0
+    errors: list[tuple[object, ...]] = []
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (
+            ("", "") if outcome == "cancel" else (str(model_path), "")
+        ),
+    )
+
+    def confirm_candidate(_parent, manifest, **_kwargs) -> bool:
+        nonlocal review_calls
+        review_calls += 1
+        if outcome == "entry-mutation":
+            manifest.entries[0].context["changed-during-review"] = True
+        return outcome != "deny"
+
+    def tracked_loads(*_args, **_kwargs):
+        nonlocal decode_calls
+        decode_calls += 1
+        raise RuntimeError("invalid model")
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "confirm_code_trust", confirm_candidate
+    )
+    monkeypatch.setattr(lmfit.model.Model, "loads", tracked_loads)
+    monkeypatch.setattr(tool, "_show_error", lambda *args: errors.append(args))
+    with QtCore.QSignalBlocker(tool.model_combo):
+        tool.model_combo.setCurrentIndex(file_index)
+
+    tool._on_model_choice_changed(file_index)
+
+    assert review_calls == expected_reviews
+    assert decode_calls == expected_decodes
+    assert bool(errors) is (outcome == "failure")
+    assert tool._model is old_model
+    assert tool._serialized_model_state == old_model_state
+    assert tool._model_load_path is None
+    assert tool._document_trust == old_trust
+
+
+def test_fit1d_model_file_application_failure_preserves_state(
+    qtbot, tmp_path, monkeypatch
+) -> None:
+    tool, _data, old_model, _params = _make_linear_fit1d_tool(qtbot, expression=True)
+    _set_signed_fit_trust(tool)
+    old_trust = tool._document_trust
+    old_params = tool._params
+    old_model_state = tool._serialized_model_state
+    old_entries = tool._fit_code_entries
+    candidate = lmfit.models.ExpressionModel("amplitude * x + offset")
+    model_path = tmp_path / "candidate.model"
+    model_path.write_text(candidate.dumps())
+    file_index = tool.model_combo.findData("__file")
+    original_loads = lmfit.model.Model.loads
+    errors: list[tuple[object, ...]] = []
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (str(model_path), ""),
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "confirm_code_trust",
+        lambda *_args, **_kwargs: True,
+    )
+
+    def tracked_loads(model, text, *args, **kwargs):
+        loaded = original_loads(model, text, *args, **kwargs)
+
+        def fail_make_params(*_args, **_kwargs):
+            raise RuntimeError("parameter creation failed")
+
+        monkeypatch.setattr(loaded, "make_params", fail_make_params)
+        return loaded
+
+    monkeypatch.setattr(lmfit.model.Model, "loads", tracked_loads)
+    monkeypatch.setattr(tool, "_show_error", lambda *args: errors.append(args))
+    with QtCore.QSignalBlocker(tool.model_combo):
+        tool.model_combo.setCurrentIndex(file_index)
+
+    tool._on_model_choice_changed(file_index)
+
+    assert errors
+    assert tool._model is old_model
+    assert tool._params is old_params
+    assert tool._serialized_model_state == old_model_state
+    assert tool._model_load_path is None
+    assert tool._fit_code_entries is old_entries
+    assert tool._document_trust == old_trust
+
+
+def test_fit1d_model_file_keeps_reviewed_state_without_second_dump(
+    qtbot, tmp_path, monkeypatch
+) -> None:
+    tool, _data, _old_model, _params = _make_linear_fit1d_tool(qtbot, expression=True)
+    _set_signed_fit_trust(tool)
+    candidate = lmfit.models.ExpressionModel("reviewed * x + offset")
+    serialized = candidate.dumps()
+    model_path = tmp_path / "candidate.model"
+    model_path.write_text(serialized)
+    different_serialized = lmfit.models.ExpressionModel(
+        "changed * x + offset", init_script="constant = 1"
+    ).dumps()
+    file_index = tool.model_combo.findData("__file")
+    review_calls = 0
+    dump_calls = 0
+    original_loads = lmfit.model.Model.loads
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (str(model_path), ""),
+    )
+
+    def confirm_candidate(*_args, **_kwargs) -> bool:
+        nonlocal review_calls
+        review_calls += 1
+        return True
+
+    def tracked_dumps(*args, **kwargs):
+        nonlocal dump_calls
+        dump_calls += 1
+        return different_serialized
+
+    def tracked_loads(model, text, *args, **kwargs):
+        loaded = original_loads(model, text, *args, **kwargs)
+        monkeypatch.setattr(loaded, "dumps", tracked_dumps)
+        return loaded
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "confirm_code_trust", confirm_candidate
+    )
+    monkeypatch.setattr(
+        lmfit.model.Model,
+        "loads",
+        tracked_loads,
+    )
+    with QtCore.QSignalBlocker(tool.model_combo):
+        tool.model_combo.setCurrentIndex(file_index)
+
+    tool._on_model_choice_changed(file_index)
+
+    assert review_calls == 1
+    assert dump_calls == 0
+    assert isinstance(tool._model, lmfit.models.ExpressionModel)
+    assert tool._model.expr == candidate.expr
+    assert tool._serialized_model_state == (
+        fit1d._model_class_reference(type(tool._model)),
+        serialized,
+    )
+    assert tool._model_load_path == str(model_path)
+    assert _trust_allows_local_code_edit(tool._document_trust)
+
+
+def test_fit1d_safe_model_file_loads_without_review(
+    qtbot, tmp_path, monkeypatch
+) -> None:
+    tool, _data, _model, _params = _make_linear_fit1d_tool(qtbot)
+    serialized = lmfit.models.LinearModel().dumps()
+    model_path = tmp_path / "linear.model"
+    model_path.write_text(serialized)
+    file_index = tool.model_combo.findData("__file")
+    original_loads = lmfit.model.Model.loads
+    decoded: list[str] = []
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (str(model_path), ""),
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "confirm_code_trust",
+        lambda *_args, **_kwargs: pytest.fail("safe model requested code review"),
+    )
+
+    def tracked_loads(model, text, *args, **kwargs):
+        decoded.append(text)
+        return original_loads(model, text, *args, **kwargs)
+
+    monkeypatch.setattr(lmfit.model.Model, "loads", tracked_loads)
+    with QtCore.QSignalBlocker(tool.model_combo):
+        tool.model_combo.setCurrentIndex(file_index)
+
+    tool._on_model_choice_changed(file_index)
+
+    assert decoded == [serialized]
+    assert tool._model_load_path == str(model_path)
+    assert (
+        tool.model_combo.currentData(role=QtCore.Qt.ItemDataRole.UserRole) == "__file"
+    )
+
+
+def test_fit1d_model_file_review_does_not_admit_unrelated_code(
+    qtbot, tmp_path, monkeypatch
+) -> None:
+    old_model = lmfit.models.ExpressionModel("slope * x + intercept")
+    old_params = old_model.make_params(slope=1.0, intercept=0.0)
+    old_params["intercept"].expr = "2 * slope"
+    tool = erlab.interactive.ftool(
+        _make_1d_data(), model=old_model, params=old_params, execute=False
+    )
+    qtbot.addWidget(tool)
+    tool.set_document_trust(untrusted_document_trust())
+    old_trust = tool._document_trust
+    candidate = lmfit.models.ExpressionModel("amplitude * x + offset")
+    serialized = candidate.dumps()
+    model_path = tmp_path / "candidate.model"
+    model_path.write_text(serialized)
+    file_index = tool.model_combo.findData("__file")
+    reviewed_manifests = []
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (str(model_path), ""),
+    )
+
+    def confirm_candidate(_parent, manifest, **_kwargs) -> bool:
+        reviewed_manifests.append(manifest)
+        return True
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "confirm_code_trust", confirm_candidate
+    )
+    with QtCore.QSignalBlocker(tool.model_combo):
+        tool.model_combo.setCurrentIndex(file_index)
+
+    tool._on_model_choice_changed(file_index)
+
+    assert len(reviewed_manifests) == 1
+    assert len(reviewed_manifests[0].entries) == 1
+    assert "2 * slope" not in reviewed_manifests[0].entries[0].code
+    assert tool._model is old_model
+    assert tool._params["intercept"].expr == "2 * slope"
+    assert tool._document_trust == old_trust
 
 
 def test_fit1d_expression_editing_and_validation(qtbot, monkeypatch) -> None:
@@ -3013,3 +3832,416 @@ def test_merge_params_composite_model_with_prefixes() -> None:
     assert new_params["g1_sigma"].value == pytest.approx(0.1)
     assert new_params["g2_center"].value == pytest.approx(2.0)
     assert new_params["g2_sigma"].value == pytest.approx(0.2)
+
+
+def test_fit1d_trust_revocation_blocks_expression_execution(qtbot, monkeypatch) -> None:
+    tool, _data, _model, _params = _make_linear_fit1d_tool(qtbot, expression=True)
+    tool.set_document_trust(untrusted_document_trust())
+    assert tool._params["intercept"].expr == "2 * slope"
+
+    def fail_if_executed(*_args, **_kwargs):
+        raise AssertionError("untrusted fit code was executed")
+
+    monkeypatch.setattr(tool._model, "eval", fail_if_executed)
+    monkeypatch.setattr(tool._model, "guess", fail_if_executed)
+    monkeypatch.setattr(fit1d, "_FitWorker", fail_if_executed)
+    monkeypatch.setattr(lmfit.Parameter, "_getval", fail_if_executed)
+
+    value_index = tool.param_model.index(
+        tool.param_model._param_names.index("intercept"), 1
+    )
+    assert tool.param_model.data(value_index) == "2"
+    tool._update_fit_curve()
+    tool._guess_params()
+    assert not tool._run_fit()
+
+
+def test_fit1d_untrusted_host_attachment_clears_cached_capability(qtbot) -> None:
+    tool, _data, _model, _params = _make_linear_fit1d_tool(qtbot, expression=True)
+    assert tool._current_fit_execution_allowed()
+    assert tool._fit_execution_capability is not None
+
+    host_trust = untrusted_document_trust()
+    tool._set_code_trust_host(
+        lambda *_args, **_kwargs: None,
+        local_edit_context=lambda *_args, **_kwargs: contextlib.nullcontext(None),
+        state_getter=lambda: host_trust,
+    )
+
+    assert tool._fit_execution_capability is None
+    assert not tool._current_fit_execution_allowed()
+
+
+def test_fit1d_result_deserialization_waits_for_approval(qtbot, monkeypatch) -> None:
+    tool, data, _safe_model, _safe_params = _make_linear_fit1d_tool(qtbot)
+
+    unsafe_model = lmfit.models.ExpressionModel("slope * x + intercept")
+    unsafe_params = unsafe_model.make_params(slope=1.0, intercept=0.0)
+    result_ds = data.xlm.modelfit("x", model=unsafe_model, params=unsafe_params).load()
+    blob = erlab.interactive.utils._serialize_fit_dataset_blob(result_ds)
+    deserialize_calls: list[np.ndarray] = []
+    original_deserialize = erlab.interactive.utils._deserialize_fit_dataset_blob
+
+    def tracked_deserialize(payload):
+        deserialize_calls.append(np.asarray(payload))
+        return original_deserialize(payload)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_deserialize_fit_dataset_blob",
+        tracked_deserialize,
+    )
+
+    tool.set_document_trust(untrusted_document_trust())
+    tool._restore_persisted_fit_result_blob(blob, fit_is_current=True)
+
+    assert deserialize_calls == []
+    assert tool._last_result_ds is None
+    assert np.array_equal(tool._serialized_fit_result_blob, blob)
+    assert tool._pending_persisted_fit_is_current is True
+
+    tool.set_document_trust(new_document_trust())
+
+    assert len(deserialize_calls) == 1
+    assert tool._pending_persisted_fit_is_current is None
+    assert tool._last_result_ds is not None
+    _assert_fit_result_dataset_equivalent(
+        tool._last_result_ds,
+        result_ds,
+        require_model_type=False,
+    )
+
+
+def test_fit1d_safe_result_can_serialize_in_untrusted_document(
+    qtbot, monkeypatch
+) -> None:
+    tool, data, model, params = _make_linear_fit1d_tool(qtbot)
+    tool._last_result_ds = data.xlm.modelfit("x", model=model, params=params).load()
+    tool._fit_is_current = True
+    tool._cache_fit_result_payload()
+    assert not tuple(tool._code_trust_payload_entries())
+
+    tool.set_document_trust(untrusted_document_trust())
+    tool._serialized_fit_result_blob = None
+    original_serialize = erlab.interactive.utils._serialize_fit_dataset_blob
+    serialize_calls: list[xr.Dataset] = []
+
+    def tracked_serialize(dataset: xr.Dataset) -> np.ndarray:
+        serialize_calls.append(dataset)
+        return original_serialize(dataset)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_serialize_fit_dataset_blob",
+        tracked_serialize,
+    )
+
+    saved = tool.to_dataset()
+
+    assert len(serialize_calls) == 1
+    assert tool._PERSISTED_FIT_RESULT_VAR in saved
+
+
+def test_fit1d_local_code_edits_use_one_scoped_capability(qtbot, monkeypatch) -> None:
+    model = lmfit.models.ExpressionModel("a * x + b")
+    tool = erlab.interactive.ftool(
+        _make_1d_data(),
+        model=model,
+        params=model.make_params(a=1.0, b=0.0),
+        execute=False,
+    )
+    qtbot.addWidget(tool)
+    _set_signed_fit_trust(tool)
+    tool.expr_edit.setPlainText("scale * x + offset")
+    tool.expr_init_script_dialog.text_edit.setPlainText("constant = 1")
+
+    original_init = lmfit.models.ExpressionModel.__init__
+    boundary_events: list[str] = []
+    edit_scope_active = False
+    original_local_code_edit = tool._local_code_edit
+
+    @contextlib.contextmanager
+    def tracked_local_code_edit(*args, **kwargs):
+        nonlocal edit_scope_active
+        with original_local_code_edit(*args, **kwargs) as capability:
+            edit_scope_active = True
+            try:
+                yield capability
+            finally:
+                edit_scope_active = False
+
+    def tracked_init(expression_model, *args, **kwargs):
+        assert edit_scope_active
+        boundary_events.append("model")
+        original_init(expression_model, *args, **kwargs)
+
+    monkeypatch.setattr(tool, "_local_code_edit", tracked_local_code_edit)
+    monkeypatch.setattr(lmfit.models.ExpressionModel, "__init__", tracked_init)
+    expression_index = tool.model_combo.findData("ExpressionModel")
+    with QtCore.QSignalBlocker(tool.model_combo):
+        tool.model_combo.setCurrentIndex(expression_index)
+
+    tool._on_model_choice_changed(expression_index)
+
+    assert boundary_events == ["model"]
+    assert isinstance(tool._model, lmfit.models.ExpressionModel)
+    assert tool._model.expr == "scale * x + offset"
+
+    _set_signed_fit_trust(tool)
+    tool.expr_edit.setPlainText("2 * scale * x + offset")
+    tool._refresh_expression_model()
+
+    assert boundary_events == ["model", "model"]
+    assert tool._model.expr == "2 * scale * x + offset"
+
+    _set_signed_fit_trust(tool)
+    original_validate = tool._validate_param_expr
+
+    def tracked_validate(param, expression):
+        assert edit_scope_active
+        boundary_events.append("parameter-edit")
+        return original_validate(param, expression)
+
+    monkeypatch.setattr(tool, "_validate_param_expr", tracked_validate)
+    tool._set_param_expr(tool.param_model._param_names.index("offset"), "2 * scale")
+
+    assert boundary_events == ["model", "model", "parameter-edit"]
+    assert tool._params["offset"].expr == "2 * scale"
+    assert tool._current_fit_execution_allowed()
+
+
+def test_fit1d_first_local_code_edit_promotes_code_free_external_document(
+    qtbot,
+) -> None:
+    model = lmfit.models.LinearModel()
+    tool = erlab.interactive.ftool(
+        _make_1d_data(), model=model, params=model.make_params(), execute=False
+    )
+    qtbot.addWidget(tool)
+    tool.set_document_trust(external_document_trust(None), notify=False)
+    assert not _trust_allows_local_code_edit(tool._document_trust)
+
+    tool.expr_edit.setPlainText("a * x + b")
+    tool._refresh_expression_model()
+
+    assert isinstance(tool._model, lmfit.models.ExpressionModel)
+    assert tool._model.expr == "a * x + b"
+    assert _trust_allows_local_code_edit(tool._document_trust)
+
+
+def test_fit1d_model_option_edit_preserves_trusted_lineage(qtbot, monkeypatch) -> None:
+    tool = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(tool)
+    _set_signed_fit_trust(tool)
+    npeaks = tool.npeaks_spin.value() + 1
+    redraws = 0
+    original_update = tool._update_fit_curve
+
+    def tracked_update() -> None:
+        nonlocal redraws
+        redraws += 1
+        original_update()
+
+    monkeypatch.setattr(tool, "_update_fit_curve", tracked_update)
+
+    tool.npeaks_spin.setValue(npeaks)
+
+    assert tool._model.func.npeaks == npeaks
+    assert _trust_allows_local_code_edit(tool._document_trust)
+    assert redraws == 1
+
+
+def test_fit1d_stored_status_rejects_partial_host_capability(
+    qtbot, monkeypatch
+) -> None:
+    model = lmfit.models.ExpressionModel("a * x + b")
+    params = model.make_params(a=1.0, b=0.0)
+    params["b"].expr = "2 * a"
+    tool = erlab.interactive.ftool(
+        _make_1d_data(), model=model, params=params, execute=False
+    )
+    qtbot.addWidget(tool)
+    entries = tool._fit_code_entries
+    assert len(entries) >= 2
+    trust = untrusted_document_trust()
+    _prospective, partial_capability = issue_local_edit_capability(
+        trust,
+        entries,
+        edited_entries=(entries[0],),
+    )
+    assert execution_capability_allows(partial_capability, (entries[0],))
+    assert not execution_capability_allows(partial_capability, entries)
+    tool._set_code_trust_host(
+        lambda *_args, **_kwargs: partial_capability,
+        local_edit_context=lambda *_args, **_kwargs: contextlib.nullcontext(
+            partial_capability
+        ),
+        state_getter=lambda: trust,
+    )
+    status = tool.tool_status
+    monkeypatch.setattr(
+        fit1d,
+        "_load_lmfit_for_ftool_restore",
+        lambda *_args, **_kwargs: pytest.fail(
+            "partially authorized status was decoded"
+        ),
+    )
+
+    tool._restoring_from_dataset = True
+    try:
+        tool.tool_status = status
+    finally:
+        tool._restoring_from_dataset = False
+
+    assert tool._pending_fit_status is status
+    assert not tool._current_fit_execution_allowed()
+
+
+def test_fit1d_local_edit_does_not_authorize_untrusted_mixed_content(
+    qtbot, monkeypatch
+) -> None:
+    model = lmfit.models.ExpressionModel("a * x + b")
+    params = model.make_params(a=1.0, b=0.0)
+    params["b"].expr = "2 * a"
+    tool = erlab.interactive.ftool(
+        _make_1d_data(), model=model, params=params, execute=False
+    )
+    qtbot.addWidget(tool)
+    tool.set_document_trust(untrusted_document_trust())
+    original_expression = tool._model.expr
+    tool.expr_edit.setPlainText("3 * a * x + b")
+
+    monkeypatch.setattr(
+        lmfit.models.ExpressionModel,
+        "__init__",
+        lambda *_args, **_kwargs: pytest.fail("blocked candidate was evaluated"),
+    )
+
+    tool._refresh_expression_model()
+
+    assert tool._model.expr == original_expression
+    assert not document_trust_has_trusted_lineage(tool._document_trust)
+
+
+def test_fit1d_failed_local_expression_validation_rolls_back_signed_trust(
+    qtbot, monkeypatch
+) -> None:
+    model = lmfit.models.ExpressionModel("a * x + b")
+    tool = erlab.interactive.ftool(
+        _make_1d_data(),
+        model=model,
+        params=model.make_params(a=1.0, b=0.0),
+        execute=False,
+    )
+    qtbot.addWidget(tool)
+    _set_signed_fit_trust(tool)
+    assert not _trust_allows_local_code_edit(tool._document_trust)
+    warnings: list[tuple[object, ...]] = []
+    monkeypatch.setattr(tool, "_show_warning", lambda *args: warnings.append(args))
+
+    tool._set_param_expr(tool.param_model._param_names.index("b"), "missing +")
+
+    assert warnings
+    assert tool._params["b"].expr is None
+    assert not _trust_allows_local_code_edit(tool._document_trust)
+
+
+def test_fit1d_clear_parameter_expression_is_local_edit(qtbot) -> None:
+    tool, _data, _model, _params = _make_linear_fit1d_tool(qtbot, expression=True)
+    _set_signed_fit_trust(tool)
+    assert not _trust_allows_local_code_edit(tool._document_trust)
+
+    tool._clear_param_expr(tool.param_model._param_names.index("intercept"))
+
+    assert tool._params["intercept"].expr is None
+    assert _trust_allows_local_code_edit(tool._document_trust)
+
+
+def test_fit1d_status_parameter_expression_change_is_local_edit(qtbot) -> None:
+    tool, _data, _model, _params = _make_linear_fit1d_tool(qtbot, expression=True)
+    status = tool.tool_status
+    params = list(status.params)
+    intercept_index = next(
+        index for index, state in enumerate(params) if state[0] == "intercept"
+    )
+    intercept = list(params[intercept_index])
+    intercept[3] = "3 * slope"
+    params[intercept_index] = tuple(intercept)
+    changed = status.model_copy(update={"params": params})
+    _set_signed_fit_trust(tool)
+
+    tool.tool_status = changed
+
+    assert tool._params["intercept"].expr == "3 * slope"
+    assert _trust_allows_local_code_edit(tool._document_trust)
+
+
+def test_fit1d_expression_model_code_generation_does_not_run_init_script(qtbot) -> None:
+    model = lmfit.models.ExpressionModel("a * x")
+    tool = erlab.interactive.ftool(
+        _make_1d_data(),
+        model=model,
+        params=model.make_params(a=1.0),
+        execute=False,
+    )
+    qtbot.addWidget(tool)
+    tool.expr_init_script_dialog.text_edit.setPlainText(
+        "raise RuntimeError('generated code must not run while copying')"
+    )
+
+    _data_name, _model_name, lines = tool._make_model_code("data")
+
+    assert lines
+
+
+def test_fit1d_numeric_fit_result_reuses_code_inventory(qtbot, monkeypatch) -> None:
+    data = _make_1d_data()
+    model = lmfit.models.ExpressionModel("a * x + b")
+    params = model.make_params(a=1.0, b=0.0)
+    tool = erlab.interactive.ftool(data, model=model, params=params, execute=False)
+    qtbot.addWidget(tool)
+    _set_signed_fit_trust(tool)
+    admitted_entries = tool._fit_code_entries
+    result_ds = data.xlm.modelfit("x", model=model, params=params, max_nfev=1).load()
+    invalidation_calls = 0
+    original_invalidate = tool._invalidate_fit_result_payload
+
+    def tracked_invalidate() -> None:
+        nonlocal invalidation_calls
+        invalidation_calls += 1
+        original_invalidate()
+
+    monkeypatch.setattr(tool, "_invalidate_fit_result_payload", tracked_invalidate)
+
+    tool._set_fit_ds(result_ds, fit1d.time.perf_counter())
+
+    assert invalidation_calls == 1
+    assert tool._fit_code_entries is admitted_entries
+    assert tool._current_fit_execution_allowed()
+
+
+def test_fit1d_source_replacement_discards_pending_result_retry(qtbot) -> None:
+    tool, data, _safe_model, _safe_params = _make_linear_fit1d_tool(qtbot)
+    unsafe_model = lmfit.models.ExpressionModel("a * x + b")
+    unsafe_result = data.xlm.modelfit(
+        "x",
+        model=unsafe_model,
+        params=unsafe_model.make_params(a=1.0, b=0.0),
+        max_nfev=1,
+    ).load()
+    blob = erlab.interactive.utils._serialize_fit_dataset_blob(unsafe_result)
+
+    tool.set_document_trust(untrusted_document_trust(), notify=False)
+
+    tool._restore_persisted_fit_result_blob(blob, fit_is_current=True)
+    assert np.array_equal(tool._serialized_fit_result_blob, blob)
+    assert tool._pending_persisted_fit_is_current is True
+    assert tool._last_result_ds is None
+
+    assert tool.update_data(data + 1.0)
+    tool.set_document_trust(new_document_trust())
+
+    assert tool._serialized_fit_result_blob is None
+    assert tool._pending_persisted_fit_is_current is None
+    assert tool._last_result_ds is None
+    assert tool._PERSISTED_FIT_RESULT_VAR not in tool.to_dataset()

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -439,6 +439,14 @@ def test_expression_model_local_entry_matches_saved_model_identity() -> None:
 
 
 def test_lmfit_code_trust_tracks_every_saved_parameter_expression() -> None:
+    assert (
+        lmfit_parameter_expression_entries(
+            None,
+            feature="test.lmfit-parameter",
+            location_prefix="parameters",
+        )
+        == ()
+    )
     entries = lmfit_parameter_expression_entries(
         [
             ("plain", None),
@@ -452,6 +460,47 @@ def test_lmfit_code_trust_tracks_every_saved_parameter_expression() -> None:
     assert entries[0].location == "parameters/constrained"
     assert entries[0].code == "2 * plain"
     assert entries[0].context == {"parameter": "constrained"}
+
+
+@pytest.mark.parametrize(
+    ("serialized", "review_text"),
+    [
+        ("{", "Invalid serialized lmfit content"),
+        (json.dumps({"params": "{"}), "Invalid serialized lmfit parameters"),
+    ],
+)
+def test_lmfit_code_trust_fails_closed_for_malformed_json(
+    serialized: str, review_text: str
+) -> None:
+    entry = lmfit_model_code_entry(
+        serialized,
+        feature="test.lmfit-model",
+        location="model",
+    )
+
+    assert entry is not None
+    assert review_text in entry.code
+
+
+def test_lmfit_code_trust_hashes_non_json_executable_details() -> None:
+    serialized = json.dumps(
+        {
+            "__class__": "Callable",
+            "__name__": "custom_model",
+            "importer": "unavailable.user_module",
+            "value": float("nan"),
+        }
+    )
+
+    entry = lmfit_model_code_entry(
+        serialized,
+        feature="test.lmfit-model",
+        location="model",
+    )
+
+    assert entry is not None
+    assert "serialized-callable" in entry.code
+    assert isinstance(entry.context["payload_sha256"], str)
 
 
 def test_lmfit_parameter_expression_locations_are_stable_and_escaped() -> None:
@@ -540,6 +589,24 @@ def test_lmfit_code_trust_classifies_result_payload_without_loading_it() -> None
     )
 
     assert entry is None
+
+
+def test_lmfit_code_trust_fails_closed_for_invalid_result_payloads() -> None:
+    missing_results = xr.Dataset({"other": xr.DataArray(1)}).to_netcdf(
+        path=None, engine="h5netcdf"
+    )
+    non_string_result = xr.Dataset({"modelfit_results": xr.DataArray(1)}).to_netcdf(
+        path=None, engine="h5netcdf"
+    )
+
+    for payload in (b"not-netcdf", bytes(missing_results), bytes(non_string_result)):
+        entry = lmfit_result_code_entry(
+            payload,
+            feature="test.lmfit-result",
+            location="fit-result",
+        )
+        assert entry is not None
+        assert "Unrecognized serialized lmfit result" in entry.code
 
 
 def test_fit1d_saved_library_model_and_result_restore_without_approval(qtbot) -> None:

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -14,6 +14,15 @@ from qtpy import QtCore, QtWidgets
 
 import erlab
 import erlab.interactive._fit2d as fit2d_module
+from erlab.interactive import _fit1d as fit1d_module
+from erlab.interactive._code_trust import (
+    create_entry,
+    issue_execution_capability,
+    new_document_trust,
+    untrusted_document_trust,
+)
+from erlab.interactive._code_trust._api import _document_trust_after_save
+from erlab.interactive._code_trust._payloads import store_code_payload_entries
 from erlab.interactive._figurecomposer import (
     FigureAxesSelectionState,
     FigureMethodFamily,
@@ -49,8 +58,93 @@ def _make_2d_data() -> xr.DataArray:
     return xr.DataArray(data, dims=("y", "x"), coords={"y": y, "x": x}, name="map")
 
 
+def _make_linear_fit2d_tool(
+    qtbot, *, expression: bool = False
+) -> tuple[Fit2DTool, lmfit.Model, lmfit.Parameters]:
+    model = lmfit.models.LinearModel()
+    params = model.make_params(slope=1.0, intercept=2.0 if expression else 0.0)
+    if expression:
+        params["intercept"].expr = "2 * slope"
+    tool = erlab.interactive.ftool(
+        _make_2d_data(), model=model, params=params, execute=False
+    )
+    qtbot.addWidget(tool)
+    if not isinstance(tool, Fit2DTool):  # pragma: no cover
+        raise TypeError("Expected Fit2DTool")
+    return tool, model, params
+
+
+def test_fit2d_inherits_reviewed_model_file_loading(
+    qtbot, tmp_path, monkeypatch
+) -> None:
+    tool, _model, _params = _make_linear_fit2d_tool(qtbot, expression=True)
+    _set_signed_fit_trust(tool)
+    candidate = lmfit.models.ExpressionModel("slope * x + intercept")
+    serialized = candidate.dumps()
+    model_path = tmp_path / "candidate.model"
+    model_path.write_text(serialized)
+    file_index = tool.model_combo.findData("__file")
+    events: list[str] = []
+    original_loads = lmfit.model.Model.loads
+
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (str(model_path), ""),
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "confirm_code_trust",
+        lambda *_args, **_kwargs: events.append("review") or True,
+    )
+
+    def tracked_loads(model, text, *args, **kwargs):
+        events.append("decode")
+        assert text == serialized
+        return original_loads(model, text, *args, **kwargs)
+
+    monkeypatch.setattr(lmfit.model.Model, "loads", tracked_loads)
+    with QtCore.QSignalBlocker(tool.model_combo):
+        tool.model_combo.setCurrentIndex(file_index)
+
+    tool._on_model_choice_changed(file_index)
+
+    assert events == ["review", "decode"]
+    assert isinstance(tool._model, lmfit.models.ExpressionModel)
+    assert tool._model.expr == candidate.expr
+    assert tool._model_load_path == str(model_path)
+    assert _trust_allows_local_code_edit(tool._document_trust)
+
+
+def _set_signed_fit_trust(tool: Fit2DTool) -> None:
+    manifest = tool._current_code_trust_manifest()
+    assert manifest is not None
+    signed = _document_trust_after_save(
+        new_document_trust(),
+        manifest,
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+    tool.set_document_trust(signed, notify=False)
+
+
+def _authorize_execution(entries):
+    _trust, capability = issue_execution_capability(new_document_trust(), entries)
+    if capability is None:  # pragma: no cover - local trust always authorizes.
+        raise RuntimeError("Could not authorize test execution")
+    return capability
+
+
+def _trust_allows_local_code_edit(trust) -> bool:
+    entry = create_entry("test.local-edit", "test", "result = source")
+    return issue_execution_capability(trust, (entry,))[1] is not None
+
+
 def _assert_fit_result_dataset_equivalent(
-    actual: xr.Dataset, expected: xr.Dataset
+    actual: xr.Dataset,
+    expected: xr.Dataset,
+    *,
+    require_model_type: bool = True,
 ) -> None:
     xr.testing.assert_identical(
         actual.drop_vars("modelfit_results"),
@@ -58,7 +152,8 @@ def _assert_fit_result_dataset_equivalent(
     )
     actual_result = actual.modelfit_results.compute().item()
     expected_result = expected.modelfit_results.compute().item()
-    assert type(actual_result.model) is type(expected_result.model)
+    if require_model_type:
+        assert type(actual_result.model) is type(expected_result.model)
     assert list(actual_result.params.keys()) == list(expected_result.params.keys())
     for name, expected_param in expected_result.params.items():
         actual_param = actual_result.params[name]
@@ -111,7 +206,10 @@ def _placeholder_fit_result_dataset(params) -> xr.Dataset:
 
 
 def _assert_fit_result_list_equivalent(
-    actual: list[xr.Dataset | None], expected: list[xr.Dataset | None]
+    actual: list[xr.Dataset | None],
+    expected: list[xr.Dataset | None],
+    *,
+    require_model_type: bool = True,
 ) -> None:
     assert len(actual) == len(expected)
     for actual_ds, expected_ds in zip(actual, expected, strict=True):
@@ -119,7 +217,11 @@ def _assert_fit_result_list_equivalent(
             assert actual_ds is None
             continue
         assert actual_ds is not None
-        _assert_fit_result_dataset_equivalent(actual_ds, expected_ds)
+        _assert_fit_result_dataset_equivalent(
+            actual_ds,
+            expected_ds,
+            require_model_type=require_model_type,
+        )
 
 
 def _configure_fit2d_for_tests(
@@ -256,6 +358,10 @@ def _saved_ftool_dataset_with_callable_pyversion(
     ds[result_var] = xr.DataArray(
         np.frombuffer(blob, dtype=np.uint8).copy(),
         dims=(Fit2DTool._PERSISTED_FIT_RESULT_DIM,),
+    )
+    store_code_payload_entries(
+        ds.attrs,
+        (Fit2DTool._fit_result_code_trust_entry(ds[result_var].values),),
     )
     return ds
 
@@ -418,7 +524,7 @@ def test_fit2d_restore_uses_saved_voigt_params_before_defaults(qtbot) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", RuntimeWarning)
         win_roundtripped = erlab.interactive.utils.ToolWindow.from_dataset(
-            win.to_dataset()
+            win.to_dataset(), _code_trust=new_document_trust()
         )
     qtbot.addWidget(win_roundtripped)
     assert isinstance(win_roundtripped, Fit2DTool)
@@ -456,7 +562,9 @@ def test_fit2d_persistence_suppresses_successful_erlab_callable_warning(
     )
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+        restored = erlab.interactive.utils.ToolWindow.from_dataset(
+            saved, _code_trust=new_document_trust()
+        )
     qtbot.addWidget(restored)
     assert isinstance(restored, Fit2DTool)
 
@@ -503,7 +611,9 @@ def test_fit2d_status_and_persistence_preserve_transpose_orientation(qtbot) -> N
     xr.testing.assert_identical(win_restored.tool_data, data.transpose("x", "y"))
     assert win_restored.y_index_spin.value() == 3
 
-    win_roundtripped = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    win_roundtripped = erlab.interactive.utils.ToolWindow.from_dataset(
+        win.to_dataset(), _code_trust=new_document_trust()
+    )
     qtbot.addWidget(win_roundtripped)
     assert isinstance(win_roundtripped, Fit2DTool)
     xr.testing.assert_identical(win_roundtripped.tool_data, data.transpose("x", "y"))
@@ -1518,7 +1628,9 @@ def test_fit2d_persistence_roundtrip_preserves_fit_results(
     ]
     expected_status = win.tool_status.model_dump()
 
-    win_restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    win_restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        win.to_dataset(), _code_trust=new_document_trust()
+    )
     qtbot.addWidget(win_restored)
     assert isinstance(win_restored, Fit2DTool)
 
@@ -1600,7 +1712,9 @@ def test_fit2d_persistence_roundtrip_preserves_sparse_results(
     ]
     expected_status = win.tool_status.model_dump()
 
-    win_restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    win_restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        win.to_dataset(), _code_trust=new_document_trust()
+    )
     qtbot.addWidget(win_restored)
     assert isinstance(win_restored, Fit2DTool)
 
@@ -1655,10 +1769,13 @@ def test_fit2d_deferred_restore_preserves_raw_fit_blob_until_needed(
     restored = erlab.interactive.utils.ToolWindow.from_dataset(
         saved,
         _defer_restore_work=True,
+        _code_trust=new_document_trust(),
     )
     qtbot.addWidget(restored)
     assert isinstance(restored, Fit2DTool)
     assert calls == []
+    assert restored._serialized_fit_result_blob is not None
+    assert restored._pending_persisted_fit_is_current is True
 
     resaved = restored.to_dataset()
     assert calls == []
@@ -1671,6 +1788,8 @@ def test_fit2d_deferred_restore_preserves_raw_fit_blob_until_needed(
     with pytest.raises(RuntimeError, match="fit deserialize failed"):
         restored._flush_restore_work()
     assert len(calls) == 1
+    assert restored._serialized_fit_result_blob is not None
+    assert restored._pending_persisted_fit_is_current is True
 
     resaved_after_failure = restored.to_dataset()
     assert len(calls) == 1
@@ -1682,6 +1801,7 @@ def test_fit2d_deferred_restore_preserves_raw_fit_blob_until_needed(
     restored._flush_restore_work()
 
     assert len(calls) == 2
+    assert restored._pending_persisted_fit_is_current is None
     _assert_fit_result_list_equivalent(restored._result_ds_full, expected_results)
 
 
@@ -1802,6 +1922,188 @@ def test_fit2d_reset_params_all(qtbot, monkeypatch) -> None:
     win._reset_params_all()
     assert all(ds is None for ds in win._result_ds_full)
     assert all(not mapping for mapping in win._params_from_coord_full)
+
+
+def test_fit2d_fill_expression_commits_local_lineage(qtbot) -> None:
+    tool, _model, params = _make_linear_fit2d_tool(qtbot, expression=True)
+    source_params = params.copy()
+    destination_params = params.copy()
+    destination_params["intercept"].expr = None
+    tool._params_full[0] = source_params
+    tool._params_full[tool._current_idx] = destination_params
+    tool._refresh_contents_from_index()
+    tool._refresh_fit_code_entries()
+    _set_signed_fit_trust(tool)
+
+    tool._fill_params_from(0, mode="previous")
+
+    current = tool._params_full[tool._current_idx]
+    assert current is not None
+    assert current["intercept"].expr == "2 * slope"
+    assert _trust_allows_local_code_edit(tool._document_trust)
+    assert tool._current_fit_execution_allowed()
+
+
+def test_fit2d_blocked_fill_expression_does_not_mutate(
+    qtbot,
+    monkeypatch,
+) -> None:
+    tool, _model, params = _make_linear_fit2d_tool(qtbot, expression=True)
+    source_params = params.copy()
+    destination_params = params.copy()
+    destination_params["intercept"].expr = None
+    tool._params_full[0] = source_params
+    tool._params_full[tool._current_idx] = destination_params
+    tool._refresh_contents_from_index()
+    tool._refresh_fit_code_entries()
+    previous_entries = tool._fit_code_entries
+    previous_params = tool._params_full[tool._current_idx]
+    calls: list[None] = []
+    copy_calls: list[lmfit.Parameters] = []
+    original_copy = lmfit.Parameters.copy
+
+    @contextlib.contextmanager
+    def blocked_edit(*_args, **_kwargs):
+        calls.append(None)
+        yield None
+
+    monkeypatch.setattr(tool, "_local_code_edit", blocked_edit)
+    monkeypatch.setattr(
+        lmfit.Parameters,
+        "copy",
+        lambda current: copy_calls.append(current) or original_copy(current),
+    )
+
+    tool._fill_params_from(0, mode="previous")
+
+    assert calls == [None]
+    assert copy_calls == []
+    assert tool._params_full[tool._current_idx] is previous_params
+    assert previous_params is not None
+    assert previous_params["intercept"].expr is None
+    assert tool._fit_code_entries == previous_entries
+
+
+def test_fit2d_fill_expression_requires_model_context(qtbot, monkeypatch) -> None:
+    model = lmfit.models.ExpressionModel("slope * x + intercept")
+    params = model.make_params(slope=1.0, intercept=2.0)
+    params["intercept"].expr = "2 * slope"
+    tool = erlab.interactive.ftool(
+        _make_2d_data(),
+        model=model,
+        params=params,
+        execute=False,
+    )
+    qtbot.addWidget(tool)
+    assert isinstance(tool, Fit2DTool)
+    source_params = params.copy()
+    destination_params = params.copy()
+    destination_params["intercept"].expr = None
+    tool._params_full[0] = source_params
+    tool._params_full[tool._current_idx] = destination_params
+    tool._refresh_contents_from_index()
+    tool._refresh_fit_code_entries()
+    candidate_params_full = tool._params_full.copy()
+    candidate_params_full[tool._current_idx] = source_params
+    candidate_entries = tool._fit_code_entries_with_params_full(candidate_params_full)
+    parameter_entries = tuple(
+        entry
+        for entry in candidate_entries
+        if entry.feature == tool._PARAMETER_CODE_TRUST_FEATURE
+    )
+    _trust, parameter_only_capability = issue_execution_capability(
+        new_document_trust(),
+        parameter_entries,
+    )
+    assert parameter_only_capability is not None
+    copy_calls: list[lmfit.Parameters] = []
+    original_copy = lmfit.Parameters.copy
+
+    @contextlib.contextmanager
+    def parameter_only_edit(*_args, **_kwargs):
+        yield parameter_only_capability
+
+    monkeypatch.setattr(tool, "_local_code_edit", parameter_only_edit)
+    monkeypatch.setattr(
+        lmfit.Parameters,
+        "copy",
+        lambda current: copy_calls.append(current) or original_copy(current),
+    )
+
+    tool._fill_params_from(0, mode="previous")
+
+    assert copy_calls == []
+    current = tool._params_full[tool._current_idx]
+    assert current is destination_params
+    assert current["intercept"].expr is None
+
+
+def test_fit2d_reset_expression_commits_local_lineage(qtbot, monkeypatch) -> None:
+    tool, _model, params = _make_linear_fit2d_tool(qtbot, expression=True)
+    tool._params_full = [params.copy() for _ in tool._params_full]
+    tool._initial_params = params.copy()
+    tool._initial_params["intercept"].expr = None
+    tool._refresh_contents_from_index()
+    tool._refresh_fit_code_entries()
+    _set_signed_fit_trust(tool)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+
+    tool._reset_params_all()
+
+    assert all(
+        params is not None and params["intercept"].expr is None
+        for params in tool._params_full
+    )
+    assert _trust_allows_local_code_edit(tool._document_trust)
+
+
+def test_fit2d_blocked_reset_expression_does_not_mutate(
+    qtbot,
+    monkeypatch,
+) -> None:
+    tool, _model, params = _make_linear_fit2d_tool(qtbot)
+    initial = params.copy()
+    initial["intercept"].expr = "2 * slope"
+    tool._initial_params_full = [initial.copy() for _ in tool._params_full]
+    marker = xr.Dataset({"marker": xr.DataArray(1)})
+    tool._result_ds_full[0] = marker
+    tool._params_from_coord_full[0] = {"slope": "y"}
+    previous_entries = tool._fit_code_entries
+    previous_params_full = tool._params_full
+    previous_result_full = tool._result_ds_full
+    previous_sources_full = tool._params_from_coord_full
+    copy_calls: list[lmfit.Parameters] = []
+    original_copy = lmfit.Parameters.copy
+
+    @contextlib.contextmanager
+    def blocked_edit(*_args, **_kwargs):
+        yield None
+
+    monkeypatch.setattr(tool, "_local_code_edit", blocked_edit)
+    monkeypatch.setattr(
+        lmfit.Parameters,
+        "copy",
+        lambda current: copy_calls.append(current) or original_copy(current),
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+
+    tool._reset_params_all()
+
+    assert copy_calls == []
+    assert tool._params_full is previous_params_full
+    assert tool._result_ds_full is previous_result_full
+    assert tool._params_from_coord_full is previous_sources_full
+    assert tool._result_ds_full[0] is marker
+    assert tool._params_from_coord_full[0] == {"slope": "y"}
+    assert tool._fit_code_entries == previous_entries
 
 
 def test_fit2d_full_copy_fit_data_name_with_domain_and_normalization(qtbot) -> None:
@@ -1965,6 +2267,7 @@ def test_fit2d_mixed_slice_ranges_copy_and_output_provenance(
     replayed = replay_script_provenance(
         output_spec,
         {"source_spectrum": data},
+        authorize=_authorize_execution,
     )
     xr.testing.assert_allclose(replayed, values)
 
@@ -2001,7 +2304,9 @@ def test_fit2d_mixed_slice_ranges_persistence_roundtrip(
         if result_ds is not None
     ]
 
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(win.to_dataset())
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        win.to_dataset(), _code_trust=new_document_trust()
+    )
     qtbot.addWidget(restored)
     assert isinstance(restored, Fit2DTool)
     assert [
@@ -2607,7 +2912,11 @@ def test_fit2d_expression_model_parameter_output_provenance_executes(qtbot) -> N
     assert "imagetool" not in code
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)
-        replayed = replay_script_provenance(spec, {"source_spectrum": data})
+        replayed = replay_script_provenance(
+            spec,
+            {"source_spectrum": data},
+            authorize=_authorize_execution,
+        )
     xr.testing.assert_allclose(replayed, values)
 
     with warnings.catch_warnings():
@@ -3479,3 +3788,350 @@ def test_fit2d_refresh_multipeak_model_merges_params(qtbot) -> None:
 
     win.y_index_spin.setValue(1)
     assert win.param_model.param_at(center_row).value == pytest.approx(0.5)
+
+
+def test_fit2d_blocked_model_edit_does_not_merge_parameters(qtbot, monkeypatch) -> None:
+    win, model, _params = _make_linear_fit2d_tool(qtbot, expression=True)
+    win.set_document_trust(untrusted_document_trust())
+    saved_params = [
+        None if params is None else win._serialize_params(params)
+        for params in win._params_full
+    ]
+    monkeypatch.setattr(
+        win,
+        "_merge_params",
+        lambda *_args, **_kwargs: pytest.fail("blocked edit evaluated parameters"),
+    )
+
+    win._refresh_multipeak_model()
+
+    assert win._model is model
+    assert [
+        None if params is None else win._serialize_params(params)
+        for params in win._params_full
+    ] == saved_params
+
+
+def test_fit2d_saved_expressions_wait_for_document_approval(qtbot, monkeypatch) -> None:
+    source, _model, _params = _make_linear_fit2d_tool(qtbot, expression=True)
+    saved = source.to_dataset()
+    saved_status = Fit2DTool.StateModel.model_validate_json(saved.attrs["tool_state"])
+    deserialize_calls: list[object] = []
+    original_deserialize = Fit2DTool._deserialize_params
+
+    def tracked_deserialize(state, **kwargs):
+        deserialize_calls.append(state)
+        return original_deserialize(state, **kwargs)
+
+    monkeypatch.setattr(
+        Fit2DTool,
+        "_deserialize_params",
+        staticmethod(tracked_deserialize),
+    )
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit2DTool)
+
+    assert deserialize_calls == []
+    assert restored._pending_fit_status == saved_status
+
+    def fail_local_edit(*_args, **_kwargs):
+        raise AssertionError("stored status retried as a local edit")
+
+    monkeypatch.setattr(restored, "_local_code_edit", fail_local_edit)
+
+    restored.set_document_trust(new_document_trust())
+
+    assert restored._pending_fit_status is None
+    assert deserialize_calls
+    assert restored._params["intercept"].expr == "2 * slope"
+    assert type(restored)._code_trust_entries_from_status(restored.tool_status) == type(
+        source
+    )._code_trust_entries_from_status(saved_status)
+
+
+def test_fit2d_status_edit_authorizes_per_slice_expression_decode(
+    qtbot, monkeypatch
+) -> None:
+    tool, _model, _params = _make_linear_fit2d_tool(qtbot, expression=True)
+    status = tool.tool_status
+    state2d = status.state2d
+    if state2d is None:  # pragma: no cover - Fit2D status always has 2D state.
+        raise RuntimeError("Fit2D status does not contain per-slice state")
+    template = next(params for params in state2d.params_full if params is not None)
+    added = [tuple(item) for item in template]
+    intercept_index = next(
+        index for index, item in enumerate(added) if item[0] == "intercept"
+    )
+    intercept = list(added[intercept_index])
+    intercept[3] = "3 * slope"
+    added[intercept_index] = tuple(intercept)
+    params_full = list(state2d.params_full)
+    params_full[0] = added
+    changed = status.model_copy(
+        update={"state2d": state2d.model_copy(update={"params_full": params_full})}
+    )
+    _set_signed_fit_trust(tool)
+    boundary_lineage: list[bool] = []
+    edit_scope_active = False
+    original_deserialize = tool._deserialize_params
+    original_local_code_edit = tool._local_code_edit
+
+    @contextlib.contextmanager
+    def tracked_local_code_edit(*args, **kwargs):
+        nonlocal edit_scope_active
+        with original_local_code_edit(*args, **kwargs) as capability:
+            edit_scope_active = True
+            try:
+                yield capability
+            finally:
+                edit_scope_active = False
+
+    def tracked_deserialize(state, **kwargs):
+        boundary_lineage.append(edit_scope_active)
+        return original_deserialize(state, **kwargs)
+
+    monkeypatch.setattr(tool, "_local_code_edit", tracked_local_code_edit)
+    monkeypatch.setattr(tool, "_deserialize_params", tracked_deserialize)
+
+    tool.tool_status = changed
+
+    assert boundary_lineage
+    assert all(boundary_lineage)
+    assert tool._params_full[0] is not None
+    assert tool._params_full[0]["intercept"].expr == "3 * slope"
+    assert _trust_allows_local_code_edit(tool._document_trust)
+
+
+def test_fit2d_sequence_serializes_full_results_once(qtbot, monkeypatch) -> None:
+    tool, model, params = _make_linear_fit2d_tool(qtbot)
+    data = tool.tool_data
+
+    result_ds = data.isel(y=0).xlm.modelfit("x", model=model, params=params).load()
+    serialized_datasets: list[xr.Dataset] = []
+    invalidation_calls = 0
+    original_invalidate = tool._invalidate_fit_result_payload
+
+    def tracked_invalidate() -> None:
+        nonlocal invalidation_calls
+        invalidation_calls += 1
+        original_invalidate()
+
+    def tracked_serialize(dataset: xr.Dataset) -> np.ndarray:
+        serialized_datasets.append(dataset)
+        return np.array([1], dtype=np.uint8)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_serialize_fit_dataset_blob",
+        tracked_serialize,
+    )
+    monkeypatch.setattr(tool, "_invalidate_fit_result_payload", tracked_invalidate)
+    tool._fit_2d_total = data.sizes["y"]
+    for index in range(data.sizes["y"]):
+        tool._store_fit_2d_sequence_result(index, result_ds, 0.0)
+
+    assert serialized_datasets == []
+    assert invalidation_calls == data.sizes["y"]
+
+    tool._fit_2d_last_completed_idx = data.sizes["y"] - 1
+    tool._finish_fit_2d_sequence()
+
+    assert len(serialized_datasets) == 1
+    assert invalidation_calls == data.sizes["y"]
+
+
+def test_fit2d_multi_fit_caches_updated_full_result(qtbot) -> None:
+    tool, model, params = _make_linear_fit2d_tool(qtbot)
+    data = tool.tool_data
+
+    current_data = data.isel(y=tool._current_idx)
+    old_result = current_data.xlm.modelfit(
+        "x", model=model, params=params, max_nfev=1
+    ).load()
+    new_result = (
+        (current_data + 5.0)
+        .xlm.modelfit("x", model=model, params=params, max_nfev=1)
+        .load()
+    )
+    tool._last_result_ds = old_result
+    tool._sync_fit_result_state(notify=False)
+    tool._cache_fit_result_payload()
+
+    tool._store_multi_fit_result(new_result, fit1d_module.time.perf_counter())
+    tool._sync_multi_fit_view(full=True)
+    expected_results = [
+        None if result is None else result.copy(deep=True)
+        for result in tool._result_ds_full
+    ]
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        tool.to_dataset(), _code_trust=new_document_trust()
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, Fit2DTool)
+    _assert_fit_result_list_equivalent(
+        restored._result_ds_full,
+        expected_results,
+        require_model_type=False,
+    )
+
+
+def test_fit2d_numeric_results_and_redraw_reuse_cached_code_inventory(
+    qtbot, monkeypatch
+) -> None:
+    x = np.linspace(-1.0, 1.0, 5)
+    y = np.arange(128.0)
+    data = xr.DataArray(
+        y[:, None] + x[None, :],
+        dims=("y", "x"),
+        coords={"y": y, "x": x},
+        name="map",
+    )
+    model = lmfit.models.ExpressionModel("slope * x + intercept")
+    params = model.make_params(slope=1.0, intercept=0.0)
+    tool = erlab.interactive.ftool(data, model=model, params=params, execute=False)
+    qtbot.addWidget(tool)
+    assert isinstance(tool, Fit2DTool)
+    _set_signed_fit_trust(tool)
+    signed_trust = tool._document_trust
+    admitted_entries = tool._fit_code_entries
+    tool._begin_fit_2d_sequence_history()
+    original_tool_status = Fit2DTool.tool_status
+
+    def unexpected_call(*_args, **_kwargs):
+        raise AssertionError("redraw rebuilt or reauthorized the code inventory")
+
+    monkeypatch.setattr(
+        Fit2DTool,
+        "_code_trust_entries_from_status",
+        classmethod(unexpected_call),
+    )
+    monkeypatch.setattr(
+        Fit2DTool,
+        "tool_status",
+        property(unexpected_call, original_tool_status.fset),
+    )
+    monkeypatch.setattr(
+        Fit2DTool,
+        "_serialize_params",
+        staticmethod(unexpected_call),
+    )
+    monkeypatch.setattr(Fit2DTool, "_build_fit_code_entries", unexpected_call)
+    monkeypatch.setattr(tool, "_issue_code_execution_capability", unexpected_call)
+
+    result_ds = (
+        data.isel(y=0).xlm.modelfit("x", model=model, params=params, max_nfev=1).load()
+    )
+    for index in range(data.sizes["y"]):
+        tool._store_fit_2d_sequence_result(index, result_ds, 0.0)
+    for index in range(0, data.sizes["y"], 11):
+        tool._set_current_index(index)
+        tool._update_fit_curve()
+
+    assert tool._fit_code_entries is admitted_entries
+    assert tool._document_trust == signed_trust
+    assert tool._current_fit_execution_allowed()
+
+
+def test_fit2d_rebuild_keeps_new_result_blob_not_previous_blob(qtbot) -> None:
+    tool, model, params = _make_linear_fit2d_tool(qtbot)
+    data = tool.tool_data
+    previous_blob = np.array([17, 29, 41], dtype=np.uint8)
+    tool._serialized_fit_result_blob = previous_blob
+    replacement = data.xlm.modelfit("x", model=model, params=params, max_nfev=1).load()
+
+    tool._restore_from_fit_dataset(replacement)
+
+    assert tool._serialized_fit_result_blob is not None
+    assert not np.array_equal(tool._serialized_fit_result_blob, previous_blob)
+    saved = tool.to_dataset()
+    assert np.array_equal(
+        saved[tool._PERSISTED_FIT_RESULT_VAR].values,
+        tool._serialized_fit_result_blob,
+    )
+
+
+def test_fit2d_transpose_discards_owned_result_blob(qtbot) -> None:
+    tool, model, params = _make_linear_fit2d_tool(qtbot)
+    _seed_fit2d_full_results(tool, model, params)
+    tool._cache_fit_result_payload()
+    assert tool._serialized_fit_result_blob is not None
+
+    tool._do_transpose()
+
+    assert tool._serialized_fit_result_blob is None
+    assert all(result is None for result in tool._result_ds_full)
+    assert tool._PERSISTED_FIT_RESULT_VAR not in tool.to_dataset()
+
+
+def test_fit2d_reset_discards_pending_result_restore(qtbot, monkeypatch) -> None:
+    tool, model, params = _make_linear_fit2d_tool(qtbot, expression=True)
+    _seed_fit2d_full_results(tool, model, params)
+    tool._cache_fit_result_payload()
+    blob = np.array(tool._serialized_fit_result_blob, copy=True)
+    deserialize_calls: list[int] = []
+    original_deserialize = erlab.interactive.utils._deserialize_fit_dataset_blob
+
+    def tracked_deserialize(blob):
+        deserialize_calls.append(np.asarray(blob).size)
+        return original_deserialize(blob)
+
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_deserialize_fit_dataset_blob",
+        tracked_deserialize,
+    )
+
+    tool._last_result_ds = None
+    tool._result_ds_full = [None] * len(tool._result_ds_full)
+    tool.set_document_trust(untrusted_document_trust(), notify=False)
+    tool._restore_persisted_fit_result_blob(blob, fit_is_current=True)
+    assert np.array_equal(tool._serialized_fit_result_blob, blob)
+    assert tool._pending_persisted_fit_is_current is True
+    assert deserialize_calls == []
+
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args, **_kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+    tool._reset_params_all()
+
+    assert tool._serialized_fit_result_blob is None
+    assert tool._pending_persisted_fit_is_current is None
+
+    tool.set_document_trust(new_document_trust())
+
+    assert deserialize_calls == []
+    assert tool._last_result_ds is None
+    assert all(result is None for result in tool._result_ds_full)
+    assert tool._PERSISTED_FIT_RESULT_VAR not in tool.to_dataset()
+
+
+def test_fit2d_source_replacement_discards_pending_result_retry(qtbot) -> None:
+    tool, _safe_model, _safe_params = _make_linear_fit2d_tool(qtbot)
+    data = tool.tool_data
+    unsafe_model = lmfit.models.ExpressionModel("slope * x + intercept")
+    unsafe_params = unsafe_model.make_params(slope=1.0, intercept=0.0)
+    unsafe_result = (
+        data.isel(y=0)
+        .xlm.modelfit("x", model=unsafe_model, params=unsafe_params, max_nfev=1)
+        .load()
+    )
+    blob = erlab.interactive.utils._serialize_fit_dataset_blob(unsafe_result)
+    tool.set_document_trust(untrusted_document_trust(), notify=False)
+
+    tool._restore_persisted_fit_result_blob(blob, fit_is_current=True)
+    assert np.array_equal(tool._serialized_fit_result_blob, blob)
+    assert tool._pending_persisted_fit_is_current is True
+    assert all(result is None for result in tool._result_ds_full)
+
+    assert tool.update_data(data + 1.0)
+    tool.set_document_trust(new_document_trust())
+
+    assert tool._serialized_fit_result_blob is None
+    assert tool._pending_persisted_fit_is_current is None
+    assert all(result is None for result in tool._result_ds_full)
+    assert tool._PERSISTED_FIT_RESULT_VAR not in tool.to_dataset()

--- a/tests/interactive/test_options.py
+++ b/tests/interactive/test_options.py
@@ -23,6 +23,7 @@ from erlab.interactive._options.parameters import (
     SavefigDpiWidget,
     SavefigPaddingWidget,
     StylesheetListWidget,
+    TrustedFoldersWidget,
 )
 from erlab.interactive._options.schema import (
     AppOptions,
@@ -134,8 +135,8 @@ def test_dialog_initial_settings(dialog: OptionDialog):
 def test_dialog_native_structure(dialog: OptionDialog):
     assert dialog.findChild(QtWidgets.QDialogButtonBox) is None
     assert dialog.findChild(QtWidgets.QTabBar, "settingsScopeTabs").count() == 1
-    assert dialog.findChild(QtWidgets.QListWidget, "settingsCategoryList").count() == 4
-    assert dialog.findChild(QtWidgets.QStackedWidget, "settingsPageStack").count() == 4
+    assert dialog.findChild(QtWidgets.QListWidget, "settingsCategoryList").count() == 5
+    assert dialog.findChild(QtWidgets.QStackedWidget, "settingsPageStack").count() == 5
     assert dialog.findChild(QtWidgets.QPushButton, "settingsRevertButton") is not None
     page = dialog.findChild(QtWidgets.QScrollArea, "settingsPage_user_colors")
     if page is None:
@@ -195,6 +196,19 @@ def test_dialog_default_directory_control_has_accessible_description(
     assert description
     assert control.toolTip() == ""
     assert control.accessibleDescription() == description
+
+
+def test_dialog_security_settings_are_user_only(qtbot) -> None:
+    manager = _WorkspaceManagerStub()
+    qtbot.addWidget(manager)
+    dialog = OptionDialog(manager)
+    qtbot.addWidget(dialog)
+
+    path = "security/trusted_workspace_folders"
+    control = _control(dialog, "user", path, TrustedFoldersWidget)
+
+    assert isinstance(control, TrustedFoldersWidget)
+    assert ("workspace", path) not in dialog._rows
 
 
 def test_dialog_recent_workspace_limit_control(dialog: OptionDialog):

--- a/tests/interactive/test_options_parameters.py
+++ b/tests/interactive/test_options_parameters.py
@@ -1,8 +1,10 @@
+import pathlib
 import warnings
 
 import pytest
 from qtpy import QtCore, QtGui, QtWidgets
 
+import erlab.interactive._options.parameters as option_parameters
 import erlab.interactive._stylesheets
 from erlab.interactive._options.parameters import (
     _STYLESHEET_AVAILABLE_ROLE,
@@ -17,6 +19,8 @@ from erlab.interactive._options.parameters import (
     SavefigDpiWidget,
     StylesheetListParameter,
     StylesheetListWidget,
+    TrustedFoldersParameter,
+    TrustedFoldersWidget,
     _stylesheet_names,
 )
 from erlab.interactive._widgets import _CenteredIconToolButton, _Separator
@@ -279,6 +283,174 @@ def test_directory_path_parameter_item_widget(qtbot) -> None:
     assert isinstance(widget, DirectoryPathWidget)
     assert not item.hideWidget
     assert widget.value() == "~/data"
+
+
+def test_trusted_folders_widget_browse_accepts_and_cancel_keeps_value(
+    qtbot, monkeypatch, tmp_path
+) -> None:
+    widget = TrustedFoldersWidget()
+    qtbot.addWidget(widget)
+    responses = iter(("", str(tmp_path)))
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getExistingDirectory",
+        lambda *_args: next(responses),
+    )
+    monkeypatch.setattr(
+        option_parameters,
+        "validate_trusted_location",
+        lambda path: pathlib.Path(path).resolve(),
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda *_args: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+
+    widget.add_folder()
+    assert widget.get_folders() == []
+
+    with qtbot.waitSignal(widget.sigFoldersChanged, timeout=1000):
+        widget.add_folder()
+    assert widget.get_folders() == [str(tmp_path.resolve())]
+
+
+def test_trusted_folders_widget_requires_confirmation(
+    qtbot, monkeypatch, tmp_path
+) -> None:
+    widget = TrustedFoldersWidget()
+    qtbot.addWidget(widget)
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getExistingDirectory",
+        lambda *_args: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        option_parameters,
+        "validate_trusted_location",
+        lambda path: pathlib.Path(path).resolve(),
+    )
+    replies = iter(
+        (
+            QtWidgets.QMessageBox.StandardButton.Cancel,
+            QtWidgets.QMessageBox.StandardButton.Yes,
+        )
+    )
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda *_args: next(replies),
+    )
+
+    widget.add_folder()
+    assert widget.get_folders() == []
+
+    widget.add_folder()
+    assert widget.get_folders() == [str(tmp_path.resolve())]
+
+
+def test_trusted_folders_widget_rejects_invalid_folder(
+    qtbot, monkeypatch, tmp_path
+) -> None:
+    widget = TrustedFoldersWidget()
+    qtbot.addWidget(widget)
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getExistingDirectory",
+        lambda *_args: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        option_parameters,
+        "validate_trusted_location",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("invalid")),
+    )
+    warnings: list[tuple] = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda *args: warnings.append(args),
+    )
+
+    widget.add_folder()
+
+    assert widget.get_folders() == []
+    assert len(warnings) == 1
+
+
+def test_trusted_folders_widget_normalizes_and_removes(qtbot) -> None:
+    widget = TrustedFoldersWidget([" first ", "first", "second"])
+    qtbot.addWidget(widget)
+
+    assert widget.get_folders() == ["first", "second"]
+
+    widget.list_widget.setCurrentRow(0)
+    with qtbot.waitSignal(widget.sigFoldersChanged, timeout=1000):
+        widget.remove_selected_folder()
+
+    assert widget.get_folders() == ["second"]
+    assert widget.remove_button.isEnabled()
+
+
+def test_trusted_folders_widget_reset_requires_confirmation(qtbot, monkeypatch) -> None:
+    widget = TrustedFoldersWidget()
+    qtbot.addWidget(widget)
+    replies = iter(
+        (
+            QtWidgets.QMessageBox.StandardButton.Cancel,
+            QtWidgets.QMessageBox.StandardButton.Yes,
+        )
+    )
+    monkeypatch.setattr(QtWidgets.QMessageBox, "question", lambda *_args: next(replies))
+    resets: list[None] = []
+    monkeypatch.setattr(
+        option_parameters,
+        "reset_saved_code_trust",
+        lambda: resets.append(None),
+    )
+
+    widget.reset_saved_trust()
+    assert resets == []
+
+    widget.reset_saved_trust()
+    assert resets == [None]
+
+
+def test_trusted_folders_widget_reports_signature_reset_failure(
+    qtbot, monkeypatch
+) -> None:
+    widget = TrustedFoldersWidget()
+    qtbot.addWidget(widget)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *_args: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+    monkeypatch.setattr(
+        option_parameters,
+        "reset_saved_code_trust",
+        lambda: (_ for _ in ()).throw(RuntimeError("failed")),
+    )
+    warning_parents: list[QtWidgets.QWidget] = []
+
+    def record_warning(parent, _title, _text):
+        warning_parents.append(parent)
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", record_warning)
+
+    widget.reset_saved_trust()
+
+    assert warning_parents == [widget]
+
+
+def test_trusted_folders_parameter_item_widget(qtbot) -> None:
+    param = TrustedFoldersParameter(name="folders", value=["~/workspaces"])
+    item = param.makeTreeItem(0)
+    widget = item.widget
+    qtbot.addWidget(widget)
+
+    assert isinstance(widget, TrustedFoldersWidget)
+    assert not item.hideWidget
+    assert widget.value() == ["~/workspaces"]
 
 
 def test_style_library_paths_falls_back_to_matplotlib_core(monkeypatch) -> None:

--- a/tests/interactive/test_options_tree.py
+++ b/tests/interactive/test_options_tree.py
@@ -115,6 +115,19 @@ def test_make_parameter_round_trips_builtin_default_loader() -> None:
     assert parameter_to_options(param).io.default_loader == loader_id
 
 
+def test_make_parameter_round_trips_trusted_folders() -> None:
+    options = AppOptions.model_validate(
+        {"security": {"trusted_workspace_folders": ["~/workspaces"]}}
+    )
+    param = make_parameter(options)
+
+    trusted_param = param.child("security").child("trusted_workspace_folders")
+    assert trusted_param.opts["type"] == "trusted_folders"
+    assert trusted_param.value() == ["~/workspaces"]
+
+    assert parameter_to_options(param).security == options.security
+
+
 def test_make_parameter_workspace_compression_uses_display_labels() -> None:
     param = make_parameter()
     compression_param = param.child("io").child("workspace").child("compression")

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -21,6 +21,15 @@ from qtpy import PYQT6, QtCore, QtGui, QtTest, QtWidgets
 import erlab.interactive._plot_state
 import erlab.interactive.colors
 import erlab.interactive.utils
+from erlab.interactive._code_trust import (
+    create_entry,
+    create_manifest,
+    execution_capability_allows,
+    issue_local_edit_capability,
+    new_document_trust,
+    untrusted_document_trust,
+)
+from erlab.interactive._code_trust._api import _document_trust_after_save
 from erlab.interactive._file_loaders import (
     BUILTIN_FILE_LOADER_SPECS,
     builtin_file_loader_for_id,
@@ -36,7 +45,12 @@ from erlab.interactive.imagetool._provenance._model import (
 from erlab.interactive.imagetool._provenance._operations import (
     ImageToolSelectionSourceBinding,
     IselOperation,
+    ModelFitOperation,
     ScriptCodeOperation,
+    _ModelFitParameterSpec,
+)
+from erlab.interactive.imagetool._provenance._trust import (
+    provenance_operation_code_trust_entries,
 )
 from erlab.interactive.imagetool.manager._dependency import _ManagerDependencyTracker
 from erlab.interactive.imagetool.manager._modelview import (
@@ -220,6 +234,20 @@ class _PersistentTool(erlab.interactive.utils.ToolWindow[_PersistentToolState]):
         self._data = new_data
 
 
+def _expression_fit_operation(expression: str = "2 * c0") -> ModelFitOperation:
+    return ModelFitOperation(
+        fit_dim="x",
+        model="PolynomialModel",
+        model_kwargs={"degree": 1},
+        parameters={
+            "c0": _ModelFitParameterSpec(value=0.0),
+            "c1": _ModelFitParameterSpec(expr=expression),
+        },
+        method="leastsq",
+        parameter="c0",
+    )
+
+
 class _FailingPersistentTool(_PersistentTool):
     @property
     def tool_status(self) -> _PersistentToolState:
@@ -341,6 +369,19 @@ class _DeferredRestoreTool(
 
     def _result_output_data(self) -> xr.DataArray:
         return self._data + self.deferred_runs
+
+
+@pytest.fixture
+def deferred_restore_tool(qtbot) -> _DeferredRestoreTool:
+    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        _DeferredRestoreTool(data).to_dataset(),
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    if not isinstance(restored, _DeferredRestoreTool):  # pragma: no cover
+        raise TypeError("Expected deferred restore test tool")
+    return restored
 
 
 def test_tool_window_history_actions_undo_redo(qtbot) -> None:
@@ -1237,133 +1278,75 @@ def test_plot_state_registry_defensive_paths(monkeypatch) -> None:
     assert base_adapter._connections == []
 
 
-def test_tool_window_direct_restore_runs_deferred_task_eagerly(qtbot) -> None:
-    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
-    saved = _DeferredRestoreTool(data).to_dataset()
-
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
-    qtbot.addWidget(restored)
-
-    assert isinstance(restored, _DeferredRestoreTool)
-    assert restored.construct_restoring is True
-    assert restored.construct_deferred is False
-    assert restored.deferred_runs == 1
-
-
-def test_tool_window_private_deferred_restore_queues_constructor_task(qtbot) -> None:
+@pytest.mark.parametrize("defer", [False, True])
+def test_tool_window_restore_runs_or_queues_constructor_task(
+    qtbot, defer: bool
+) -> None:
     data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
     saved = _DeferredRestoreTool(data).to_dataset()
 
     restored = erlab.interactive.utils.ToolWindow.from_dataset(
         saved,
-        _defer_restore_work=True,
+        _defer_restore_work=defer,
     )
     qtbot.addWidget(restored)
 
     assert isinstance(restored, _DeferredRestoreTool)
     assert restored.construct_restoring is True
-    assert restored.construct_deferred is True
-    assert restored.deferred_runs == 0
-
-    assert restored._flush_restore_work(key="dummy-restore-task")
+    assert restored.construct_deferred is defer
+    assert restored.deferred_runs == int(not defer)
+    if defer:
+        assert restored._flush_restore_work(key="dummy-restore-task")
     assert restored.deferred_runs == 1
 
 
-def test_tool_window_deferred_restore_flushes_before_save(qtbot) -> None:
-    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
-    saved = _DeferredRestoreTool(data).to_dataset()
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(
-        saved,
-        _defer_restore_work=True,
-    )
-    qtbot.addWidget(restored)
-    assert isinstance(restored, _DeferredRestoreTool)
+@pytest.mark.parametrize("action", ["save", "output", "copy"])
+def test_tool_window_deferred_restore_flushes_before_use(
+    deferred_restore_tool, monkeypatch, action: str
+) -> None:
+    if action == "save":
+        deferred_restore_tool.to_dataset()
+    elif action == "output":
+        xr.testing.assert_identical(
+            deferred_restore_tool.output_imagetool_data(
+                _DeferredRestoreTool.Output.RESULT
+            ),
+            deferred_restore_tool.tool_data + 1,
+        )
+    else:
+        monkeypatch.setattr(
+            erlab.interactive.utils, "copy_to_clipboard", lambda code: code
+        )
+        deferred_restore_tool.copy_code()
 
-    restored.to_dataset()
-
-    assert restored.deferred_runs == 1
-
-
-def test_tool_window_deferred_restore_flushes_on_show(qtbot) -> None:
-    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
-    saved = _DeferredRestoreTool(data).to_dataset()
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(
-        saved,
-        _defer_restore_work=True,
-    )
-    qtbot.addWidget(restored)
-    assert isinstance(restored, _DeferredRestoreTool)
-
-    restored.show()
-    qtbot.waitUntil(lambda: restored.deferred_runs == 1, timeout=1000)
+    assert deferred_restore_tool.deferred_runs == 1
 
 
-def test_tool_window_deferred_restore_is_discarded_on_close(qtbot) -> None:
-    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
-    saved = _DeferredRestoreTool(data).to_dataset()
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(
-        saved,
-        _defer_restore_work=True,
-    )
-    qtbot.addWidget(restored)
-    assert isinstance(restored, _DeferredRestoreTool)
-
-    restored.close()
-
-    assert restored.deferred_runs == 0
-    assert not restored._flush_restore_work()
+def test_tool_window_deferred_restore_flushes_on_show(
+    deferred_restore_tool, qtbot
+) -> None:
+    deferred_restore_tool.show()
+    qtbot.waitUntil(lambda: deferred_restore_tool.deferred_runs == 1, timeout=1000)
 
 
-def test_tool_window_deferred_restore_flushes_before_output(qtbot) -> None:
-    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
-    saved = _DeferredRestoreTool(data).to_dataset()
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(
-        saved,
-        _defer_restore_work=True,
-    )
-    qtbot.addWidget(restored)
-    assert isinstance(restored, _DeferredRestoreTool)
+def test_tool_window_deferred_restore_is_discarded_on_close(
+    deferred_restore_tool,
+) -> None:
+    deferred_restore_tool.close()
 
-    xr.testing.assert_identical(
-        restored.output_imagetool_data(_DeferredRestoreTool.Output.RESULT),
-        data + 1,
-    )
-    assert restored.deferred_runs == 1
+    assert deferred_restore_tool.deferred_runs == 0
+    assert not deferred_restore_tool._flush_restore_work()
 
 
-def test_tool_window_deferred_restore_flushes_before_copy(qtbot, monkeypatch) -> None:
-    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
-    saved = _DeferredRestoreTool(data).to_dataset()
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(
-        saved,
-        _defer_restore_work=True,
-    )
-    qtbot.addWidget(restored)
-    assert isinstance(restored, _DeferredRestoreTool)
-    monkeypatch.setattr(erlab.interactive.utils, "copy_to_clipboard", lambda code: code)
-
-    restored.copy_code()
-
-    assert restored.deferred_runs == 1
-
-
-def test_tool_window_failed_deferred_restore_can_retry(qtbot) -> None:
-    data = xr.DataArray(np.arange(3.0), dims=("x",), name="data")
-    saved = _DeferredRestoreTool(data).to_dataset()
-    restored = erlab.interactive.utils.ToolWindow.from_dataset(
-        saved,
-        _defer_restore_work=True,
-    )
-    qtbot.addWidget(restored)
-    assert isinstance(restored, _DeferredRestoreTool)
-    restored.fail_next_deferred_restore = True
+def test_tool_window_failed_deferred_restore_can_retry(deferred_restore_tool) -> None:
+    deferred_restore_tool.fail_next_deferred_restore = True
 
     with pytest.raises(RuntimeError, match="deferred restore failed"):
-        restored._flush_restore_work(key="dummy-restore-task")
+        deferred_restore_tool._flush_restore_work(key="dummy-restore-task")
 
-    assert restored.deferred_runs == 0
-    assert restored._flush_restore_work(key="dummy-restore-task")
-    assert restored.deferred_runs == 1
+    assert deferred_restore_tool.deferred_runs == 0
+    assert deferred_restore_tool._flush_restore_work(key="dummy-restore-task")
+    assert deferred_restore_tool.deferred_runs == 1
 
 
 def test_tool_window_deferred_restore_helper_edges(qtbot) -> None:
@@ -1390,6 +1373,35 @@ def test_tool_window_deferred_restore_helper_edges(qtbot) -> None:
         assert not win._flush_restore_work()
     finally:
         win._flushing_restore_work = False
+
+
+def test_tool_window_deferred_restore_flush_skips_canceled_and_replaced_work(
+    qtbot,
+) -> None:
+    win = _DeferredRestoreTool(xr.DataArray(np.arange(3.0), dims=("x",)))
+    qtbot.addWidget(win)
+    win._restoring_from_dataset = True
+    win._defer_restored_tool_work = True
+    calls: list[str] = []
+
+    def first() -> None:
+        calls.append("first")
+        win._discard_restore_work(key="canceled")
+        win._deferred_restore_work["replaced"] = (
+            lambda: calls.append("replacement"),
+            False,
+        )
+
+    assert win._defer_restore_work(first, key="first")
+    assert win._defer_restore_work(lambda: calls.append("canceled"), key="canceled")
+    assert win._defer_restore_work(lambda: calls.append("stale"), key="replaced")
+
+    assert win._flush_restore_work()
+
+    assert calls == ["first"]
+    assert tuple(win._deferred_restore_work) == ("replaced",)
+    assert win._flush_restore_work()
+    assert calls == ["first", "replacement"]
 
 
 @pytest.fixture
@@ -4571,6 +4583,225 @@ def test_tool_window_resolves_saved_reference_errors() -> None:
         )
 
 
+def test_tool_window_saved_source_reference_authorizes_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4.0)})
+    operation = _expression_fit_operation()
+    ds = xr.Dataset({erlab.interactive.utils._SAVED_TOOL_DATA_NAME: data})
+    ds.attrs[erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR] = json.dumps(
+        full_data(operation).model_dump(mode="json")
+    )
+    executions: list[None] = []
+
+    def apply(
+        operation: ModelFitOperation,
+        source: xr.DataArray,
+        *,
+        authorization: object | None = None,
+    ) -> xr.DataArray:
+        entries = provenance_operation_code_trust_entries(
+            operation,
+            location_prefix="runtime-operation",
+        )
+        assert execution_capability_allows(authorization, entries)
+        executions.append(None)
+        return source
+
+    monkeypatch.setattr(ModelFitOperation, "apply", apply)
+
+    with pytest.raises(ValueError, match="untrusted code"):
+        erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+            {"kind": "parent_source"},
+            ds,
+            source_parent_data=data,
+            reference_resolver=None,
+            document_trust=untrusted_document_trust(),
+        )
+    assert executions == []
+
+    resolved = erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
+        {"kind": "parent_source"},
+        ds,
+        source_parent_data=data,
+        reference_resolver=None,
+        document_trust=new_document_trust(),
+    )
+    xr.testing.assert_identical(resolved, data)
+    assert executions == [None]
+
+
+def test_tool_window_manifest_includes_saved_source_expressions() -> None:
+    class _SourceTrustTool(_PersistentTool):
+        _CODE_TRUST_DOMAIN = "test.tool-source"
+
+    attrs = {
+        erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR: json.dumps(
+            full_data(_expression_fit_operation()).model_dump(mode="json")
+        )
+    }
+
+    manifest = _SourceTrustTool._code_trust_manifest_from_saved_metadata(
+        _PersistentToolState(),
+        attrs,
+    )
+
+    assert manifest is not None
+    assert [entry.feature for entry in manifest.entries] == [
+        "erlab.provenance.model-fit-parameter-expression"
+    ]
+    assert manifest.entries[0].location == (
+        "tool-source/provenance/operations/0/parameters/c1"
+    )
+
+
+def test_tool_window_local_code_edit_changes_signed_trust_to_local_lineage(
+    qtbot,
+) -> None:
+    class _SourceTrustTool(_PersistentTool):
+        _CODE_TRUST_DOMAIN = "test.tool-source"
+
+    data = xr.DataArray(np.arange(3.0), dims="x", name="data")
+    tool = _SourceTrustTool(data)
+    qtbot.addWidget(tool)
+
+    def source(expression: str) -> ToolProvenanceSpec:
+        return full_data(_expression_fit_operation(expression))
+
+    tool.set_source_binding(source("2 * c0"))
+    manifest = tool._current_code_trust_manifest()
+    assert manifest is not None
+    signed = _document_trust_after_save(
+        new_document_trust(),
+        manifest,
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+    tool.set_document_trust(signed)
+    changed_source = source("3 * c0")
+    changed_entries = tuple(tool._source_spec_code_trust_entries(changed_source))
+    with tool._local_code_edit(
+        changed_entries,
+        edited_entries=changed_entries,
+    ) as capability:
+        assert execution_capability_allows(capability, changed_entries)
+        tool.set_source_binding(changed_source)
+
+    assert tool._authorize_code_execution(changed_entries)
+
+
+def test_tool_window_local_code_edit_commits_only_after_success(qtbot) -> None:
+    tool = _PersistentTool(xr.DataArray(np.arange(3.0), dims="x"))
+    qtbot.addWidget(tool)
+    saved_entry = create_entry("test.code", "operations/0", "saved()")
+    edited_entry = create_entry("test.code", "operations/0", "edited()")
+    signed = _document_trust_after_save(
+        new_document_trust(),
+        create_manifest("test.tool", 1, (saved_entry,)),
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+    tool.set_document_trust(signed)
+
+    def fail_edit() -> None:
+        with tool._local_code_edit(
+            (edited_entry,),
+            edited_entries=(edited_entry,),
+        ) as capability:
+            assert tool._document_trust == signed
+            assert tool._issue_code_execution_capability((edited_entry,)) is capability
+            raise RuntimeError("validation failed")
+
+    with pytest.raises(RuntimeError, match="validation failed"):
+        fail_edit()
+
+    assert tool._document_trust == signed
+
+    with tool._local_code_edit(
+        (edited_entry,),
+        edited_entries=(edited_entry,),
+    ):
+        assert tool._document_trust == signed
+
+    assert tool._document_trust != signed
+
+
+def test_tool_window_managed_authorization_uses_document_host(qtbot) -> None:
+    approved_entry = create_entry(
+        "test.code",
+        "operations/0",
+        "value = 1",
+    )
+    denied_entry = create_entry(
+        "test.code",
+        "operations/0",
+        "value = 2",
+    )
+    manifest = create_manifest("test.tool", 1, (approved_entry,))
+    calls: list[object] = []
+    current_trust = signed = _document_trust_after_save(
+        new_document_trust(),
+        manifest,
+        saved_trusted_lineage=True,
+        signature_stored=True,
+    )
+
+    def issue(entries, **kwargs):
+        calls.append((tuple(entries), kwargs))
+        return
+
+    @contextlib.contextmanager
+    def local_edit_context(entries, *, edited_entries, **kwargs):
+        calls.append((tuple(entries), tuple(edited_entries), kwargs))
+        yield "local-edit-capability"
+
+    tool = _PersistentTool(xr.DataArray(np.arange(3.0), dims="x"))
+    qtbot.addWidget(tool)
+    tool._set_code_trust_host(
+        issue,
+        local_edit_context=local_edit_context,
+        state_getter=lambda: current_trust,
+    )
+
+    assert not tool._authorize_code_execution((denied_entry,))
+    with tool._local_code_edit(
+        (denied_entry,), edited_entries=(denied_entry,)
+    ) as capability:
+        assert capability == "local-edit-capability"
+    tool._review_code_trust()
+    assert tool._current_document_trust() is signed
+    assert calls == [
+        ((denied_entry,), {"focus_on_block": False}),
+        ((denied_entry,), (denied_entry,), {"focus_on_block": False}),
+    ]
+
+
+def test_tool_window_rejects_partial_capability_from_document_host(qtbot) -> None:
+    local_entry = create_entry("test.code", "operations/local", "local()")
+    external_entry = create_entry("test.code", "operations/external", "external()")
+    trust = untrusted_document_trust()
+    _prospective, partial_capability = issue_local_edit_capability(
+        trust,
+        (local_entry, external_entry),
+        edited_entries=(local_entry,),
+    )
+    assert execution_capability_allows(partial_capability, (local_entry,))
+    assert not execution_capability_allows(partial_capability, (external_entry,))
+
+    tool = _PersistentTool(xr.DataArray(np.arange(3.0), dims="x"))
+    qtbot.addWidget(tool)
+    tool._set_code_trust_host(
+        lambda *_args, **_kwargs: partial_capability,
+        local_edit_context=lambda *_args, **_kwargs: contextlib.nullcontext(
+            partial_capability
+        ),
+        state_getter=lambda: trust,
+    )
+
+    assert tool._issue_code_execution_capability((local_entry,)) is partial_capability
+    assert tool._issue_code_execution_capability((local_entry, external_entry)) is None
+
+
 def test_tool_window_resolves_references_with_missing_placeholder_variables() -> None:
     ds = xr.Dataset({erlab.interactive.utils._SAVED_TOOL_DATA_NAME: xr.DataArray(0)})
     ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = json.dumps(
@@ -4681,6 +4912,10 @@ def test_managed_tool_window_node_source_binding_branches(qtbot, monkeypatch) ->
             self._tool_graph = _ManagerToolGraph(self._handle_node_change)
             self._metadata_node_uid: str | None = None
             self._dependency_tracker = _ManagerDependencyTracker(self._tool_graph)
+            self._workspace_controller = types.SimpleNamespace(
+                _configure_tool_code_trust=lambda _tool, **_kwargs: None,
+                _configure_imagetool_code_trust=lambda _tool, **_kwargs: None,
+            )
 
         def _handle_node_change(
             self,
@@ -4933,6 +5168,10 @@ def test_managed_tool_window_node_detached_update_branches(
                     ),
                 )
             )
+            self._workspace_controller = types.SimpleNamespace(
+                _configure_tool_code_trust=lambda _tool, **_kwargs: None,
+                _configure_imagetool_code_trust=lambda _tool, **_kwargs: None,
+            )
             self.parent_node = types.SimpleNamespace(
                 tool_window=parent_tool,
                 provenance_spec=None,
@@ -5168,6 +5407,10 @@ def test_imagetool_wrapper_item_model_child_edge_branches(qtbot, monkeypatch) ->
             self._tool_graph = _ManagerToolGraph()
             self._metadata_node_uid: str | None = None
             self._dependency_tracker = _ManagerDependencyTracker(self._tool_graph)
+            self._workspace_controller = types.SimpleNamespace(
+                _configure_tool_code_trust=lambda _tool, **_kwargs: None,
+                _configure_imagetool_code_trust=lambda _tool, **_kwargs: None,
+            )
             self.updated: list[str] = []
             self.removed: list[str] = []
             self.renamed: list[tuple[int, object]] = []

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -4095,9 +4095,11 @@ def test_tool_window_operations_provenance_methods_normalize_results(qtbot) -> N
 
     single_spec = tool.current_provenance_spec()
     assert single_spec is not None
-    expected_operation = operation.model_copy(update={"framework_owned": True})
+    expected_operation = operation.model_copy(
+        update={"uses_implicit_framework_imports": True}
+    )
     assert single_spec.operations == (expected_operation,)
-    assert operation.framework_owned is False
+    assert operation.uses_implicit_framework_imports is False
 
     tool._operations = [operation]
     sequence_spec = tool.current_provenance_spec()


### PR DESCRIPTION
## Summary

- Add durable local trust for saved documents that contain executable Python.
- Protect script provenance, Figure Composer Python, lmfit executable payloads, and parameter expressions at their execution boundaries.
- Preserve trusted lineage across successful saves without changing the `.itws` schema.
- Explain what saved workspaces can execute and when ERLab asks for approval.

## Trust model

The private trust service builds a canonical manifest from exact code and execution context. It stores HMAC signatures in a local SQLite database that is protected by a separate user secret. New local edits receive narrow, temporary execution capabilities. External executable content stays paused until the user approves it. Failed and untrusted saves do not create signatures.

The implementation keeps execution decisions in the trust framework. Feature adapters only describe executable entries. The final capability check stays next to the guarded operation.

## Plugin framework integration

Registered extensions remain a separate local approval boundary. A workspace can record an extension script name, source hash, and capability identifier. Replay still requires the matching installed, enabled, and approved local extension. Embedded extension source is recovery data only and never executes.

The document trust manifest does not include extension source bytes. Combining both approval systems would duplicate policy and could let document approval replace the stricter installed-extension check. The manager instead composes the two independent decisions at replay boundaries.

Saved tool types now resolve through built-in or installed entry-point registrations. Workspace metadata cannot select an arbitrary import target. Registered built-ins cannot be replaced, and an entry point must return the identifier that it declares.

## Validation

- `uv run pytest -q tests/interactive/test_code_trust.py tests/interactive/imagetool/manager/figurecomposer/test_trust.py tests/interactive/imagetool/manager/test_console.py::test_manager_reload_script_derived_target_honors_trust_cancel`
- `QT_API=pyside6 uv run pytest -q tests/interactive/test_code_trust.py tests/interactive/imagetool/manager/figurecomposer/test_trust.py tests/interactive/imagetool/manager/test_console.py::test_manager_reload_script_derived_target_honors_trust_cancel`
- `uv run pytest -q tests/interactive/imagetool/manager/figurecomposer/test_trust.py tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py`
- `QT_API=pyside6 uv run pytest -q tests/interactive/imagetool/manager/figurecomposer/test_trust.py tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py`
- Focused PyQt6 tests for provenance, replay graphs, workspace load and save, manager integration, Figure Composer, fitting tools, extensions, and ToolWindow persistence.
- Ruff checks and formatting checks for all changed files.
- `uv run mypy src`
- `uv run python -m scripts.ci_test_groups --check-partition`

The full test suite was not run. CI will run it.
