### PR TITLE
fix(io.erpes): normalize timestamp coordinates

### DIFF
--- a/src/erlab/io/plugins/erpes.py
+++ b/src/erlab/io/plugins/erpes.py
@@ -17,6 +17,8 @@ import xarray as xr
 import erlab
 from erlab.io.plugins.da30 import DA30Loader
 
+_DATETIME_DTYPE = np.dtype("datetime64[us]")
+
 
 def _determine_kind(data: xr.DataArray) -> str:
     data_type = "cut"
@@ -30,31 +32,47 @@ def _determine_kind(data: xr.DataArray) -> str:
     return data_type
 
 
-def _make_iso(x: str) -> datetime.datetime | str:
-    """Convert a string to ISO format."""
-    return datetime.datetime.fromisoformat(x) if str(x) != "nan" else "NaT"
+def _make_iso(x: str) -> np.datetime64:
+    """Convert a string to a NumPy datetime."""
+    if str(x) == "nan":
+        return np.datetime64("NaT", "us")
+    return np.datetime64(datetime.datetime.fromisoformat(x), "us")
 
 
-def _make_iso_date_time(d, t) -> datetime.datetime | str:
-    """Convert a string to ISO format."""
+def _make_iso_date_time(d, t) -> np.datetime64:
+    """Convert date and time strings to a NumPy datetime."""
     if str(d) == "nan" or str(t) == "nan":
-        return "NaT"
+        return np.datetime64("NaT", "us")
     return _make_iso(f"{d} {t}")
 
 
 def _get_start_time(data: xr.DataArray) -> xr.DataArray:
     """Get the start time from raw data."""
     return xr.apply_ufunc(
-        _make_iso_date_time, data["Date"], data["Time"], vectorize=True
+        _make_iso_date_time,
+        data["Date"],
+        data["Time"],
+        vectorize=True,
+        output_dtypes=[_DATETIME_DTYPE],
     )
 
 
 def _get_seq_start(data: xr.DataArray) -> xr.DataArray:
-    return xr.apply_ufunc(_make_iso, data["seq_start"], vectorize=True)
+    return xr.apply_ufunc(
+        _make_iso,
+        data["seq_start"],
+        vectorize=True,
+        output_dtypes=[_DATETIME_DTYPE],
+    )
 
 
 def _get_attrs_time(data: xr.DataArray) -> xr.DataArray:
-    return xr.apply_ufunc(_make_iso, data["attrs_time"], vectorize=True)
+    return xr.apply_ufunc(
+        _make_iso,
+        data["attrs_time"],
+        vectorize=True,
+        output_dtypes=[_DATETIME_DTYPE],
+    )
 
 
 def _emit_ambiguous_file_warning(num, file_to_use):

--- a/tests/io/plugins/test_erpes.py
+++ b/tests/io/plugins/test_erpes.py
@@ -1,9 +1,16 @@
+import numpy as np
 import pytest
 import xarray as xr
 
 import erlab
 from erlab.io.plugins.da30 import DA30Loader
-from erlab.io.plugins.erpes import ERPESLoader, get_cache_file
+from erlab.io.plugins.erpes import (
+    ERPESLoader,
+    _get_attrs_time,
+    _get_seq_start,
+    _get_start_time,
+    get_cache_file,
+)
 
 
 @pytest.fixture(scope="module")
@@ -16,6 +23,83 @@ def data_dir(test_data_dir):
 @pytest.fixture(scope="module")
 def expected_dir(data_dir):
     return data_dir / "expected"
+
+
+@pytest.mark.parametrize(
+    ("coordinate", "converter"),
+    [("seq_start", _get_seq_start), ("attrs_time", _get_attrs_time)],
+)
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        pytest.param(
+            ["2024-01-02T03:04:05.123456", "2024-01-03T04:05:06"],
+            ["2024-01-02T03:04:05.123456", "2024-01-03T04:05:06"],
+            id="valid",
+        ),
+        pytest.param(
+            ["2024-01-02T03:04:05.123456", np.nan],
+            ["2024-01-02T03:04:05.123456", "NaT"],
+            id="partially-missing",
+        ),
+        pytest.param(
+            [np.nan, np.nan],
+            ["NaT", "NaT"],
+            id="missing",
+        ),
+    ],
+)
+def test_sequence_timestamp_dtype(coordinate, converter, values, expected) -> None:
+    data = xr.DataArray(
+        np.zeros(len(values)),
+        dims="scan",
+        coords={coordinate: ("scan", values)},
+    )
+
+    actual = converter(data)
+
+    assert actual.dtype == np.dtype("datetime64[us]")
+    np.testing.assert_array_equal(
+        actual.values, np.asarray(expected, dtype="datetime64[us]")
+    )
+
+
+@pytest.mark.parametrize(
+    ("dates", "times", "expected"),
+    [
+        pytest.param(
+            ["2024-01-02", "2024-01-03"],
+            ["03:04:05.123456", "04:05:06"],
+            ["2024-01-02T03:04:05.123456", "2024-01-03T04:05:06"],
+            id="valid",
+        ),
+        pytest.param(
+            ["2024-01-02", np.nan, "2024-01-04"],
+            ["03:04:05.123456", "04:05:06", np.nan],
+            ["2024-01-02T03:04:05.123456", "NaT", "NaT"],
+            id="partially-missing",
+        ),
+        pytest.param(
+            [np.nan, np.nan],
+            [np.nan, np.nan],
+            ["NaT", "NaT"],
+            id="missing",
+        ),
+    ],
+)
+def test_start_timestamp_dtype(dates, times, expected) -> None:
+    data = xr.DataArray(
+        np.zeros(len(dates)),
+        dims="scan",
+        coords={"Date": ("scan", dates), "Time": ("scan", times)},
+    )
+
+    actual = _get_start_time(data)
+
+    assert actual.dtype == np.dtype("datetime64[us]")
+    np.testing.assert_array_equal(
+        actual.values, np.asarray(expected, dtype="datetime64[us]")
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Normalize ERPES datetime, seq_start, and attrs_time coordinates to datetime64[us].
- Preserve missing timestamps as typed NaT values.
- Keep workspace schema 6 unchanged.

This prevents xarray from producing mixed object arrays when an ERPES timestamp coordinate contains both valid timestamps and missing values. Workspace saves can therefore use the existing HDF5 path.

## Verification

- uv run --group pyqt6 pytest tests/io/plugins/test_erpes.py -q
- uv run --group pyqt6 mypy src/erlab/io/plugins/erpes.py
- uv run ruff format --check src/erlab/io/plugins/erpes.py tests/io/plugins/test_erpes.py
- uv run ruff check src/erlab/io/plugins/erpes.py tests/io/plugins/test_erpes.py
- Manual h5netcdf round trip with mixed ERPES timestamp coordinates