### PR TITLE
perf(manager): avoid eager workspace dimension scans

### DIFF
--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -386,7 +386,7 @@ class WorkspaceFileManager(CachingFileManager):
             mode="r",
             kwargs={
                 "invalid_netcdf": None,
-                "phony_dims": "sort",
+                "phony_dims": "access",
                 "decode_vlen_strings": True,
                 "locking": "best-effort",
             },
@@ -461,7 +461,7 @@ class WorkspaceFileManager(CachingFileManager):
                 store.read_h5_file,
                 mode="r",
                 invalid_netcdf=True,
-                phony_dims="sort",
+                phony_dims="access",
                 decode_vlen_strings=True,
                 locking="best-effort",
             )
@@ -477,7 +477,7 @@ class WorkspaceFileManager(CachingFileManager):
                 self.reader_path,
                 mode="r",
                 invalid_netcdf=True,
-                phony_dims="sort",
+                phony_dims="access",
                 decode_vlen_strings=True,
                 locking="best-effort",
             ) as netcdf_file:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -394,6 +394,66 @@ def test_workspace_file_manager_opens_unassociated_file_read_only(tmp_path) -> N
         gc.collect()
 
 
+def test_workspace_file_managers_use_access_phony_dimensions(
+    monkeypatch, tmp_path
+) -> None:
+    fname = tmp_path / "phony-dimensions.itws"
+    values = np.arange(6).reshape(2, 3)
+    with h5py.File(fname, "w") as h5_file:
+        h5_file.create_group("payload").create_dataset("data", data=values)
+
+    phony_dims: list[str | None] = []
+    h5netcdf_file_init = workspace_arrays.h5netcdf.File.__init__
+
+    def _record_h5netcdf_file_init(self, *args, **kwargs):
+        phony_dims.append(kwargs.get("phony_dims"))
+        h5netcdf_file_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        workspace_arrays.h5netcdf.File,
+        "__init__",
+        _record_h5netcdf_file_init,
+    )
+
+    opened = workspace_arrays.open_workspace_dataset(fname, "/payload", chunks=None)
+    try:
+        np.testing.assert_array_equal(opened["data"].values, values)
+    finally:
+        opened.close()
+    assert phony_dims
+    assert set(phony_dims) == {"access"}
+
+    phony_dims.clear()
+    with workspace_store.WorkspaceStore(fname):
+        opened = workspace_arrays.open_workspace_dataset(fname, "/payload", chunks=None)
+        try:
+            np.testing.assert_array_equal(opened["data"].values, values)
+        finally:
+            opened.close()
+    assert phony_dims
+    assert set(phony_dims) == {"access"}
+
+    phony_dims.clear()
+    path = str(fname.resolve())
+    worker = workspace_arrays.WorkspaceFileManager.__new__(
+        workspace_arrays.WorkspaceFileManager
+    )
+    worker.__setstate__(
+        (
+            "erlab-workspace-bounded-reader-v1",
+            path,
+            path,
+            None,
+            None,
+            "/payload",
+        )
+    )
+    np.testing.assert_array_equal(
+        worker._read_bounded_variable("data", slice(None)), values
+    )
+    assert phony_dims == ["access"]
+
+
 def test_workspace_file_managers_serialize_shared_cached_handle_access(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Use on-access phony-dimension discovery for every workspace h5netcdf reader.
- Avoid a recursive scan of the complete HDF5 workspace for each payload open.
- Preserve the existing store locks, reader isolation, generation checks, and bounded worker reads.
- Add regression coverage for standalone, store-associated, and serialized-worker readers.

## Performance

The supplied 1.18 GiB workspace previously took about 19.2 seconds for a warm full Manager load. Three warm loads with this change took 9.25, 8.45, and 6.94 seconds. The median was 8.45 seconds. Each run restored 53 nodes, kept 51 hidden nodes pending, showed 2 tools, and skipped 0 nodes.

## Validation

- `uv run pytest -q tests/interactive/imagetool/manager/workspace` (634 passed)
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `git diff --check`