### PR TITLE
test(manager): exercise real workspace warning dialog

### DIFF
--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -11,7 +11,7 @@ import h5py
 import numpy as np
 import pytest
 import xarray as xr
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui
 
 import erlab
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
@@ -1343,23 +1343,12 @@ def test_generation_save_detaches_pending_figure_composer_from_removed_source(
 def test_hidden_toolwindow_with_missing_saved_class_is_skipped(
     qtbot,
     monkeypatch,
+    accept_dialog,
     tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    class _AcceptingMessageDialog(QtWidgets.QDialog):
-        def __init__(self, *args, **kwargs) -> None:
-            del args, kwargs
-            super().__init__()
-
-        def exec(self):
-            return QtWidgets.QDialog.DialogCode.Accepted
-
-    monkeypatch.setattr(
-        erlab.interactive.utils, "MessageDialog", _AcceptingMessageDialog
-    )
-
     data = xr.DataArray(np.arange(4.0), dims=("x",), name="source")
     with manager_context() as manager:
         root = itool(data, manager=False, execute=False)
@@ -1394,9 +1383,19 @@ def test_hidden_toolwindow_with_missing_saved_class_is_skipped(
             _record_skipped,
         )
 
-        assert manager._workspace_controller.loading._load_workspace_file(
-            fname, replace=True, associate=True, mark_dirty=False, select=False
+        loaded: list[bool] = []
+        accept_dialog(
+            lambda: loaded.append(
+                manager._workspace_controller.loading._load_workspace_file(
+                    fname,
+                    replace=True,
+                    associate=True,
+                    mark_dirty=False,
+                    select=False,
+                )
+            )
         )
+        assert loaded == [True]
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         assert child_uid not in manager._tool_graph.nodes


### PR DESCRIPTION
## Summary

- Use the real workspace warning dialog when a missing saved tool class is skipped.
- Remove the incomplete dialog test double that caused recursive PySide6 alert failures.
- Keep the workspace load result assertion.

## Tests

- QT_API=pyside6 PYTEST_QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/workspace/test_pending_persistence.py::test_hidden_toolwindow_with_missing_saved_class_is_skipped tests/interactive/test_fermiedge.py::test_restool
- QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/workspace/test_pending_persistence.py::test_hidden_toolwindow_with_missing_saved_class_is_skipped tests/interactive/test_fermiedge.py::test_restool
- uv run ruff format tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
- uv run ruff check --fix tests/interactive/imagetool/manager/workspace/test_pending_persistence.py