### PR TITLE
perf(analysis): accelerate rotational transforms

### DIFF
--- a/src/erlab/analysis/transform.py
+++ b/src/erlab/analysis/transform.py
@@ -9,11 +9,13 @@ __all__ = [
     "symmetrize_nfold",
 ]
 
+import threading
 import typing
 import warnings
 from collections.abc import Hashable, Mapping
 from dataclasses import dataclass
 
+import numba
 import numpy as np
 import scipy
 import xarray as xr
@@ -23,6 +25,15 @@ import erlab
 if typing.TYPE_CHECKING:
     import scipy.ndimage
     import scipy.special  # noqa: TC004
+
+_NUMBA_AFFINE_DTYPES = frozenset(
+    {
+        np.dtype(np.float32),
+        np.dtype(np.float64),
+        np.dtype(np.complex64),
+        np.dtype(np.complex128),
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,6 +189,200 @@ def _aligned_affine_matrix(
     return translation @ base_matrix
 
 
+@numba.njit(nogil=True, inline="always", cache=True, fastmath={"contract"})
+def _map_affine_point(
+    matrix: np.ndarray, y_index: int, x_index: int
+) -> tuple[float, float]:
+    """Map one output point to input pixel coordinates."""
+    mapped_y = matrix[0, 2]
+    mapped_y += matrix[0, 0] * y_index
+    mapped_y += matrix[0, 1] * x_index
+    mapped_x = matrix[1, 2]
+    mapped_x += matrix[1, 0] * y_index
+    mapped_x += matrix[1, 1] * x_index
+    return mapped_y, mapped_x
+
+
+@numba.njit(nogil=True, cache=True, fastmath={"contract"})
+def _rotation_geometry_bounds(
+    matrices: np.ndarray,
+    input_shape: tuple[int, int],
+    output_shape: tuple[int, int],
+) -> tuple[int, int, int, int]:
+    """Return the tight output bounds that sample the input plane."""
+    input_y, input_x = input_shape
+    output_y, output_x = output_shape
+    y_start = output_y
+    y_stop = 0
+    x_start = output_x
+    x_stop = 0
+
+    for y_index in range(output_y):
+        for x_index in range(output_x):
+            for matrix_index in range(matrices.shape[0]):
+                mapped_y, mapped_x = _map_affine_point(
+                    matrices[matrix_index], y_index, x_index
+                )
+                if 0.0 <= mapped_y <= input_y - 1 and 0.0 <= mapped_x <= input_x - 1:
+                    y_start = min(y_start, y_index)
+                    y_stop = max(y_stop, y_index + 1)
+                    x_start = min(x_start, x_index)
+                    x_stop = max(x_stop, x_index + 1)
+                    break
+
+    if y_stop == 0:
+        return 0, 0, 0, 0
+    return y_start, y_stop, x_start, x_stop
+
+
+@numba.njit(nogil=True, inline="always", cache=True, fastmath={"contract"})
+def _fill_affine_row(
+    arr: np.ndarray,
+    matrices: np.ndarray,
+    output_origin: tuple[int, int],
+    cval: complex,
+    out: np.ndarray,
+    batch_index: int,
+    y_index: int,
+) -> None:
+    """Fill one output row with one affine transform or their mean."""
+    matrix_count = matrices.shape[0]
+    _, input_y, input_x = arr.shape
+    output_y_index = y_index + output_origin[0]
+    for x_index in range(out.shape[2]):
+        output_x_index = x_index + output_origin[1]
+        count = 0
+        for matrix_index in range(matrix_count):
+            mapped_y, mapped_x = _map_affine_point(
+                matrices[matrix_index], output_y_index, output_x_index
+            )
+            if (
+                mapped_y < 0.0
+                or mapped_y > input_y - 1
+                or mapped_x < 0.0
+                or mapped_x > input_x - 1
+            ):
+                value = cval
+            else:
+                y0 = int(np.floor(mapped_y))
+                x0 = int(np.floor(mapped_x))
+                y_weight = mapped_y - y0
+                x_weight = mapped_x - x0
+                if y0 == input_y - 1:
+                    y0 -= 1
+                    y_weight = 1.0
+                if x0 == input_x - 1:
+                    x0 -= 1
+                    x_weight = 1.0
+                y1 = y0 + 1
+                x1 = x0 + 1
+                value00 = arr[batch_index, y0, x0]
+                value01 = arr[batch_index, y0, x1]
+                value10 = arr[batch_index, y1, x0]
+                value11 = arr[batch_index, y1, x1]
+                weight00 = (1.0 - y_weight) * (1.0 - x_weight)
+                weight01 = (1.0 - y_weight) * x_weight
+                weight10 = y_weight * (1.0 - x_weight)
+                weight11 = y_weight * x_weight
+                if isinstance(value00, (complex, np.complex64, np.complex128)):
+                    value = complex(
+                        weight00 * value00.real
+                        + weight01 * value01.real
+                        + weight10 * value10.real
+                        + weight11 * value11.real,
+                        weight00 * value00.imag
+                        + weight01 * value01.imag
+                        + weight10 * value10.imag
+                        + weight11 * value11.imag,
+                    )
+                elif (
+                    np.isnan(value00)
+                    or np.isnan(value01)
+                    or np.isnan(value10)
+                    or np.isnan(value11)
+                ):
+                    value = np.nan
+                else:
+                    value = (
+                        weight00 * value00
+                        + weight01 * value01
+                        + weight10 * value10
+                        + weight11 * value11
+                    )
+
+            if matrix_count == 1:
+                out[batch_index, y_index, x_index] = value
+            elif not np.isnan(value):
+                if count == 0:
+                    out[batch_index, y_index, x_index] = value
+                else:
+                    out[batch_index, y_index, x_index] += value
+                count += 1
+
+        if matrix_count != 1:
+            if count == 0:
+                out[batch_index, y_index, x_index] = np.nan
+            else:
+                out[batch_index, y_index, x_index] /= count
+
+
+@numba.njit(nogil=True, parallel=True, cache=True, fastmath={"contract"})
+def _apply_affine_linear_numba(
+    arr: np.ndarray,
+    matrices: np.ndarray,
+    output_origin: tuple[int, int],
+    cval: complex,
+    out: np.ndarray,
+) -> None:
+    """Apply one or average multiple affine transforms in parallel."""
+    for row_index in numba.prange(arr.shape[0] * out.shape[1]):
+        batch_index = row_index // out.shape[1]
+        y_index = row_index - batch_index * out.shape[1]
+        _fill_affine_row(arr, matrices, output_origin, cval, out, batch_index, y_index)
+
+
+@numba.njit(nogil=True, cache=True, fastmath={"contract"})
+def _apply_affine_linear_numba_serial(
+    arr: np.ndarray,
+    matrices: np.ndarray,
+    output_origin: tuple[int, int],
+    cval: complex,
+    out: np.ndarray,
+) -> None:
+    """Apply one or average multiple affine transforms serially."""
+    for row_index in range(arr.shape[0] * out.shape[1]):
+        batch_index = row_index // out.shape[1]
+        y_index = row_index - batch_index * out.shape[1]
+        _fill_affine_row(arr, matrices, output_origin, cval, out, batch_index, y_index)
+
+
+def _apply_affine_linear(
+    arr: np.ndarray,
+    matrices: np.ndarray,
+    output_shape: tuple[int, int],
+    cval: complex,
+    *,
+    serial: bool,
+    output_origin: tuple[int, int] = (0, 0),
+) -> np.ndarray:
+    """Apply affine transforms over arbitrary batch dimensions."""
+    input_shape = arr.shape
+    arr = np.ascontiguousarray(arr).reshape((-1, *arr.shape[-2:]))
+    out = np.empty((arr.shape[0], *output_shape), dtype=arr.dtype)
+    use_serial = serial or threading.current_thread() is not threading.main_thread()
+    kernel = (
+        _apply_affine_linear_numba_serial if use_serial else _apply_affine_linear_numba
+    )
+    kernel(
+        arr,
+        matrices,
+        output_origin,
+        np.asarray(cval, dtype=arr.dtype)[()],
+        out,
+    )
+    return out.reshape((*input_shape[:-2], *output_shape))
+
+
 def _rotated_plane_shape(
     base_matrix: np.ndarray, in_plane_shape: tuple[int, int]
 ) -> tuple[int, int]:
@@ -216,8 +421,9 @@ def rotate(
         along the dimensions specified in `axes`. If a dict, it must have keys that
         correspond to `axes`. Default is (0, 0).
     reshape
-        If `True`, the output shape is adapted so that the input array is contained
-        completely in the output. Default is `True`.
+        If `True`, the output shape is adapted to the full rotated bounding box. The
+        extent depends on the input coordinates, not on finite data values. Default is
+        `True`.
     order
         The order of the spline interpolation, default is 1. The order has to be in the
         range 0-5.
@@ -258,34 +464,49 @@ def rotate(
             plane.in_pixel_center[:2],
         )
 
-    # Apply the same 2D affine transform to each plane slice.
-    def _affine_2d(arr2d: np.ndarray) -> np.ndarray:
-        out = np.empty(tuple(out_plane_shape), dtype=arr2d.dtype)
-        scipy.ndimage.affine_transform(
-            arr2d,
-            matrix,
-            output_shape=tuple(out_plane_shape),
-            output=out,
-            order=order,
-            mode=mode,
-            cval=cval,
-            prefilter=prefilter,
-        )
-        return out
-
     rot_ydim, rot_xdim, output_core_dims, output_sizes = _rotation_output_signature(
         plane.ydim, plane.xdim, out_plane_shape, reshape=reshape
     )
 
+    if order == 1 and mode == "constant" and darr.dtype in _NUMBA_AFFINE_DTYPES:
+        apply_affine = _apply_affine_linear
+        apply_kwargs = {
+            "matrices": matrix[None, ...],
+            "output_shape": out_plane_shape,
+            "cval": cval,
+            "serial": darr.chunks is not None,
+        }
+        vectorize = False
+    else:
+
+        def _apply_affine_scipy(arr2d: np.ndarray) -> np.ndarray:
+            out = np.empty(out_plane_shape, dtype=arr2d.dtype)
+            scipy.ndimage.affine_transform(
+                arr2d,
+                matrix,
+                output_shape=out_plane_shape,
+                output=out,
+                order=order,
+                mode=mode,
+                cval=cval,
+                prefilter=prefilter,
+            )
+            return out
+
+        apply_affine = _apply_affine_scipy
+        apply_kwargs = {}
+        vectorize = True
+
     rotated: xr.DataArray = xr.apply_ufunc(
-        _affine_2d,
+        apply_affine,
         darr,
         input_core_dims=[[plane.ydim, plane.xdim]],
         output_core_dims=output_core_dims,
+        kwargs=apply_kwargs,
         dask="parallelized",
         output_dtypes=[darr.dtype],
         dask_gufunc_kwargs={"output_sizes": output_sizes},
-        vectorize=True,
+        vectorize=vectorize,
         keep_attrs="no_conflicts",
     )
 
@@ -316,9 +537,6 @@ def rotate(
                 plane.xdim: np.linspace(start_x, end_x, out_plane_shape[1]),
             }
         )
-
-        # Trim all-NaN edges
-        rotated = erlab.utils.array.trim_na(rotated, plane.axes_dims)
 
     return rotated.transpose(*darr.dims)
 
@@ -358,8 +576,9 @@ def symmetrize_nfold(
         correspond to `axes`. Default is (0, 0).
     reshape
         If `True`, the output shape is expanded to contain the full extent of all
-        rotated copies. If `False`, the symmetrized result is returned on the original
-        grid. Default is `True`.
+        rotated copies. The extent depends on the input coordinates, not on finite data
+        values. If `False`, the symmetrized result is returned on the original grid.
+        Default is `True`.
     order
         The order of the spline interpolation, default is 1. The order has to be in the
         range 0-5.
@@ -453,64 +672,95 @@ def symmetrize_nfold(
         out_center = plane.in_pixel_center[:2]
 
     # Precompute aligned affine matrices for each rotated copy.
-    matrices = [
-        _aligned_affine_matrix(
-            plane.base_matrix(360.0 * idx / fold),
-            plane.in_pixel_center[:2],
-            out_center,
+    matrices = np.stack(
+        [
+            _aligned_affine_matrix(
+                plane.base_matrix(360.0 * idx / fold),
+                plane.in_pixel_center[:2],
+                out_center,
+            )
+            for idx in range(fold)
+        ]
+    )
+
+    full_out_plane_shape = out_plane_shape
+    output_origin = (0, 0)
+    output_slices = (slice(None), slice(None))
+    if reshape and mode == "constant" and bool(np.isnan(cval)):
+        y_start, y_stop, x_start, x_stop = _rotation_geometry_bounds(
+            matrices, plane.in_plane_shape, out_plane_shape
         )
-        for idx in range(fold)
-    ]
+        y_slice = slice(y_start, y_stop)
+        x_slice = slice(x_start, x_stop)
+        out_ycoords = typing.cast("np.ndarray", out_ycoords)[y_slice]
+        out_xcoords = typing.cast("np.ndarray", out_xcoords)[x_slice]
+        out_plane_shape = (len(out_ycoords), len(out_xcoords))
+        output_origin = (y_start, x_start)
+        output_slices = (y_slice, x_slice)
 
     dtype = rotated_input.dtype
-    nan_value = np.array(np.nan, dtype=dtype)[()]
-
-    # Accumulate the mean directly to avoid concat/mean overhead.
-    def _average_rotations(arr2d: np.ndarray) -> np.ndarray:
-        total = np.zeros(out_plane_shape, dtype=dtype)
-        count = np.zeros(out_plane_shape, dtype=np.intp)
-        rotated = np.empty(out_plane_shape, dtype=dtype)
-
-        for matrix in matrices:
-            scipy.ndimage.affine_transform(
-                arr2d,
-                matrix,
-                output_shape=out_plane_shape,
-                output=rotated,
-                order=order,
-                mode=mode,
-                cval=cval,
-                prefilter=prefilter,
-            )
-
-            valid = ~np.isnan(rotated)
-            # Fast path when the full rotated plane is finite.
-            if bool(valid.all()):
-                total += rotated
-                count += 1
-            else:
-                np.copyto(rotated, 0, where=~valid)
-                total += rotated
-                count += valid
-
-        out = np.full(out_plane_shape, nan_value, dtype=dtype)
-        np.divide(total, count, out=out, where=count > 0)
-        return out
-
-    # Apply the precomputed symmetrization kernel slice by slice.
     rot_ydim, rot_xdim, output_core_dims, output_sizes = _rotation_output_signature(
         plane.ydim, plane.xdim, out_plane_shape, reshape=reshape
     )
 
+    if order == 1 and mode == "constant" and dtype in _NUMBA_AFFINE_DTYPES:
+        average_rotations = _apply_affine_linear
+        apply_kwargs = {
+            "matrices": matrices,
+            "output_shape": out_plane_shape,
+            "output_origin": output_origin,
+            "cval": cval,
+            "serial": rotated_input.chunks is not None,
+        }
+        vectorize = False
+    else:
+        nan_value = np.array(np.nan, dtype=dtype)[()]
+
+        # Accumulate the mean directly to avoid concat/mean overhead.
+        def _average_rotations_scipy(arr2d: np.ndarray) -> np.ndarray:
+            total = np.zeros(full_out_plane_shape, dtype=dtype)
+            count = np.zeros(full_out_plane_shape, dtype=np.intp)
+            rotated = np.empty(full_out_plane_shape, dtype=dtype)
+
+            for matrix in matrices:
+                scipy.ndimage.affine_transform(
+                    arr2d,
+                    matrix,
+                    output_shape=full_out_plane_shape,
+                    output=rotated,
+                    order=order,
+                    mode=mode,
+                    cval=cval,
+                    prefilter=prefilter,
+                )
+
+                valid = ~np.isnan(rotated)
+                if bool(valid.all()):
+                    total += rotated
+                    count += 1
+                else:
+                    np.copyto(rotated, 0, where=~valid)
+                    total += rotated
+                    count += valid
+
+            out = np.full(full_out_plane_shape, nan_value, dtype=dtype)
+            np.divide(total, count, out=out, where=count > 0)
+            return out[output_slices]
+
+        average_rotations = _average_rotations_scipy
+        apply_kwargs = {}
+        vectorize = True
+
     out = xr.apply_ufunc(
-        _average_rotations,
+        average_rotations,
         rotated_input,
         input_core_dims=[[plane.ydim, plane.xdim]],
         output_core_dims=output_core_dims,
+        kwargs=apply_kwargs,
         dask="parallelized",
         output_dtypes=[dtype],
         dask_gufunc_kwargs={"output_sizes": output_sizes},
-        vectorize=True,
+        vectorize=vectorize,
         keep_attrs="no_conflicts",
     )
 
@@ -522,10 +772,6 @@ def symmetrize_nfold(
 
     # Drop dependent coordinates tied to the rotated plane.
     out = _drop_rotated_axis_coords(out, plane.axes_dims)
-
-    if reshape:
-        # Remove empty margins introduced by the expanded bounding box.
-        out = erlab.utils.array.trim_na(out, plane.axes_dims)
 
     return out.assign_attrs(darr.attrs).transpose(*darr.dims)
 

--- a/src/erlab/analysis/transform.py
+++ b/src/erlab/analysis/transform.py
@@ -98,6 +98,14 @@ def _resolve_rotation_plane(
     dy = float(ycoords[1] - ycoords[0])
     dx = float(xcoords[1] - xcoords[0])
     pixel_ratio = float(abs(dy / dx))
+    # Keep nominally square pixels exact across affine compiler implementations.
+    if np.isclose(
+        pixel_ratio,
+        1.0,
+        rtol=8 * np.finfo(float).eps,
+        atol=0.0,
+    ):
+        pixel_ratio = 1.0
 
     # Interpret the center in data coordinates.
     if isinstance(center, Mapping):

--- a/tests/analysis/test_transform.py
+++ b/tests/analysis/test_transform.py
@@ -330,6 +330,10 @@ def test_rotate_linear_numba_scipy_boundary_rounding(
 
     np.testing.assert_array_equal(np.isnan(actual), np.isnan(expected))
     xr.testing.assert_allclose(actual, expected)
+    if angle == 90.0:
+        expected_nan = np.zeros((9, 7), dtype=bool)
+        expected_nan[7:, 3:5] = True
+        np.testing.assert_array_equal(np.isnan(actual), expected_nan)
 
 
 def test_rotate_linear_numba_dask_matches_eager(monkeypatch) -> None:

--- a/tests/analysis/test_transform.py
+++ b/tests/analysis/test_transform.py
@@ -1,9 +1,50 @@
+import concurrent.futures
+
+import dask.callbacks
 import numpy as np
 import pytest
 import xarray as xr
 import xarray.testing
 
+import erlab.analysis.transform
 from erlab.analysis.transform import rotate, shift, symmetrize, symmetrize_nfold
+
+
+def _symmetrize_nfold_reference(
+    darr: xr.DataArray,
+    fold: int,
+    *,
+    order: int,
+    monkeypatch: pytest.MonkeyPatch,
+    center: tuple[float, float] = (0.0, 0.0),
+    mode: str = "constant",
+) -> xr.DataArray:
+    if not (
+        np.issubdtype(darr.dtype, np.floating)
+        or np.issubdtype(darr.dtype, np.complexfloating)
+    ):
+        darr = darr.astype(np.result_type(darr.dtype, float))
+    with monkeypatch.context() as scipy_path:
+        scipy_path.setattr(
+            erlab.analysis.transform, "_NUMBA_AFFINE_DTYPES", frozenset()
+        )
+        return xr.concat(
+            [
+                rotate(
+                    darr,
+                    360.0 * idx / fold,
+                    axes=("y", "x"),
+                    center=center,
+                    reshape=False,
+                    order=order,
+                    mode=mode,
+                    cval=np.nan,
+                    prefilter=order > 1,
+                )
+                for idx in range(fold)
+            ],
+            dim="rotation",
+        ).mean("rotation", skipna=True)
 
 
 @pytest.mark.parametrize("use_dask", [False, True], ids=["no_dask", "dask"])
@@ -125,6 +166,310 @@ def test_rotate(use_dask) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("dtype", "array_order", "read_only"),
+    [
+        pytest.param(np.float32, "C", False, id="float32-c-writeable"),
+        pytest.param(np.float64, "F", True, id="float64-f-read-only"),
+        pytest.param(np.complex64, "C", True, id="complex64-c-read-only"),
+        pytest.param(np.complex128, "F", False, id="complex128-f-writeable"),
+    ],
+)
+def test_rotate_linear_numba_dtype(dtype, array_order, read_only, monkeypatch) -> None:
+    values = np.array(np.arange(63).reshape(7, 9), dtype=dtype, order=array_order)
+    if np.issubdtype(dtype, np.complexfloating):
+        values *= 1.0 + 0.5j
+    values[2, 5] = np.nan
+    values.setflags(write=not read_only)
+    original = values.copy()
+    darr = xr.DataArray(
+        values,
+        dims=("y", "x"),
+        coords={"y": np.linspace(-1.2, 1.2, 7), "x": np.linspace(-2.0, 2.0, 9)},
+    )
+    kwargs = {
+        "angle": 33.0,
+        "axes": ("y", "x"),
+        "center": (0.15, -0.2),
+        "reshape": False,
+        "order": 1,
+        "mode": "constant",
+        "cval": 0.25,
+        "prefilter": False,
+    }
+
+    with monkeypatch.context() as scipy_path:
+        scipy_path.setattr(
+            erlab.analysis.transform, "_NUMBA_AFFINE_DTYPES", frozenset()
+        )
+        expected = rotate(darr, **kwargs)
+    actual = rotate(darr, **kwargs)
+
+    assert actual.dtype == np.dtype(dtype)
+    xr.testing.assert_allclose(actual, expected)
+    np.testing.assert_array_equal(values, original)
+    assert values.flags.writeable == (not read_only)
+
+
+@pytest.mark.parametrize(
+    "missing_value",
+    [
+        pytest.param(complex(np.nan, 7.0), id="real-nan"),
+        pytest.param(complex(7.0, np.nan), id="imaginary-nan"),
+    ],
+)
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_rotate_linear_numba_complex_nan_components(
+    dtype, missing_value, monkeypatch
+) -> None:
+    values = np.arange(15, dtype=dtype).reshape(3, 5) + 1j * np.arange(
+        100, 115, dtype=dtype
+    ).reshape(3, 5)
+    values[1, 2] = missing_value
+    darr = xr.DataArray(
+        values,
+        dims=("y", "x"),
+        coords={"y": np.arange(-1.0, 2.0), "x": np.arange(-2.0, 3.0)},
+    )
+    kwargs = {
+        "angle": 0.0,
+        "axes": ("y", "x"),
+        "reshape": False,
+        "order": 1,
+        "mode": "constant",
+        "cval": np.nan,
+        "prefilter": False,
+    }
+
+    with monkeypatch.context() as scipy_path:
+        scipy_path.setattr(
+            erlab.analysis.transform, "_NUMBA_AFFINE_DTYPES", frozenset()
+        )
+        expected = rotate(darr, **kwargs)
+    actual = rotate(darr, **kwargs)
+
+    xr.testing.assert_allclose(actual.real, expected.real)
+    xr.testing.assert_allclose(actual.imag, expected.imag)
+
+
+@pytest.mark.parametrize(
+    ("order", "mode", "dtype"),
+    [
+        pytest.param(1, "constant", np.int16, id="integer"),
+        pytest.param(0, "constant", np.float64, id="nearest-order"),
+        pytest.param(3, "constant", np.float64, id="spline-order"),
+        pytest.param(1, "nearest", np.float64, id="boundary-mode"),
+    ],
+)
+def test_rotate_scipy_fallback(order, mode, dtype, monkeypatch) -> None:
+    def _fail_fast_path(*args, **kwargs) -> None:
+        raise AssertionError("Numba fast path was used")
+
+    monkeypatch.setattr(
+        erlab.analysis.transform, "_apply_affine_linear", _fail_fast_path
+    )
+    darr = xr.DataArray(
+        np.arange(63).reshape(7, 9).astype(dtype),
+        dims=("y", "x"),
+        coords={"y": np.linspace(-1.2, 1.2, 7), "x": np.linspace(-2.0, 2.0, 9)},
+    )
+
+    actual = rotate(
+        darr,
+        33.0,
+        axes=("y", "x"),
+        center=(0.15, -0.2),
+        reshape=False,
+        order=order,
+        mode=mode,
+        cval=0.0,
+        prefilter=order > 1,
+    )
+
+    assert actual.shape == darr.shape
+    assert actual.dtype == np.dtype(dtype)
+
+
+@pytest.mark.parametrize(
+    ("shape", "angle", "reshape", "nan_index"),
+    [
+        pytest.param((3, 5), 0.0, False, (2, 1), id="identity-stencil"),
+        pytest.param((7, 9), 90.0, True, (4, 1), id="right-angle-reshape"),
+    ],
+)
+def test_rotate_linear_numba_scipy_boundary_rounding(
+    shape, angle, reshape, nan_index, monkeypatch
+) -> None:
+    values = np.arange(np.prod(shape), dtype=float).reshape(shape)
+    values[nan_index] = np.nan
+    darr = xr.DataArray(
+        values,
+        dims=("y", "x"),
+        coords={
+            "y": (np.arange(shape[0]) - (shape[0] - 1) / 2) * 0.4,
+            "x": (np.arange(shape[1]) - (shape[1] - 1) / 2) * 0.4,
+        },
+    )
+    kwargs = {
+        "angle": angle,
+        "axes": ("y", "x"),
+        "center": (0.0, 0.0),
+        "reshape": reshape,
+        "order": 1,
+        "mode": "constant",
+        "cval": np.nan,
+        "prefilter": False,
+    }
+
+    with monkeypatch.context() as scipy_path:
+        scipy_path.setattr(
+            erlab.analysis.transform, "_NUMBA_AFFINE_DTYPES", frozenset()
+        )
+        expected = rotate(darr, **kwargs)
+    actual = rotate(darr, **kwargs)
+
+    np.testing.assert_array_equal(np.isnan(actual), np.isnan(expected))
+    xr.testing.assert_allclose(actual, expected)
+
+
+def test_rotate_linear_numba_dask_matches_eager(monkeypatch) -> None:
+    values = np.arange(126, dtype=float).reshape(2, 7, 9)
+    values[0, 2, 5] = np.nan
+    darr = xr.DataArray(
+        values,
+        dims=("eV", "y", "x"),
+        coords={
+            "eV": [-0.1, 0.0],
+            "y": np.linspace(-1.2, 1.2, 7),
+            "x": np.linspace(-2.0, 2.0, 9),
+        },
+    )
+    kwargs = {
+        "angle": 33.0,
+        "axes": ("y", "x"),
+        "center": (0.15, -0.2),
+        "reshape": False,
+        "order": 1,
+        "mode": "constant",
+        "cval": np.nan,
+        "prefilter": False,
+    }
+    expected = rotate(darr, **kwargs)
+
+    def _fail_parallel_kernel(*args, **kwargs) -> None:
+        raise AssertionError("Parallel Numba kernel was used inside a Dask task")
+
+    monkeypatch.setattr(
+        erlab.analysis.transform, "_apply_affine_linear_numba", _fail_parallel_kernel
+    )
+    construction_tasks = []
+
+    with dask.callbacks.Callback(
+        pretask=lambda key, *args: construction_tasks.append(key)
+    ):
+        actual = rotate(darr.chunk({"eV": 1, "y": -1, "x": -1}), **kwargs)
+
+    assert construction_tasks == []
+    assert actual.chunks is not None
+    compute_tasks = []
+    with dask.callbacks.Callback(pretask=lambda key, *args: compute_tasks.append(key)):
+        computed = actual.compute(scheduler="threads")
+    kernel_tasks = [
+        key
+        for key in compute_tasks
+        if "apply_affine_linear" in str(key[0] if isinstance(key, tuple) else key)
+    ]
+    assert len(kernel_tasks) == 2
+    xr.testing.assert_allclose(computed, expected)
+
+
+def test_affine_linear_numba_worker_threads_use_serial(monkeypatch) -> None:
+    darr = xr.DataArray(
+        np.arange(63, dtype=float).reshape(7, 9),
+        dims=("y", "x"),
+        coords={"y": np.linspace(-1.2, 1.2, 7), "x": np.linspace(-2.0, 2.0, 9)},
+    )
+    rotate_kwargs = {
+        "angle": 33.0,
+        "axes": ("y", "x"),
+        "center": (0.15, -0.2),
+        "reshape": False,
+    }
+    symmetrize_kwargs = {
+        "fold": 3,
+        "axes": ("y", "x"),
+        "center": (0.15, -0.2),
+        "reshape": False,
+    }
+    expected_rotate = rotate(darr, **rotate_kwargs)
+    expected_symmetrized = symmetrize_nfold(darr, **symmetrize_kwargs)
+
+    def _fail_parallel_kernel(*args, **kwargs) -> None:
+        raise AssertionError("Parallel Numba kernel was used inside a worker thread")
+
+    monkeypatch.setattr(
+        erlab.analysis.transform, "_apply_affine_linear_numba", _fail_parallel_kernel
+    )
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        rotate_future = executor.submit(rotate, darr, **rotate_kwargs)
+        symmetrize_future = executor.submit(symmetrize_nfold, darr, **symmetrize_kwargs)
+        actual_rotate = rotate_future.result()
+        actual_symmetrized = symmetrize_future.result()
+
+    xr.testing.assert_allclose(actual_rotate, expected_rotate)
+    xr.testing.assert_allclose(actual_symmetrized, expected_symmetrized)
+
+
+def test_rotate_reshape_dask_is_lazy_and_geometry_based() -> None:
+    values = np.full((2, 3, 5), np.nan)
+    darr = xr.DataArray(
+        values,
+        dims=("eV", "y", "x"),
+        coords={
+            "eV": [-0.1, 0.0],
+            "y": np.arange(-1.0, 2.0),
+            "x": np.arange(-2.0, 3.0),
+        },
+    )
+    lazy = darr.chunk({"eV": 1, "y": -1, "x": -1})
+    construction_tasks = []
+
+    with dask.callbacks.Callback(
+        pretask=lambda key, *args: construction_tasks.append(key)
+    ):
+        actual = rotate(
+            lazy,
+            30.0,
+            axes=("y", "x"),
+            center=(0.0, 0.0),
+            reshape=True,
+            order=1,
+            mode="constant",
+            cval=np.nan,
+            prefilter=False,
+        )
+
+    assert construction_tasks == []
+    assert actual.chunks is not None
+    assert actual.sizes == {"eV": 2, "y": 5, "x": 6}
+    np.testing.assert_allclose(actual.y, np.arange(-2.0, 3.0), atol=1e-14)
+    np.testing.assert_allclose(actual.x, np.arange(-2.5, 3.0), atol=1e-14)
+
+    expected = rotate(
+        darr,
+        30.0,
+        axes=("y", "x"),
+        center=(0.0, 0.0),
+        reshape=True,
+        order=1,
+        mode="constant",
+        cval=np.nan,
+        prefilter=False,
+    )
+    computed = actual.compute(scheduler="threads")
+    xr.testing.assert_allclose(computed, expected)
+
+
 @pytest.mark.parametrize("use_dask", [False, True], ids=["no_dask", "dask"])
 def test_shift(use_dask) -> None:
     # Create a test input DataArray
@@ -219,6 +564,240 @@ def test_symmetrize_nfold(use_dask) -> None:
 
     assert np.issubdtype(sym.dtype, np.floating)
     xr.testing.assert_allclose(sym, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype", [np.int16, np.float32, np.float64, np.complex64, np.complex128]
+)
+@pytest.mark.parametrize("array_order", ["C", "F"], ids=["c_order", "f_order"])
+@pytest.mark.parametrize("read_only", [False, True], ids=["writeable", "read_only"])
+def test_symmetrize_nfold_linear_numba_dtype(
+    dtype, array_order, read_only, monkeypatch
+) -> None:
+    values = np.array(np.arange(63).reshape(7, 9), dtype=dtype, order=array_order)
+    if np.issubdtype(dtype, np.complexfloating):
+        values *= 1.0 + 0.5j
+    values[2, 5] = np.nan if not np.issubdtype(dtype, np.integer) else 0
+    values.setflags(write=not read_only)
+    original = values.copy()
+    darr = xr.DataArray(
+        values,
+        dims=("y", "x"),
+        coords={"y": np.linspace(-1.2, 1.2, 7), "x": np.linspace(-2.0, 2.0, 9)},
+    )
+    center = (0.15, -0.2)
+
+    expected = _symmetrize_nfold_reference(
+        darr, 3, order=1, monkeypatch=monkeypatch, center=center
+    )
+    actual = symmetrize_nfold(
+        darr,
+        3,
+        axes=("y", "x"),
+        center=center,
+        reshape=False,
+        order=1,
+        mode="constant",
+        cval=np.nan,
+        prefilter=False,
+    )
+
+    expected_dtype = (
+        np.dtype(np.float64) if np.issubdtype(dtype, np.integer) else np.dtype(dtype)
+    )
+    assert actual.dtype == expected_dtype
+    xr.testing.assert_allclose(actual, expected)
+    np.testing.assert_array_equal(values, original)
+    assert values.flags.writeable == (not read_only)
+
+
+@pytest.mark.parametrize(
+    ("order", "mode"),
+    [(0, "constant"), (1, "constant"), (3, "constant"), (1, "nearest")],
+)
+def test_symmetrize_nfold_interpolation_orders(order, mode, monkeypatch) -> None:
+    darr = xr.DataArray(
+        np.arange(63, dtype=float).reshape(7, 9),
+        dims=("y", "x"),
+        coords={"y": np.linspace(-1.2, 1.2, 7), "x": np.linspace(-2.0, 2.0, 9)},
+    )
+    center = (0.15, -0.2)
+
+    expected = _symmetrize_nfold_reference(
+        darr,
+        3,
+        order=order,
+        monkeypatch=monkeypatch,
+        center=center,
+        mode=mode,
+    )
+    actual = symmetrize_nfold(
+        darr,
+        3,
+        axes=("y", "x"),
+        center=center,
+        reshape=False,
+        order=order,
+        mode=mode,
+        cval=np.nan,
+        prefilter=order > 1,
+    )
+
+    xr.testing.assert_allclose(actual, expected)
+
+
+def test_symmetrize_nfold_linear_numba_nan_stencil(monkeypatch) -> None:
+    values = np.arange(15, dtype=float).reshape(3, 5)
+    values[1, 2] = np.nan
+    darr = xr.DataArray(
+        values,
+        dims=("y", "x"),
+        coords={"y": np.arange(-1.0, 2.0), "x": np.arange(-2.0, 3.0)},
+    )
+
+    expected = _symmetrize_nfold_reference(darr, 2, order=1, monkeypatch=monkeypatch)
+    actual = symmetrize_nfold(
+        darr,
+        2,
+        axes=("y", "x"),
+        center=(0.0, 0.0),
+        reshape=False,
+        order=1,
+        mode="constant",
+        cval=np.nan,
+        prefilter=False,
+    )
+
+    xr.testing.assert_allclose(actual, expected)
+
+
+def test_symmetrize_nfold_reshape_dask_is_lazy_and_geometry_based() -> None:
+    values = np.full((2, 3, 5), np.nan)
+    darr = xr.DataArray(
+        values,
+        dims=("eV", "y", "x"),
+        coords={
+            "eV": [-0.1, 0.0],
+            "y": np.arange(-1.0, 2.0),
+            "x": np.arange(-2.0, 3.0),
+        },
+    )
+    lazy = darr.chunk({"eV": 1, "y": -1, "x": -1})
+    executed_tasks = []
+
+    with dask.callbacks.Callback(pretask=lambda key, *args: executed_tasks.append(key)):
+        actual = symmetrize_nfold(
+            lazy,
+            4,
+            axes=("y", "x"),
+            center=(0.0, 0.0),
+            reshape=True,
+            order=1,
+            mode="constant",
+            cval=np.nan,
+            prefilter=False,
+        )
+
+    assert executed_tasks == []
+    assert actual.chunks is not None
+    assert actual.sizes == {"eV": 2, "y": 5, "x": 5}
+    expected = symmetrize_nfold(
+        darr,
+        4,
+        axes=("y", "x"),
+        center=(0.0, 0.0),
+        reshape=True,
+        order=1,
+        mode="constant",
+        cval=np.nan,
+        prefilter=False,
+    )
+    compute_tasks = []
+    with dask.callbacks.Callback(pretask=lambda key, *args: compute_tasks.append(key)):
+        computed = actual.compute(scheduler="threads")
+    kernel_tasks = [
+        key
+        for key in compute_tasks
+        if "apply_affine_linear" in str(key[0] if isinstance(key, tuple) else key)
+    ]
+    assert len(kernel_tasks) == 2
+    xr.testing.assert_allclose(computed, expected)
+
+
+def test_symmetrize_nfold_reshape_numba_matches_scipy(monkeypatch) -> None:
+    darr = xr.DataArray(
+        np.arange(15, dtype=float).reshape(3, 5),
+        dims=("y", "x"),
+        coords={
+            "y": (np.arange(3) - 1) * 0.4,
+            "x": (np.arange(5) - 2) * 0.4,
+        },
+    )
+    kwargs = {
+        "fold": 3,
+        "axes": ("y", "x"),
+        "center": (0.0, 0.0),
+        "reshape": True,
+        "order": 1,
+        "mode": "constant",
+        "cval": np.nan,
+        "prefilter": False,
+    }
+
+    with monkeypatch.context() as scipy_path:
+        scipy_path.setattr(
+            erlab.analysis.transform, "_NUMBA_AFFINE_DTYPES", frozenset()
+        )
+        expected = symmetrize_nfold(darr, **kwargs)
+    actual = symmetrize_nfold(darr, **kwargs)
+
+    np.testing.assert_array_equal(np.isnan(actual), np.isnan(expected))
+    xr.testing.assert_allclose(actual, expected)
+
+
+def test_symmetrize_nfold_reshape_geometry_matches_scipy_support() -> None:
+    darr = xr.DataArray(
+        np.ones((11, 11)),
+        dims=("y", "x"),
+        coords={
+            "y": (np.arange(11) - 5) * -0.4,
+            "x": (np.arange(11) - 5) * 0.7,
+        },
+    )
+
+    actual = symmetrize_nfold(darr, 3, axes=("y", "x"), reshape=True)
+
+    assert actual.sizes == {"y": 21, "x": 11}
+    np.testing.assert_allclose(actual.y, np.linspace(4.0, -4.0, 21), atol=1e-14)
+    np.testing.assert_allclose(actual.x, np.linspace(-3.5, 3.5, 11), atol=1e-14)
+
+
+def test_rotation_geometry_bounds_no_intersection() -> None:
+    matrices = np.array([[[1.0, 0.0, 100.0], [0.0, 1.0, 100.0], [0.0, 0.0, 1.0]]])
+
+    bounds = erlab.analysis.transform._rotation_geometry_bounds(
+        matrices, (3, 3), (4, 5)
+    )
+
+    assert bounds == (0, 0, 0, 0)
+
+
+@pytest.mark.parametrize(
+    ("mode", "cval"),
+    [pytest.param("constant", 0.25, id="finite-cval"), pytest.param("nearest", np.nan)],
+)
+def test_symmetrize_nfold_reshape_keeps_finite_padding(mode, cval) -> None:
+    darr = xr.DataArray(
+        np.ones((3, 5)),
+        dims=("y", "x"),
+        coords={"y": np.arange(-1.0, 2.0), "x": np.arange(-2.0, 3.0)},
+    )
+
+    actual = symmetrize_nfold(
+        darr, 3, axes=("y", "x"), reshape=True, mode=mode, cval=cval
+    )
+
+    assert actual.sizes == {"y": 7, "x": 7}
 
 
 def test_symmetrize_nfold_broadcasts_over_remaining_dims() -> None:


### PR DESCRIPTION
## Summary

- Accelerate linear rotations and n-fold symmetrization with one shared Numba path.
- Keep reshaped Dask results lazy by deriving crop bounds from rotation geometry.
- Preserve SciPy fallbacks, dtype behavior, complex missing-value semantics, and safe worker-thread execution.

## Validation

- `uv run pytest tests/analysis/test_transform.py -q` (90 passed)
- `uv run ruff check src/erlab/analysis/transform.py tests/analysis/test_transform.py`
- `uv run ruff format --check src/erlab/analysis/transform.py tests/analysis/test_transform.py`
- `uv run mypy src`
- Reproduced two concurrent eager rotations with the Numba workqueue threading layer.
- Compared real and complex results against SciPy across dtypes, memory layouts, and read-only arrays.