### PR TITLE
fix(manager): scale large workspace loading and saves

### DIFF
--- a/src/erlab/interactive/imagetool/_provenance/_graph.py
+++ b/src/erlab/interactive/imagetool/_provenance/_graph.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import ast
 import builtins
+import hashlib
 import io
 import json
 import keyword
@@ -223,11 +224,13 @@ _FILE_LOAD_OUTPUT_SENTINEL = "_itool_file_load_output"
 
 
 def _canonical_key(kind: str, payload: Mapping[str, typing.Any]) -> str:
-    return json.dumps(
+    canonical_payload = json.dumps(
         {"kind": kind, **dict(payload)},
         sort_keys=True,
         separators=(",", ":"),
     )
+    digest = hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
+    return f"canonical-sha256:{digest}"
 
 
 def _is_semantic_replay_name(name: str) -> bool:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -136,6 +136,8 @@ class _WorkspaceController:
             workspace_saving._WorkspaceGcResultReceiver | None
         ) = None
         self._workspace_gc_requested = False
+        self._code_trust_manifest_binding_depth = 0
+        self._code_trust_manifest_binding_pending = False
 
     def _loaded_workspace_code_trust(
         self,
@@ -181,6 +183,7 @@ class _WorkspaceController:
     ) -> bool:
         """Apply incoming trust while payloads load, and roll it back on failure."""
         previous = self._manager._workspace_state.code_trust
+        previous_binding_pending = self._code_trust_manifest_binding_pending
         if (
             not replace
             and document_trust_needs_review(previous)
@@ -190,13 +193,29 @@ class _WorkspaceController:
             # signed pre-rebase location authorize an equal existing location.
             incoming = untrusted_document_trust(incoming.manifest)
         self._merge_workspace_code_trust(incoming, replace=replace)
+        self._code_trust_manifest_binding_depth += 1
         try:
             loaded = load()
         except Exception:
+            self._code_trust_manifest_binding_pending = previous_binding_pending
             self._set_workspace_code_trust(previous)
             raise
+        finally:
+            self._code_trust_manifest_binding_depth -= 1
         if not loaded:
+            self._code_trust_manifest_binding_pending = previous_binding_pending
             self._set_workspace_code_trust(previous)
+        elif (
+            self._code_trust_manifest_binding_depth == 0
+            and self._code_trust_manifest_binding_pending
+        ):
+            self._code_trust_manifest_binding_pending = False
+            try:
+                self._bind_current_workspace_manifest_if_review_needed()
+            except Exception:
+                self._code_trust_manifest_binding_pending = previous_binding_pending
+                self._set_workspace_code_trust(previous)
+                raise
         return loaded
 
     def _set_workspace_code_trust(self, trust: _DocumentTrust) -> None:
@@ -426,6 +445,9 @@ class _WorkspaceController:
         """Bind the full inventory after a node changes a paused workspace."""
         trust = self._manager._workspace_state.code_trust
         if not document_trust_needs_review(trust):
+            return
+        if self._code_trust_manifest_binding_depth > 0:
+            self._code_trust_manifest_binding_pending = True
             return
         try:
             manifest = workspace_trust.current_workspace_code_trust_manifest(
@@ -2155,6 +2177,7 @@ class _WorkspaceController:
                 self.saving._save_workspace_document(
                     existing_access.path,
                     document_access=existing_access,
+                    legacy_source_path=existing_access.path,
                 )
             return str(existing_access.path), self._take_workspace_access_lock(
                 existing_access

--- a/src/erlab/interactive/imagetool/manager/_workspace/_format.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_format.py
@@ -344,23 +344,28 @@ def _workspace_root_keys(
     tree: typing.Any, manifest: Mapping[str, typing.Any] | None
 ) -> list[str]:
     root_keys: list[str] = []
+    root_key_set: set[str] = set()
     if manifest is not None:
         raw_root_order = manifest.get("root_order", ())
         if isinstance(raw_root_order, list):
-            root_keys.extend(
-                str(item)
-                for item in raw_root_order
-                if str(item) not in root_keys
-                and str(item) != "figures"
-                and not _is_workspace_internal_group_name(item)
-            )
-    root_keys.extend(
-        str(key)
-        for key in tree
-        if str(key) not in root_keys
-        and str(key) != "figures"
-        and not _is_workspace_internal_group_name(key)
-    )
+            for item in raw_root_order:
+                key = str(item)
+                if (
+                    key not in root_key_set
+                    and key != "figures"
+                    and not _is_workspace_internal_group_name(item)
+                ):
+                    root_keys.append(key)
+                    root_key_set.add(key)
+    for item in tree:
+        key = str(item)
+        if (
+            key not in root_key_set
+            and key != "figures"
+            and not _is_workspace_internal_group_name(item)
+        ):
+            root_keys.append(key)
+            root_key_set.add(key)
     return root_keys
 
 

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -1354,14 +1354,50 @@ class _WorkspaceLoader:
         if saved_uid is not None:
             loaded_targets_by_uid[saved_uid] = target
 
+    @staticmethod
+    def _workspace_manifest_indexes(
+        manifest: Mapping[str, typing.Any] | None,
+    ) -> tuple[
+        dict[str, Mapping[str, typing.Any]],
+        dict[str, tuple[str, ...]],
+    ]:
+        entries_by_path: dict[str, Mapping[str, typing.Any]] = {}
+        for entry in workspace_format._iter_workspace_manifest_node_entries(manifest):
+            path = entry.get("path")
+            if not isinstance(path, str) or entry.get("kind") not in {
+                "imagetool",
+                "tool",
+            }:
+                continue
+            if path in entries_by_path:
+                raise ValueError(
+                    f"Workspace manifest contains duplicate node path {path!r}"
+                )
+            entries_by_path[path] = entry
+        direct_children: dict[str, list[str]] = {}
+        for path in entries_by_path:
+            parent, separator, child = path.rpartition("/")
+            if separator and child:
+                direct_children.setdefault(parent, []).append(child)
+        return entries_by_path, {
+            parent: tuple(children) for parent, children in direct_children.items()
+        }
+
     @classmethod
     def _workspace_manifest_node_entry(
         cls,
         manifest: Mapping[str, typing.Any] | None,
         node_path: str | None,
         kind: typing.Literal["imagetool", "tool"],
+        *,
+        entries_by_path: Mapping[str, Mapping[str, typing.Any]] | None = None,
     ) -> Mapping[str, typing.Any] | None:
         if node_path is None:
+            return None
+        if entries_by_path is not None:
+            entry = entries_by_path.get(node_path)
+            if entry is not None and entry.get("kind") == kind:
+                return entry
             return None
         for entry in workspace_format._iter_workspace_manifest_node_entries(manifest):
             if entry.get("path") == node_path and entry.get("kind") == kind:
@@ -1370,8 +1406,14 @@ class _WorkspaceLoader:
 
     @classmethod
     def _workspace_manifest_direct_child_keys(
-        cls, manifest: Mapping[str, typing.Any] | None, prefix: str
+        cls,
+        manifest: Mapping[str, typing.Any] | None,
+        prefix: str,
+        *,
+        direct_children: Mapping[str, tuple[str, ...]] | None = None,
     ) -> list[str]:
+        if direct_children is not None:
+            return list(direct_children.get(prefix.rstrip("/"), ()))
         child_keys: list[str] = []
         for entry in workspace_format._iter_workspace_manifest_node_entries(manifest):
             path = entry.get("path")
@@ -1482,12 +1524,19 @@ class _WorkspaceLoader:
         workspace_file_path: str | os.PathLike[str] | None = None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
         reserved_uids: Mapping[str, str] | None = None,
+        manifest_entries_by_path: (
+            Mapping[str, Mapping[str, typing.Any]] | None
+        ) = None,
+        manifest_direct_children: Mapping[str, tuple[str, ...]] | None = None,
     ) -> int | str:
         if "imagetool" in node_tree:
             ds = None
             pending_imagetool_payload: tuple[str | os.PathLike[str], str] | None = None
             entry = self._workspace_manifest_node_entry(
-                manifest, node_path, "imagetool"
+                manifest,
+                node_path,
+                "imagetool",
+                entries_by_path=manifest_entries_by_path,
             )
             if entry is not None and workspace_file_path is not None:
                 payload_path = f"{node_path}/imagetool"
@@ -1545,7 +1594,12 @@ class _WorkspaceLoader:
         elif "tool" in node_tree:
             ds = None
             pending_tool_payload: tuple[str | os.PathLike[str], str] | None = None
-            entry = self._workspace_manifest_node_entry(manifest, node_path, "tool")
+            entry = self._workspace_manifest_node_entry(
+                manifest,
+                node_path,
+                "tool",
+                entries_by_path=manifest_entries_by_path,
+            )
             if entry is not None and workspace_file_path is not None:
                 payload_path = f"{node_path}/tool"
                 if not _workspace_payload_window_visible_h5py(
@@ -1589,11 +1643,16 @@ class _WorkspaceLoader:
             child_keys: list[str] = []
             if manifest is not None and node_path is not None:
                 child_keys = self._workspace_manifest_direct_child_keys(
-                    manifest, f"{node_path}/childtools/"
+                    manifest,
+                    f"{node_path}/childtools/",
+                    direct_children=manifest_direct_children,
                 )
-            child_keys.extend(
-                str(key) for key in childtools if str(key) not in child_keys
-            )
+            child_key_set = set(child_keys)
+            for item in childtools:
+                child_key = str(item)
+                if child_key not in child_key_set:
+                    child_keys.append(child_key)
+                    child_key_set.add(child_key)
 
             for child_key in child_keys:
                 if child_key not in childtools:
@@ -1618,6 +1677,8 @@ class _WorkspaceLoader:
                     ),
                     loaded_targets_by_uid=loaded_targets_by_uid,
                     reserved_uids=reserved_uids,
+                    manifest_entries_by_path=manifest_entries_by_path,
+                    manifest_direct_children=manifest_direct_children,
                 )
         return target
 
@@ -1632,6 +1693,10 @@ class _WorkspaceLoader:
         workspace_file_path: str | os.PathLike[str] | None = None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
         reserved_uids: Mapping[str, str] | None = None,
+        manifest_entries_by_path: (
+            Mapping[str, Mapping[str, typing.Any]] | None
+        ) = None,
+        manifest_direct_children: Mapping[str, tuple[str, ...]] | None = None,
     ) -> int | str | None:
         try:
             return self._load_workspace_node(
@@ -1643,6 +1708,8 @@ class _WorkspaceLoader:
                 workspace_file_path=workspace_file_path,
                 loaded_targets_by_uid=loaded_targets_by_uid,
                 reserved_uids=reserved_uids,
+                manifest_entries_by_path=manifest_entries_by_path,
+                manifest_direct_children=manifest_direct_children,
             )
         except Exception as exc:
             self._record_skipped_workspace_node(node_path, exc)
@@ -1658,6 +1725,10 @@ class _WorkspaceLoader:
         workspace_file_path: str | os.PathLike[str] | None = None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
         reserved_uids: Mapping[str, str] | None = None,
+        manifest_entries_by_path: (
+            Mapping[str, Mapping[str, typing.Any]] | None
+        ) = None,
+        manifest_direct_children: Mapping[str, tuple[str, ...]] | None = None,
     ) -> int:
         loaded_count = 0
         for key in root_keys:
@@ -1674,6 +1745,8 @@ class _WorkspaceLoader:
                     node_path=key,
                     loaded_targets_by_uid=loaded_targets_by_uid,
                     reserved_uids=reserved_uids,
+                    manifest_entries_by_path=manifest_entries_by_path,
+                    manifest_direct_children=manifest_direct_children,
                 )
                 if target is not None:
                     loaded_count += 1
@@ -1688,12 +1761,25 @@ class _WorkspaceLoader:
         workspace_file_path: str | os.PathLike[str] | None = None,
         loaded_targets_by_uid: dict[str, int | str] | None = None,
         reserved_uids: Mapping[str, str] | None = None,
+        manifest_entries_by_path: (
+            Mapping[str, Mapping[str, typing.Any]] | None
+        ) = None,
+        manifest_direct_children: Mapping[str, tuple[str, ...]] | None = None,
     ) -> int:
         if "figures" not in tree:
             return 0
         figures = typing.cast("xr.DataTree", tree["figures"])
-        figure_keys = self._workspace_manifest_direct_child_keys(manifest, "figures/")
-        figure_keys.extend(str(key) for key in figures if str(key) not in figure_keys)
+        figure_keys = self._workspace_manifest_direct_child_keys(
+            manifest,
+            "figures/",
+            direct_children=manifest_direct_children,
+        )
+        figure_key_set = set(figure_keys)
+        for item in figures:
+            figure_key = str(item)
+            if figure_key not in figure_key_set:
+                figure_keys.append(figure_key)
+                figure_key_set.add(figure_key)
 
         loaded_count = 0
         for figure_key in figure_keys:
@@ -1715,6 +1801,8 @@ class _WorkspaceLoader:
                 node_path=figure_path,
                 loaded_targets_by_uid=loaded_targets_by_uid,
                 reserved_uids=reserved_uids,
+                manifest_entries_by_path=manifest_entries_by_path,
+                manifest_direct_children=manifest_direct_children,
             )
             if target is not None:
                 loaded_count += 1
@@ -1738,25 +1826,27 @@ class _WorkspaceLoader:
         root_order = manifest.get("root_order", ())
         if not isinstance(nodes, list) or not isinstance(root_order, list):
             raise TypeError("Workspace manifest is missing node ordering")
-        entries_by_path: dict[str, Mapping[str, typing.Any]] = {}
-        for entry in workspace_format._iter_workspace_manifest_node_entries(manifest):
-            path = entry.get("path")
-            kind = entry.get("kind")
-            if not isinstance(path, str) or kind not in {"imagetool", "tool"}:
-                continue
-            entries_by_path[path] = entry
+        entries_by_path, _manifest_direct_children = self._workspace_manifest_indexes(
+            manifest
+        )
         if nodes and not entries_by_path:
             raise ValueError("Workspace manifest has no loadable nodes")
 
         root_paths: list[str] = []
+        root_path_set: set[str] = set()
         for root in root_order:
             path = str(root)
-            if path in entries_by_path and "/" not in path and path not in root_paths:
+            if (
+                path in entries_by_path
+                and "/" not in path
+                and path not in root_path_set
+            ):
                 root_paths.append(path)
+                root_path_set.add(path)
         root_paths.extend(
             path
             for path in entries_by_path
-            if "/" not in path and path not in root_paths
+            if "/" not in path and path not in root_path_set
         )
         figure_paths = [
             path
@@ -2130,6 +2220,9 @@ class _WorkspaceLoader:
                         f"Unsupported workspace schema version {schema_version}, "
                         "file may be from a newer version of erlab"
                     )
+            manifest_entries_by_path, manifest_direct_children = (
+                self._workspace_manifest_indexes(manifest)
+            )
             if replace:
                 manifest_workspace_link_id = (
                     None if manifest is None else manifest.get("workspace_link_id")
@@ -2193,6 +2286,8 @@ class _WorkspaceLoader:
                             workspace_file_path=workspace_file_path,
                             loaded_targets_by_uid=loaded_targets_by_uid,
                             reserved_uids=reserved_uids,
+                            manifest_entries_by_path=manifest_entries_by_path,
+                            manifest_direct_children=manifest_direct_children,
                         )
                         loaded_count += self._load_workspace_figures(
                             tree,
@@ -2201,6 +2296,8 @@ class _WorkspaceLoader:
                             workspace_file_path=workspace_file_path,
                             loaded_targets_by_uid=loaded_targets_by_uid,
                             reserved_uids=reserved_uids,
+                            manifest_entries_by_path=manifest_entries_by_path,
+                            manifest_direct_children=manifest_direct_children,
                         )
                     if loaded_count == 0 and self._skipped_workspace_nodes:
                         self._raise_no_workspace_windows_loaded()
@@ -2452,9 +2549,12 @@ class _WorkspaceLoader:
         uid: str,
         *,
         chunks: typing.Any,
+        payload_path: str | None = None,
     ) -> xr.DataArray:
         ds = workspace_arrays.open_workspace_dataset(
-            fname, self._workspace_payload_path_for_uid(fname, uid), chunks=chunks
+            fname,
+            payload_path or self._workspace_payload_path_for_uid(fname, uid),
+            chunks=chunks,
         )
         try:
             ds = workspace_format._restore_workspace_dataset_attrs(ds)
@@ -2469,11 +2569,10 @@ class _WorkspaceLoader:
         finally:
             ds.close()
 
-    def _workspace_payload_path_for_uid(
+    def _workspace_manifest_for_path(
         self,
         fname: str | os.PathLike[str],
-        uid: str,
-    ) -> str:
+    ) -> Mapping[str, typing.Any] | None:
         manifest = None
         store = getattr(self._controller, "_workspace_store", None)
         if (
@@ -2489,6 +2588,14 @@ class _WorkspaceLoader:
                 _schema, manifest = (
                     workspace_format._workspace_file_metadata_from_attrs(attrs)
                 )
+        return manifest
+
+    def _workspace_payload_path_for_uid(
+        self,
+        fname: str | os.PathLike[str],
+        uid: str,
+    ) -> str:
+        manifest = self._workspace_manifest_for_path(fname)
         payload_path = workspace_format._workspace_manifest_payload_path(manifest, uid)
         if payload_path is not None:
             return payload_path
@@ -2578,6 +2685,13 @@ class _WorkspaceLoader:
             )
         if not pending:
             return
+        manifest = self._workspace_manifest_for_path(fname)
+        payload_paths = {
+            uid: payload_path
+            for uid, _kind, payload_path in (
+                workspace_format._workspace_manifest_payload_entries(manifest)
+            )
+        }
         with self._controller._workspace_load_context():
             for node, state, name, chunks in pending:
                 tool = node.imagetool
@@ -2585,7 +2699,11 @@ class _WorkspaceLoader:
                     continue
                 slicer_area = tool.slicer_area
                 data = self._workspace_rebind_data_for_uid(
-                    fname, node.uid, chunks=chunks
+                    fname,
+                    node.uid,
+                    chunks=chunks,
+                    payload_path=payload_paths.get(node.uid)
+                    or self._controller.saving._workspace_payload_path(node.uid),
                 )
                 slicer_area.set_data(data, auto_compute=False)
                 slicer_area.state = state

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -1108,6 +1108,7 @@ class _WorkspaceSaver:
         )
         current_manifest: dict[str, typing.Any] | None = None
         legacy_manifest: dict[str, typing.Any] | None = None
+        legacy_schema_version: int | None = None
         if source_store is not None and not source_store.closed:
             with contextlib.suppress(Exception):
                 current_manifest = source_store.current_generation().manifest
@@ -1128,6 +1129,7 @@ class _WorkspaceSaver:
                     current_manifest = manifest
                 else:
                     legacy_manifest = manifest
+                    legacy_schema_version = schema_version
 
         previous_entries: dict[str, Mapping[str, typing.Any]] = {}
         if current_manifest is not None:
@@ -1398,9 +1400,18 @@ class _WorkspaceSaver:
             object_id = entry.get("payload_object_id")
             if not isinstance(uid, str) or not isinstance(object_id, str):
                 continue
-            legacy_path = legacy_payload_paths.get(
-                uid, f"/{self._workspace_payload_path(uid).strip('/')}"
-            )
+            legacy_path = legacy_payload_paths.get(uid)
+            if legacy_path is None:
+                node_path = entry.get("path")
+                kind = entry.get("kind")
+                if (
+                    legacy_schema_version == 2
+                    and kind == "tool"
+                    and isinstance(node_path, str)
+                ):
+                    legacy_path = f"/{node_path.strip('/')}"
+                else:
+                    legacy_path = f"/{self._workspace_payload_path(uid).strip('/')}"
             if (
                 current_manifest is None
                 and in_place_legacy_source is not None

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -770,6 +770,7 @@ class _WorkspaceSaver:
         *,
         document_access: _WorkspaceDocumentAccess | None = None,
         mark_clean: bool = True,
+        legacy_source_path: str | os.PathLike[str] | None = None,
     ) -> None:
         if document_access is None:
             _require_itws_workspace_path(fname, _WORKSPACE_SAVE_SUFFIX_ERROR)
@@ -779,6 +780,7 @@ class _WorkspaceSaver:
                     access.path,
                     document_access=access,
                     mark_clean=mark_clean,
+                    legacy_source_path=legacy_source_path,
                 )
             return
 
@@ -792,6 +794,7 @@ class _WorkspaceSaver:
             snapshot = self._workspace_generation_save_snapshot(
                 self._manager._workspace_state.dirty_generation,
                 fname=fname,
+                legacy_source_path=legacy_source_path,
             )
             self._close_workspace_idle_readers(fname)
             target_store = workspace_store.WorkspaceStore.active(fname)
@@ -1094,17 +1097,27 @@ class _WorkspaceSaver:
         generation: int,
         *,
         fname: str | os.PathLike[str],
+        legacy_source_path: str | os.PathLike[str] | None = None,
     ) -> _WorkspaceSaveSnapshot:
         """Capture one immutable generation without copying unchanged payloads."""
         source_store = getattr(self._controller, "_workspace_store", None)
+        explicit_legacy_source_path = (
+            None
+            if legacy_source_path is None
+            else pathlib.Path(legacy_source_path).resolve()
+        )
         current_manifest: dict[str, typing.Any] | None = None
+        legacy_manifest: dict[str, typing.Any] | None = None
         if source_store is not None and not source_store.closed:
             with contextlib.suppress(Exception):
                 current_manifest = source_store.current_generation().manifest
-        if current_manifest is None and self._manager._workspace_state.path is not None:
+        metadata_path = (
+            explicit_legacy_source_path or self._manager._workspace_state.path
+        )
+        if current_manifest is None and metadata_path is not None:
             with contextlib.suppress(Exception):
                 root_attrs = workspace_arrays._read_workspace_root_attrs_h5py(
-                    self._manager._workspace_state.path
+                    metadata_path
                 )
                 schema_version, manifest = (
                     workspace_format._workspace_file_metadata_from_attrs(root_attrs)
@@ -1113,6 +1126,8 @@ class _WorkspaceSaver:
                     schema_version
                 ):
                     current_manifest = manifest
+                else:
+                    legacy_manifest = manifest
 
         previous_entries: dict[str, Mapping[str, typing.Any]] = {}
         if current_manifest is not None:
@@ -1122,6 +1137,12 @@ class _WorkspaceSaver:
                 uid = entry.get("uid")
                 if isinstance(uid, str):
                     previous_entries[uid] = entry
+        legacy_payload_paths = {
+            uid: f"/{payload_path.strip('/')}"
+            for uid, _kind, payload_path in (
+                workspace_format._workspace_manifest_payload_entries(legacy_manifest)
+            )
+        }
 
         script_snapshot = self._workspace_script_snapshot()
         manifest = self._workspace_manifest(script_snapshot=script_snapshot)
@@ -1143,12 +1164,18 @@ class _WorkspaceSaver:
             | self._manager._workspace_state.dirty_added
             | stale_reference_uids
         )
+        legacy_link_blocked_uids = (
+            self._manager._workspace_state.dirty_data | stale_reference_uids
+        )
+        if explicit_legacy_source_path is None:
+            legacy_link_blocked_uids |= self._manager._workspace_state.dirty_added
         dirty_state = self._manager._workspace_state.dirty_state
         source_workspace_path = self._manager._workspace_state.path
 
         object_writes: dict[str, workspace_storage._WorkspaceObjectWrite] = {}
         final_entries: list[dict[str, typing.Any]] = []
         serialized_datasets: list[xr.Dataset] = []
+        legacy_payload_rewrite_uids: set[str] = set()
         extension_object_ids = set(
             workspace_store.WorkspaceStore.manifest_extension_object_ids(manifest)
         )
@@ -1179,6 +1206,8 @@ class _WorkspaceSaver:
             has_saved_input_provenance = kind == "tool" and (
                 self._tool_payload_has_saved_input_provenance(node, previous)
             )
+            if has_saved_input_provenance:
+                legacy_payload_rewrite_uids.add(uid)
             can_reuse_object = (
                 isinstance(previous_object_id, str)
                 and bool(previous_object_id)
@@ -1346,28 +1375,64 @@ class _WorkspaceSaver:
         legacy_object_links: tuple[tuple[str, str], ...] = ()
         legacy_reader_rebindings: tuple[tuple[str, str], ...] = ()
         leased_legacy_group_paths: frozenset[str] = frozenset()
+        target_path = pathlib.Path(fname).resolve()
+        source_store_path = (
+            source_store.path
+            if source_store is not None and not source_store.closed
+            else None
+        )
+        target_is_source = (
+            source_store_path is not None and target_path == source_store_path
+        )
+        in_place_legacy_source: pathlib.Path | None = None
+        if target_is_source:
+            in_place_legacy_source = source_store_path
+        elif explicit_legacy_source_path == target_path:
+            in_place_legacy_source = explicit_legacy_source_path
+        legacy_link_candidates: list[tuple[str, str]] = []
         if source_store is not None and not source_store.closed:
             leased_legacy_group_paths = source_store.leased_legacy_group_paths
-            safe_rebindings: list[tuple[str, str]] = []
-            for entry in final_entries:
-                uid = entry.get("uid")
-                object_id = entry.get("payload_object_id")
-                if (
-                    not isinstance(uid, str)
-                    or uid in dirty_data
-                    or not isinstance(object_id, str)
-                ):
-                    continue
-                legacy_path = f"/{self._workspace_payload_path(uid).strip('/')}"
-                if legacy_path in leased_legacy_group_paths:
-                    safe_rebindings.append((legacy_path, object_id))
-            legacy_reader_rebindings = tuple(sorted(safe_rebindings))
-            if pathlib.Path(fname).resolve() == source_store.path:
-                legacy_object_links = legacy_reader_rebindings
-        if (
-            source_store is not None
-            and pathlib.Path(fname).resolve() != source_store.path
-        ):
+        safe_rebindings: list[tuple[str, str]] = []
+        for entry in final_entries:
+            uid = entry.get("uid")
+            object_id = entry.get("payload_object_id")
+            if not isinstance(uid, str) or not isinstance(object_id, str):
+                continue
+            legacy_path = legacy_payload_paths.get(
+                uid, f"/{self._workspace_payload_path(uid).strip('/')}"
+            )
+            if (
+                current_manifest is None
+                and in_place_legacy_source is not None
+                and object_id in object_writes
+                and uid not in legacy_link_blocked_uids
+                and uid not in legacy_payload_rewrite_uids
+            ):
+                legacy_link_candidates.append((legacy_path, object_id))
+            if uid not in dirty_data and legacy_path in leased_legacy_group_paths:
+                safe_rebindings.append((legacy_path, object_id))
+        legacy_reader_rebindings = tuple(sorted(safe_rebindings))
+        if legacy_link_candidates:
+            if target_is_source and source_store is not None:
+                legacy_object_links = tuple(
+                    sorted(
+                        (legacy_path, object_id)
+                        for legacy_path, object_id in legacy_link_candidates
+                        if legacy_path.strip("/") in source_store.h5_file
+                    )
+                )
+            elif in_place_legacy_source is not None:
+                with workspace_arrays._open_workspace_h5_file_for_read(
+                    in_place_legacy_source
+                ) as legacy_h5_file:
+                    legacy_object_links = tuple(
+                        sorted(
+                            (legacy_path, object_id)
+                            for legacy_path, object_id in legacy_link_candidates
+                            if legacy_path.strip("/") in legacy_h5_file
+                        )
+                    )
+        if source_store is not None and target_path != source_store.path:
             source_path = str(source_store.path)
             for object_id in source_store.leased_object_ids:
                 object_writes.setdefault(

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -1234,10 +1234,17 @@ class WorkspaceStore:
 
     def current_generation(self) -> _WorkspaceGeneration:
         """Return the newest valid committed generation."""
-        generations = self.generations()
-        if not generations:
-            raise ValueError("Workspace has no committed generation")
-        return generations[-1]
+        with self.read_session() as h5_file:
+            root = h5_file.get(_WORKSPACE_GENERATIONS_GROUP)
+            if root is not None:
+                for name in sorted(root, reverse=True):
+                    if len(name) != _WORKSPACE_GENERATION_WIDTH or not name.isdigit():
+                        continue
+                    with contextlib.suppress(Exception):
+                        return _WorkspaceGeneration(
+                            int(name), self._read_manifest(root[name])
+                        )
+        raise ValueError("Workspace has no committed generation")
 
     def publish(self, manifest: Mapping[str, typing.Any]) -> _WorkspaceGeneration:
         """Publish one completed manifest as the newest generation."""

--- a/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
@@ -16,6 +16,10 @@ from erlab.interactive._code_trust import (
 )
 from erlab.interactive._code_trust._payloads import CODE_PAYLOAD_ENTRIES_ATTR
 from erlab.interactive._saved_tools import resolve_saved_tool_class
+from erlab.interactive.imagetool._provenance._model import (
+    ToolProvenanceSpec,
+    parse_tool_provenance_spec,
+)
 from erlab.interactive.imagetool._provenance._trust import provenance_code_trust_entries
 
 if typing.TYPE_CHECKING:
@@ -139,6 +143,8 @@ def _node_code_trust_entries(
 ):
     """Return deduplicated provenance and relocated tool entries for one node."""
     entries = []
+    entry_identities: set[bytes] = set()
+    seen_specs: list[tuple[str, ToolProvenanceSpec]] = []
     located_specs = [
         *((f"{path}/provenance", spec) for spec in provenance_specs),
         *(
@@ -155,14 +161,22 @@ def _node_code_trust_entries(
         for attr, segment in saved_source_attrs
     )
     for location, provenance_spec in located_specs:
-        if provenance_spec is None:
+        parsed_spec = parse_tool_provenance_spec(provenance_spec)
+        if parsed_spec is None or any(
+            location == previous_location and parsed_spec == previous_spec
+            for previous_location, previous_spec in seen_specs
+        ):
             continue
+        seen_specs.append((location, parsed_spec))
         for entry in provenance_code_trust_entries(
-            provenance_spec,
+            parsed_spec,
             location_prefix=location,
         ):
-            if entry not in entries:
-                entries.append(entry)
+            identity = entry.document_identity()
+            if identity in entry_identities:
+                continue
+            entry_identities.add(identity)
+            entries.append(entry)
     if tool_manifest is not None:
         entries.extend(relocate_manifest_entries(tool_manifest, location_prefix=path))
     return entries

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -413,6 +413,49 @@ def test_workspace_uid_reservation_validates_manifest_and_requirement_uids() -> 
         )
 
 
+def test_workspace_manifest_indexes_avoid_per_node_rescans(monkeypatch) -> None:
+    root_count = 256
+    manifest = {
+        "nodes": [
+            *({"path": str(index), "kind": "imagetool"} for index in range(root_count)),
+            *(
+                {
+                    "path": f"{index}/childtools/child-{index}",
+                    "kind": "tool",
+                }
+                for index in range(root_count)
+            ),
+        ]
+    }
+    loader = workspace_loading._WorkspaceLoader
+    entries_by_path, direct_children = loader._workspace_manifest_indexes(manifest)
+
+    def _fail_manifest_scan(_manifest):
+        raise AssertionError("Indexed manifest lookups must not rescan all nodes")
+
+    monkeypatch.setattr(
+        workspace_format,
+        "_iter_workspace_manifest_node_entries",
+        _fail_manifest_scan,
+    )
+    for index in range(root_count):
+        root_path = str(index)
+        assert (
+            loader._workspace_manifest_node_entry(
+                manifest,
+                root_path,
+                "imagetool",
+                entries_by_path=entries_by_path,
+            )
+            is entries_by_path[root_path]
+        )
+        assert loader._workspace_manifest_direct_child_keys(
+            manifest,
+            f"{root_path}/childtools/",
+            direct_children=direct_children,
+        ) == [f"child-{index}"]
+
+
 @pytest.mark.parametrize(
     ("field", "entry"),
     [
@@ -3279,6 +3322,19 @@ def test_manager_from_h5py_workspace_manifest_validation(
                 replace=False,
                 mark_dirty=False,
             )
+        with pytest.raises(ValueError, match="duplicate node path '0'"):
+            manager._workspace_controller.loading._from_h5py_workspace_file(
+                fname,
+                {
+                    "root_order": ["0"],
+                    "nodes": [
+                        {"path": "0", "kind": "imagetool"},
+                        {"path": "0", "kind": "tool"},
+                    ],
+                },
+                replace=False,
+                mark_dirty=False,
+            )
         with pytest.raises(ValueError, match="no loadable root nodes"):
             manager._workspace_controller.loading._from_h5py_workspace_file(
                 fname,
@@ -3468,8 +3524,8 @@ def test_manager_workspace_rebind_skips_missing_snapshot_and_keeps_chunks(
         uid = manager._tool_graph.root_wrappers[0].uid
         calls: list[typing.Any] = []
 
-        def _fake_rebind_data(_fname, _uid, *, chunks):
-            calls.append(chunks)
+        def _fake_rebind_data(_fname, _uid, *, chunks, payload_path=None):
+            calls.append((chunks, payload_path))
             return data
 
         monkeypatch.setattr(
@@ -3488,7 +3544,59 @@ def test_manager_workspace_rebind_skips_missing_snapshot_and_keeps_chunks(
         )
 
         assert uid in manager._tool_graph.nodes
-        assert calls == [{}]
+        assert calls == [({}, "0/imagetool")]
+
+
+def test_manager_workspace_rebind_reads_manifest_once(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        data = xr.DataArray(np.arange(16.0).reshape(4, 4), dims=("x", "y"))
+        for _ in range(2):
+            tool = itool(data, manager=False, execute=False)
+            assert isinstance(tool, erlab.interactive.imagetool.ImageTool)
+            manager.add_imagetool(tool, show=False)
+        uids = [wrapper.uid for wrapper in manager._tool_graph.root_wrappers.values()]
+        manifest_calls = 0
+        payload_paths: list[str | None] = []
+
+        def _manifest(_fname):
+            nonlocal manifest_calls
+            manifest_calls += 1
+            return {
+                "nodes": [
+                    {
+                        "uid": uid,
+                        "kind": "imagetool",
+                        "path": str(index),
+                        "payload_path": f"/objects/{uid}",
+                    }
+                    for index, uid in enumerate(uids)
+                ]
+            }
+
+        def _fake_rebind_data(
+            _fname, _uid, *, chunks, payload_path=None
+        ) -> xr.DataArray:
+            payload_paths.append(payload_path)
+            return data
+
+        loading = manager._workspace_controller.loading
+        monkeypatch.setattr(loading, "_workspace_manifest_for_path", _manifest)
+        monkeypatch.setattr(
+            loading, "_workspace_rebind_data_for_uid", _fake_rebind_data
+        )
+
+        loading._rebind_workspace_backed_imagetools(tmp_path / "workspace.itws")
+
+        assert manifest_calls == 1
+        assert payload_paths == [f"/objects/{uid}" for uid in uids]
 
 
 def test_manager_loaded_workspace_association_updates_file_path(

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -3887,9 +3887,11 @@ def test_manager_workspace_save_as_rebinds_lazy_data_to_new_document(
                 manager._workspace_controller.loading._workspace_rebind_data_for_uid
             )
 
-            def _record_rebind(fname, node_uid: str, *, chunks):
+            def _record_rebind(fname, node_uid: str, *, chunks, payload_path=None):
                 rebind_calls.append(node_uid)
-                return rebind_data(fname, node_uid, chunks=chunks)
+                return rebind_data(
+                    fname, node_uid, chunks=chunks, payload_path=payload_path
+                )
 
             monkeypatch.setattr(
                 manager._workspace_controller.loading,
@@ -4013,9 +4015,11 @@ def test_workspace_full_save_external_dask_rebind_rolls_back_on_later_failure(
             manager._workspace_controller.loading._workspace_rebind_data_for_uid
         )
 
-        def _record_rebind(fname, node_uid: str, *, chunks):
+        def _record_rebind(fname, node_uid: str, *, chunks, payload_path=None):
             rebind_calls.append(node_uid)
-            return rebind_data(fname, node_uid, chunks=chunks)
+            return rebind_data(
+                fname, node_uid, chunks=chunks, payload_path=payload_path
+            )
 
         monkeypatch.setattr(
             manager._workspace_controller.loading,
@@ -4657,12 +4661,27 @@ def test_manager_workspace_same_path_conversion_deduplicates_legacy_payload(
             raise TypeError("Expected an ImageTool")
         manager.add_imagetool(tool, show=False)
         uid = manager._tool_graph.root_wrappers[0].uid
+        child = _AddedTimeChildTool((data + 1000).rename("child"))
+        child_uid = add_source_childtool(manager, child, 0, show=False)
 
-        tree = manager._workspace_controller.saving._to_datatree()
-        tree.attrs["imagetool_workspace_schema_version"] = schema_version
-        tree.attrs.pop(workspace_format._WORKSPACE_MANIFEST_ATTR, None)
-        tree.to_netcdf(path, engine="h5netcdf", invalid_netcdf=True)
-        tree.close()
+        current_tree = manager._workspace_controller.saving._to_datatree()
+        try:
+            tree = xr.DataTree.from_dict(
+                {
+                    "0/imagetool": typing.cast(
+                        "xr.DataTree", current_tree["0/imagetool"]
+                    ).to_dataset(inherit=False),
+                    f"0/childtools/{child_uid}": typing.cast(
+                        "xr.DataTree",
+                        current_tree[f"0/childtools/{child_uid}/tool"],
+                    ).to_dataset(inherit=False),
+                }
+            )
+            tree.attrs["imagetool_workspace_schema_version"] = schema_version
+            tree.to_netcdf(path, engine="h5netcdf", invalid_netcdf=True)
+            tree.close()
+        finally:
+            current_tree.close()
         manager.remove_all_tools()
 
         monkeypatch.setattr(
@@ -4686,22 +4705,25 @@ def test_manager_workspace_same_path_conversion_deduplicates_legacy_payload(
         store = manager._workspace_controller._workspace_store
         if store is None:
             raise RuntimeError("Expected an associated workspace store")
-        entry = next(
-            entry
+        entries = {
+            str(entry["uid"]): entry
             for entry in workspace_format._iter_workspace_manifest_node_entries(
                 store.current_generation().manifest
             )
-            if entry.get("uid") == uid
-        )
-        object_path = str(entry["payload_path"])
-        legacy_path = "/0/imagetool"
+        }
+        assert set(entries) == {uid, child_uid}
         assert not store.leased_legacy_group_paths
-        with store.read_session() as h5_file:
-            assert legacy_path in h5_file
-            assert (
-                h5py.h5o.get_info(h5_file[legacy_path].id).addr
-                == h5py.h5o.get_info(h5_file[object_path].id).addr
-            )
+        for node_uid, legacy_path in (
+            (uid, "/0/imagetool"),
+            (child_uid, f"/0/childtools/{child_uid}"),
+        ):
+            object_path = str(entries[node_uid]["payload_path"])
+            with store.read_session() as h5_file:
+                assert legacy_path in h5_file
+                assert (
+                    h5py.h5o.get_info(h5_file[legacy_path].id).addr
+                    == h5py.h5o.get_info(h5_file[object_path].id).addr
+                )
         np.testing.assert_array_equal(manager._get_imagetool_data(0), data)
 
 

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -4532,14 +4532,16 @@ def test_manager_workspace_compact_drops_history_and_keeps_store(
         assert generations[0].manifest == generations[1].manifest == current_manifest
 
 
+@pytest.mark.parametrize("schema_version", [3, 4])
 def test_manager_workspace_save_deduplicates_legacy_payload_in_place(
     qtbot,
     tmp_path,
     manager_context: Callable[
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
+    schema_version: int,
 ) -> None:
-    path = tmp_path / "schema-4.itws"
+    path = tmp_path / f"schema-{schema_version}.itws"
     data = xr.DataArray(
         np.arange(400, dtype=np.float64).reshape((20, 20)),
         dims=("x", "y"),
@@ -4551,11 +4553,20 @@ def test_manager_workspace_save_deduplicates_legacy_payload_in_place(
         if not isinstance(tool, erlab.interactive.imagetool.ImageTool):
             raise TypeError("Expected an ImageTool")
         manager.add_imagetool(tool, show=False)
+        root_uid = manager._tool_graph.root_wrappers[0].uid
+        child = _AddedTimeChildTool((data + 1000).rename("child"))
+        child_uid = add_source_childtool(manager, child, 0, show=False)
+        child.hide()
+        dirty_tool = itool(data + 2000, manager=False, execute=False)
+        if not isinstance(dirty_tool, erlab.interactive.imagetool.ImageTool):
+            raise TypeError("Expected an ImageTool")
+        manager.add_imagetool(dirty_tool, show=False)
+        dirty_uid = manager._tool_graph.root_wrappers[1].uid
 
         tree = manager._workspace_controller.saving._to_datatree()
         manifest = manager._workspace_controller.saving._workspace_manifest()
-        manifest["schema_version"] = 4
-        tree.attrs["imagetool_workspace_schema_version"] = 4
+        manifest["schema_version"] = schema_version
+        tree.attrs["imagetool_workspace_schema_version"] = schema_version
         tree.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(manifest)
         tree.to_netcdf(path, engine="h5netcdf", invalid_netcdf=True)
         tree.close()
@@ -4568,15 +4579,119 @@ def test_manager_workspace_save_deduplicates_legacy_payload_in_place(
             mark_dirty=False,
             select=False,
         )
+        store = manager._workspace_controller._workspace_store
+        if store is None:
+            raise RuntimeError("Expected an associated workspace store")
+        child_node = manager._child_node(child_uid)
+        if schema_version == 4:
+            assert child_node.pending_workspace_tool_payload is not None
+        else:
+            assert child_node.tool_window is not None
+        child_legacy_path = f"/0/childtools/{child_uid}/tool"
+        child_readers = [
+            reader
+            for reader in tuple(store._readers)
+            if reader.legacy_group_path == child_legacy_path
+        ]
+        assert bool(child_readers) == (schema_version == 4)
+        for reader in child_readers:
+            reader.close()
+            store.unregister_reader(reader)
+        assert store.leased_legacy_group_paths == frozenset(
+            {"/0/imagetool", "/1/imagetool"}
+        )
+        assert child_legacy_path not in store.leased_legacy_group_paths
+        replacement = data + 3000
+        manager.get_imagetool(1).slicer_area.replace_source_data(
+            replacement,
+            auto_compute=False,
+            emit_edited=True,
+        )
         assert _request_workspace_save_and_wait(qtbot, manager)
+
+        entries = {
+            str(entry["uid"]): entry
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
+                store.current_generation().manifest
+            )
+        }
+        assert set(entries) == {root_uid, child_uid, dirty_uid}
+        assert not store.leased_legacy_group_paths
+        for uid, legacy_path in (
+            (root_uid, "/0/imagetool"),
+            (child_uid, child_legacy_path),
+        ):
+            object_path = str(entries[uid]["payload_path"])
+            with store.read_session() as h5_file:
+                assert legacy_path in h5_file
+                assert (
+                    h5py.h5o.get_info(h5_file[legacy_path].id).addr
+                    == h5py.h5o.get_info(h5_file[object_path].id).addr
+                )
+        dirty_object_path = str(entries[dirty_uid]["payload_path"])
+        with store.read_session() as h5_file:
+            assert (
+                h5py.h5o.get_info(h5_file["/1/imagetool"].id).addr
+                != h5py.h5o.get_info(h5_file[dirty_object_path].id).addr
+            )
+        np.testing.assert_array_equal(manager._get_imagetool_data(0), data)
+        np.testing.assert_array_equal(manager._get_imagetool_data(1), replacement)
+
+
+def test_manager_workspace_same_path_conversion_deduplicates_legacy_payload(
+    qtbot,
+    monkeypatch,
+    tmp_path,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    schema_version = 2
+    path = tmp_path / "schema-2.itws"
+    data = xr.DataArray(np.arange(400).reshape((20, 20)), dims=("x", "y"))
+
+    with manager_context() as manager:
+        qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
+        tool = itool(data, manager=False, execute=False)
+        if not isinstance(tool, erlab.interactive.imagetool.ImageTool):
+            raise TypeError("Expected an ImageTool")
+        manager.add_imagetool(tool, show=False)
+        uid = manager._tool_graph.root_wrappers[0].uid
+
+        tree = manager._workspace_controller.saving._to_datatree()
+        tree.attrs["imagetool_workspace_schema_version"] = schema_version
+        tree.attrs.pop(workspace_format._WORKSPACE_MANIFEST_ATTR, None)
+        tree.to_netcdf(path, engine="h5netcdf", invalid_netcdf=True)
+        tree.close()
+        manager.remove_all_tools()
+
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_show_legacy_workspace_upgrade_message",
+            lambda _fname: None,
+        )
+        monkeypatch.setattr(
+            manager._workspace_controller,
+            "_workspace_save_dialog",
+            lambda **_kwargs: str(path),
+        )
+        assert manager._workspace_controller.loading._load_workspace_file(
+            path,
+            replace=True,
+            associate=True,
+            mark_dirty=False,
+            select=False,
+        )
 
         store = manager._workspace_controller._workspace_store
         if store is None:
             raise RuntimeError("Expected an associated workspace store")
         entry = next(
-            workspace_format._iter_workspace_manifest_node_entries(
+            entry
+            for entry in workspace_format._iter_workspace_manifest_node_entries(
                 store.current_generation().manifest
             )
+            if entry.get("uid") == uid
         )
         object_path = str(entry["payload_path"])
         legacy_path = "/0/imagetool"

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -641,7 +641,9 @@ def test_workspace_store_rejects_invalid_gc_limit_and_clears_staging(
         assert len(store.h5_file[workspace_store._WORKSPACE_STAGING_GROUP]) == 0
 
 
-def test_workspace_store_publishes_valid_generations(tmp_path: pathlib.Path) -> None:
+def test_workspace_store_publishes_valid_generations(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
@@ -651,9 +653,24 @@ def test_workspace_store_publishes_valid_generations(tmp_path: pathlib.Path) -> 
         first = store.publish(_manifest("first"))
         second = store.publish(_manifest("second"))
 
+        read_names: list[str] = []
+        read_manifest = workspace_store.WorkspaceStore._read_manifest.__func__
+
+        def _record_read_manifest(cls, group):
+            read_names.append(group.name)
+            return read_manifest(cls, group)
+
+        monkeypatch.setattr(
+            workspace_store.WorkspaceStore,
+            "_read_manifest",
+            classmethod(_record_read_manifest),
+        )
         assert first.sequence == 1
         assert second.sequence == 2
         assert store.current_generation() == second
+        assert read_names == [
+            f"/{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}"
+        ]
 
         with store.write_session() as h5_file:
             generation_group = h5_file[
@@ -663,7 +680,12 @@ def test_workspace_store_publishes_valid_generations(tmp_path: pathlib.Path) -> 
                 "sha256"
             ] = "invalid"
 
+        read_names.clear()
         assert store.current_generation() == first
+        assert read_names == [
+            f"/{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}",
+            f"/{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{first.sequence:020d}",
+        ]
 
 
 def test_workspace_store_rejects_generation_with_missing_object(

--- a/tests/interactive/imagetool/manager/workspace/test_trust.py
+++ b/tests/interactive/imagetool/manager/workspace/test_trust.py
@@ -800,6 +800,107 @@ def test_failed_workspace_load_restores_trust_notification(
         assert len(notifications) == 2
 
 
+def test_workspace_load_binds_trust_manifest_once_after_node_batch(
+    manager_context, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest = create_manifest(
+        workspace_trust.WORKSPACE_CODE_TRUST_DOMAIN,
+        workspace_trust.WORKSPACE_CODE_TRUST_POLICY_VERSION,
+        (create_entry("test.code", "nodes/source", "run_code()"),),
+    )
+    manifest_calls: list[None] = []
+
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        monkeypatch.setattr(controller, "_mark_workspace_dirty", lambda **_: False)
+        monkeypatch.setattr(
+            workspace_trust,
+            "current_workspace_code_trust_manifest",
+            lambda _manager: manifest_calls.append(None) or manifest,
+        )
+
+        def load() -> bool:
+            for uid in ("first", "second", "third"):
+                controller._mark_node_added(uid)
+            assert not manifest_calls
+            return True
+
+        assert controller._load_with_code_trust(
+            untrusted_document_trust(), replace=True, load=load
+        )
+
+        assert manifest_calls == [None]
+        assert controller._code_trust_manifest_binding_depth == 0
+        assert not controller._code_trust_manifest_binding_pending
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_failed_workspace_load_discards_pending_manifest_binding(
+    manager_context, monkeypatch: pytest.MonkeyPatch, *, raises: bool
+) -> None:
+    manifest_calls: list[None] = []
+
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        previous = manager._workspace_state.code_trust
+        monkeypatch.setattr(
+            workspace_trust,
+            "current_workspace_code_trust_manifest",
+            lambda _manager: manifest_calls.append(None),
+        )
+
+        def load() -> bool:
+            controller._bind_current_workspace_manifest_if_review_needed()
+            if raises:
+                raise RuntimeError("load failed")
+            return False
+
+        if raises:
+            with pytest.raises(RuntimeError, match="load failed"):
+                controller._load_with_code_trust(
+                    untrusted_document_trust(), replace=True, load=load
+                )
+        else:
+            assert not controller._load_with_code_trust(
+                untrusted_document_trust(), replace=True, load=load
+            )
+
+        assert manager._workspace_state.code_trust == previous
+        assert not manifest_calls
+        assert controller._code_trust_manifest_binding_depth == 0
+        assert not controller._code_trust_manifest_binding_pending
+
+
+def test_workspace_load_restores_trust_if_deferred_manifest_binding_fails(
+    manager_context, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        previous = manager._workspace_state.code_trust
+
+        def fail_manifest(_manager):
+            raise RuntimeError("manifest failed")
+
+        monkeypatch.setattr(
+            workspace_trust,
+            "current_workspace_code_trust_manifest",
+            fail_manifest,
+        )
+
+        def load() -> bool:
+            controller._bind_current_workspace_manifest_if_review_needed()
+            return True
+
+        with pytest.raises(RuntimeError, match="manifest failed"):
+            controller._load_with_code_trust(
+                untrusted_document_trust(), replace=True, load=load
+            )
+
+        assert manager._workspace_state.code_trust == previous
+        assert controller._code_trust_manifest_binding_depth == 0
+        assert not controller._code_trust_manifest_binding_pending
+
+
 def test_selected_workspace_import_retains_complete_manifest_signature(
     external_workspace, manager_context
 ) -> None:
@@ -1031,9 +1132,22 @@ def test_workspace_code_trust_manifest_includes_live_python_provenance(
     assert manifest.entries[0].feature == "erlab.provenance.script-code"
 
 
-def test_workspace_manifest_deduplicates_saved_imagetool_provenance() -> None:
+def test_workspace_manifest_deduplicates_saved_imagetool_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     provenance = _script_source()
     serialized = provenance.model_dump_json()
+    calls: list[None] = []
+
+    def counted_entries(spec, *, location_prefix):
+        calls.append(None)
+        return provenance_code_trust_entries(spec, location_prefix=location_prefix)
+
+    monkeypatch.setattr(
+        workspace_trust,
+        "provenance_code_trust_entries",
+        counted_entries,
+    )
     manifest = workspace_code_trust_manifest(
         _workspace_manifest_from_attrs(
             {
@@ -1044,6 +1158,7 @@ def test_workspace_manifest_deduplicates_saved_imagetool_provenance() -> None:
     )
 
     assert len(manifest.entries) == 1
+    assert calls == [None]
 
 
 def test_workspace_manifest_ignores_legacy_tool_manager_provenance() -> None:

--- a/tests/interactive/imagetool/test_replay_graph.py
+++ b/tests/interactive/imagetool/test_replay_graph.py
@@ -1236,6 +1236,32 @@ def test_replay_graph_manual_error_and_cache_paths() -> None:
         execute_replay_graph(empty_graph)
 
 
+def test_canonical_replay_keys_stay_bounded_for_long_chains() -> None:
+    first = _graph._canonical_key("source", {"left": 1, "right": 2})
+    reordered = _graph._canonical_key("source", {"right": 2, "left": 1})
+
+    assert first == reordered
+    assert first.startswith("canonical-sha256:")
+    assert len(first) == 81
+    assert first != _graph._canonical_key("other", {"left": 1, "right": 2})
+
+    keys: list[str] = []
+    parent = first
+    for index in range(256):
+        parent = _graph._canonical_key(
+            "operation",
+            {
+                "context": parent,
+                "operation": {"index": index},
+                "parent": parent,
+            },
+        )
+        keys.append(parent)
+
+    assert len(keys) == len(set(keys))
+    assert {len(key) for key in keys} == {81}
+
+
 def test_replay_graph_partial_capability_reuses_cached_numeric_data() -> None:
     data = xr.DataArray(np.arange(3.0), dims=("x",))
     graph = ReplayGraph()


### PR DESCRIPTION
## Summary

- Keep replay cache keys at a fixed size so deep provenance graphs do not create exponentially large intermediate strings.
- Bind and deduplicate executable-content trust once after a workspace load instead of once for each node.
- Build manifest indexes once per load and rebind. This removes repeated full-manifest scans as the workspace node count grows.
- Read only the newest valid workspace generation. Fall back to an older generation only when a newer one is invalid.
- Reuse unchanged schema 2 through 4 HDF5 payloads during same-file conversion. This includes schema 2 child-tool payloads. Dirty data and payloads that require provenance migration are still rewritten.
- Reject duplicate manifest paths instead of loading an ambiguous entry.

## User impact

Large workspaces now load with work proportional to their graph size. The first save of a legacy schema 2 through 4 workspace no longer duplicates unchanged arrays inside the same file. Existing inflated files still require Compact Workspace to reclaim their physical storage.

Schema 1 remains readable. It is outside the scalability and zero-copy compatibility guarantee.

## Validation

- Ruff check and format check passed.
- Mypy passed for 295 source files.
- PyQt6 full workspace suite: 630 passed.
- PyQt6 provenance and trust suite: 260 passed.
- PySide6 focused workspace, provenance, and trust suite: 265 passed.
- PySide6 focused route audit after the additional fixes: 7 passed.

No visible UI changed.