### PR TITLE
test(manager): restore extension patches before teardown

### DIFF
--- a/tests/interactive/imagetool/manager/test_extensions.py
+++ b/tests/interactive/imagetool/manager/test_extensions.py
@@ -7207,13 +7207,13 @@ def test_catalog_change_refreshes_visible_extension_consumers(
         def refresh_loader_choices(self) -> None:
             calls.append("explorer")
 
-    with manager_context() as manager:
+    with manager_context() as manager, monkeypatch.context() as test_patch:
         controller = manager._extensions
         menu = controller.menu
         if menu is None:
             raise RuntimeError("The manager extension menu was not created")
-        monkeypatch.setattr(menu, "isVisible", lambda: True)
-        monkeypatch.setattr(controller, "_populate_menu", lambda: calls.append("menu"))
+        test_patch.setattr(menu, "isVisible", lambda: True)
+        test_patch.setattr(controller, "_populate_menu", lambda: calls.append("menu"))
         explorer = Explorer(manager)
         manager._standalone_app_windows["explorer"] = explorer
         tool = types.SimpleNamespace(
@@ -7222,8 +7222,8 @@ def test_catalog_change_refreshes_visible_extension_consumers(
         manager._tool_graph.nodes["extension-test-tool"] = types.SimpleNamespace(
             tool_window=tool
         )
-        monkeypatch.setattr(manager, "_update_actions", lambda: calls.append("actions"))
-        monkeypatch.setattr(manager, "_update_info", lambda: calls.append("details"))
+        test_patch.setattr(manager, "_update_actions", lambda: calls.append("actions"))
+        test_patch.setattr(manager, "_update_info", lambda: calls.append("details"))
 
         try:
             controller._catalog_changed(controller.catalog.model)


### PR DESCRIPTION
## Summary

- Restore the extension consumer test patches before manager shutdown.
- Prevent the PySide6 signal disconnect failure and its downstream test contamination.

## Tests

- `QT_API=pyside6 PYTEST_QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/test_extensions.py::test_catalog_change_refreshes_visible_extension_consumers tests/interactive/imagetool/manager/test_registry_server.py::test_watcher_server_run_stops_cleanly_without_pending_payload`
- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/test_extensions.py::test_catalog_change_refreshes_visible_extension_consumers tests/interactive/imagetool/manager/test_registry_server.py::test_watcher_server_run_stops_cleanly_without_pending_payload`
- `uv run ruff format --check tests/interactive/imagetool/manager/test_extensions.py`
- `uv run ruff check tests/interactive/imagetool/manager/test_extensions.py`
- `git diff --check`