### PR TITLE
fix(ftool): recognize exact built-in model code

### DIFF
--- a/src/erlab/interactive/_code_trust/_api.py
+++ b/src/erlab/interactive/_code_trust/_api.py
@@ -99,16 +99,42 @@ def relocate_document_trust(
     )
 
 
-def manifest_review_text(manifest: CodeTrustManifest) -> str:
-    """Return plain text for review of all executable manifest entries."""
-    blocks: list[str] = []
+def _group_manifest_review_entries(
+    manifest: CodeTrustManifest,
+) -> tuple[tuple[CodeTrustEntry, tuple[str, ...]], ...]:
+    """Group equal execution content while retaining its document locations."""
+    representatives: dict[bytes, CodeTrustEntry] = {}
+    locations: dict[bytes, list[str]] = {}
     for entry in manifest.entries:
-        block = f"[{entry.feature} — {entry.location}]\n{entry.code}"
+        identity = entry.execution_identity()
+        representatives.setdefault(identity, entry)
+        locations.setdefault(identity, []).append(entry.location)
+    return tuple(
+        (entry, tuple(locations[identity]))
+        for identity, entry in representatives.items()
+    )
+
+
+def manifest_review_text(manifest: CodeTrustManifest) -> str:
+    """Return compact plain text for review of executable manifest entries."""
+    blocks: list[str] = []
+    for entry, locations in _group_manifest_review_entries(manifest):
+        location_label = (
+            locations[0] if len(locations) == 1 else f"{len(locations)} locations"
+        )
+        block = f"[{entry.feature} — {location_label}]\n{entry.code}"
         if entry.context:
             context = json.dumps(
                 entry.payload()["context"], ensure_ascii=False, sort_keys=True, indent=2
             )
             block = f"{block}\nExecution context:\n{context}"
+        if len(locations) > 1:
+            shown_locations = locations[:10]
+            location_text = "\n".join(f"- {location}" for location in shown_locations)
+            remaining = len(locations) - len(shown_locations)
+            if remaining:
+                location_text = f"{location_text}\n- and {remaining} more"
+            block = f"{block}\nLocations:\n{location_text}"
         blocks.append(block)
     return "\n\n".join(blocks)
 

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -27,6 +27,7 @@ from erlab.interactive._code_trust import execution_capability_allows
 from erlab.interactive._fit_code_trust import (
     lmfit_expression_model_code_entries,
     lmfit_model_code_entry,
+    lmfit_model_safe_parameter_expressions,
     lmfit_parameter_expression_entries,
     lmfit_result_code_entry,
 )
@@ -991,7 +992,14 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             model_state[1],
             feature=cls._MODEL_CODE_TRUST_FEATURE,
             location="model",
+            model_reference=model_state[0],
         )
+
+    @staticmethod
+    def _safe_model_parameter_expressions(
+        model_state: tuple[str, str],
+    ) -> dict[str, str]:
+        return lmfit_model_safe_parameter_expressions(model_state[1], model_state[0])
 
     @classmethod
     def _parameter_code_trust_entries(
@@ -999,11 +1007,13 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         expressions: Iterable[tuple[typing.Any, typing.Any]],
         *,
         location_prefix: str,
+        safe_expressions: Mapping[str, str] | None = None,
     ) -> tuple[typing.Any, ...]:
         return lmfit_parameter_expression_entries(
             expressions,
             feature=cls._PARAMETER_CODE_TRUST_FEATURE,
             location_prefix=location_prefix,
+            safe_expressions=safe_expressions,
         )
 
     @classmethod
@@ -1022,12 +1032,14 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 (f"initial-parameters-full/{index}", params or ())
                 for index, params in enumerate(status.state2d.initial_params_full or ())
             )
+        safe_expressions = cls._safe_model_parameter_expressions(status.model_state)
         entries = [
             entry
             for location, params in parameter_groups
             for entry in cls._parameter_code_trust_entries(
                 ((state[0], state[3]) for state in params if len(state) >= 4),
                 location_prefix=location,
+                safe_expressions=safe_expressions,
             )
         ]
         model_entry = cls._model_code_trust_entry(status.model_state)
@@ -1413,6 +1425,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         if model_entry is not None:
             entries.append(model_entry)
         edited_locations = self._parameter_expression_edit_locations()
+        safe_expressions = self._safe_model_parameter_expressions(
+            self._serialized_model_state
+        )
         for location, params in self._fit_parameter_groups():
             if (
                 parameter_group_overrides is not None
@@ -1436,6 +1451,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 type(self)._parameter_code_trust_entries(
                     expressions,
                     location_prefix=location,
+                    safe_expressions=safe_expressions,
                 )
             )
         return tuple(entries)

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -2391,6 +2391,9 @@ class Fit2DTool(Fit1DTool):
         candidate_entries = self._fit_code_entries_with_params_full(
             candidate_params_full
         )
+        safe_expressions = self._safe_model_parameter_expressions(
+            self._serialized_model_state
+        )
         evaluation_entries = (
             *(
                 entry
@@ -2400,6 +2403,7 @@ class Fit2DTool(Fit1DTool):
             *self._parameter_code_trust_entries(
                 self._live_parameter_expressions(params),
                 location_prefix="evaluation",
+                safe_expressions=safe_expressions,
             ),
         )
         code_changed = candidate_entries != self._fit_code_entries
@@ -2483,6 +2487,9 @@ class Fit2DTool(Fit1DTool):
             else [self._initial_params] * len(self._params_full)
         )
         candidate_entries = self._fit_code_entries_with_params_full(source_params_full)
+        safe_expressions = self._safe_model_parameter_expressions(
+            self._serialized_model_state
+        )
         evaluation_entries = (
             *(
                 entry
@@ -2495,6 +2502,7 @@ class Fit2DTool(Fit1DTool):
                 for entry in self._parameter_code_trust_entries(
                     self._live_parameter_expressions(params),
                     location_prefix=f"evaluation/{index}",
+                    safe_expressions=safe_expressions,
                 )
             ),
         )

--- a/src/erlab/interactive/_fit_code_trust.py
+++ b/src/erlab/interactive/_fit_code_trust.py
@@ -130,21 +130,23 @@ def _pickle_scalar_after_key(payload: str, key: str) -> int | bool | None:
     """Read one primitive pickle state value without constructing any objects."""
     try:
         operations = pickletools.genops(base64.b64decode(payload, validate=True))
+        key_found = False
         for operation, argument, _position in operations:
-            if operation.name not in {"SHORT_BINUNICODE", "BINUNICODE"}:
+            if not key_found:
+                key_found = (
+                    operation.name in {"SHORT_BINUNICODE", "BINUNICODE"}
+                    and argument == key
+                )
                 continue
-            if argument != key:
+            if operation.name == "MEMOIZE":
                 continue
-            for value_operation, value_argument, _position in operations:
-                if value_operation.name == "MEMOIZE":
-                    continue
-                if value_operation.name == "NEWTRUE":
-                    return True
-                if value_operation.name == "NEWFALSE":
-                    return False
-                if value_operation.name in {"BININT", "BININT1", "BININT2"}:
-                    return typing.cast("int", value_argument)
-                return None
+            if operation.name == "NEWTRUE":
+                return True
+            if operation.name == "NEWFALSE":
+                return False
+            if operation.name in {"BININT", "BININT1", "BININT2"}:
+                return typing.cast("int", argument)
+            return None
     except (TypeError, ValueError):
         return None
     return None
@@ -420,7 +422,7 @@ def _payload_model_match(
     if key is None:
         key = (serialized_item, model_reference)
         cached = memo.get(key)
-        if cached is not None and item == cached[0]:
+        if cached is not None:
             return cached[1]
     match = _known_model_match(serialized_item, model_reference)
     if match is None:
@@ -532,8 +534,7 @@ def _executable_details(
                 )
             )
             continue
-        if item is None:
-            continue
+        item = typing.cast("dict[str, typing.Any]", item)
         if item.get("__class__") == "Callable":
             importer = item.get("importer")
             name = item.get("__name__")

--- a/src/erlab/interactive/_fit_code_trust.py
+++ b/src/erlab/interactive/_fit_code_trust.py
@@ -2,24 +2,35 @@
 
 These helpers inspect JSON and NetCDF text. They never import a module named by a
 document and never deserialize a saved callable. Callables that resolve to exact,
-locally known library symbols produce no trust entry. Unknown callables,
+locally known library symbols and embedded models that exactly match a model produced
+by the installed ERLab library produce no trust entry. Unknown callables,
 ``ExpressionModel`` code, init scripts, and saved parameter expressions produce an
 entry for the shared authorization policy.
 """
 
 from __future__ import annotations
 
+import base64
 import functools
 import hashlib
 import io
 import json
+import pickletools
+import re
 import typing
 import urllib.parse
 
 from erlab.interactive._code_trust import create_entry, create_payload_entry
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Iterable, Iterator, Mapping
+
+
+_ModelExpressions = tuple[tuple[str, str], ...]
+_ModelMatch = tuple[str, _ModelExpressions]
+_ModelMatchKey = tuple[str, str | None]
+_ModelMatchMemo = dict[_ModelMatchKey, tuple[dict[str, typing.Any], _ModelMatch | None]]
+_SerializedItem = tuple[str, dict[str, typing.Any] | None, str | None]
 
 
 def _detail(
@@ -30,10 +41,10 @@ def _detail(
 
 def _walk_serialized(
     value: typing.Any, path: str = "root"
-) -> Iterator[tuple[str, typing.Any, str | None]]:
-    """Yield parsed lmfit values and malformed nested parameter strings."""
-    yield path, value, None
+) -> Iterator[_SerializedItem]:
+    """Yield lmfit dictionaries and malformed nested parameter strings."""
     if isinstance(value, dict):
+        yield path, value, None
         if value.get("__class__") == "Callable":
             return
         for key in sorted(value):
@@ -67,6 +78,405 @@ def _callable_references(value: typing.Any) -> set[tuple[str, str]]:
     return references
 
 
+def _wrapped_list(value: typing.Any) -> list[typing.Any] | None:
+    if (
+        isinstance(value, dict)
+        and value.get("__class__") == "List"
+        and isinstance(value.get("value"), list)
+    ):
+        return value["value"]
+    return None
+
+
+def _serialized_model_dict(model: typing.Any) -> dict[str, typing.Any] | None:
+    """Return the first serialized lmfit model dictionary produced locally."""
+    try:
+        value = json.loads(model.dumps())
+    except (AttributeError, TypeError, ValueError):
+        return None
+    for _path, item, malformed in _walk_serialized(value):
+        if (
+            malformed is None
+            and isinstance(item, dict)
+            and isinstance(item.get("funcname"), str)
+            and isinstance(item.get("funcdef"), dict)
+            and "param_hints" in item
+        ):
+            return item
+    return None
+
+
+def _model_reference(model: typing.Any) -> str:
+    model_class = type(model)
+    return f"{model_class.__module__}:{model_class.__qualname__}"
+
+
+def _common_model_kwargs(
+    item: dict[str, typing.Any],
+) -> dict[str, typing.Any] | None:
+    name = item.get("name")
+    prefix = item.get("prefix")
+    nan_policy = item.get("nan_policy")
+    if (
+        not isinstance(name, str)
+        or not isinstance(prefix, str)
+        or nan_policy not in {"raise", "propagate", "omit"}
+    ):
+        return None
+    return {"name": name, "prefix": prefix, "nan_policy": nan_policy}
+
+
+def _pickle_scalar_after_key(payload: str, key: str) -> int | bool | None:
+    """Read one primitive pickle state value without constructing any objects."""
+    try:
+        operations = pickletools.genops(base64.b64decode(payload, validate=True))
+        for operation, argument, _position in operations:
+            if operation.name not in {"SHORT_BINUNICODE", "BINUNICODE"}:
+                continue
+            if argument != key:
+                continue
+            for value_operation, value_argument, _position in operations:
+                if value_operation.name == "MEMOIZE":
+                    continue
+                if value_operation.name == "NEWTRUE":
+                    return True
+                if value_operation.name == "NEWFALSE":
+                    return False
+                if value_operation.name in {"BININT", "BININT1", "BININT2"}:
+                    return typing.cast("int", value_argument)
+                return None
+    except (TypeError, ValueError):
+        return None
+    return None
+
+
+def _multipeak_candidate_options(
+    item: dict[str, typing.Any],
+) -> tuple[int, list[str], bool, str, int, bool, int, bool] | None:
+    """Infer bounded declarative options without decoding the callable payload."""
+    raw_names = _wrapped_list(item.get("param_root_names"))
+    hints = item.get("param_hints")
+    funcdef = item.get("funcdef")
+    if (
+        raw_names is None
+        or not isinstance(hints, dict)
+        or not isinstance(funcdef, dict)
+        or not isinstance((callable_payload := funcdef.get("value")), str)
+    ):
+        return None
+    if not all(isinstance(name, str) for name in raw_names):
+        return None
+    names = typing.cast("list[str]", raw_names)
+    name_set = set(names)
+    peak_indices = {
+        int(match.group(1))
+        for name in names
+        if (match := re.fullmatch(r"p(\d+)_.*", name)) is not None
+    }
+    if not peak_indices:
+        return None
+    npeaks = max(peak_indices) + 1
+    if npeaks > 20 or peak_indices != set(range(npeaks)):
+        return None
+
+    peak_shapes: list[str] = []
+    for index in range(npeaks):
+        label = f"p{index}_"
+        roots = {name.removeprefix(label) for name in names if name.startswith(label)}
+        if {"sigma", "gamma", "amplitude"}.issubset(roots):
+            peak_shapes.append("voigt")
+        elif {f"{label}gamma", f"{label}amplitude"}.issubset(hints):
+            peak_shapes.append("lorentzian")
+        elif {f"{label}sigma", f"{label}amplitude"}.issubset(hints):
+            peak_shapes.append("gaussian")
+        else:
+            return None
+
+    fd_names = {"efermi", "temp", "offset"}
+    if name_set.intersection(fd_names) not in (set(), fd_names):
+        return None
+    fd = fd_names.issubset(name_set)
+    convolve = "resolution" in name_set
+    oversample = _pickle_scalar_after_key(callable_payload, "oversample")
+    segmented = _pickle_scalar_after_key(callable_payload, "segmented")
+    if (
+        type(oversample) is not int
+        or not 1 <= oversample <= 64
+        or type(segmented) is not bool
+    ):
+        return None
+
+    if any(re.fullmatch(r"k_step_\d+", name) for name in names):
+        background = "shirley"
+        degree = 2
+    else:
+        coefficients = [
+            int(match.group(1))
+            for name in names
+            if (match := re.fullmatch(r"c(\d+)", name)) is not None
+        ]
+        if coefficients:
+            if set(coefficients) != set(range(max(coefficients) + 1)):
+                return None
+            background = "polynomial"
+            degree = max(coefficients)
+            if degree > 10:
+                return None
+        elif {"const_bkg", "lin_bkg"}.issubset(name_set):
+            background = "linear"
+            degree = 2
+        elif "const_bkg" in name_set:
+            background = "constant"
+            degree = 2
+        else:
+            background = "none"
+            degree = 2
+    return (
+        npeaks,
+        peak_shapes,
+        fd,
+        background,
+        degree,
+        convolve,
+        oversample,
+        segmented,
+    )
+
+
+def _known_model_candidates(item: dict[str, typing.Any]) -> Iterator[typing.Any]:
+    """Yield bounded local models that could have produced one saved dictionary."""
+    import erlab.analysis.fit.models
+
+    common = _common_model_kwargs(item)
+    funcname = item.get("funcname")
+    if common is None or not isinstance(funcname, str):
+        return
+    if funcname == "MultiPeakFunction":
+        options = _multipeak_candidate_options(item)
+        if options is None:
+            return
+        (
+            npeaks,
+            peak_shapes,
+            fd,
+            background,
+            degree,
+            convolve,
+            oversample,
+            segmented,
+        ) = options
+        yield erlab.analysis.fit.models.MultiPeakModel(
+            npeaks=npeaks,
+            peak_shapes=peak_shapes,
+            fd=fd,
+            background=typing.cast("typing.Any", background),
+            degree=degree,
+            convolve=convolve,
+            oversample=oversample,
+            segmented=segmented,
+            **common,
+        )
+        return
+    if funcname == "PolynomialFunction":
+        names = _wrapped_list(item.get("param_root_names"))
+        if names is None:
+            return
+        coefficients = [
+            int(match.group(1))
+            for name in names
+            if isinstance(name, str)
+            and (match := re.fullmatch(r"c(\d+)", name)) is not None
+        ]
+        if not coefficients or set(coefficients) != set(range(max(coefficients) + 1)):
+            return
+        degree = max(coefficients)
+        if degree <= 20:
+            yield erlab.analysis.fit.models.PolynomialModel(degree=degree, **common)
+        return
+    if funcname == "FermiEdge2dFunction":
+        names = _wrapped_list(item.get("param_root_names"))
+        if names is None:
+            return
+        coefficients = [
+            int(match.group(1))
+            for name in names
+            if isinstance(name, str)
+            and (match := re.fullmatch(r"c(\d+)", name)) is not None
+        ]
+        if coefficients and set(coefficients) == set(range(max(coefficients) + 1)):
+            degree = max(coefficients)
+            if degree <= 20:
+                yield erlab.analysis.fit.models.FermiEdge2dModel(
+                    degree=degree, **common
+                )
+        return
+    simple_models = {
+        "_broadFermiDirac": erlab.analysis.fit.models.FermiDiracModel,
+        "_lin_broad_fd": erlab.analysis.fit.models.FermiEdgeModel,
+        "_step_linbkg_broad": erlab.analysis.fit.models.StepEdgeModel,
+    }
+    if (model_class := simple_models.get(funcname)) is not None:
+        yield model_class(**common)
+
+
+def _compute_known_model_match(
+    serialized_item: str,
+    model_reference: str | None,
+) -> _ModelMatch | None:
+    """Match exact embedded bytes against a model generated by local library code."""
+    try:
+        item = json.loads(serialized_item)
+    except ValueError:
+        return None
+    if not isinstance(item, dict):
+        return None
+    for _attempt in range(2):
+        try:
+            candidates = _known_model_candidates(item)
+            for model in candidates:
+                reference = _model_reference(model)
+                if model_reference is not None and reference != model_reference:
+                    continue
+                local_items = [_serialized_model_dict(model)]
+                if item.get("funcname") == "MultiPeakFunction":
+                    # Evaluation materializes this local cached property. It contains
+                    # only information derived from the installed peak functions.
+                    _peak_argnames = model.func.peak_argnames
+                    local_items.append(_serialized_model_dict(model))
+                if item not in local_items:
+                    continue
+                expressions = tuple(
+                    (str(name), expression)
+                    for name, param in model.make_params().items()
+                    if isinstance((expression := param._expr), str)
+                    and expression.strip()
+                )
+                return reference, expressions
+        except Exception:
+            return None
+        # lmfit serialization can materialize benign callable cache state on the
+        # first local comparison. Rebuild the candidates once before failing closed.
+    return None
+
+
+class _NoKnownModelMatch(Exception):
+    """Prevent transient failed local comparisons from entering the cache."""
+
+
+@functools.lru_cache(maxsize=256)
+def _cached_known_model_match(
+    serialized_item: str,
+    model_reference: str | None,
+) -> _ModelMatch:
+    match = _compute_known_model_match(serialized_item, model_reference)
+    if match is None:
+        raise _NoKnownModelMatch
+    return match
+
+
+def _known_model_match(
+    serialized_item: str,
+    model_reference: str | None,
+) -> _ModelMatch | None:
+    try:
+        return _cached_known_model_match(serialized_item, model_reference)
+    except _NoKnownModelMatch:
+        return None
+
+
+def _payload_model_match(
+    item: dict[str, typing.Any],
+    model_reference: str | None,
+    memo: _ModelMatchMemo,
+) -> _ModelMatch | None:
+    """Reuse an exact match only within one serialized result payload."""
+    function_definition = item.get("funcdef")
+    callable_payload = (
+        function_definition.get("value")
+        if isinstance(function_definition, dict)
+        else None
+    )
+    key = (
+        (callable_payload, model_reference)
+        if isinstance(callable_payload, str)
+        else None
+    )
+    if key is not None:
+        cached = memo.get(key)
+        if cached is not None and item == cached[0]:
+            return cached[1]
+    else:
+        cached = None
+    try:
+        serialized_item = json.dumps(
+            item,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError):
+        return None
+    if key is None:
+        key = (serialized_item, model_reference)
+        cached = memo.get(key)
+        if cached is not None and item == cached[0]:
+            return cached[1]
+    match = _known_model_match(serialized_item, model_reference)
+    if match is None:
+        match = _known_model_match(serialized_item, model_reference)
+    if cached is None:
+        memo[key] = (item, match)
+    return match
+
+
+def _safe_model_matches(
+    value: typing.Any,
+    model_reference: str | None = None,
+    path: str = "root",
+    *,
+    model_match_memo: _ModelMatchMemo | None = None,
+    serialized_items: Iterable[_SerializedItem] | None = None,
+) -> tuple[dict[str, _ModelExpressions], frozenset[tuple[str, str]]]:
+    matches: dict[str, _ModelExpressions] = {}
+    expressions: set[tuple[str, str]] = set()
+    if serialized_items is None:
+        serialized_items = _walk_serialized(value, path)
+    for item_path, item, malformed in serialized_items:
+        if (
+            malformed is not None
+            or item is None
+            or not isinstance(item.get("funcname"), str)
+            or not isinstance(item.get("funcdef"), dict)
+            or "param_hints" not in item
+        ):
+            continue
+        if model_match_memo is None:
+            try:
+                serialized_item = json.dumps(
+                    item,
+                    ensure_ascii=False,
+                    allow_nan=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            except (TypeError, ValueError):
+                continue
+            match = _known_model_match(serialized_item, model_reference)
+        else:
+            match = _payload_model_match(
+                item,
+                model_reference,
+                model_match_memo,
+            )
+        if match is None:
+            continue
+        _reference, model_expressions = match
+        matches[item_path] = model_expressions
+        expressions.update(model_expressions)
+    return matches, frozenset(expressions)
+
+
 @functools.cache
 def _safe_library_callable_references() -> frozenset[tuple[str, str]]:
     """Return exact importable callable references emitted by local lmfit."""
@@ -91,10 +501,27 @@ def _safe_library_callable_references() -> frozenset[tuple[str, str]]:
 
 
 def _executable_details(
-    value: typing.Any, path: str = "root"
+    value: typing.Any,
+    path: str = "root",
+    *,
+    model_reference: str | None = None,
+    model_match_memo: _ModelMatchMemo | None = None,
 ) -> list[dict[str, typing.Any]]:
     details: list[dict[str, typing.Any]] = []
-    for item_path, item, malformed in _walk_serialized(value, path):
+    serialized_items = tuple(_walk_serialized(value, path))
+    safe_models, safe_parameter_expressions = _safe_model_matches(
+        value,
+        model_reference,
+        path,
+        model_match_memo=model_match_memo,
+        serialized_items=serialized_items,
+    )
+    for item_path, item, malformed in serialized_items:
+        if any(
+            item_path == safe_path or item_path.startswith(f"{safe_path}/")
+            for safe_path in safe_models
+        ):
+            continue
         if malformed is not None:
             details.append(
                 _detail(
@@ -105,7 +532,7 @@ def _executable_details(
                 )
             )
             continue
-        if not isinstance(item, dict):
+        if item is None:
             continue
         if item.get("__class__") == "Callable":
             importer = item.get("importer")
@@ -151,6 +578,7 @@ def _executable_details(
                     and len(state) >= 4
                     and isinstance(state[3], str)
                     and state[3].strip()
+                    and (str(state[0]), state[3]) not in safe_parameter_expressions
                 ):
                     details.append(
                         _detail(
@@ -163,7 +591,11 @@ def _executable_details(
 
 
 def _serialized_lmfit_details(
-    serialized: str, path: str = "root"
+    serialized: str,
+    path: str = "root",
+    *,
+    model_reference: str | None = None,
+    model_match_memo: _ModelMatchMemo | None = None,
 ) -> list[dict[str, typing.Any]]:
     try:
         value = json.loads(serialized)
@@ -176,7 +608,27 @@ def _serialized_lmfit_details(
                 serialized_sha256=hashlib.sha256(serialized.encode()).hexdigest(),
             )
         ]
-    return _executable_details(value, path)
+    return _executable_details(
+        value,
+        path,
+        model_reference=model_reference,
+        model_match_memo=model_match_memo,
+    )
+
+
+def lmfit_model_safe_parameter_expressions(
+    serialized_model: str,
+    model_reference: str,
+) -> dict[str, str]:
+    """Return model hints only for an exact model generated by local library code."""
+    try:
+        value = json.loads(serialized_model)
+    except ValueError:
+        return {}
+    matches, expressions = _safe_model_matches(value, model_reference)
+    if len(matches) != 1:
+        return {}
+    return dict(expressions)
 
 
 def _entry(
@@ -235,10 +687,13 @@ def lmfit_model_code_entry(
     *,
     feature: str,
     location: str,
+    model_reference: str | None = None,
 ):
     """Return an entry only when a serialized model can run non-library code."""
     details = (
-        _canonical_model_details(_serialized_lmfit_details(serialized_model))
+        _canonical_model_details(
+            _serialized_lmfit_details(serialized_model, model_reference=model_reference)
+        )
         if serialized_model
         else []
     )
@@ -284,6 +739,7 @@ def lmfit_parameter_expression_entries(
     *,
     feature: str,
     location_prefix: str,
+    safe_expressions: Mapping[str, str] | None = None,
 ):
     """Return entries for saved ``(parameter name, expression)`` pairs."""
     if expressions is None:
@@ -296,7 +752,9 @@ def lmfit_parameter_expression_entries(
             {"parameter": name},
         )
         for name, expression in expressions
-        if isinstance(expression, str) and expression.strip()
+        if isinstance(expression, str)
+        and expression.strip()
+        and (safe_expressions is None or safe_expressions.get(str(name)) != expression)
     )
 
 
@@ -312,6 +770,7 @@ def lmfit_result_code_entry(
 
     details: list[dict[str, typing.Any]] = []
     invalid = False
+    model_match_memo: _ModelMatchMemo = {}
     try:
         with xr.open_dataset(io.BytesIO(payload), engine="h5netcdf") as dataset:
             result_names = sorted(
@@ -337,6 +796,7 @@ def lmfit_result_code_entry(
                         _serialized_lmfit_details(
                             serialized,
                             path=f"{name}/{index}/root",
+                            model_match_memo=model_match_memo,
                         )
                     )
     except Exception:

--- a/tests/interactive/imagetool/manager/workspace/test_trust.py
+++ b/tests/interactive/imagetool/manager/workspace/test_trust.py
@@ -6,6 +6,7 @@ import sys
 import typing
 from types import SimpleNamespace
 
+import lmfit
 import numpy as np
 import pydantic
 import pytest
@@ -484,7 +485,10 @@ def test_workspace_manifest_includes_serialized_fit_callables(qtbot) -> None:
     from erlab.interactive._fit1d import Fit1DTool
 
     data = xr.DataArray(np.arange(3.0), dims="x", name="data")
-    tool = Fit1DTool(data)
+    model = lmfit.Model(lambda x, slope=1.0, intercept=0.0: slope * x + intercept)
+    params = model.make_params()
+    params["intercept"].expr = "2 * slope"
+    tool = Fit1DTool(data, model=model, params=params)
     qtbot.addWidget(tool)
     tool._serialized_fit_result_blob = np.arange(8, dtype=np.uint8)
     tool._pending_persisted_fit_is_current = False
@@ -517,7 +521,7 @@ def test_signed_workspace_rejects_payload_metadata_added_outside_manifest(
 
     with manager_context() as manager:
         manager.add_imagetool(ImageTool(data), show=False)
-        fit_tool = Fit1DTool(data)
+        fit_tool = Fit1DTool(data, model=lmfit.Model(lambda x: x))
         qtbot.addWidget(fit_tool)
         fit_uid = add_source_childtool(manager, fit_tool, 0, show=False)
         fit_tool.hide()

--- a/tests/interactive/imagetool/test_provenance.py
+++ b/tests/interactive/imagetool/test_provenance.py
@@ -3693,9 +3693,8 @@ def test_tool_provenance_roundtrip_correct_with_edge_fit_dataset(
         reparsed_operation,
         location_prefix="operation",
     )
-    with pytest.raises(PermissionError, match="not authorized"):
-        _ = reparsed_operation.decoded_edge_fit
-    decoded = reparsed_operation._decode_edge_fit(_authorize_execution(entries))
+    assert entries == ()
+    decoded = reparsed_operation.decoded_edge_fit
     xr.testing.assert_identical(
         decoded.drop_vars("modelfit_results"),
         gold_fit_res.drop_vars("modelfit_results"),
@@ -3709,7 +3708,7 @@ def test_tool_provenance_roundtrip_correct_with_edge_fit_dataset(
     assert reparsed_spec is not None
     assert reparsed_spec.derivation_code() is None
     xr.testing.assert_allclose(
-        reparsed_spec.apply(gold, authorization=_authorize_execution(entries)),
+        reparsed_spec.apply(gold),
         erlab.analysis.gold.correct_with_edge(gold, gold_fit_res, shift_coords=False),
     )
 

--- a/tests/interactive/test_code_trust.py
+++ b/tests/interactive/test_code_trust.py
@@ -222,6 +222,23 @@ def test_manifest_review_groups_equal_code_across_locations() -> None:
     assert manifest.canonical_bytes() == identity
 
 
+def test_manifest_review_lists_each_location_for_small_groups() -> None:
+    entries = tuple(
+        code_trust.create_entry(
+            "test.repeated-code",
+            f"operations/{index}",
+            "run()",
+        )
+        for index in range(2)
+    )
+
+    review = code_trust.manifest_review_text(
+        code_trust.create_manifest("test.review", 1, entries)
+    )
+
+    assert all(entry.location in review for entry in entries)
+
+
 @pytest.mark.parametrize("approve", [False, True])
 def test_code_trust_review_dialog_returns_selected_action(
     qtbot, monkeypatch: pytest.MonkeyPatch, approve: bool

--- a/tests/interactive/test_code_trust.py
+++ b/tests/interactive/test_code_trust.py
@@ -24,7 +24,10 @@ from erlab.interactive._code_trust import (
     trusted_location_document_trust,
     untrusted_document_trust,
 )
-from erlab.interactive._code_trust._api import _document_trust_after_save
+from erlab.interactive._code_trust._api import (
+    _document_trust_after_save,
+    _group_manifest_review_entries,
+)
 from erlab.interactive._code_trust._core import CodeTrustEntry, CodeTrustManifest
 from erlab.interactive._code_trust._locations import (
     document_path_is_trusted,
@@ -184,6 +187,39 @@ def test_manifest_review_includes_signed_execution_context() -> None:
 
     assert manifest.entries[0].code in review
     assert serialized_context in review
+
+
+def test_manifest_review_groups_equal_code_across_locations() -> None:
+    repeated = tuple(
+        code_trust.create_entry(
+            "erlab.fit.parameter-expression",
+            f"parameters-full/{index}/p1_sigma",
+            "p0_sigma",
+            {"parameter": "p1_sigma"},
+        )
+        for index in range(233)
+    )
+    different_context = code_trust.create_entry(
+        "erlab.fit.parameter-expression",
+        "parameters/p0_sigma",
+        "p0_sigma",
+        {"parameter": "p0_sigma"},
+    )
+    manifest = code_trust.create_manifest(
+        "test.review", 1, (*repeated, different_context)
+    )
+    identity = manifest.canonical_bytes()
+
+    groups = _group_manifest_review_entries(manifest)
+    review = code_trust.manifest_review_text(manifest)
+
+    assert len(groups) == 2
+    assert len(groups[0][1]) == 233
+    assert groups[1][1] == ("parameters/p0_sigma",)
+    assert "233 locations" in review
+    assert "and 223 more" in review
+    assert review.count("\np0_sigma\n") == 2
+    assert manifest.canonical_bytes() == identity
 
 
 @pytest.mark.parametrize("approve", [False, True])

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -1,6 +1,8 @@
+import base64
 import contextlib
 import gc
 import json
+import pickle
 
 import lmfit
 import numpy as np
@@ -832,9 +834,42 @@ def test_fit1d_saved_model_class_does_not_import_document_target(
             id="erlab-embedded-multipeak-options",
         ),
         pytest.param(
+            erlab.analysis.fit.models.MultiPeakModel(
+                fd=False,
+                background="shirley",
+                convolve=False,
+            ),
+            None,
+            id="erlab-embedded-multipeak-shirley",
+        ),
+        pytest.param(
+            erlab.analysis.fit.models.MultiPeakModel(
+                fd=False,
+                background="constant",
+                convolve=False,
+            ),
+            None,
+            id="erlab-embedded-multipeak-constant",
+        ),
+        pytest.param(
+            erlab.analysis.fit.models.MultiPeakModel(
+                fd=False,
+                background="polynomial",
+                degree=3,
+                convolve=False,
+            ),
+            None,
+            id="erlab-embedded-multipeak-polynomial",
+        ),
+        pytest.param(
             erlab.analysis.fit.models.PolynomialModel(),
             None,
             id="erlab-embedded-polynomial",
+        ),
+        pytest.param(
+            erlab.analysis.fit.models.FermiEdge2dModel(),
+            None,
+            id="erlab-embedded-fermi-edge-2d",
         ),
         pytest.param(
             erlab.analysis.fit.models.StepEdgeModel(),
@@ -904,6 +939,231 @@ def test_lmfit_code_trust_rejects_modified_embedded_library_model() -> None:
     assert wrong_reference_entry is not None
     assert "serialized-callable" in entry.code
     assert "serialized-callable" in wrong_reference_entry.code
+
+
+def test_lmfit_code_trust_serialized_helper_guards() -> None:
+    class EmptySerializedModel:
+        def dumps(self) -> str:
+            return "{}"
+
+    assert fit_code_trust._wrapped_list({"__class__": "List", "value": ()}) is None
+    assert fit_code_trust._serialized_model_dict(object()) is None
+    assert fit_code_trust._serialized_model_dict(EmptySerializedModel()) is None
+    assert fit_code_trust._common_model_kwargs({}) is None
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"oversample": None},
+        {"other": 3},
+    ],
+)
+def test_lmfit_code_trust_rejects_non_scalar_pickle_state(
+    state: dict[str, object],
+) -> None:
+    payload = base64.b64encode(pickle.dumps(state)).decode()
+
+    assert fit_code_trust._pickle_scalar_after_key(payload, "oversample") is None
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "non-string-callable",
+        "non-string-name",
+        "no-peaks",
+        "non-contiguous-peaks",
+        "unknown-shape",
+        "partial-fermi-dirac",
+        "non-contiguous-polynomial",
+        "high-degree-polynomial",
+    ],
+)
+def test_lmfit_code_trust_rejects_invalid_multipeak_options(case: str) -> None:
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        1,
+        "voigt",
+        fd=False,
+        background="none",
+        convolve=False,
+    )
+    item = json.loads(model.dumps())["value"][0]
+    names = item["param_root_names"]["value"]
+
+    if case == "non-string-callable":
+        item["funcdef"]["value"] = 1
+    elif case == "non-string-name":
+        names.append(1)
+    elif case == "no-peaks":
+        names.clear()
+    elif case == "non-contiguous-peaks":
+        names[:] = [name.replace("p0_", "p1_") for name in names]
+    elif case == "unknown-shape":
+        names[:] = ["p0_center"]
+        item["param_hints"].clear()
+    elif case == "partial-fermi-dirac":
+        names.append("temp")
+    elif case == "non-contiguous-polynomial":
+        names.append("c1")
+    elif case == "high-degree-polynomial":
+        names.extend(f"c{index}" for index in range(12))
+
+    assert fit_code_trust._multipeak_candidate_options(item) is None
+
+
+def test_lmfit_code_trust_known_model_candidate_guards() -> None:
+    common = {"name": "model", "prefix": "", "nan_policy": "raise"}
+    wrapped = {"__class__": "List", "value": ["c0", "c1"]}
+
+    assert not list(
+        fit_code_trust._known_model_candidates({"funcname": "PolynomialFunction"})
+    )
+    assert not list(
+        fit_code_trust._known_model_candidates(
+            {**common, "funcname": "PolynomialFunction"}
+        )
+    )
+    assert not list(
+        fit_code_trust._known_model_candidates(
+            {
+                **common,
+                "funcname": "PolynomialFunction",
+                "param_root_names": {
+                    "__class__": "List",
+                    "value": ["c0", "c2"],
+                },
+            }
+        )
+    )
+    assert not list(
+        fit_code_trust._known_model_candidates(
+            {
+                **common,
+                "funcname": "PolynomialFunction",
+                "param_root_names": {
+                    "__class__": "List",
+                    "value": [f"c{index}" for index in range(22)],
+                },
+            }
+        )
+    )
+    assert not list(
+        fit_code_trust._known_model_candidates(
+            {**common, "funcname": "FermiEdge2dFunction"}
+        )
+    )
+    assert not list(
+        fit_code_trust._known_model_candidates(
+            {
+                **common,
+                "funcname": "FermiEdge2dFunction",
+                "param_root_names": {"__class__": "List", "value": []},
+            }
+        )
+    )
+    assert not list(
+        fit_code_trust._known_model_candidates(
+            {
+                **common,
+                "funcname": "FermiEdge2dFunction",
+                "param_root_names": {
+                    "__class__": "List",
+                    "value": [f"c{index}" for index in range(22)],
+                },
+            }
+        )
+    )
+    candidates = list(
+        fit_code_trust._known_model_candidates(
+            {
+                **common,
+                "funcname": "FermiEdge2dFunction",
+                "param_root_names": wrapped,
+            }
+        )
+    )
+
+    assert len(candidates) == 1
+    assert isinstance(candidates[0], erlab.analysis.fit.models.FermiEdge2dModel)
+
+
+@pytest.mark.parametrize("serialized", ["{", "[]"])
+def test_lmfit_code_trust_known_model_match_rejects_invalid_json(
+    serialized: str,
+) -> None:
+    assert fit_code_trust._compute_known_model_match(serialized, None) is None
+
+
+def test_lmfit_code_trust_known_model_match_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_candidate_error(_item: dict[str, object]):
+        raise RuntimeError("candidate construction failed")
+
+    monkeypatch.setattr(
+        fit_code_trust, "_known_model_candidates", raise_candidate_error
+    )
+
+    assert fit_code_trust._compute_known_model_match("{}", None) is None
+
+
+def test_lmfit_code_trust_payload_match_uses_serialized_memo_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    item = {"funcdef": {}}
+    serialized_item = json.dumps(
+        item,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    match = ("test:Model", ())
+    memo = {(serialized_item, None): (item, match)}
+
+    def unexpected_match(*_args):
+        pytest.fail("The exact payload memo entry was not used")
+
+    monkeypatch.setattr(fit_code_trust, "_known_model_match", unexpected_match)
+
+    assert fit_code_trust._payload_model_match(item, None, memo) == match
+
+
+def test_lmfit_code_trust_payload_match_stores_serialized_memo_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    item = {"funcdef": {}}
+    serialized_item = json.dumps(
+        item,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    match = ("test:Model", ())
+    memo = {}
+
+    monkeypatch.setattr(fit_code_trust, "_known_model_match", lambda *_args: match)
+
+    assert fit_code_trust._payload_model_match(item, None, memo) == match
+    assert memo == {(serialized_item, None): (item, match)}
+
+
+def test_lmfit_code_trust_rejects_non_json_model_items() -> None:
+    payload_item = {"funcdef": {"value": "callable"}, "bad": float("nan")}
+    serialized_item = {
+        "funcname": "CustomFunction",
+        "funcdef": {},
+        "param_hints": {},
+        "bad": float("nan"),
+    }
+
+    assert fit_code_trust._payload_model_match(payload_item, None, {}) is None
+    assert fit_code_trust._safe_model_matches(
+        None,
+        serialized_items=(("root", serialized_item, None),),
+    ) == ({}, frozenset())
 
 
 def test_lmfit_code_trust_omits_exact_model_parameter_hints() -> None:

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -10,6 +10,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 from erlab.interactive import _fit1d as fit1d
+from erlab.interactive import _fit_code_trust as fit_code_trust
 from erlab.interactive._code_trust import (
     authorize_document_execution,
     create_entry,
@@ -29,6 +30,7 @@ from erlab.interactive._fit1d import (
 from erlab.interactive._fit_code_trust import (
     lmfit_expression_model_code_entries,
     lmfit_model_code_entry,
+    lmfit_model_safe_parameter_expressions,
     lmfit_parameter_expression_entries,
     lmfit_result_code_entry,
 )
@@ -671,7 +673,8 @@ def test_fit1d_saved_model_restore_waits_for_document_approval(
     qtbot, monkeypatch
 ) -> None:
     data = _make_1d_data()
-    source = erlab.interactive.ftool(data, execute=False)
+    model = lmfit.Model(lambda x: x, independent_vars=["x"])
+    source = erlab.interactive.ftool(data, model=model, execute=False)
     qtbot.addWidget(source)
     saved = source.to_dataset()
     saved_status = Fit1DTool.StateModel.model_validate_json(saved.attrs["tool_state"])
@@ -697,6 +700,31 @@ def test_fit1d_saved_model_restore_waits_for_document_approval(
 
     assert calls == [saved_status.model_state[1]]
     assert restored.tool_status.model_name == saved_status.model_name
+
+
+def test_fit1d_saved_builtin_model_restores_without_approval(
+    qtbot, monkeypatch
+) -> None:
+    source = erlab.interactive.ftool(_make_1d_data(), execute=False)
+    qtbot.addWidget(source)
+    saved = source.to_dataset()
+    saved_status = Fit1DTool.StateModel.model_validate_json(saved.attrs["tool_state"])
+    calls: list[str] = []
+    original_loads = lmfit.model.Model.loads
+
+    def tracked_loads(model, state, **kwargs):
+        calls.append(state)
+        return original_loads(model, state, **kwargs)
+
+    monkeypatch.setattr(lmfit.model.Model, "loads", tracked_loads)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
+    qtbot.addWidget(restored)
+
+    assert isinstance(restored, Fit1DTool)
+    assert calls == [saved_status.model_state[1]]
+    assert restored._pending_fit_status is None
+    assert restored._fit_code_entries == ()
 
 
 @pytest.mark.parametrize("ndim", [1, 2])
@@ -789,6 +817,31 @@ def test_fit1d_saved_model_class_does_not_import_document_target(
         pytest.param(lmfit.models.ExponentialModel(), None, id="lmfit-library"),
         pytest.param(erlab.analysis.fit.models.TLLModel(), None, id="erlab-library"),
         pytest.param(
+            erlab.analysis.fit.models.MultiPeakModel(),
+            None,
+            id="erlab-embedded-multipeak",
+        ),
+        pytest.param(
+            erlab.analysis.fit.models.MultiPeakModel(
+                2,
+                "voigt gaussian",
+                oversample=64,
+                segmented=True,
+            ),
+            None,
+            id="erlab-embedded-multipeak-options",
+        ),
+        pytest.param(
+            erlab.analysis.fit.models.PolynomialModel(),
+            None,
+            id="erlab-embedded-polynomial",
+        ),
+        pytest.param(
+            erlab.analysis.fit.models.StepEdgeModel(),
+            None,
+            id="erlab-embedded-step-edge",
+        ),
+        pytest.param(
             lmfit.models.ExpressionModel("amplitude * exp(-x / decay)"),
             "amplitude * exp(-x / decay)",
             id="expression",
@@ -800,7 +853,7 @@ def test_fit1d_saved_model_class_does_not_import_document_target(
         ),
         pytest.param(
             erlab.analysis.fit.models.FermiEdgeModel(),
-            "serialized-callable",
+            None,
             id="embedded-library-callable",
         ),
     ],
@@ -812,6 +865,7 @@ def test_lmfit_code_trust_classifies_models_without_loading(
         model.dumps(),
         feature="test.lmfit-model",
         location="model",
+        model_reference=fit1d._model_class_reference(type(model)),
     )
 
     if expected_code is None:
@@ -819,6 +873,64 @@ def test_lmfit_code_trust_classifies_models_without_loading(
     else:
         assert entry is not None
         assert expected_code in entry.code
+
+
+def test_lmfit_code_trust_rejects_modified_embedded_library_model() -> None:
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        2,
+        "voigt voigt",
+        fd=False,
+        background="none",
+        convolve=False,
+    )
+    reference = fit1d._model_class_reference(type(model))
+    serialized = json.loads(model.dumps())
+    serialized["value"][0]["funcdef"]["value"] += "modified"
+
+    entry = lmfit_model_code_entry(
+        json.dumps(serialized),
+        feature="test.lmfit-model",
+        location="model",
+        model_reference=reference,
+    )
+    wrong_reference_entry = lmfit_model_code_entry(
+        model.dumps(),
+        feature="test.lmfit-model",
+        location="model",
+        model_reference="lmfit.model:Model",
+    )
+
+    assert entry is not None
+    assert wrong_reference_entry is not None
+    assert "serialized-callable" in entry.code
+    assert "serialized-callable" in wrong_reference_entry.code
+
+
+def test_lmfit_code_trust_omits_exact_model_parameter_hints() -> None:
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        2,
+        "voigt voigt",
+        fd=False,
+        background="none",
+        convolve=False,
+    )
+    reference = fit1d._model_class_reference(type(model))
+    safe_expressions = lmfit_model_safe_parameter_expressions(model.dumps(), reference)
+    expressions = [
+        *((name, param.expr) for name, param in model.make_params().items()),
+        ("p1_sigma", "p0_sigma"),
+    ]
+
+    entries = lmfit_parameter_expression_entries(
+        expressions,
+        feature="test.lmfit-parameter",
+        location_prefix="parameters",
+        safe_expressions=safe_expressions,
+    )
+
+    assert [(entry.location, entry.code) for entry in entries] == [
+        ("parameters/p1_sigma", "p0_sigma")
+    ]
 
 
 def test_expression_model_local_entry_matches_saved_model_identity() -> None:
@@ -992,6 +1104,123 @@ def test_lmfit_code_trust_classifies_result_payload_without_loading_it() -> None
     )
 
     assert entry is None
+
+
+def test_lmfit_code_trust_accepts_exact_local_multipeak_result() -> None:
+    x = np.linspace(-1.0, 1.0, 21)
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        1,
+        "voigt",
+        fd=False,
+        background="none",
+        convolve=False,
+    )
+    params = model.make_params(
+        p0_center=0.0,
+        p0_sigma=0.2,
+        p0_gamma=0.2,
+        p0_amplitude=1.0,
+    )
+    result = model.fit(model.eval(params, x=x), params, x=x)
+    payload = xr.Dataset({"modelfit_results": xr.DataArray(result.dumps())}).to_netcdf(
+        path=None, engine="h5netcdf"
+    )
+
+    entry = lmfit_result_code_entry(
+        bytes(payload),
+        feature="test.lmfit-result",
+        location="fit-result",
+    )
+
+    assert entry is None
+
+
+@pytest.mark.parametrize("transient_miss", [False, True])
+def test_lmfit_result_code_trust_memoizes_confirmed_model_match(
+    monkeypatch, transient_miss: bool
+) -> None:
+    x = np.linspace(-1.0, 1.0, 21)
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        1,
+        "voigt",
+        fd=False,
+        background="none",
+        convolve=False,
+    )
+    params = model.make_params(
+        p0_center=0.0,
+        p0_sigma=0.2,
+        p0_gamma=0.2,
+        p0_amplitude=1.0,
+    )
+    result = model.fit(model.eval(params, x=x), params, x=x)
+    payload = xr.Dataset(
+        {"modelfit_results": xr.DataArray([result.dumps()] * 10, dims="row")}
+    ).to_netcdf(path=None, engine="h5netcdf")
+    expressions = tuple(
+        (name, expression)
+        for name, param in model.make_params().items()
+        if isinstance((expression := param._expr), str) and expression.strip()
+    )
+    match = (fit1d._model_class_reference(type(model)), expressions)
+    calls: list[tuple[str, str | None]] = []
+
+    def model_match(serialized_item: str, model_reference: str | None):
+        calls.append((serialized_item, model_reference))
+        if transient_miss and len(calls) > 1:
+            return match
+        return None
+
+    monkeypatch.setattr(fit_code_trust, "_known_model_match", model_match)
+
+    entry = lmfit_result_code_entry(
+        bytes(payload),
+        feature="test.lmfit-result",
+        location="fit-result",
+    )
+
+    assert len(calls) == 2
+    assert (entry is None) is transient_miss
+
+
+@pytest.mark.parametrize("tampered_first", [False, True])
+def test_lmfit_result_code_trust_memo_requires_exact_model_match(
+    tampered_first: bool,
+) -> None:
+    x = np.linspace(-1.0, 1.0, 21)
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        1,
+        "voigt",
+        fd=False,
+        background="none",
+        convolve=False,
+    )
+    params = model.make_params(
+        p0_center=0.0,
+        p0_sigma=0.2,
+        p0_gamma=0.2,
+        p0_amplitude=1.0,
+    )
+    result = model.fit(model.eval(params, x=x), params, x=x)
+    serialized = result.dumps()
+    tampered = json.loads(serialized)
+    tampered["model"]["value"][0]["funcdef"]["pyversion"] = "modified"
+    serialized_tampered = json.dumps(tampered)
+    results = [serialized_tampered, serialized]
+    if not tampered_first:
+        results.reverse()
+    payload = xr.Dataset(
+        {"modelfit_results": xr.DataArray(results, dims="row")}
+    ).to_netcdf(path=None, engine="h5netcdf")
+
+    entry = lmfit_result_code_entry(
+        bytes(payload),
+        feature="test.lmfit-result",
+        location="fit-result",
+    )
+
+    assert entry is not None
+    assert "serialized-callable" in entry.code
 
 
 def test_lmfit_code_trust_fails_closed_for_invalid_result_payloads() -> None:

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -409,7 +409,7 @@ def _lmfit_json_with_callable_pyversion(
 
 
 def _saved_ftool_dataset_with_callable_pyversion(
-    ds: xr.Dataset, callable_name: str, pyversion: str = "3.13"
+    ds: xr.Dataset, callable_name: str, pyversion: str = "0.0"
 ) -> xr.Dataset:
     ds = ds.copy()
     state = json.loads(ds.attrs["tool_state"])

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -2480,6 +2480,44 @@ def test_fit2d_reset_params_all(qtbot, monkeypatch) -> None:
     assert all(not mapping for mapping in win._params_from_coord_full)
 
 
+def test_fit2d_trust_omits_repeated_model_hints(qtbot) -> None:
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        2,
+        "voigt voigt",
+        fd=False,
+        background="none",
+        convolve=False,
+    )
+    tool = erlab.interactive.ftool(
+        _make_2d_data(), model=model, params=model.make_params(), execute=False
+    )
+    qtbot.addWidget(tool)
+    assert isinstance(tool, Fit2DTool)
+    status = tool.tool_status
+    assert status.state2d is not None
+    params = []
+    for state in status.params:
+        updated = list(state)
+        if state[0] == "p1_sigma":
+            updated[3] = "p0_sigma"
+        params.append(tuple(updated))
+    repeated_params = [params for _index in range(233)]
+    changed = status.model_copy(
+        update={
+            "params": params,
+            "state2d": status.state2d.model_copy(
+                update={"params_full": repeated_params}
+            ),
+        }
+    )
+
+    entries = type(tool)._code_trust_entries_from_status(changed)
+
+    assert len(entries) == 234
+    assert {entry.code for entry in entries} == {"p0_sigma"}
+    assert {entry.context["parameter"] for entry in entries} == {"p1_sigma"}
+
+
 def test_fit2d_fill_expression_commits_local_lineage(qtbot) -> None:
     tool, _model, params = _make_linear_fit2d_tool(qtbot, expression=True)
     source_params = params.copy()


### PR DESCRIPTION
## Summary

- Treat serialized ERLab fit models as library code only when they exactly match a model generated by the installed library.
- Omit parameter expressions that exactly match the selected model's built-in hints.
- Keep custom, modified, and malformed serialized content subject to code review.
- Group repeated executable content into one review block with its locations.
- Reuse exact model classifications and scan each result once for large fit result arrays.

## Performance

A local benchmark with repeated two-peak fit results produced these scan times:

- 233 fits: 0.075-0.092 seconds
- 1,000 fits: 0.32-0.35 seconds

The previous 233-fit scan took approximately 0.82 seconds.

## Validation

- `uv run pytest -q tests/interactive/test_code_trust.py tests/interactive/test_fit1d.py tests/interactive/test_fit2d.py tests/interactive/imagetool/manager/workspace/test_trust.py` (467 passed)
- PySide6 focused trust tests (14 passed)
- `uv run ruff format --check` for all changed files
- `uv run ruff check` for all changed files
- `uv run mypy src`
- `uv run python -m scripts.ci_test_groups --check-partition`
