### PR TITLE
fix(kspace): restore saved parent-source coordinates

### DIFF
--- a/src/erlab/interactive/kspace.py
+++ b/src/erlab/interactive/kspace.py
@@ -857,6 +857,44 @@ class KspaceTool(KspaceToolGUI):
         self._source_configuration_missing = status.source_configuration_missing
         self._source_input_data = source_data
 
+    @staticmethod
+    def _prepare_restored_tool_data_for_constructor(
+        data: xr.DataArray, status: StateModel
+    ) -> xr.DataArray:
+        """Restore constructor inputs that a saved data reference can omit."""
+        configuration = _kspace_conversion.kspace_configuration(data)
+        if configuration is not None:
+            input_coordinate_values = _kspace_conversion.kspace_input_coordinate_values(
+                data
+            )
+            if all(value is not None for value in input_coordinate_values.values()):
+                return data
+
+        if configuration is None:
+            configuration = status.source_configuration
+            if configuration is None:
+                return data
+            data = _kspace_conversion.assign_kspace_configuration(data, configuration)
+
+        if (
+            status.configuration is not None
+            and int(configuration) != status.configuration
+        ):
+            data = data.kspace.as_configuration(status.configuration)
+
+        coordinate_names = _kspace_conversion.kspace_input_coordinate_names(data)
+        input_coordinates = {
+            name: status.input_coordinates[name]
+            for name in coordinate_names
+            if name in status.input_coordinates
+        }
+        if not input_coordinates:
+            return data
+        return _kspace_conversion.assign_kspace_input_coordinates(
+            data,
+            input_coordinates,
+        )
+
     _OFFSET_LABELS: typing.ClassVar[dict[str, str]] = {
         "delta": "𝛿",
         "chi": "𝜒₀",

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -5274,6 +5274,14 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Return the state model to serialize for this tool."""
         return self.tool_status
 
+    @staticmethod
+    def _prepare_restored_tool_data_for_constructor(
+        data: xr.DataArray, status: M
+    ) -> xr.DataArray:
+        """Prepare restored primary data before tool construction."""
+        del status
+        return data
+
     def _code_trust_payload_entries(self) -> Iterable[CodeTrustEntry]:
         """Return executable opaque-payload entries for the current tool state."""
         return ()
@@ -5419,11 +5427,18 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     def _reference_resolves_current_tool_data(
         resolved: xr.DataArray, data: xr.DataArray
     ) -> bool:
+        """Check reference structure and coordinates without loading primary values.
+
+        Source freshness and snapshot tokens protect array values. Comparing those
+        values here could materialize a large lazy array during every workspace save.
+        """
         if resolved.ndim != data.ndim:
             return False
         if resolved.sizes != data.sizes:
             return False
-        return tuple(resolved.dims) == tuple(data.dims)
+        if tuple(resolved.dims) != tuple(data.dims):
+            return False
+        return resolved.coords.to_dataset().identical(data.coords.to_dataset())
 
     def _tool_data_reference_payload(
         self, variable_name: str, data: xr.DataArray
@@ -5993,8 +6008,13 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             tool_data_name = None
         token = _TOOL_WINDOW_RESTORE_DEFER.set(defer_restore_work)
         try:
+            constructor_data = cls_obj._prepare_restored_tool_data_for_constructor(
+                data_items[_SAVED_TOOL_DATA_NAME].rename(tool_data_name),
+                saved_status,
+            )
             tool = cls_obj(
-                data_items[_SAVED_TOOL_DATA_NAME].rename(tool_data_name), **kwargs
+                constructor_data,
+                **kwargs,
             )
         finally:
             _TOOL_WINDOW_RESTORE_DEFER.reset(token)

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -133,7 +133,7 @@ def test_manager_workspace_saves_added_time_for_all_node_kinds(
     )
 
 
-def test_manager_workspace_restores_hidden_ktool_angle_scales(
+def test_manager_workspace_restores_hidden_ktool_added_coordinates_and_angle_scales(
     qtbot,
     tmp_path: pathlib.Path,
     manager_context: Callable[
@@ -154,10 +154,11 @@ def test_manager_workspace_restores_hidden_ktool_angle_scales(
         attrs={"configuration": int(erlab.constants.AxesConfiguration.Type1)},
     )
     data.kspace.work_function = 4.5
+    source_data = data.drop_vars("xi")
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)
-        root = itool(data, manager=False, execute=False)
+        root = itool(source_data, manager=False, execute=False)
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(
             root,
@@ -173,6 +174,10 @@ def test_manager_workspace_restores_hidden_ktool_angle_scales(
 
         workspace_path = tmp_path / "hidden-ktool-scales.itws"
         manager._workspace_controller.saving._save_workspace_document(workspace_path)
+        saved_attrs = _current_workspace_payload_attrs(
+            workspace_path, f"0/childtools/{tool_uid}"
+        )
+        assert erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR not in saved_attrs
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -1,4 +1,5 @@
 import gc
+import json
 import tempfile
 import warnings
 from types import SimpleNamespace
@@ -3049,6 +3050,168 @@ def test_ktool_hidden_angle_scales_restore_and_remain_active(qtbot, anglemap) ->
     assert "beta_scale=0.75" in code
     namespace = _exec_generated_code(code, scan=anglemap.copy(deep=True))
     xr.testing.assert_allclose(namespace["scan_kconv"], restored._converted_output())
+
+
+@pytest.mark.parametrize(
+    ("source_configuration", "missing_configuration"),
+    [
+        pytest.param(AxesConfiguration.Type2DA, False, id="same-configuration"),
+        pytest.param(AxesConfiguration.Type2DA, True, id="missing-configuration"),
+        pytest.param(AxesConfiguration.Type1DA, False, id="changed-configuration"),
+    ],
+)
+def test_ktool_restore_prepares_referenced_data_from_saved_coordinates(
+    qtbot,
+    anglemap,
+    source_configuration: AxesConfiguration,
+    missing_configuration: bool,
+) -> None:
+    source_data = (
+        _make_da_ktool_data(anglemap)
+        .isel(beta=0)
+        .drop_vars(("xi", "chi"))
+        .copy(deep=True)
+    )
+    source_data.attrs["configuration"] = int(source_configuration)
+    if missing_configuration:
+        source_data.attrs.pop("configuration")
+    saved_data = (
+        _kspace_conversion.assign_kspace_configuration(
+            source_data, source_configuration
+        )
+        .assign_coords(xi=0.0, chi=0.0)
+        .kspace.as_configuration(AxesConfiguration.Type2DA)
+    )
+    tool = ktool(saved_data, data_name="scan", execute=False)
+    _add_hidden_tool(qtbot, tool)
+
+    status = tool.tool_status
+    source_input_coordinates = dict(status.source_input_coordinates)
+    source_input_coordinates.update({"xi": None, "chi": None})
+    tool.tool_status = status.model_copy(
+        update={
+            "source_configuration": int(source_configuration),
+            "source_configuration_missing": missing_configuration,
+            "source_input_coordinates": source_input_coordinates,
+        }
+    )
+    tool.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                source_spec=full_data().model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+        state="fresh",
+    )
+    expected = tool._converted_output()
+    saved = tool.to_dataset()
+    saved.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = json.dumps(
+        {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: {"kind": "parent_source"}}
+    )
+    saved_tool_data = saved[erlab.interactive.utils._SAVED_TOOL_DATA_NAME]
+    assert saved_tool_data.dims == ("alpha", "eV")
+    assert float(saved_tool_data.xi) == pytest.approx(0.0)
+    assert float(saved_tool_data.chi) == pytest.approx(0.0)
+    assert "xi" not in source_data.coords
+    assert "chi" not in source_data.coords
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _source_parent_data=source_data,
+        _materialize_tool_data_references=True,
+        _defer_restore_work=True,
+    )
+    _add_hidden_tool(qtbot, restored)
+
+    assert isinstance(restored, KspaceTool)
+    assert restored.data.kspace.configuration == AxesConfiguration.Type2DA
+    assert restored._source_configuration == int(source_configuration)
+    assert restored.input_coordinates == pytest.approx(
+        {
+            "hv": float(source_data.hv),
+            "beta": float(source_data.beta),
+            "xi": 0.0,
+            "chi": 0.0,
+        }
+    )
+    assert "xi" not in restored._source_input_data.coords
+    assert "chi" not in restored._source_input_data.coords
+    assert ("configuration" not in restored._source_input_data.attrs) is (
+        missing_configuration
+    )
+    if not missing_configuration:
+        assert restored._source_input_data.kspace.configuration == source_configuration
+    assert restored.tool_status.source_input_coordinates == {
+        "hv": pytest.approx(float(source_data.hv)),
+        "beta": pytest.approx(float(source_data.beta)),
+        "xi": None,
+        "chi": None,
+    }
+    assert "xi" not in source_data.coords
+    assert "chi" not in source_data.coords
+    xr.testing.assert_allclose(restored._converted_output(), expected)
+
+
+@pytest.mark.parametrize(
+    ("missing_input", "error_match"),
+    [
+        pytest.param(
+            "configuration",
+            "Missing momentum-conversion configuration",
+            id="configuration",
+        ),
+        pytest.param(
+            "coordinates",
+            "Missing scalar momentum-conversion input coordinates",
+            id="coordinates",
+        ),
+    ],
+)
+def test_ktool_restore_rejects_unrecoverable_referenced_data(
+    qtbot, anglemap, missing_input: str, error_match: str
+) -> None:
+    source_data = (
+        _make_da_ktool_data(anglemap)
+        .isel(beta=0)
+        .drop_vars(("xi", "chi"))
+        .copy(deep=True)
+    )
+    source_data.attrs["configuration"] = int(AxesConfiguration.Type2DA)
+    saved_data = source_data.assign_coords(xi=0.0, chi=0.0)
+    tool = ktool(saved_data, execute=False)
+    _add_hidden_tool(qtbot, tool)
+    tool.set_script_inputs(
+        (
+            ScriptInput(
+                name="data",
+                source_spec=full_data().model_dump(mode="json"),
+            ),
+        ),
+        primary_input="data",
+        state="fresh",
+    )
+
+    status_update: dict[str, object] = {"input_coordinates": {}}
+    if missing_input == "configuration":
+        source_data.attrs.pop("configuration")
+        status_update = {"source_configuration": None}
+    saved = tool.to_dataset()
+    saved.attrs["tool_state"] = tool.tool_status.model_copy(
+        update=status_update
+    ).model_dump_json()
+    saved.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = json.dumps(
+        {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: {"kind": "parent_source"}}
+    )
+
+    with pytest.raises(ValueError, match=error_match):
+        erlab.interactive.utils.ToolWindow.from_dataset(
+            saved,
+            _source_parent_data=source_data,
+            _materialize_tool_data_references=True,
+            _defer_restore_work=True,
+        )
 
 
 def test_ktool_copy_code_aliases_expression_input_names(qtbot) -> None:

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -5332,6 +5332,7 @@ def test_tool_window_legacy_input_fallback_replays_source_transform_once(
 def test_tool_window_saved_reference_requires_matching_resolved_data(qtbot) -> None:
     parent_data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": range(4)})
     tool_data = parent_data.isel(x=slice(0, 2))
+    tool_data_with_scalar = tool_data.assign_coords(hv=21.2)
     tool = _PersistentTool(tool_data)
     qtbot.addWidget(tool)
 
@@ -5350,6 +5351,31 @@ def test_tool_window_saved_reference_requires_matching_resolved_data(qtbot) -> N
     assert (
         erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
             tool_data.rename({"x": "y"}), tool_data
+        )
+        is False
+    )
+    square_data = xr.DataArray(np.arange(4.0).reshape(2, 2), dims=("x", "y"))
+    assert (
+        erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
+            square_data.transpose("y", "x"), square_data
+        )
+        is False
+    )
+    assert (
+        erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
+            tool_data, tool_data_with_scalar
+        )
+        is False
+    )
+    assert (
+        erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
+            tool_data.assign_coords(hv=21.3), tool_data_with_scalar
+        )
+        is False
+    )
+    assert (
+        erlab.interactive.utils.ToolWindow._reference_resolves_current_tool_data(
+            tool_data.assign_coords(x=tool_data.x + 1), tool_data
         )
         is False
     )


### PR DESCRIPTION
## Summary

- Restore missing KspaceTool configuration and scalar coordinates from saved tool state before construction.
- Preserve the recorded source configuration when the saved tool uses a different display configuration.
- Require resolved workspace references to have matching dimensions and coordinates before omitting embedded tool data.
- Store an embedded payload when KspaceTool adds scalar coordinates that are absent from its parent ImageTool.
- Reject referenced workspace states that do not contain enough information for a safe restore.

## Verification

- Restored the supplied schema-5 workspace through the corrected path. The momentum inputs were `hv=50`, `beta=0`, `xi=0`, and `chi=0`. The converted result matched the saved output.
- `QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/workspace` — 634 passed.
- Focused restore and save tests under PySide6 — 7 passed.
- `uv run mypy src` — passed for 295 source files.
- `uv run ruff check .` — passed.
- Ruff formatting for all changed files — passed.
- `git diff --check` — passed.
