### PR TITLE
test(figurecomposer): clean up standalone windows

### DIFF
--- a/tests/interactive/imagetool/manager/figurecomposer/_common.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/_common.py
@@ -85,6 +85,18 @@ class _SourcePickerDummyTool(
         self._status = status
 
 
+def _delete_test_widgets(*widgets: QtWidgets.QWidget | None) -> None:
+    """Delete test widgets in reverse creation order before pytest-qt resumes."""
+    for widget in reversed(widgets):
+        if widget is not None and erlab.interactive.utils.qt_is_valid(widget):
+            widget.close()
+            widget.deleteLater()
+    QtWidgets.QApplication.sendPostedEvents(
+        None, int(QtCore.QEvent.Type.DeferredDelete.value)
+    )
+    QtWidgets.QApplication.processEvents()
+
+
 def _materialized_figure_tool(
     manager: erlab.interactive.imagetool.manager.ImageToolManager, figure_uid: str
 ) -> FigureComposerTool:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -47,6 +47,7 @@ from tests.interactive.imagetool.manager.helpers import _exec_generated_code
 
 from ._common import (
     _activate_combo_text,
+    _delete_test_widgets,
     _expected_line_colormap_colors,
     _figure_composer_line_slice_source,
     _operation_section_button,
@@ -224,32 +225,36 @@ def test_imagetool_line_profile_seeds_public_nonuniform_coordinate(qtbot) -> Non
     assert isinstance(source_tool, erlab.interactive.imagetool.ImageTool)
     qtbot.addWidget(source_tool)
 
-    operation = figurecomposer_adapter.build_figure_composer_operation(
-        source_tool.slicer_area.profiles[0], source_name="data"
-    )
-
-    assert operation.kind == FigureOperationKind.LINE
-    assert operation.line_x == "sample_temp"
-    assert "sample_temp_idx" not in operation.model_dump_json()
-
-    composer = FigureComposerTool.from_sources(
-        {"data": source_tool.slicer_area._tool_source_parent_data()},
-        sources=(FigureSourceState(name="data", label="map"),),
-        operations=(operation,),
-        setup=FigureSubplotsState(),
-        primary_source="data",
-    )
-    qtbot.addWidget(composer)
-
-    figure = plt.figure()
+    composer: FigureComposerTool | None = None
+    figure: Figure | None = None
     try:
+        operation = figurecomposer_adapter.build_figure_composer_operation(
+            source_tool.slicer_area.profiles[0], source_name="data"
+        )
+
+        assert operation.kind == FigureOperationKind.LINE
+        assert operation.line_x == "sample_temp"
+        assert "sample_temp_idx" not in operation.model_dump_json()
+
+        composer = FigureComposerTool.from_sources(
+            {"data": source_tool.slicer_area._tool_source_parent_data()},
+            sources=(FigureSourceState(name="data", label="map"),),
+            operations=(operation,),
+            setup=FigureSubplotsState(),
+            primary_source="data",
+        )
+        qtbot.addWidget(composer)
+
+        figure = plt.figure()
         figurecomposer_rendering._render_into_figure(
             composer, figure, sync_visible=False
         )
         assert composer._operation_render_errors == {}
         assert any(axis.lines for axis in figure.axes)
     finally:
-        plt.close(figure)
+        if figure is not None:
+            plt.close(figure)
+        _delete_test_widgets(source_tool, composer)
 
 
 def test_figure_composer_line_profile_uses_public_nonuniform_dims(qtbot) -> None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -74,6 +74,7 @@ from erlab.interactive.imagetool._provenance._graph import _validate_script_code
 from ._common import (
     _activate_combo_index,
     _activate_combo_text,
+    _delete_test_widgets,
     _drag_widget,
     _expected_line_colormap_colors,
     _figure_composer_image_source,
@@ -630,15 +631,18 @@ def test_imagetool_main_image_seeds_nonuniform_plot_slices_selection(qtbot) -> N
     assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
     qtbot.addWidget(tool)
 
-    tool.slicer_area.set_value(axis=0, value=30.0, cursor=0)
-    operation = figurecomposer_adapter.build_figure_composer_operation(
-        tool.slicer_area.images[2], source_name="data"
-    )
+    try:
+        tool.slicer_area.set_value(axis=0, value=30.0, cursor=0)
+        operation = figurecomposer_adapter.build_figure_composer_operation(
+            tool.slicer_area.images[2], source_name="data"
+        )
 
-    assert operation.kind == FigureOperationKind.PLOT_ARRAY
-    assert len(operation.map_selections) == 1
-    assert operation.map_selections[0].source == "data"
-    assert "sample_temp_idx" not in operation.model_dump_json()
+        assert operation.kind == FigureOperationKind.PLOT_ARRAY
+        assert len(operation.map_selections) == 1
+        assert operation.map_selections[0].source == "data"
+        assert "sample_temp_idx" not in operation.model_dump_json()
+    finally:
+        _delete_test_widgets(tool)
 
 
 def test_imagetool_main_image_seeds_plot_slices_selection_with_spaced_dim(
@@ -658,30 +662,36 @@ def test_imagetool_main_image_seeds_plot_slices_selection_with_spaced_dim(
     assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
     qtbot.addWidget(tool)
 
-    tool.slicer_area.set_value(axis=0, value=1.0, cursor=0)
-    operation = figurecomposer_adapter.build_figure_composer_operation(
-        tool.slicer_area.images[2], source_name="data"
-    )
+    try:
+        tool.slicer_area.set_value(axis=0, value=1.0, cursor=0)
+        operation = figurecomposer_adapter.build_figure_composer_operation(
+            tool.slicer_area.images[2], source_name="data"
+        )
 
-    assert operation.kind == FigureOperationKind.PLOT_ARRAY
-    assert operation.map_selections == (
-        FigureDataSelectionState(source="data", qsel={"Track Shift": 1.0}),
-    )
+        assert operation.kind == FigureOperationKind.PLOT_ARRAY
+        assert operation.map_selections == (
+            FigureDataSelectionState(source="data", qsel={"Track Shift": 1.0}),
+        )
+    finally:
+        _delete_test_widgets(tool)
 
 
 def test_imagetool_rejects_uneditable_plot_slices_selection(qtbot) -> None:
     tool = erlab.interactive.imagetool.ImageTool(_unsupported_plot_slices_data())
     qtbot.addWidget(tool)
 
-    _set_unsupported_plot_slices_cursor_state(tool)
+    try:
+        _set_unsupported_plot_slices_cursor_state(tool)
 
-    with pytest.raises(
-        FigureComposerPlotSlicesSelectionError,
-        match="Cannot plot when more than one dimension",
-    ):
-        figurecomposer_adapter.build_figure_composer_operation(
-            tool.slicer_area.images[0], source_name="data"
-        )
+        with pytest.raises(
+            FigureComposerPlotSlicesSelectionError,
+            match="Cannot plot when more than one dimension",
+        ):
+            figurecomposer_adapter.build_figure_composer_operation(
+                tool.slicer_area.images[0], source_name="data"
+            )
+    finally:
+        _delete_test_widgets(tool)
 
 
 def test_imagetool_plot_slices_selection_warning_shows_error_detail(


### PR DESCRIPTION
## Summary

- Close standalone ImageTool and Figure Composer windows before pytest-qt processes pending events.
- Delete widgets in reverse creation order.
- Deliver deferred deletion events before each test returns.
- Keep the change limited to Figure Composer tests.

This addresses the intermittent PyQt6 worker segfault in `Coverage cov-qt-manager-figurecomposer` on `main`.

## Tests

- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run --python 3.13 --all-extras --group pyqt6 pytest --cov erlab --cov-report= -n 2 --dist=loadgroup --max-worker-restart=0 <four focused tests>`: 4 passed.
- `QT_API=pyside6 PYTEST_QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run --python 3.13 --all-extras --group pyside6 pytest -n 2 --dist=loadgroup --max-worker-restart=0 <four focused tests>`: 4 passed.
- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run --python 3.13 --all-extras --group pyqt6 pytest -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --cov erlab --cov-report= -n 2 --dist=loadgroup --max-worker-restart=0 tests/interactive/imagetool/manager/figurecomposer`: 817 passed.
- `uv run --python 3.13 --all-extras --group pyqt6 ruff format --check` on the changed files: passed.
- `uv run --python 3.13 --all-extras --group pyqt6 ruff check` on the changed files: passed.
- `git diff --check`: passed.
