### PR TITLE
fix(interactive): preserve native window sizing and placement

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -651,6 +651,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         ):
             self._figure_window = _FigureComposerDisplayWindow(
                 self._document.recipe.setup,
+                owner=self,
                 export_callback=lambda: self.export_figure(),
                 subplot_adjust_callback=lambda: self._show_subplot_adjust_dialog(),
                 axes_customize_callback=lambda: self._show_axes_customize_dialog(),
@@ -746,7 +747,6 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         figure_window.show_for_setup(
             self._document.recipe.setup, self._figure_window_title(), activate=activate
         )
-        figure_window._place_beside(self)
         self._configure_managed_secondary_window(figure_window)
         self._cancel_preview_render_update()
         self._redraw_plot(show_window=True)

--- a/src/erlab/interactive/_figurecomposer/_ui/_figure_window.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_figure_window.py
@@ -91,65 +91,6 @@ def _false_mime_state(_mime: QtCore.QMimeData) -> bool:
     return False
 
 
-def _centered_window_position(
-    window_size: QtCore.QSize, screen_geometry: QtCore.QRect
-) -> QtCore.QPoint | None:
-    """Center a window frame while keeping its top-left corner on-screen."""
-    screen = QtCore.QRect(screen_geometry)
-    if window_size.isEmpty() or screen.isEmpty():
-        return None
-
-    width = window_size.width()
-    height = window_size.height()
-    centered = QtCore.QRect(QtCore.QPoint(), window_size)
-    centered.moveCenter(screen.center())
-    return QtCore.QPoint(
-        screen.left()
-        if width > screen.width()
-        else min(max(centered.left(), screen.left()), screen.right() - width + 1),
-        screen.top()
-        if height > screen.height()
-        else min(max(centered.top(), screen.top()), screen.bottom() - height + 1),
-    )
-
-
-def _non_overlapping_window_position(
-    reference_frame: QtCore.QRect,
-    window_size: QtCore.QSize,
-    screen_geometry: QtCore.QRect,
-    *,
-    gap: int = 8,
-) -> QtCore.QPoint | None:
-    """Choose a same-screen position without overlap when space permits."""
-    screen = QtCore.QRect(screen_geometry)
-    if reference_frame.isEmpty() or window_size.isEmpty() or screen.isEmpty():
-        return None
-
-    width = window_size.width()
-    height = window_size.height()
-
-    def clamp(value: int, minimum: int, maximum: int) -> int:
-        return min(max(value, minimum), maximum)
-
-    if width <= screen.width() and height <= screen.height():
-        max_left = screen.right() - width + 1
-        max_top = screen.bottom() - height + 1
-        aligned_top = clamp(reference_frame.top(), screen.top(), max_top)
-        aligned_left = clamp(reference_frame.left(), screen.left(), max_left)
-        candidates = (
-            QtCore.QPoint(reference_frame.right() + gap + 1, aligned_top),
-            QtCore.QPoint(reference_frame.left() - gap - width, aligned_top),
-            QtCore.QPoint(aligned_left, reference_frame.bottom() + gap + 1),
-            QtCore.QPoint(aligned_left, reference_frame.top() - gap - height),
-        )
-        for position in candidates:
-            candidate = QtCore.QRect(position, window_size)
-            if screen.contains(candidate) and not reference_frame.intersects(candidate):
-                return position
-
-    return _centered_window_position(window_size, screen)
-
-
 def _axis_limit_pair(axis: object, getter_name: str) -> tuple[float, float] | None:
     getter = getattr(axis, getter_name, None)
     if getter is None:
@@ -455,6 +396,7 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
         self,
         setup: FigureSubplotsState,
         *,
+        owner: QtWidgets.QWidget,
         export_callback: Callable[[], None] = _noop_toolbar_callback,
         subplot_adjust_callback: Callable[[], None] = _noop_toolbar_callback,
         axes_customize_callback: Callable[[], None] = _noop_toolbar_callback,
@@ -474,10 +416,9 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
         ] = _false_mime_state,
         source_drop_callback: Callable[[QtCore.QMimeData], bool] = _false_mime_state,
     ) -> None:
-        super().__init__(None)
+        super().__init__(owner, QtCore.Qt.WindowType.Window)
         erlab.interactive.utils.patch_macos_matplotlib_qt_cursor()
         self._closing_from_owner = False
-        self._initial_placement_done = False
         self._suppress_resize_signal = False
         self._resize_signal_pending = False
         self._resize_signal_generation = 0
@@ -686,67 +627,6 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
             return
         self._suppress_resize_signal = False
 
-    def _ensure_recallable_geometry(self) -> None:
-        window = self.windowHandle()
-        if window is None:
-            return
-        frame = window.frameGeometry()
-        if frame.isEmpty():
-            return
-        screen_geometries = tuple(
-            geometry
-            for screen in QtGui.QGuiApplication.screens()
-            for geometry in (screen.availableGeometry(),)
-            if not geometry.isEmpty()
-        )
-        if not screen_geometries or any(
-            geometry.intersects(frame) for geometry in screen_geometries
-        ):
-            return
-        target_screen = window.screen() or QtGui.QGuiApplication.primaryScreen()
-        if target_screen is None:
-            target_geometry = screen_geometries[0]
-        else:
-            target_geometry = target_screen.availableGeometry()
-            if target_geometry.isEmpty():
-                target_geometry = screen_geometries[0]
-        position = _centered_window_position(frame.size(), target_geometry)
-        if position is not None:
-            window.setFramePosition(position)
-
-    def _place_beside(self, owner: QtWidgets.QWidget) -> None:
-        if self._initial_placement_done:
-            return
-        owner_top_level = owner.window()
-        if owner_top_level is None:
-            return
-        owner_window = owner_top_level.windowHandle()
-        window = self.windowHandle()
-        if owner_window is None or window is None:
-            return
-        owner_frame = owner_window.frameGeometry()
-        window_size = window.frameGeometry().size()
-        if owner_frame.isEmpty() or window_size.isEmpty():
-            return
-
-        target_screen = owner_window.screen()
-        if target_screen is None:
-            target_screen = QtGui.QGuiApplication.screenAt(owner_frame.center())
-        if target_screen is None:
-            target_screen = QtGui.QGuiApplication.primaryScreen()
-        if target_screen is None:
-            return
-
-        position = _non_overlapping_window_position(
-            owner_frame,
-            window_size,
-            target_screen.availableGeometry(),
-        )
-        if position is None:
-            return
-        window.setFramePosition(position)
-        self._initial_placement_done = True
-
     def show_for_setup(
         self, setup: FigureSubplotsState, title: str, *, activate: bool
     ) -> None:
@@ -759,7 +639,6 @@ class _FigureComposerDisplayWindow(QtWidgets.QMainWindow):
             self.showNormal()
         elif not self.isVisible():
             self.show()
-        self._ensure_recallable_geometry()
         if activate:
             self.raise_()
             self.activateWindow()

--- a/src/erlab/interactive/_figurecomposer/_ui/_label_help.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_label_help.py
@@ -23,6 +23,9 @@ _DIALOG_ATTR = "_figure_composer_legend_label_help_dialog"
 class LegendLabelHelpDialog(QtWidgets.QDialog):
     """Modeless help for Figure Composer legend-label placeholder syntax."""
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(520, 420)
+
     def __init__(
         self,
         contexts: Sequence[Mapping[str, typing.Any]],
@@ -90,8 +93,6 @@ class LegendLabelHelpDialog(QtWidgets.QDialog):
         )
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
-
-        self.resize(520, 420)
 
     def _placeholder_table(
         self, rows: Sequence[LabelPlaceholderHelpRow]

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -1299,6 +1299,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._write_history: bool = True
         self._write_state()
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(987, 610)
+
     def _emit_info_changed(self, *_args: typing.Any) -> None:
         self.sigInfoChanged.emit()
 
@@ -1669,8 +1672,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._connect_fit_finished_once(self._replace_last_state)
 
     def _build_ui(self) -> None:
-        self.resize(987, 610)
-
         central = QtWidgets.QWidget(self)
         self.setCentralWidget(central)
         layout = QtWidgets.QHBoxLayout(central)

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -597,6 +597,9 @@ class Fit2DTool(Fit1DTool):
         self._refresh_contents_from_index()
         self._reset_history_stack()
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(1024, 610)
+
     def _summary_2d_rows(self) -> list[tuple[str, str]]:
         y_values = self._y_values()
         min_idx = self.y_min_spin.value()
@@ -1261,7 +1264,6 @@ class Fit2DTool(Fit1DTool):
         self.main_splitter.setStretchFactor(0, 3)
         self.main_splitter.setStretchFactor(1, 2)
 
-        self.resize(1024, 610)
         self._update_param_plot_options()
         self._update_param_plot_overlays()
 

--- a/src/erlab/interactive/_options/ui.py
+++ b/src/erlab/interactive/_options/ui.py
@@ -397,6 +397,9 @@ class _SettingsRow(QtWidgets.QFrame):
 class OptionDialog(QtWidgets.QDialog):
     """Native settings dialog with immediate save and session revert."""
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(780, 560)
+
     def __init__(self, parent: QtWidgets.QWidget | None = None):
         super().__init__(parent)
         self.setObjectName("settingsDialog")
@@ -531,7 +534,6 @@ class OptionDialog(QtWidgets.QDialog):
         )
         escape_shortcut.activated.connect(self.close)
 
-        self.resize(780, 560)
         self.setMinimumSize(640, 420)
 
     def _build_pages(self) -> None:

--- a/src/erlab/interactive/_qt_state.py
+++ b/src/erlab/interactive/_qt_state.py
@@ -114,9 +114,7 @@ def restore_qt_window_state(
     geometry = qt_bytearray_from_base64(parsed.geometry)
     if geometry is not None:
         restored = bool(widget.restoreGeometry(geometry))
-    if parsed.rect is not None and (
-        not restored or widget.geometry().getRect()[2:] != parsed.rect[2:]
-    ):
+    if parsed.rect is not None and not restored:
         widget.setGeometry(*parsed.rect)
         restored = True
     return restored

--- a/src/erlab/interactive/_qt_state.py
+++ b/src/erlab/interactive/_qt_state.py
@@ -67,6 +67,15 @@ def qt_bytearray_from_base64(value: object) -> QtCore.QByteArray | None:
 
 
 def qt_window_state(widget: QtWidgets.QWidget) -> QtWindowState:
+    # Qt gives a never-shown widget placeholder geometry. Keep that geometry
+    # unset so the first show can use sizeHint() and native screen constraints.
+    has_explicit_size = widget.testAttribute(QtCore.Qt.WidgetAttribute.WA_Resized)
+    has_been_shown = widget.testAttribute(
+        QtCore.Qt.WidgetAttribute.WA_WState_ExplicitShowHide
+    ) and not widget.testAttribute(QtCore.Qt.WidgetAttribute.WA_PendingResizeEvent)
+    if not (has_explicit_size or has_been_shown):
+        return QtWindowState(visible=bool(widget.isVisible()))
+
     return QtWindowState(
         geometry=qt_bytearray_to_base64(widget.saveGeometry()),
         rect=widget.geometry().getRect(),

--- a/src/erlab/interactive/explorer/_base_explorer.py
+++ b/src/erlab/interactive/explorer/_base_explorer.py
@@ -1483,7 +1483,9 @@ class _DataExplorer(QtWidgets.QMainWindow):
 
         self.setMinimumWidth(487)
         self.setMinimumHeight(301)
-        self.resize(974, 602)
+
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(974, 602)
 
     @QtCore.Slot()
     def _dir_loaded(self) -> None:

--- a/src/erlab/interactive/explorer/_tabbed_explorer.py
+++ b/src/erlab/interactive/explorer/_tabbed_explorer.py
@@ -79,7 +79,9 @@ class _TabbedExplorer(QtWidgets.QMainWindow):
 
         self.setMinimumWidth(487)
         self.setMinimumHeight(301)
-        self.resize(974, 602)
+
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(974, 602)
 
     def _setup_actions(self) -> None:
         """Set up the main window actions."""

--- a/src/erlab/interactive/fermiedge.py
+++ b/src/erlab/interactive/fermiedge.py
@@ -2003,8 +2003,6 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self.connect_signals()
         self.graphics_layout.setFocus()
 
-        self.resize(800, 600)
-
         self._result_ds: xr.Dataset | None = None
         self._fit_thread: ResolutionFitThread | None = None
         self._fit_closing = False
@@ -2014,6 +2012,9 @@ class ResolutionTool(erlab.interactive.utils.ToolWindow):
         self._fit_signature_current: tuple[typing.Any, ...] | None = None
         self._fit_signature_displayed: tuple[typing.Any, ...] | None = None
         self._reset_history_stack()
+
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(800, 600)
 
     def _configure_data(self, data: xr.DataArray) -> None:
         if (data.ndim != 2) or ("eV" not in data.dims):

--- a/src/erlab/interactive/imagetool/_highdim.py
+++ b/src/erlab/interactive/imagetool/_highdim.py
@@ -135,6 +135,9 @@ class _ReduceDimensionRow:
 class _HighDimensionalReductionDialog(QtWidgets.QDialog):
     """Dialog used before opening data with more than four effective dimensions."""
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(780, super().sizeHint().height())
+
     def __init__(
         self,
         parent: QtWidgets.QWidget | None,
@@ -210,7 +213,6 @@ class _HighDimensionalReductionDialog(QtWidgets.QDialog):
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.reject)
         layout.addWidget(self.button_box)
-        self.resize(780, self.sizeHint().height())
         self.update_preview()
 
     @property

--- a/src/erlab/interactive/imagetool/_history.py
+++ b/src/erlab/interactive/imagetool/_history.py
@@ -670,6 +670,9 @@ def _history_entries(
 
 
 class HistoryDialog(QtWidgets.QDialog):
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(460, 210)
+
     def __init__(
         self,
         slicer_area: erlab.interactive.imagetool.viewer.ImageSlicerArea,
@@ -680,7 +683,6 @@ class HistoryDialog(QtWidgets.QDialog):
         self.setObjectName("itool_history_dialog")
         self.setWindowTitle("History")
         self.setModal(False)
-        self.resize(460, 210)
         self.setSizeGripEnabled(False)
         self._fitting_height = False
 

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -98,7 +98,6 @@ class BaseImageTool(QtWidgets.QMainWindow):
         central_layout.addWidget(self.controls_bar)
         central_layout.addWidget(self.slicer_area, 1)
         self.setCentralWidget(central_widget)
-        self.resize(720, 720)
 
         try:
             if state is not None:
@@ -111,6 +110,9 @@ class BaseImageTool(QtWidgets.QMainWindow):
 
         # Allow writing history after initialization
         self.slicer_area._write_history = True
+
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(720, 720)
 
     @property
     def slicer_area(self) -> erlab.interactive.imagetool.viewer.ImageSlicerArea:

--- a/src/erlab/interactive/imagetool/manager/_acquisition_context.py
+++ b/src/erlab/interactive/imagetool/manager/_acquisition_context.py
@@ -388,6 +388,9 @@ class _ContextSourcePickerDialog(QtWidgets.QDialog):
 
 
 class AcquisitionContextDialog(QtWidgets.QDialog):
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(720, 420)
+
     def __init__(
         self, parent: QtWidgets.QWidget, controller: _AcquisitionContextController
     ) -> None:
@@ -501,7 +504,6 @@ class AcquisitionContextDialog(QtWidgets.QDialog):
         self.table.itemSelectionChanged.connect(self._sync_buttons)
         self._populate_table()
         self._sync_buttons()
-        self.resize(720, 420)
 
     def _selected_data(self) -> xr.DataArray | None:
         targets = self._manager._selected_imagetool_targets()

--- a/src/erlab/interactive/imagetool/manager/_extensions/_dialogs.py
+++ b/src/erlab/interactive/imagetool/manager/_extensions/_dialogs.py
@@ -51,6 +51,9 @@ def _source_is_unavailable(state: str) -> bool:
 class _SourceReviewDialog(QtWidgets.QDialog):
     """Show extension source before the user approves it."""
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(760, 600)
+
     def __init__(
         self,
         path: pathlib.Path | None,
@@ -61,7 +64,6 @@ class _SourceReviewDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.setObjectName("manager_extension_source_review_dialog")
         self.setWindowTitle("Review Extension Source")
-        self.resize(760, 600)
         layout = QtWidgets.QVBoxLayout(self)
         source = erlab.interactive.utils.PythonCodeEditor(self)
         source.setObjectName("manager_extension_source_review")
@@ -306,6 +308,9 @@ class _RoutineSelectionDialog(QtWidgets.QDialog):
 class _SourceViewerDialog(QtWidgets.QDialog):
     """Show extension source with Python highlighting."""
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(800, 600)
+
     def __init__(
         self,
         source_text: str,
@@ -316,7 +321,6 @@ class _SourceViewerDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.setObjectName("manager_extension_source_viewer_dialog")
         self.setWindowTitle(title)
-        self.resize(800, 600)
         layout = QtWidgets.QVBoxLayout(self)
         self.source = erlab.interactive.utils.PythonCodeEditor(self)
         self.source.setObjectName("manager_extension_running_source")
@@ -337,11 +341,13 @@ class _ManageExtensionsDialog(QtWidgets.QDialog):
     selection_changed = QtCore.Signal(str)
     activated = QtCore.Signal()
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(1120, 620)
+
     def __init__(self, parent: QtWidgets.QWidget) -> None:
         super().__init__(parent)
         self.setObjectName("manager_manage_extensions_dialog")
         self.setWindowTitle("Manage Extensions")
-        self.resize(1120, 620)
         layout = QtWidgets.QVBoxLayout(self)
         controls = QtWidgets.QHBoxLayout()
         self.add_script_button = QtWidgets.QPushButton("Add Script…", self)

--- a/src/erlab/interactive/imagetool/manager/_keyboard_shortcuts.py
+++ b/src/erlab/interactive/imagetool/manager/_keyboard_shortcuts.py
@@ -799,6 +799,9 @@ class _ShortcutTab(QtWidgets.QScrollArea):
 class KeyboardShortcutsDialog(QtWidgets.QDialog):
     """Modeless keyboard shortcut reference for Manager applications."""
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(760, 580)
+
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("managerKeyboardShortcutsDialog")
@@ -856,7 +859,6 @@ class KeyboardShortcutsDialog(QtWidgets.QDialog):
         self._close_shortcut.activated.connect(self.close)
 
         self.setMinimumSize(560, 420)
-        self.resize(760, 580)
 
     def _apply_filter(self, text: str) -> None:
         query = " ".join(text.casefold().split())

--- a/src/erlab/interactive/imagetool/manager/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/manager/_mainwindow.py
@@ -1125,7 +1125,6 @@ class ImageToolManager(_ImageToolManagerBase):
         # Golden ratio :)
         self.setMinimumWidth(301)
         self.setMinimumHeight(487)
-        self.resize(487, 487)
 
         # Install event filter for keyboard shortcuts
         self._kb_filter = erlab.interactive.utils.KeyboardEventFilter(self)
@@ -1152,6 +1151,9 @@ class ImageToolManager(_ImageToolManagerBase):
         )
         self._status_bar.showMessage("")
         self._manager_layout_tracking_enabled = True
+
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(487, 487)
 
     def event(self, event: QtCore.QEvent | None) -> bool:
         handled = super().event(event)

--- a/src/erlab/interactive/imagetool/manager/_metadata_editor.py
+++ b/src/erlab/interactive/imagetool/manager/_metadata_editor.py
@@ -1234,6 +1234,10 @@ class _MetadataFieldChooser(QtWidgets.QWidget):
 
 
 class MetadataEditorDialog(QtWidgets.QDialog):
+    def sizeHint(self) -> QtCore.QSize:
+        targets = getattr(self, "targets", ())
+        return QtCore.QSize(980, min(720, 280 + 34 * len(targets)))
+
     def __init__(
         self,
         parent: QtWidgets.QWidget,
@@ -1384,7 +1388,6 @@ class MetadataEditorDialog(QtWidgets.QDialog):
         selection_model.selectionChanged.connect(self._refresh_summary)
         selection_model.currentChanged.connect(self._refresh_summary)
         self._refresh_summary()
-        self.resize(980, min(720, 280 + 34 * len(targets)))
 
     @QtCore.Slot(str)
     def _show_cell_edit_error(self, details: str) -> None:

--- a/src/erlab/interactive/imagetool/manager/_provenance_edit/_reorder.py
+++ b/src/erlab/interactive/imagetool/manager/_provenance_edit/_reorder.py
@@ -264,6 +264,9 @@ class _ProvenanceReorderDialog(QtWidgets.QDialog):
 
     apply_requested = QtCore.Signal()
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(520, 420)
+
     def __init__(
         self,
         *,
@@ -365,7 +368,6 @@ class _ProvenanceReorderDialog(QtWidgets.QDialog):
         self.cancel_button.clicked.connect(self.reject)
         layout.addWidget(self.button_box)
 
-        self.resize(520, 420)
         self._update_controls()
 
     @staticmethod

--- a/src/erlab/interactive/imagetool/manager/_spreadsheet_metadata.py
+++ b/src/erlab/interactive/imagetool/manager/_spreadsheet_metadata.py
@@ -484,6 +484,9 @@ def _column_display_label(columns: tuple[str, ...], column: str | None) -> str:
 class _SpreadsheetMetadataDialog(QtWidgets.QDialog):
     """Configure an Excel or Google Sheets metadata source for a file load."""
 
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(760, 560)
+
     def __init__(
         self,
         parent: QtWidgets.QWidget,
@@ -498,7 +501,6 @@ class _SpreadsheetMetadataDialog(QtWidgets.QDialog):
         self.setWindowTitle("Spreadsheet Metadata")
         self.setModal(True)
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose, False)
-        self.resize(760, 560)
 
         self._selected_source: SpreadsheetMetadataSource | None = source
         self._initial_directory = initial_directory

--- a/src/erlab/interactive/imagetool/manager/_widgets.py
+++ b/src/erlab/interactive/imagetool/manager/_widgets.py
@@ -684,9 +684,7 @@ class _LoadSourceDetailsDialog(QtWidgets.QDialog):
         close_button.clicked.connect(self.accept)
         layout.addWidget(self.button_box)
         target_width = max(self.minimumWidth(), self.sizeHint().width())
-        self.resize(target_width, self.minimumSizeHint().height())
-        target_height = self.height()
-        self.setFixedSize(target_width, target_height)
+        self.setFixedSize(target_width, self.minimumSizeHint().height())
 
     @QtCore.Slot()
     def _request_file_load_edit(self) -> None:
@@ -1024,9 +1022,7 @@ class _WorkspacePropertiesDialog(QtWidgets.QDialog):
         close_button.clicked.connect(self.accept)
         layout.addWidget(self.button_box)
         target_width = max(self.minimumWidth(), self.sizeHint().width())
-        self.resize(target_width, self.minimumSizeHint().height())
-        target_height = self.height()
-        self.setFixedSize(target_width, target_height)
+        self.setFixedSize(target_width, self.minimumSizeHint().height())
 
     @staticmethod
     def _status_text(

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -424,7 +424,8 @@ class _ManagedWindowNode(QtCore.QObject):
         self._manager = weakref.ref(manager)
         self.uid = uid
         self.parent_uid = parent_uid
-        self._recent_geometry: QtCore.QRect | None = None
+        self._recent_geometry: QtCore.QByteArray | None = None
+        self._has_been_shown = False
         self._created_time = _coerce_added_time(created_time, node_uid=uid)
 
         self._childtools: dict[str, QtWidgets.QWidget] = {}
@@ -728,6 +729,10 @@ class _ManagedWindowNode(QtCore.QObject):
             self._sync_manager_window_reference()
             self._notify_info_and_type_badge_change(previous_type_badge)
             return
+
+        if value.isVisible():
+            self._has_been_shown = True
+            self._recent_geometry = value.saveGeometry()
 
         if isinstance(value, ImageTool):
             self._window_kind = "imagetool"
@@ -2862,6 +2867,8 @@ class _ManagedWindowNode(QtCore.QObject):
             QtCore.QEvent.Type.WindowStateChange,
         )
         if obj == self.window and event_type in tracked_event_types:
+            if event_type == QtCore.QEvent.Type.Show:
+                self._has_been_shown = True
             if self.imagetool is not None and event_type == QtCore.QEvent.Type.Show:
                 erlab.interactive.utils.single_shot(
                     self.slicer_area, 0, self.slicer_area._ensure_secondary_plots
@@ -2897,8 +2904,8 @@ class _ManagedWindowNode(QtCore.QObject):
     @QtCore.Slot()
     def visibility_changed(self, *, mark_dirty: bool = True) -> None:
         window = self.window
-        if isinstance(window, QtWidgets.QWidget):
-            self._recent_geometry = window.geometry()
+        if isinstance(window, QtWidgets.QWidget) and self._has_been_shown:
+            self._recent_geometry = window.saveGeometry()
             if mark_dirty:
                 self.manager._mark_node_state_dirty(self.uid)
 
@@ -2909,18 +2916,21 @@ class _ManagedWindowNode(QtCore.QObject):
         window = self.window
         if window is None:
             return
-        if not window.isVisible() and self._recent_geometry is not None:
-            window.setGeometry(self._recent_geometry)
+        first_show = not self._has_been_shown and self._recent_geometry is None
+        if not window.isVisible() and not first_show:
+            recent_geometry = self._recent_geometry
+            if recent_geometry is not None:
+                window.restoreGeometry(recent_geometry)
 
-        if sys.platform == "win32":
+        if sys.platform == "win32" and not first_show:
             window_flags = window.windowFlags()
-            window_geometry = window.geometry()
+            window_geometry = window.saveGeometry()
             window.setWindowFlags(
                 window_flags | QtCore.Qt.WindowType.WindowStaysOnTopHint
             )
             window.show()
             window.setWindowFlags(window_flags)
-            window.setGeometry(window_geometry)
+            window.restoreGeometry(window_geometry)
 
         window.show()
         window.activateWindow()

--- a/src/erlab/interactive/imagetool/viewer_state.py
+++ b/src/erlab/interactive/imagetool/viewer_state.py
@@ -146,6 +146,9 @@ def _datatree_dataarray_selection(
 
 
 class _SelectDataArraysDialog(QtWidgets.QDialog):
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(820, 420)
+
     def __init__(
         self,
         parent: QtWidgets.QWidget | None,
@@ -187,7 +190,6 @@ class _SelectDataArraysDialog(QtWidgets.QDialog):
                         variable_names.append(str(variable_name))
 
         self.setWindowTitle("Select Data Variables")
-        self.resize(820, 420)
 
         layout = QtWidgets.QVBoxLayout(self)
 

--- a/src/erlab/interactive/ptable/_window.py
+++ b/src/erlab/interactive/ptable/_window.py
@@ -455,7 +455,6 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         self._workspace_state_restoring = False
 
         self.setWindowTitle("Periodic Table of the Elements")
-        self.resize(1600, 920)
 
         self.central = QtWidgets.QWidget(self)
         self.setCentralWidget(self.central)
@@ -640,6 +639,9 @@ class PeriodicTableWindow(QtWidgets.QMainWindow):
         self._apply_theme()
         self._refresh_inputs()
         self._refresh_window_state(ensure_visible=False)
+
+    def sizeHint(self) -> QtCore.QSize:
+        return QtCore.QSize(1600, 920)
 
     @property
     def selected_atomic_number(self) -> int | None:

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -145,9 +145,22 @@ def test_manager_windows_figure_activation_preserves_resized_geometry(
     ],
 ) -> None:
     class _FlagResizeFigureComposer(FigureComposerTool):
+        flag_changes = 0
+        geometry_sets = 0
+        geometry_restores = 0
+
         def setWindowFlags(self, flags: QtCore.Qt.WindowType) -> None:
+            self.flag_changes += 1
             super().setWindowFlags(flags)
             self.resize(self.width(), self.sizeHint().height())
+
+        def setGeometry(self, rect: QtCore.QRect) -> None:
+            self.geometry_sets += 1
+            super().setGeometry(rect)
+
+        def restoreGeometry(self, geometry: QtCore.QByteArray) -> bool:
+            self.geometry_restores += 1
+            return super().restoreGeometry(geometry)
 
     monkeypatch.setattr(manager_wrapper.sys, "platform", "win32")
     data = xr.DataArray(
@@ -159,12 +172,22 @@ def test_manager_windows_figure_activation_preserves_resized_geometry(
 
     with manager_context() as manager:
         tool = _FlagResizeFigureComposer(data)
-        figure_uid = manager.add_figuretool(tool, show=True)
+        tool.geometry_sets = 0
+        figure_uid = manager.add_figuretool(tool, show=False)
+        node = manager._child_node(figure_uid)
+        assert not node._has_been_shown
+        node.visibility_changed(mark_dirty=False)
+        assert node._recent_geometry is None
+
+        node.show()
         qtbot.waitUntil(tool.isVisible, timeout=5000)
         qtbot.waitUntil(
             lambda: tool.width() >= tool.minimumSizeHint().width(), timeout=5000
         )
-        tool.setGeometry(80, 60, tool.width() + 80, tool.height() + 180)
+        assert tool.flag_changes == 0
+        assert tool.geometry_sets == 0
+        assert tool.geometry_restores == 0
+        tool.setGeometry(QtCore.QRect(80, 60, tool.width() + 80, tool.height() + 180))
         QtWidgets.QApplication.processEvents()
         resized_geometry = tool.geometry()
 
@@ -173,6 +196,65 @@ def test_manager_windows_figure_activation_preserves_resized_geometry(
         manager._figure_collection._show_item(item)
 
         assert tool.geometry() == resized_geometry
+        assert tool.flag_changes == 2
+        assert tool.geometry_sets == 1
+        assert tool.geometry_restores == 1
+
+        tool.hide()
+        qtbot.waitUntil(lambda: not tool.isVisible(), timeout=5000)
+        qtbot.waitUntil(
+            lambda: (
+                manager._child_node(figure_uid)._recent_geometry == tool.saveGeometry()
+            ),
+            timeout=5000,
+        )
+        manager._figure_collection._show_item(item)
+
+        assert tool.geometry() == resized_geometry
+        assert tool.flag_changes == 4
+        assert tool.geometry_sets == 1
+        assert tool.geometry_restores == 3
+
+        tool.showMaximized()
+        qtbot.waitUntil(tool.isMaximized, timeout=5000)
+        normal_geometry = tool.normalGeometry()
+        tool.hide()
+        qtbot.waitUntil(lambda: not tool.isVisible(), timeout=5000)
+        qtbot.waitUntil(
+            lambda: node._recent_geometry == tool.saveGeometry(), timeout=5000
+        )
+        node.show()
+        qtbot.waitUntil(tool.isMaximized, timeout=5000)
+        tool.showNormal()
+        QtWidgets.QApplication.processEvents()
+        assert tool.geometry() == normal_geometry
+
+        previsible = _FlagResizeFigureComposer(data)
+        previsible.show()
+        qtbot.waitUntil(previsible.isVisible, timeout=5000)
+        previsible.setGeometry(
+            QtCore.QRect(120, 90, previsible.width() + 40, previsible.height() + 80)
+        )
+        QtWidgets.QApplication.processEvents()
+        previsible_geometry = previsible.geometry()
+        previsible.flag_changes = 0
+        previsible.geometry_sets = 0
+        previsible.geometry_restores = 0
+
+        previsible_uid = manager.add_figuretool(previsible, show=False)
+        previsible_node = manager._child_node(previsible_uid)
+
+        assert previsible_node._has_been_shown
+        assert previsible_node._recent_geometry == previsible.saveGeometry()
+
+        previsible.hide()
+        qtbot.waitUntil(lambda: not previsible.isVisible(), timeout=5000)
+        previsible_node.show()
+
+        assert previsible.geometry() == previsible_geometry
+        assert previsible.flag_changes == 2
+        assert previsible.geometry_sets == 0
+        assert previsible.geometry_restores == 2
 
 
 def test_manager_figures_ui_is_lazy_and_figures_survive_source_removal(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -2008,10 +2008,6 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     qtbot, monkeypatch, recwarn
 ) -> None:
     import matplotlib.pyplot as plt
-    from matplotlib.backends.backend_qtagg import (
-        FigureCanvasQTAgg,
-        NavigationToolbar2QT,
-    )
 
     data = xr.DataArray(
         np.arange(12.0).reshape(3, 2, 2),
@@ -2046,8 +2042,9 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     tool.show_figure_window(activate=False)
     tool._update_operation_editor()
 
-    assert tool.findChildren(FigureCanvasQTAgg) == []
-    assert tool.findChildren(NavigationToolbar2QT) == []
+    assert tool.figure_window.isWindow()
+    assert tool.figure_window.canvas.window() is tool.figure_window
+    assert tool.figure_window.toolbar.window() is tool.figure_window
     assert set(tool.findChildren(QtWidgets.QSplitter)) == {
         tool.source_panel.source_splitter,
         tool.operation_panel.splitter,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_source_selection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pydantic
 import pytest
-from qtpy import QtCore, QtGui
+from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab.interactive._figurecomposer._model._sources as figurecomposer_sources
 import erlab.interactive._figurecomposer._ui._figure_window as figure_window_ui
@@ -176,8 +176,11 @@ def test_figure_composer_state_serializes_slice_values() -> None:
 
 
 def test_figure_display_window_source_drop_event_branches(qtbot) -> None:
-    window = figure_window_ui._FigureComposerDisplayWindow(FigureSubplotsState())
-    qtbot.addWidget(window)
+    owner = QtWidgets.QWidget()
+    qtbot.addWidget(owner)
+    window = figure_window_ui._FigureComposerDisplayWindow(
+        FigureSubplotsState(), owner=owner
+    )
     mime = QtCore.QMimeData()
     assert figure_window_ui._false_mime_state(mime) is False
     assert window._handle_source_drag_event(None) is False

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -1671,8 +1671,9 @@ def test_figure_composer_source_add_callbacks_handle_unavailable_paths(
     data = _figure_composer_profile_source("data")
     tool = FigureComposerTool(data)
     qtbot.addWidget(tool)
-    figure_window = figure_window_ui._FigureComposerDisplayWindow(FigureSubplotsState())
-    qtbot.addWidget(figure_window)
+    figure_window = figure_window_ui._FigureComposerDisplayWindow(
+        FigureSubplotsState(), owner=tool
+    )
     tool._figure_window = figure_window
     mime = QtCore.QMimeData()
     calls: list[str] = []

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -1161,7 +1161,11 @@ def test_figure_display_window_uses_safe_resize_callbacks(qtbot, monkeypatch) ->
         calls.append((receiver, msec, callback_name, guards))
 
     monkeypatch.setattr(erlab.interactive.utils, "single_shot", record_single_shot)
-    window = figure_window_ui._FigureComposerDisplayWindow(FigureSubplotsState())
+    owner = QtWidgets.QWidget()
+    qtbot.addWidget(owner)
+    window = figure_window_ui._FigureComposerDisplayWindow(
+        FigureSubplotsState(), owner=owner
+    )
 
     window.resize_to_setup(FigureSubplotsState())
     window._suppress_resize_signal = False
@@ -1174,8 +1178,10 @@ def test_figure_display_window_uses_safe_resize_callbacks(qtbot, monkeypatch) ->
 
 
 def test_figure_display_window_skips_stale_resize_callbacks(qtbot) -> None:
+    owner = QtWidgets.QWidget()
+    qtbot.addWidget(owner)
     window = figure_window_ui._FigureComposerDisplayWindow(
-        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0)
+        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0), owner=owner
     )
     emitted_sizes: list[tuple[float, float]] = []
     window.sigCanvasSizeChanged.connect(
@@ -1196,8 +1202,10 @@ def test_figure_display_window_skips_stale_resize_callbacks(qtbot) -> None:
 
 
 def test_figure_display_window_close_and_canvas_size_contracts(qtbot) -> None:
+    owner = QtWidgets.QWidget()
+    qtbot.addWidget(owner)
     window = figure_window_ui._FigureComposerDisplayWindow(
-        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0)
+        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0), owner=owner
     )
 
     emitted_sizes: list[tuple[float, float]] = []
@@ -1242,8 +1250,10 @@ def test_figure_display_window_close_and_canvas_size_contracts(qtbot) -> None:
     assert not window.isVisible()
     QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
 
+    app_quit_owner = QtWidgets.QWidget()
+    qtbot.addWidget(app_quit_owner)
     app_quit_window = figure_window_ui._FigureComposerDisplayWindow(
-        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0)
+        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0), owner=app_quit_owner
     )
     app_quit_window.show()
     erlab.interactive.utils._set_application_quit_requested(True)
@@ -1257,8 +1267,11 @@ def test_figure_display_window_close_and_canvas_size_contracts(qtbot) -> None:
 
 
 def test_figure_display_window_event_filter_accepts_source_drag(qtbot) -> None:
-    window = figure_window_ui._FigureComposerDisplayWindow(FigureSubplotsState())
-    qtbot.addWidget(window)
+    owner = QtWidgets.QWidget()
+    qtbot.addWidget(owner)
+    window = figure_window_ui._FigureComposerDisplayWindow(
+        FigureSubplotsState(), owner=owner
+    )
     mime = QtCore.QMimeData()
     window.set_source_drop_callbacks(can_drop=lambda data: data is mime)
 
@@ -1288,34 +1301,13 @@ def test_figure_display_window_event_filter_accepts_source_drag(qtbot) -> None:
     assert event.dropAction() == QtCore.Qt.DropAction.CopyAction
 
 
-def test_figure_display_window_show_for_setup_recalls_hidden_states(
+def test_figure_display_window_show_for_setup_recalls_minimized_state(
     qtbot, monkeypatch
 ) -> None:
-    class _FakeScreen:
-        def availableGeometry(self) -> QtCore.QRect:
-            return QtCore.QRect(0, 0, 800, 600)
-
-    class _MovedDisplayWindow(figure_window_ui._FigureComposerDisplayWindow):
-        def __init__(self) -> None:
-            super().__init__(FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0))
-            self._test_frame = QtCore.QRect(5000, 5000, 120, 120)
-            self.moved_to: list[QtCore.QPoint] = []
-
-        def frameGeometry(self) -> QtCore.QRect:
-            return QtCore.QRect(self._test_frame)
-
-        def windowHandle(self) -> typing.Any:
-            return self
-
-        def setFramePosition(self, point: QtCore.QPoint) -> None:
-            self.moved_to.append(QtCore.QPoint(point))
-            self._test_frame.moveTopLeft(point)
-
-        def screen(self) -> _FakeScreen:
-            return _FakeScreen()
-
+    owner = QtWidgets.QWidget()
+    qtbot.addWidget(owner)
     minimized = figure_window_ui._FigureComposerDisplayWindow(
-        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0)
+        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0), owner=owner
     )
     show_calls: list[str] = []
     monkeypatch.setattr(minimized, "isMinimized", lambda: True)
@@ -1332,164 +1324,30 @@ def test_figure_display_window_show_for_setup_recalls_hidden_states(
     minimized.close_from_owner()
     QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
 
-    offscreen = _MovedDisplayWindow()
-    offscreen.show_for_setup(
-        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0),
-        "offscreen",
-        activate=False,
-    )
 
-    assert offscreen.moved_to
-    assert _FakeScreen().availableGeometry().intersects(offscreen.frameGeometry())
-    offscreen.close_from_owner()
+def test_figure_display_window_uses_qt_window_ownership(qtbot) -> None:
+    tool = FigureComposerTool(_figure_composer_image_source("data"))
+    qtbot.addWidget(tool)
+
+    window = tool.figure_window
+
+    assert window.parentWidget() is tool
+    assert window.isWindow()
+    assert window.windowType() == QtCore.Qt.WindowType.Window
+
+    tool.show()
+    window.show()
+    QtWidgets.QApplication.processEvents()
+
+    owner_handle = tool.windowHandle()
+    window_handle = window.windowHandle()
+    assert owner_handle is not None
+    assert window_handle is not None
+    assert window_handle.transientParent() is owner_handle
+
+    tool.deleteLater()
     QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
-
-    oversized = _MovedDisplayWindow()
-    oversized._test_frame = QtCore.QRect(5000, 5000, 900, 700)
-    oversized.show_for_setup(
-        FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0),
-        "oversized",
-        activate=False,
-    )
-
-    assert oversized.moved_to == [QtCore.QPoint(0, 0)]
-    oversized.close_from_owner()
-    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
-
-
-@pytest.mark.parametrize(
-    ("reference", "window_size", "screen", "expected"),
-    [
-        (
-            QtCore.QRect(100, 100, 300, 300),
-            QtCore.QSize(200, 150),
-            QtCore.QRect(0, 0, 1000, 800),
-            QtCore.QPoint(408, 100),
-        ),
-        (
-            QtCore.QRect(700, 100, 250, 300),
-            QtCore.QSize(300, 150),
-            QtCore.QRect(0, 0, 1000, 800),
-            QtCore.QPoint(392, 100),
-        ),
-        (
-            QtCore.QRect(100, 100, 600, 200),
-            QtCore.QSize(500, 200),
-            QtCore.QRect(0, 0, 800, 800),
-            QtCore.QPoint(100, 308),
-        ),
-        (
-            QtCore.QRect(100, 500, 600, 200),
-            QtCore.QSize(500, 200),
-            QtCore.QRect(0, 0, 800, 800),
-            QtCore.QPoint(100, 292),
-        ),
-        (
-            QtCore.QRect(0, 0, 800, 600),
-            QtCore.QSize(300, 200),
-            QtCore.QRect(0, 0, 800, 600),
-            QtCore.QPoint(250, 200),
-        ),
-        (
-            QtCore.QRect(0, 0, 800, 600),
-            QtCore.QSize(900, 700),
-            QtCore.QRect(0, 0, 800, 600),
-            QtCore.QPoint(0, 0),
-        ),
-    ],
-)
-def test_non_overlapping_figure_window_position(
-    reference: QtCore.QRect,
-    window_size: QtCore.QSize,
-    screen: QtCore.QRect,
-    expected: QtCore.QPoint,
-) -> None:
-    assert (
-        figure_window_ui._non_overlapping_window_position(
-            reference,
-            window_size,
-            screen,
-        )
-        == expected
-    )
-
-
-@pytest.mark.parametrize(
-    ("reference", "window_size", "screen"),
-    [
-        (QtCore.QRect(), QtCore.QSize(200, 150), QtCore.QRect(0, 0, 800, 600)),
-        (
-            QtCore.QRect(0, 0, 300, 300),
-            QtCore.QSize(),
-            QtCore.QRect(0, 0, 800, 600),
-        ),
-        (
-            QtCore.QRect(0, 0, 300, 300),
-            QtCore.QSize(200, 150),
-            QtCore.QRect(),
-        ),
-    ],
-)
-def test_non_overlapping_figure_window_position_requires_geometry(
-    reference: QtCore.QRect,
-    window_size: QtCore.QSize,
-    screen: QtCore.QRect,
-) -> None:
-    assert (
-        figure_window_ui._non_overlapping_window_position(
-            reference,
-            window_size,
-            screen,
-        )
-        is None
-    )
-
-
-def test_figure_display_window_is_placed_beside_composer_once(qtbot) -> None:
-    class _FakeScreen:
-        def availableGeometry(self) -> QtCore.QRect:
-            return QtCore.QRect(0, 40, 1000, 760)
-
-    class _Owner(QtWidgets.QWidget):
-        def frameGeometry(self) -> QtCore.QRect:
-            return QtCore.QRect(100, 40, 300, 300)
-
-        def screen(self) -> _FakeScreen:
-            return _FakeScreen()
-
-        def windowHandle(self) -> typing.Any:
-            return self
-
-    class _MovedDisplayWindow(figure_window_ui._FigureComposerDisplayWindow):
-        def __init__(self) -> None:
-            super().__init__(FigureSubplotsState(figsize=(1.0, 1.0), dpi=100.0))
-            self._test_frame = QtCore.QRect(0, 0, 200, 150)
-            self.moved_to: list[QtCore.QPoint] = []
-
-        def frameGeometry(self) -> QtCore.QRect:
-            return QtCore.QRect(self._test_frame)
-
-        def windowHandle(self) -> typing.Any:
-            return self
-
-        def setFramePosition(self, point: QtCore.QPoint) -> None:
-            self.moved_to.append(QtCore.QPoint(point))
-            self._test_frame.moveTopLeft(point)
-
-        def move(self, point: QtCore.QPoint) -> None:
-            raise AssertionError(f"Widget.move() received frame position {point!r}")
-
-    owner = _Owner()
-    qtbot.addWidget(owner)
-    window = _MovedDisplayWindow()
-
-    window._place_beside(owner)
-    window._place_beside(owner)
-
-    assert window.moved_to == [QtCore.QPoint(408, 40)]
-    assert window._initial_placement_done
-    window.close_from_owner()
-    QtWidgets.QApplication.sendPostedEvents(None, QtCore.QEvent.Type.DeferredDelete)
+    assert not erlab.interactive.utils.qt_is_valid(window)
 
 
 def test_figure_composer_managed_display_window_configures_save_shortcut(
@@ -7246,9 +7104,8 @@ def test_figure_composer_toolbar_navigation_helper_edges(qtbot, monkeypatch) -> 
             limited_toolitems,
         )
         limited_window = figure_window_ui._FigureComposerDisplayWindow(
-            FigureSubplotsState()
+            FigureSubplotsState(), owner=tool
         )
-        qtbot.addWidget(limited_window)
     assert "back" not in limited_window.toolbar._actions
     assert "forward" not in limited_window.toolbar._actions
 

--- a/tests/interactive/imagetool/manager/test_extensions.py
+++ b/tests/interactive/imagetool/manager/test_extensions.py
@@ -405,6 +405,7 @@ def test_source_review_dialog_reads_source(
     source.write_text("VALUE = 1\n")
     dialog = extension_dialogs._SourceReviewDialog(source, parent)
     qtbot.addWidget(dialog)
+    assert dialog.sizeHint() == QtCore.QSize(760, 600)
     source_editor = dialog.findChild(
         erlab.interactive.utils.PythonCodeEditor,
         "manager_extension_source_review",
@@ -551,6 +552,7 @@ def test_manage_dialog_preserves_selected_extension(
     )
     dialog = extension_dialogs._ManageExtensionsDialog(parent)
     qtbot.addWidget(dialog)
+    assert dialog.sizeHint() == QtCore.QSize(1120, 620)
     dialog.set_catalog(_ExtensionCatalogModel(extensions={"lab.py": record}))
     top = dialog.tree.topLevelItem(0)
     assert top.childCount() == 0
@@ -8598,6 +8600,7 @@ def test_extension_source_viewer_uses_python_editor(
         "value = 1\n", parent, title="Source"
     )
     qtbot.addWidget(viewer)
+    assert viewer.sizeHint() == QtCore.QSize(800, 600)
     assert isinstance(viewer.source, erlab.interactive.utils.PythonCodeEditor)
     assert viewer.source.isReadOnly()
 

--- a/tests/interactive/imagetool/manager/test_mainwindow.py
+++ b/tests/interactive/imagetool/manager/test_mainwindow.py
@@ -840,7 +840,7 @@ def test_arrange_selected_windows_accepts_and_cancels(
         assert [first.frameGeometry(), second.frameGeometry()] == expected
         qtbot.wait_until(
             lambda: all(
-                manager._child_node(uid)._recent_geometry == window.geometry()
+                manager._child_node(uid)._recent_geometry == window.saveGeometry()
                 for uid, window in zip(
                     (first_uid, second_uid), (first, second), strict=True
                 )

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -255,6 +255,23 @@ def test_imagetool_dataset_uses_window_state_and_keeps_rect_fallback(
     )
 
 
+def test_imagetool_dataset_preserves_never_shown_size_hint(qtbot, test_data) -> None:
+    tool = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
+    qtbot.addWidget(tool)
+
+    ds = tool.to_dataset()
+    assert json.loads(ds.attrs["itool_window_state"]) == {"visible": False}
+
+    restored = erlab.interactive.imagetool.ImageTool.from_dataset(ds, _in_manager=True)
+    qtbot.addWidget(restored)
+    assert restored.sizeHint() == tool.sizeHint()
+
+    tool.show()
+    restored.show()
+    QtWidgets.QApplication.processEvents()
+    assert restored.size() == tool.size()
+
+
 def test_toolwindow_dataset_uses_window_state_and_keeps_rect_fallback(
     qtbot, test_data
 ) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_format.py
+++ b/tests/interactive/imagetool/manager/workspace/test_format.py
@@ -145,6 +145,87 @@ def test_qt_window_state_helpers_parse_invalid_and_restore_rect(qtbot) -> None:
     assert widget.geometry().getRect() == (10, 20, 123, 45)
 
 
+def test_qt_window_state_native_geometry_is_authoritative(qtbot, monkeypatch) -> None:
+    widget = QtWidgets.QWidget()
+    qtbot.addWidget(widget)
+    native_geometry = qt_state.qt_bytearray_to_base64(QtCore.QByteArray(b"native"))
+    set_geometry_calls = []
+
+    monkeypatch.setattr(widget, "restoreGeometry", lambda geometry: True)
+    monkeypatch.setattr(
+        widget,
+        "setGeometry",
+        lambda *rect: set_geometry_calls.append(rect),
+    )
+
+    assert qt_state.restore_qt_window_state(
+        widget,
+        {"geometry": native_geometry, "rect": [10, 20, 123, 45]},
+    )
+    assert set_geometry_calls == []
+
+
+def test_qt_window_state_falls_back_when_native_restore_fails(
+    qtbot, monkeypatch
+) -> None:
+    widget = QtWidgets.QWidget()
+    qtbot.addWidget(widget)
+    native_geometry = qt_state.qt_bytearray_to_base64(QtCore.QByteArray(b"native"))
+    set_geometry_calls = []
+
+    monkeypatch.setattr(widget, "restoreGeometry", lambda geometry: False)
+    monkeypatch.setattr(
+        widget,
+        "setGeometry",
+        lambda *rect: set_geometry_calls.append(rect),
+    )
+
+    assert qt_state.restore_qt_window_state(
+        widget,
+        {"geometry": native_geometry, "rect": [10, 20, 123, 45]},
+    )
+    assert set_geometry_calls == [(10, 20, 123, 45)]
+
+
+def test_qt_window_state_restores_maximized_normal_geometry(qtbot) -> None:
+    screen = QtWidgets.QApplication.primaryScreen()
+    assert screen is not None
+    available = screen.availableGeometry()
+    requested_geometry = QtCore.QRect(
+        available.left() + 20,
+        available.top() + 20,
+        min(320, available.width() - 40),
+        min(240, available.height() - 40),
+    )
+
+    source = QtWidgets.QMainWindow()
+    restored = QtWidgets.QMainWindow()
+    qtbot.addWidget(source)
+    qtbot.addWidget(restored)
+    source.setGeometry(requested_geometry)
+    source.show()
+    QtWidgets.QApplication.processEvents()
+    normal_geometry = source.geometry()
+    source.showMaximized()
+    QtWidgets.QApplication.processEvents()
+
+    state = qt_state.qt_window_state(source)
+    assert qt_state.restore_qt_window_state(restored, state)
+    restored.show()
+    QtWidgets.QApplication.processEvents()
+
+    assert restored.isMaximized()
+    restored_normal_geometry = restored.normalGeometry()
+    assert restored_normal_geometry.size() == normal_geometry.size()
+    restored.showNormal()
+    QtWidgets.QApplication.processEvents()
+    assert restored.geometry() == restored_normal_geometry
+    assert any(
+        candidate.availableGeometry().intersects(restored.frameGeometry())
+        for candidate in QtWidgets.QApplication.screens()
+    )
+
+
 def test_imagetool_private_coord_serialization_edge_cases() -> None:
     private_attr = imagetool_serialization._PRIVATE_COORDS_ATTR
     private_prefix = imagetool_serialization._PRIVATE_COORD_VAR_PREFIX

--- a/tests/interactive/imagetool/manager/workspace/test_format.py
+++ b/tests/interactive/imagetool/manager/workspace/test_format.py
@@ -145,6 +145,66 @@ def test_qt_window_state_helpers_parse_invalid_and_restore_rect(qtbot) -> None:
     assert widget.geometry().getRect() == (10, 20, 123, 45)
 
 
+def test_qt_window_state_leaves_never_shown_geometry_unset(qtbot) -> None:
+    class HintedWindow(QtWidgets.QMainWindow):
+        def sizeHint(self) -> QtCore.QSize:
+            return QtCore.QSize(321, 243)
+
+    source = HintedWindow()
+    restored = HintedWindow()
+    qtbot.addWidget(source)
+    qtbot.addWidget(restored)
+    restored_size = restored.size()
+
+    state = qt_state.qt_window_state(source)
+
+    assert state == qt_state.QtWindowState(visible=False)
+    assert qt_state.qt_window_state_payload(source) == {"visible": False}
+    assert json.loads(qt_state.qt_window_state_json(source)) == {"visible": False}
+    assert not qt_state.restore_qt_window_state(restored, state)
+    assert restored.size() == restored_size
+
+    source.show()
+    restored.show()
+    QtWidgets.QApplication.processEvents()
+
+    assert restored.size() == source.size()
+
+
+def test_qt_window_state_ignores_native_handle_and_position_before_show(
+    qtbot,
+) -> None:
+    native = QtWidgets.QWidget()
+    hidden = QtWidgets.QWidget()
+    moved = QtWidgets.QWidget()
+    for widget in (native, hidden, moved):
+        qtbot.addWidget(widget)
+
+    native.winId()
+    hidden.hide()
+    moved.move(17, 23)
+
+    for widget in (native, hidden, moved):
+        assert qt_state.qt_window_state_payload(widget) == {"visible": False}
+
+
+def test_qt_window_state_keeps_initialized_hidden_geometry(qtbot) -> None:
+    shown = QtWidgets.QWidget()
+    resized = QtWidgets.QWidget()
+    for widget in (shown, resized):
+        qtbot.addWidget(widget)
+
+    shown.show()
+    QtWidgets.QApplication.processEvents()
+    shown.hide()
+    resized.resize(511, 433)
+
+    for widget in (shown, resized):
+        state = qt_state.qt_window_state(widget)
+        assert state.geometry is not None
+        assert state.rect == widget.geometry().getRect()
+
+
 def test_qt_window_state_native_geometry_is_authoritative(qtbot, monkeypatch) -> None:
     widget = QtWidgets.QWidget()
     qtbot.addWidget(widget)

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -1445,6 +1445,16 @@ def _workspace_sweep_assert_data_items_equal(
 def _workspace_sweep_assert_snapshot_equal(
     actual: typing.Any, expected: typing.Any, path: str = "snapshot"
 ) -> None:
+    if path.startswith("snapshot.standalone_apps."):
+        if path.endswith(".window_state.geometry"):
+            # Qt geometry is opaque and can change when Qt moves a restored frame
+            # into the available screen geometry.
+            return
+        if path.endswith(".window_state.rect"):
+            assert actual[2:] == expected[2:], (
+                f"{path}: restored size {actual[2:]!r} != {expected[2:]!r}"
+            )
+            return
     if isinstance(expected, Mapping):
         assert isinstance(actual, Mapping), (
             f"{path}: expected mapping, got {type(actual).__name__}"

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -2037,6 +2037,7 @@ def test_manager_workspace_roundtrip_restores_loader_and_standalone_apps(
         fname = tmp_path / "loader-standalone.itws"
         manager._workspace_controller.saving._save_workspace_document(fname)
         expected_ptable_size = ptable.size()
+        expected_ptable_frame_size = ptable.frameGeometry().size()
 
         manifest = _current_workspace_manifest(fname)
         assert manifest["loader_state"]["recent_directory"] == str(example_data_dir)
@@ -2103,8 +2104,27 @@ def test_manager_workspace_roundtrip_restores_loader_and_standalone_apps(
         assert manager._standalone_app_pending_states["explorer"]["active_tab"] == 1
         restored_ptable = manager.ptable_window
         assert restored_ptable.isVisible()
-        assert restored_ptable.size().width() >= expected_ptable_size.width()
-        assert restored_ptable.size().height() == expected_ptable_size.height()
+        restored_screen = restored_ptable.screen()
+        assert restored_screen is not None
+        available_geometry = restored_screen.availableGeometry()
+        restored_frame = restored_ptable.frameGeometry()
+        if expected_ptable_frame_size.width() <= available_geometry.width():
+            assert restored_ptable.width() == expected_ptable_size.width()
+        else:
+            assert restored_ptable.width() < expected_ptable_size.width()
+            assert restored_ptable.width() <= available_geometry.width()
+        if expected_ptable_frame_size.height() <= available_geometry.height():
+            assert restored_ptable.height() == expected_ptable_size.height()
+        else:
+            assert restored_ptable.height() < expected_ptable_size.height()
+            assert restored_ptable.height() <= available_geometry.height()
+        assert (
+            available_geometry.top()
+            <= restored_frame.top()
+            <= available_geometry.bottom()
+        )
+        assert available_geometry.left() <= restored_frame.right()
+        assert restored_frame.left() <= available_geometry.right()
         assert restored_ptable.selected_atomic_numbers == (6, 8)
         assert restored_ptable._plot_atomic_number == 6
         assert restored_ptable.hv_edit.text() == "80"

--- a/tests/interactive/imagetool/test_history.py
+++ b/tests/interactive/imagetool/test_history.py
@@ -939,6 +939,7 @@ def test_history_dialog_open_does_not_consume_new_entry(qtbot):
     start_index = area.current_indices[0]
     dialog = _history.HistoryDialog(area)
     qtbot.addWidget(dialog)
+    assert dialog.sizeHint() == QtCore.QSize(460, 210)
 
     area.set_index(0, start_index + 1)
     area.undo()

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -1152,11 +1152,7 @@ def test_itool_dataset_metadata_fields_roundtrip(qtbot, tmp_path: pathlib.Path) 
     assert ds.attrs["itool_title"] == "saved scan"
     assert ds.attrs["itool_name"] == "scan"
     assert ds.attrs["erlab_version"] == erlab.__version__
-    assert json.loads(ds.attrs["itool_window_state"]).keys() >= {
-        "geometry",
-        "rect",
-        "visible",
-    }
+    assert json.loads(ds.attrs["itool_window_state"]) == {"visible": False}
     assert json.loads(ds.attrs["itool_provenance_spec"]) == (
         provenance_spec.model_dump(mode="json")
     )
@@ -6489,6 +6485,21 @@ def _apply_constrained_splitter_geometry(qtbot, area, splitter_index: int = 0) -
             )
         )
     )
+
+
+def test_window_initial_size_is_a_hint(qtbot) -> None:
+    class ResizeTrackingImageTool(ImageTool):
+        def resize(self, *args: typing.Any) -> None:
+            self.resize_calls = (*getattr(self, "resize_calls", ()), args)
+            super().resize(*args)
+
+    win = ResizeTrackingImageTool(
+        xr.DataArray(np.arange(25).reshape((5, 5)), dims=("x", "y"))
+    )
+    qtbot.addWidget(win)
+
+    assert getattr(win, "resize_calls", ()) == ()
+    assert win.sizeHint() == QtCore.QSize(720, 720)
 
 
 def test_window_resize_preserves_splitter_layout_without_reapplying_sizes(

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -5872,6 +5872,7 @@ def test_select_dataarrays_dialog_preserves_tree_source_paths(qtbot) -> None:
 
     dialog = _SelectDataArraysDialog(None, tree)
     qtbot.addWidget(dialog)
+    assert dialog.sizeHint() == QtCore.QSize(820, 420)
     selected_data = dialog.selected_dataarrays()
 
     assert [prepared.selection for prepared in selected_data] == [
@@ -10204,6 +10205,7 @@ def test_high_dimensional_reduction_dialog_selects_scalar(qtbot) -> None:
     data = _high_dimensional_data()
     dialog = imagetool_highdim._HighDimensionalReductionDialog(None, data)
     qtbot.addWidget(dialog)
+    assert dialog.sizeHint().width() == 780
     open_button = dialog.button_box.button(
         QtWidgets.QDialogButtonBox.StandardButton.Open
     )

--- a/tests/interactive/test_explorer.py
+++ b/tests/interactive/test_explorer.py
@@ -478,6 +478,7 @@ def test_explorer_loader_extensions_apply_only_to_manager_loads(
 ) -> None:
     explorer = _DataExplorer(root_path=example_data_dir, loader_name="example")
     qtbot.addWidget(explorer)
+    assert explorer.sizeHint() == QtCore.QSize(974, 602)
 
     file_path = example_data_dir / "data_002.h5"
     assert explorer._manager_load_kwargs({"single": True}) == {"single": True}

--- a/tests/interactive/test_fermiedge.py
+++ b/tests/interactive/test_fermiedge.py
@@ -1547,6 +1547,7 @@ def test_restool(qtbot) -> None:
     )
     win = restool(gold, execute=False)
     qtbot.addWidget(win)
+    assert win.sizeHint() == QtCore.QSize(800, 600)
     win.timeout_spin.setValue(5.0)
 
     win._guess_temp()

--- a/tests/interactive/test_ptable.py
+++ b/tests/interactive/test_ptable.py
@@ -2408,8 +2408,6 @@ def test_ptable_plot_ranges_and_metadata_snapshot(
         win.table_view.verticalScrollBarPolicy()
         == QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
     )
-    assert win.table_view.horizontalScrollBar().maximum() == 0
-    assert win.table_view.verticalScrollBar().maximum() == 0
     assert plot.log_x is True
     assert plot.log_y is True
     assert plot.x_range_eV == (10.0, 1500.0)


### PR DESCRIPTION
## Summary

- Give the Figure Composer display native Qt window ownership.
- Remove manual screen-coordinate placement from the Figure Composer display.
- Let Qt select the placement and screen-safe size on the first show.
- Replace constructor-time resize() calls with sizeHint() in active interactive windows, including ImageTool.
- Do not save placeholder geometry for windows that Qt has not sized or shown.
- Preserve native geometry for shown, resized, restored, and maximized windows.
- Use the saved rectangle only when native geometry restoration fails.

## Tests

- Full Figure Composer suite: 819 passed.
- Full ImageTool Manager workspace suite: 641 passed with PyQt6.
- Focused first-show and geometry regressions: 10 passed with PyQt6 and 10 passed with PySide6.
- Broader ImageTool, fit, explorer, dialog, and Periodic Table regressions: 1,373 passed.
- Ruff lint passed.
- Ruff format passed for all changed files.
- Mypy passed for all 295 source files.
- CI test partition validation passed.

## Platform note

The Windows activation path has regression coverage with a simulated Windows platform. A native Windows GUI smoke test was not available on the macOS host.