### PR TITLE
fix(imagetool): keep data names consistent across actions

### DIFF
--- a/src/erlab/interactive/imagetool/_provenance/_model.py
+++ b/src/erlab/interactive/imagetool/_provenance/_model.py
@@ -2967,7 +2967,7 @@ class ToolProvenanceSpec(pydantic.BaseModel):
             )
         return self.append_operations(operation)
 
-    def append_final_rename(self, name: str) -> ToolProvenanceSpec:
+    def append_final_rename(self, name: str | None) -> ToolProvenanceSpec:
         return self.drop_trailing_rename().append_operations(
             _operation_instance("rename", name=name)
         )

--- a/src/erlab/interactive/imagetool/_provenance/_operations/_selection.py
+++ b/src/erlab/interactive/imagetool/_provenance/_operations/_selection.py
@@ -447,7 +447,7 @@ class SqueezeOperation(ToolProvenanceOperation):
 
 class RenameOperation(ToolProvenanceOperation):
     op: typing.Literal["rename"] = "rename"
-    name: str
+    name: str | None
 
     @classmethod
     def from_console_call(cls, call: ConsoleCall) -> ToolProvenanceOperation | None:

--- a/src/erlab/interactive/imagetool/dialogs.py
+++ b/src/erlab/interactive/imagetool/dialogs.py
@@ -755,9 +755,7 @@ class DataTransformDialog(_DataManipulationDialog):
     def source_spec_for_data(
         self,
         data: xr.DataArray,
-        new_name: str | None = None,
     ) -> ToolProvenanceSpec:
-        del new_name
         operations = self.source_operations()
         builder = public_data if self.apply_on_nonuniform_data else full_data
         if not self.apply_on_nonuniform_data:
@@ -768,28 +766,24 @@ class DataTransformDialog(_DataManipulationDialog):
                 )
         return builder(*operations)
 
-    def source_spec(self, new_name: str | None = None) -> ToolProvenanceSpec:
-        return self.source_spec_for_data(self.slicer_area.data, new_name)
+    def source_spec(self) -> ToolProvenanceSpec:
+        return self.source_spec_for_data(self.slicer_area.data)
 
     def _detached_provenance_spec(
         self,
         parent_provenance: ToolProvenanceSpec | None,
         source_spec: ToolProvenanceSpec,
-        new_name: str,
     ) -> ToolProvenanceSpec:
         return self._compose_transform_provenance(
             parent_provenance,
             source_spec,
-            new_name,
         )
 
     @staticmethod
     def _compose_transform_provenance(
         base_spec: ToolProvenanceSpec | None,
         source_spec: ToolProvenanceSpec,
-        new_name: str,
     ) -> ToolProvenanceSpec:
-        del new_name
         if base_spec is None:
             return source_spec
         with contextlib.suppress(TypeError):
@@ -809,18 +803,15 @@ class DataTransformDialog(_DataManipulationDialog):
     def _compose_replace_source_spec(
         self,
         existing_spec: ToolProvenanceSpec,
-        new_name: str,
     ) -> ToolProvenanceSpec:
         return self._compose_transform_provenance(
             existing_spec,
-            self.source_spec(new_name),
-            new_name,
+            self.source_spec(),
         )
 
     def _rewrite_target_provenance(
         self,
         target: int | str,
-        new_name: str,
         fallback_spec: ToolProvenanceSpec | None,
     ) -> bool:
         manager, _ = self._manager_target()
@@ -830,7 +821,7 @@ class DataTransformDialog(_DataManipulationDialog):
         source_spec = node.displayed_source_spec
         if source_spec is not None:
             node.set_source_binding(
-                self._compose_replace_source_spec(source_spec, new_name),
+                self._compose_replace_source_spec(source_spec),
                 auto_update=node.source_auto_update,
                 state=node.source_state,
             )
@@ -839,7 +830,7 @@ class DataTransformDialog(_DataManipulationDialog):
         replay_source_data = node.resolved_replay_source_data()
         if displayed_provenance is not None:
             node.set_detached_provenance(
-                self._compose_replace_source_spec(displayed_provenance, new_name),
+                self._compose_replace_source_spec(displayed_provenance),
                 replay_source_data=replay_source_data,
             )
             return True
@@ -989,9 +980,6 @@ class DataTransformDialog(_DataManipulationDialog):
             return
 
         input_name = self.slicer_area.data.name
-        new_name = ""
-        if input_name is not None:
-            new_name = str(input_name)
 
         try:
             if self.apply_on_nonuniform_data:
@@ -1011,7 +999,7 @@ class DataTransformDialog(_DataManipulationDialog):
             processed = processed.rename(input_name)
 
             manager, target = self._manager_target()
-            source_spec = self.source_spec(new_name)
+            source_spec = self.source_spec()
             parent_provenance = self.slicer_area.displayed_provenance_spec()
             if manager is not None and target is not None:
                 with contextlib.suppress(Exception):
@@ -1025,7 +1013,6 @@ class DataTransformDialog(_DataManipulationDialog):
             detached_provenance_spec = self._detached_provenance_spec(
                 parent_provenance,
                 source_spec,
-                new_name,
             )
 
             if self.launch_mode == "replace":
@@ -1036,7 +1023,6 @@ class DataTransformDialog(_DataManipulationDialog):
                 ):
                     self._rewrite_target_provenance(
                         target,
-                        new_name,
                         detached_provenance_spec,
                     )
                 else:
@@ -2001,9 +1987,7 @@ class KspaceConversionDialog(DataTransformDialog):
     def source_spec_for_data(
         self,
         data: xr.DataArray,
-        new_name: str | None = None,
     ) -> ToolProvenanceSpec:
-        del new_name
         return public_data(*self._operations_for_data(data))
 
     def process_data(self, data: xr.DataArray) -> xr.DataArray:

--- a/src/erlab/interactive/imagetool/manager/_actions.py
+++ b/src/erlab/interactive/imagetool/manager/_actions.py
@@ -48,6 +48,7 @@ from erlab.interactive.imagetool.manager._window_layout import (
 from erlab.interactive.imagetool.manager._wrapper import (
     _ImageToolWrapper,
     _ManagedWindowNode,
+    _normalize_dataarray_name,
 )
 
 if typing.TYPE_CHECKING:
@@ -678,8 +679,7 @@ class _ActionsController:
                 node = self._manager._node_for_target(target)
                 slicer_area = self._manager.get_imagetool(target).slicer_area
                 input_name = slicer_area.data.name
-                new_name = "" if input_name is None else str(input_name)
-                source_spec = dialog.source_spec_for_data(slicer_area.data, new_name)
+                source_spec = dialog.source_spec_for_data(slicer_area.data)
                 self._validate_batch_operations(
                     dialog,
                     source_spec.operations,
@@ -703,7 +703,6 @@ class _ActionsController:
                         node,
                         slicer_area,
                         input_name,
-                        new_name,
                         source_spec,
                     )
                 )
@@ -721,7 +720,6 @@ class _ActionsController:
             node,
             slicer_area,
             input_name,
-            new_name,
             source_spec,
         ) in preflight_plan:
             try:
@@ -744,7 +742,6 @@ class _ActionsController:
                 detached_provenance = dialog._detached_provenance_spec(
                     parent_provenance,
                     source_spec,
-                    new_name,
                 )
 
                 replace_kind = ""
@@ -757,14 +754,12 @@ class _ActionsController:
                         replace_provenance = dialog._compose_transform_provenance(
                             displayed_source,
                             source_spec,
-                            new_name,
                         )
                     elif node.displayed_provenance_spec is not None:
                         replace_kind = "detached"
                         replace_provenance = dialog._compose_transform_provenance(
                             node.displayed_provenance_spec,
                             source_spec,
-                            new_name,
                         )
                     else:
                         replace_kind = "detached"
@@ -1367,6 +1362,7 @@ class _ActionsController:
         else:
             # Update data in the existing tool
             wrapper = self._manager._tool_graph.root_wrappers[idx]
+            current_name = wrapper.name
             wrapper.set_watched_binding(
                 varname,
                 uid,
@@ -1409,10 +1405,12 @@ class _ActionsController:
             if prepared_data is None:  # pragma: no cover - no dialog is shown here
                 return
             prepared = prepared_data[0]
+            replacement_name = _normalize_dataarray_name(current_name)
+            replacement_data = prepared.data.rename(replacement_name)
             try:
                 replacement = self._manager._metadata_editor.prepare_replacement(
                     idx,
-                    prepared.data,
+                    replacement_data,
                     source_input_dtype=prepared.source_dtype,
                 )
             except Exception as exc:
@@ -1434,7 +1432,7 @@ class _ActionsController:
                 # A notebook-side update replaces the watched variable itself, so
                 # prior ImageTool operations no longer describe the displayed array.
                 wrapper.replace_with_detached_data(
-                    prepared.data,
+                    replacement_data,
                     None,
                     replay_source_data=None,
                 )
@@ -1443,7 +1441,7 @@ class _ActionsController:
                 # metadata assignments that still apply to it.
                 processed, provenance = replacement
                 self._manager._metadata_editor.commit_replacement(
-                    idx, prepared.data, processed, provenance
+                    idx, replacement_data, processed, provenance
                 )
 
     def _data_unwatch(self, uid: str) -> None:

--- a/src/erlab/interactive/imagetool/manager/_io.py
+++ b/src/erlab/interactive/imagetool/manager/_io.py
@@ -270,6 +270,8 @@ class _DataIngressController:
                 else prepared.source_dtype
             )
             source_data = prepared.data
+            if watched_var is not None:
+                source_data = source_data.rename(watched_var[0])
             context_data = source_data
             context_operations: tuple[ToolProvenanceOperation, ...] = ()
             context_resolution = None

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -356,6 +356,10 @@ def _dataarray_name(data: xr.DataArray | None) -> str:
     return "" if name.strip() == "" else name
 
 
+def _normalize_dataarray_name(name: str) -> str | None:
+    return None if name.strip() == "" else name
+
+
 def _append_unique_path(paths: list[pathlib.Path], path: str | pathlib.Path) -> None:
     normalized = pathlib.Path(path).expanduser()
     with contextlib.suppress(OSError, RuntimeError):
@@ -1171,18 +1175,21 @@ class _ManagedWindowNode(QtCore.QObject):
     def _rename_imagetool_data(self, name: str, *, record_provenance: bool) -> None:
         if self.imagetool is None:
             return
-        if name == self.name:
+        slicer_area = self.slicer_area
+        data_name = _normalize_dataarray_name(name)
+        if data_name == slicer_area._data.name or (
+            data_name is not None and name == self.name
+        ):
             self.imagetool.setWindowTitle(self.label_text)
             return
-        slicer_area = self.slicer_area
-        slicer_area._data = slicer_area._data.rename(name)
-        slicer_area.array_slicer._obj = slicer_area.array_slicer._obj.rename(name)
+        slicer_area._data = slicer_area._data.rename(data_name)
+        slicer_area.array_slicer._obj = slicer_area.array_slicer._obj.rename(data_name)
         if slicer_area._accepted_filter_data is not None:
             slicer_area._accepted_filter_data = (
-                slicer_area._accepted_filter_data.rename(name)
+                slicer_area._accepted_filter_data.rename(data_name)
             )
         if record_provenance:
-            self._record_data_rename_provenance(name)
+            self._record_data_rename_provenance(data_name)
         self._invalidate_info_text_cache()
         self.imagetool.setWindowTitle(self.label_text)
         self._notify_change(
@@ -1190,7 +1197,7 @@ class _ManagedWindowNode(QtCore.QObject):
         )
         self.manager._mark_node_state_dirty(self.uid)
 
-    def _record_data_rename_provenance(self, name: str) -> None:
+    def _record_data_rename_provenance(self, name: str | None) -> None:
         spec = self.provenance_spec
         if spec is not None:
             self._provenance_spec = spec.append_final_rename(name)
@@ -3230,11 +3237,12 @@ class _ImageToolWrapper(_ManagedWindowNode):
             np.dtype(np.float64),
         ):
             seed_source = f"{seed_source}.astype(np.float64)"
-        return script(
+        spec = script(
             start_label=f"Start from watched variable {varname!r}",
             seed_code=f"derived = {seed_source}",
             active_name="derived",
         )
+        return spec.append_final_rename(_normalize_dataarray_name(self.name))
 
     def _watched_root_provenance_spec(self) -> ToolProvenanceSpec | None:
         if self._provenance_spec is not None or self._source_spec is not None:

--- a/src/erlab/interactive/imagetool/plot_items.py
+++ b/src/erlab/interactive/imagetool/plot_items.py
@@ -230,10 +230,7 @@ class ItoolDisplayObject:
     @property
     def sliced_data(self) -> xr.DataArray:
         with xr.set_options(keep_attrs=True):
-            sliced = self.array_slicer.xslice(self.cursor_index, self.display_axis)
-            if sliced.name is not None and sliced.name != "":
-                sliced = sliced.rename(f"{sliced.name} Sliced")
-            return sliced
+            return self.array_slicer.xslice(self.cursor_index, self.display_axis)
 
     def fetch_new_data(
         self,
@@ -2372,7 +2369,7 @@ class ItoolPlotItem(pg.PlotItem):
         data_to_save = self.current_data
 
         default_name = data_to_save.name
-        if default_name is not None and default_name != "":
+        if default_name is None or default_name == "":
             default_name = "data"
 
         dialog = QtWidgets.QFileDialog()
@@ -2386,11 +2383,15 @@ class ItoolPlotItem(pg.PlotItem):
         if not last_dir:
             last_dir = os.getcwd()
 
-        dialog.setDirectory(os.path.join(last_dir, f"{default_name}.h5"))
+        dialog.setDirectory(last_dir)
+        dialog.selectFile(f"{default_name}.h5")
 
         if dialog.exec():
             filename = dialog.selectedFiles()[0]
-            data_to_save.to_netcdf(filename, engine="h5netcdf", invalid_netcdf=True)
+            data_to_write = (
+                data_to_save.rename(None) if data_to_save.name == "" else data_to_save
+            )
+            data_to_write.to_netcdf(filename, engine="h5netcdf", invalid_netcdf=True)
             pg.PlotItem.lastFileDir = os.path.dirname(filename)
 
     @QtCore.Slot()

--- a/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
+++ b/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
@@ -24,7 +24,10 @@ from erlab.interactive.imagetool._provenance._model import (
     ScriptInput,
     full_data,
 )
-from erlab.interactive.imagetool._provenance._operations import AverageOperation
+from erlab.interactive.imagetool._provenance._operations import (
+    AverageOperation,
+    RenameOperation,
+)
 from erlab.interactive.imagetool.manager import fetch
 from erlab.interactive.imagetool.manager._server import _remove_idx, _show_idx
 from tests.interactive.imagetool.manager.helpers import (
@@ -113,7 +116,9 @@ def test_manager_data_watched_update_replaces_existing_tool_source_data(
         tool = manager.get_imagetool(0)
         wrapper = manager._tool_graph.root_wrappers[0]
         assert wrapper.replay_source_data is None
-        xr.testing.assert_identical(wrapper.resolved_replay_source_data(), test_data)
+        xr.testing.assert_identical(
+            wrapper.resolved_replay_source_data(), test_data.rename("data")
+        )
         wrapper.set_detached_provenance(
             full_data(AverageOperation(dims=("alpha",))),
             replay_source_data=test_data,
@@ -124,11 +129,13 @@ def test_manager_data_watched_update_replaces_existing_tool_source_data(
         with qtbot.wait_signal(tool.slicer_area.sigSourceDataReplaced):
             manager._data_watched_update("data", "kernel-0", updated)
 
-        xr.testing.assert_identical(tool.slicer_area.data, updated)
+        xr.testing.assert_identical(tool.slicer_area.data, updated.rename("data"))
         assert wrapper.provenance_spec is not None
-        assert wrapper.provenance_spec.operations == ()
+        assert wrapper.provenance_spec.operations == (RenameOperation(name="data"),)
         assert wrapper.replay_source_data is None
-        xr.testing.assert_identical(wrapper.resolved_replay_source_data(), updated)
+        xr.testing.assert_identical(
+            wrapper.resolved_replay_source_data(), updated.rename("data")
+        )
 
 
 def test_manager_high_dimensional_watched_data_errors_without_reduction_dialog(
@@ -253,7 +260,9 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
         assert wrapper._watched_source_uid == "kernel-a"
         assert wrapper._watched_connected is False
         assert wrapper.replay_source_data is None
-        xr.testing.assert_identical(wrapper.resolved_replay_source_data(), test_data)
+        xr.testing.assert_identical(
+            wrapper.resolved_replay_source_data(), test_data.rename("data")
+        )
 
         with qtbot.wait_signal(manager._sigReplyData) as blocker:
             manager._send_watch_info()
@@ -406,21 +415,25 @@ def test_manager_watched_root_provenance_uses_variable_name(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
+    source = test_data.rename("source_array")
+
     with manager_context() as manager:
         manager.show()
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
 
         manager._data_ingress.receive_data(
-            [test_data], {}, watched_var=("my_data", "kernel-0")
+            [source], {}, watched_var=("my_data", "kernel-0")
         )
         qtbot.wait_until(lambda: manager.ntools == 1, timeout=5000)
 
         node = manager._tool_graph.root_wrappers[0]
+        assert source.name == "source_array"
+        assert node.name == "my_data"
         provenance = node.provenance_spec
         assert provenance is not None
         code = provenance.display_code()
         assert code is not None
-        namespace = _exec_generated_code(code, {"my_data": test_data.copy(deep=True)})
+        namespace = _exec_generated_code(code, {"my_data": source.copy(deep=True)})
         derived = namespace["derived"]
         assert isinstance(derived, xr.DataArray)
         xr.testing.assert_identical(derived, manager.get_imagetool(0).slicer_area.data)
@@ -447,7 +460,7 @@ def test_manager_watched_root_provenance_uses_variable_name(
         trigger_menu_action(menu, manager._metadata_copy_full_action)
         namespace = _exec_generated_code(
             copied[-1],
-            {"my_data": test_data.copy(deep=True)},
+            {"my_data": source.copy(deep=True)},
         )
         derived = namespace["derived"]
         assert isinstance(derived, xr.DataArray)

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -807,9 +807,8 @@ class _BatchTransformStub:
     def source_spec_for_data(
         self,
         data: xr.DataArray,
-        new_name: str | None = None,
     ) -> ToolProvenanceSpec:
-        del data, new_name
+        del data
         builder = public_data if self._public_source else full_data
         return builder(*self.source_operations())
 
@@ -817,18 +816,16 @@ class _BatchTransformStub:
         self,
         parent_provenance: ToolProvenanceSpec | None,
         source_spec: ToolProvenanceSpec,
-        new_name: str,
     ) -> ToolProvenanceSpec:
-        del parent_provenance, new_name
+        del parent_provenance
         return source_spec
 
     def _compose_transform_provenance(
         self,
         base_spec: ToolProvenanceSpec | None,
         source_spec: ToolProvenanceSpec,
-        new_name: str,
     ) -> ToolProvenanceSpec:
-        del base_spec, new_name
+        del base_spec
         return source_spec
 
     def _itool_kwargs(
@@ -1873,6 +1870,141 @@ def test_metadata_assignments_survive_watched_variable_updates(
         manager._data_watched_update("scan", "watched-uid", incompatible)
         assert messages
         xr.testing.assert_identical(manager.get_imagetool(0).slicer_area.data, expected)
+
+
+def test_watched_variable_uses_binding_name_and_preserves_manual_name(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("source_array")
+    original = source.copy(deep=True)
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager._data_watched_update("scan", "watched-uid", source)
+
+        xr.testing.assert_identical(source, original)
+        assert manager.name_of_imagetool(0) == "scan"
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area.data,
+            source.rename("scan"),
+        )
+
+        manager.rename_imagetool(0, "manual scan")
+        replacement = _batch_data("replacement_array", offset=100.0)
+        manager._data_watched_update("scan", "watched-uid", replacement)
+
+        expected = replacement.rename("manual scan")
+        assert replacement.name == "replacement_array"
+        assert manager.name_of_imagetool(0) == "manual scan"
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area.data,
+            expected,
+        )
+
+        node = manager._tool_graph.root_wrappers[0]
+        provenance = node.provenance_spec
+        assert provenance is not None
+        code = provenance.display_code()
+        assert code is not None
+        namespace = _exec_generated_code(code, {"scan": replacement})
+        xr.testing.assert_identical(namespace["derived"], expected)
+
+        workspace_path = tmp_path / "watched-manual-name.itws"
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+
+        restored = manager._tool_graph.root_wrappers[0]
+        assert restored.name == "manual scan"
+        reconnected = _batch_data("reconnected_array", offset=200.0)
+        manager._data_watched_update("scan", "watched-uid", reconnected)
+
+        assert restored.name == "manual scan"
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area.data,
+            reconnected.rename("manual scan"),
+        )
+
+
+def test_watched_variable_preserves_empty_manual_name(
+    qtbot,
+    tmp_path: pathlib.Path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    source = _batch_data("source_array")
+
+    with manager_context() as manager:
+        manager.show()
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+
+        manager._data_watched_update("scan", "watched-uid", source)
+        manager.rename_imagetool(0, "")
+
+        expected = source.rename(None)
+        node = manager._tool_graph.root_wrappers[0]
+        assert node.name == ""
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area.data,
+            expected,
+        )
+        provenance = node.provenance_spec
+        assert provenance is not None
+        assert provenance.operations == (RenameOperation(name=None),)
+        code = provenance.display_code()
+        assert code is not None
+        namespace = _exec_generated_code(code, {"scan": source})
+        xr.testing.assert_identical(namespace["derived"], expected)
+
+        workspace_path = tmp_path / "watched-empty-name.itws"
+        manager._workspace_controller.saving._save_workspace_document(workspace_path)
+        assert manager._workspace_controller.loading._load_workspace_file(
+            workspace_path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
+
+        restored = manager._tool_graph.root_wrappers[0]
+        assert restored.name == ""
+        restored_data = manager.get_imagetool(0).slicer_area.data
+        xr.testing.assert_identical(restored_data, expected)
+        provenance = restored.provenance_spec
+        assert provenance is not None
+        assert provenance.operations == (RenameOperation(name=None),)
+        code = provenance.display_code()
+        assert code is not None
+        namespace = _exec_generated_code(code, {"scan": source})
+        xr.testing.assert_identical(namespace["derived"], restored_data)
+
+        reconnected = _batch_data("reconnected_array", offset=100.0)
+        manager._data_watched_update("scan", "watched-uid", reconnected)
+
+        expected = reconnected.rename(None)
+        assert restored.name == ""
+        xr.testing.assert_identical(
+            manager.get_imagetool(0).slicer_area.data,
+            expected,
+        )
+        provenance = restored.provenance_spec
+        assert provenance is not None
+        code = provenance.display_code()
+        assert code is not None
+        namespace = _exec_generated_code(code, {"scan": reconnected})
+        xr.testing.assert_identical(namespace["derived"], expected)
 
 
 def test_watched_metadata_assignments_retain_workspace_replay_source(
@@ -3710,10 +3842,9 @@ def test_batch_transform_memory_preflight_runs_before_processing(
         def source_spec_for_data(
             self,
             data: xr.DataArray,
-            new_name: str | None = None,
         ) -> ToolProvenanceSpec:
             self.source_spec_calls += 1
-            return super().source_spec_for_data(data, new_name)
+            return super().source_spec_for_data(data)
 
         def preflight_data(self, data: xr.DataArray) -> None:
             del data

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -5462,11 +5462,9 @@ def test_image_open_in_new_window_preserves_spaced_qsel_dimension(qtbot) -> None
     image = win.slicer_area.images[2]
     win.slicer_area.set_value(axis=0, value=1.0, cursor=0)
     expected = image.current_data
+    assert expected.name == "map"
     source_spec = image.make_tool_source_spec()
-    xarray.testing.assert_identical(
-        source_spec.apply(data).rename(None),
-        expected.rename(None),
-    )
+    xarray.testing.assert_identical(source_spec.apply(data), expected)
 
     image.open_in_new_window()
     qtbot.wait_until(
@@ -5475,20 +5473,14 @@ def test_image_open_in_new_window_preserves_spaced_qsel_dimension(qtbot) -> None
     )
     child = typing.cast("ImageTool", win.slicer_area._associated_tools_list[-1])
 
-    xarray.testing.assert_identical(
-        child.slicer_area.data.rename(None),
-        expected.rename(None),
-    )
+    xarray.testing.assert_identical(child.slicer_area.data, expected)
     assert child.provenance_spec is not None
     display_code = child.provenance_spec.display_code()
     assert display_code is not None
     assert "qsel({" in display_code
     assert "Track Shift" in display_code
     namespace = _exec_generated_code(display_code, {"data": data.copy(deep=True)})
-    xarray.testing.assert_identical(
-        namespace["derived"].rename(None),
-        expected.rename(None),
-    )
+    xarray.testing.assert_identical(namespace["derived"], expected)
 
     child.close()
     win.close()
@@ -5510,6 +5502,7 @@ def test_image_open_in_new_window_handles_binned_unindexed_dimension(qtbot) -> N
     source_spec = image.make_tool_source_spec()
     resolved = source_spec.apply(data)
     xr.testing.assert_identical(resolved, expected)
+    assert image.current_data.name == expected.name == "map"
     np.testing.assert_allclose(image.current_data.values, expected.values)
 
     image.open_in_new_window()
@@ -5519,6 +5512,7 @@ def test_image_open_in_new_window_handles_binned_unindexed_dimension(qtbot) -> N
     )
     child = typing.cast("ImageTool", win.slicer_area._associated_tools_list[-1])
 
+    assert child.slicer_area.data.name == expected.name == "map"
     np.testing.assert_allclose(child.slicer_area.data.values, expected.values)
     assert child.provenance_spec is not None
     display_code = child.provenance_spec.display_code()
@@ -5549,10 +5543,7 @@ def test_image_open_in_new_window_restores_nonuniform_public_dims(qtbot) -> None
 
     assert image.current_data.dims == ("sample_temp", "eV")
     assert "sample_temp_idx" not in image.current_data.dims
-    xarray.testing.assert_identical(
-        image.current_data.rename(None),
-        expected.rename(None),
-    )
+    xarray.testing.assert_identical(image.current_data, expected)
 
     image.open_in_new_window()
     qtbot.wait_until(
@@ -5563,12 +5554,65 @@ def test_image_open_in_new_window_restores_nonuniform_public_dims(qtbot) -> None
 
     assert child.slicer_area._data.dims == ("sample_temp", "eV")
     assert child.slicer_area.displayed_data.dims == ("sample_temp", "eV")
-    xarray.testing.assert_identical(
-        child.slicer_area.displayed_data.rename(None),
-        expected.rename(None),
-    )
+    xarray.testing.assert_identical(child.slicer_area.displayed_data, expected)
 
     child.close()
+    win.close()
+
+
+@pytest.mark.parametrize(
+    ("data_name", "expected_filename"),
+    [("scan", "scan.h5"), (None, "data.h5"), ("", "data.h5")],
+)
+@pytest.mark.parametrize("accept", [False, True])
+def test_save_current_data_uses_data_name_for_default_filename(
+    qtbot,
+    monkeypatch,
+    tmp_path: pathlib.Path,
+    data_name: str | None,
+    expected_filename: str,
+    accept: bool,
+) -> None:
+    data = xr.DataArray(
+        np.arange(12.0).reshape(3, 4),
+        dims=("x", "y"),
+        name=data_name,
+    )
+    win = itool(data, execute=False)
+    qtbot.addWidget(win)
+    real_file_dialog = QtWidgets.QFileDialog
+
+    class _FileDialog(real_file_dialog):
+        instance: typing.ClassVar[QtWidgets.QFileDialog | None] = None
+
+        def __init__(self) -> None:
+            super().__init__()
+            type(self).instance = self
+
+        def exec(self) -> int:
+            if accept:
+                return int(real_file_dialog.DialogCode.Accepted.value)
+            return int(real_file_dialog.DialogCode.Rejected.value)
+
+    monkeypatch.setattr(QtWidgets, "QFileDialog", _FileDialog)
+    monkeypatch.setattr(pg.PlotItem, "lastFileDir", str(tmp_path))
+
+    win.slicer_area.main_image.save_current_data()
+
+    dialog = _FileDialog.instance
+    assert dialog is not None
+    assert dialog.directory().absolutePath() == str(tmp_path)
+    assert dialog.selectedFiles() == [str(tmp_path / expected_filename)]
+    if accept:
+        expected_data = win.slicer_area.main_image.current_data
+        if expected_data.name == "":
+            expected_data = expected_data.rename(None)
+        xr.testing.assert_identical(
+            xr.load_dataarray(tmp_path / expected_filename, engine="h5netcdf"),
+            expected_data,
+        )
+    else:
+        assert not (tmp_path / expected_filename).exists()
     win.close()
 
 
@@ -9486,7 +9530,7 @@ def test_crop_to_view_nonuniform_source_spec_uses_public_indices(qtbot) -> None:
 
     expected = data.isel(x=slice(1, 4)).sel(y=slice(0.0, 2.0))
     public_data = erlab.utils.array._restore_nonuniform_dims(win.slicer_area.data)
-    source_spec = dialog.source_spec("ignored")
+    source_spec = dialog.source_spec()
     code = dialog.make_code()
 
     assert source_spec.kind == "public_data"
@@ -9530,7 +9574,7 @@ def test_crop_between_cursors_nonuniform_source_spec_uses_public_indices(qtbot) 
 
     expected = data.isel(x=slice(1, 4)).sel(y=slice(0.0, 2.0))
     public_data = erlab.utils.array._restore_nonuniform_dims(win.slicer_area.data)
-    source_spec = dialog.source_spec("ignored")
+    source_spec = dialog.source_spec()
     code = dialog.make_code()
 
     assert source_spec.kind == "public_data"
@@ -9960,7 +10004,7 @@ def test_average_source_spec_restores_nonuniform_dims_after_refresh(qtbot) -> No
     qtbot.addWidget(dialog)
     dialog.dim_checks["y"].setChecked(True)
 
-    spec = dialog.source_spec("ignored")
+    spec = dialog.source_spec()
     expected = erlab.utils.array._restore_nonuniform_dims(
         dialog.process_data(win.slicer_area.data)
     )
@@ -10046,7 +10090,7 @@ def test_aggregate_source_spec_restores_nonuniform_dims_after_refresh(qtbot) -> 
     dialog.dim_checks["y"].setChecked(True)
     _set_combo_data(dialog.reducer_combo, "sum")
 
-    spec = dialog.source_spec("ignored")
+    spec = dialog.source_spec()
     expected = erlab.utils.array._restore_nonuniform_dims(
         dialog.process_data(win.slicer_area.data)
     )
@@ -11564,7 +11608,7 @@ def test_selection_dialog_uses_public_nonuniform_dimensions(qtbot) -> None:
     xarray.testing.assert_identical(
         _exec_data_fragment(data, dialog.make_code()), expected
     )
-    spec = dialog.source_spec("ignored")
+    spec = dialog.source_spec()
     assert spec.kind == "public_data"
     xarray.testing.assert_identical(spec.apply(win.slicer_area.data), expected)
 


### PR DESCRIPTION
## Summary

- Name newly watched ImageTool data after its Python variable without modifying the notebook array.
- Preserve manual and blank names across watcher updates, generated code, and workspace restoration.
- Keep slice names unchanged and remove obsolete action-result rename plumbing.
- Use the data name as the default save filename and save blank names as unnamed arrays.

## Validation

- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest ...` (44 passed)
- `QT_API=pyside6 PYTEST_QT_API=pyside6 QT_QPA_PLATFORM=offscreen uv run pytest ...` (8 passed)
- `uv run mypy src`
- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `git diff --check`
