### PR TITLE
test: keep copied code off the system clipboard

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ import lmfit
 import numexpr
 import numpy as np
 import pooch
+import pyperclip
 import pytest
 import requests
 import xarray as xr
@@ -338,6 +339,23 @@ def _restore_interactive_options_between_tests() -> Iterator[None]:
         yield
     finally:
         erlab.interactive.options.restore()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_pyperclip() -> Iterator[None]:
+    clipboard_text = ""
+
+    def copy_to_memory(content: object) -> None:
+        nonlocal clipboard_text
+        clipboard_text = str(content)
+
+    def paste_from_memory() -> str:
+        return clipboard_text
+
+    with pytest.MonkeyPatch.context() as clipboard_patch:
+        clipboard_patch.setattr(pyperclip, "copy", copy_to_memory)
+        clipboard_patch.setattr(pyperclip, "paste", paste_from_memory)
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -164,21 +164,6 @@ def _record_reload_unavailable_dialog(monkeypatch: pytest.MonkeyPatch) -> list[s
     return reasons
 
 
-@pytest.fixture(autouse=True)
-def isolate_pyperclip(monkeypatch) -> None:
-    clipboard_text = ""
-
-    def copy_to_memory(content: object) -> None:
-        nonlocal clipboard_text
-        clipboard_text = str(content)
-
-    def paste_from_memory() -> str:
-        return clipboard_text
-
-    monkeypatch.setattr(pyperclip, "copy", copy_to_memory)
-    monkeypatch.setattr(pyperclip, "paste", paste_from_memory)
-
-
 _TEST_DATA: dict[str, xr.DataArray] = {
     "2D": xr.DataArray(
         np.arange(25).reshape((5, 5)),


### PR DESCRIPTION
## Summary

- Store test clipboard text in memory for each test.
- Apply the isolation to the full test suite instead of only ImageTool tests.
- Use an independent patch context so test-specific patches restore before shared cleanup.
- Prevent copy-code tests from overwriting the local system clipboard.

## Tests

- Targeted clipboard, CI teardown-order, and Explorer tests (10 passed)
- `uv run ruff check tests/conftest.py tests/interactive/imagetool/test_imagetool.py`
- `uv run ruff format --check tests/conftest.py tests/interactive/imagetool/test_imagetool.py`
- `git diff --check`

The full test suite was not run locally.
