### PR TITLE
docs(plotting): add calculation-first gallery workflows

### DIFF
--- a/docs/source/how-to/plotting/brillouin-zones.md
+++ b/docs/source/how-to/plotting/brillouin-zones.md
@@ -40,6 +40,7 @@ eplt.plot_array(
 eplt.plot_bz(
     avec,
     ax=ax,
+    rotate=30.0,
     edgecolor="tab:purple",
     linestyle="--",
     linewidth=1.2,
@@ -81,6 +82,7 @@ avec = erlab.lattice.abc2avec(
 eplt.plot_bz(
     avec,
     ax=ax,
+    rotate=30.0,
     fill=False,
 )
 ```

--- a/docs/source/how-to/plotting/cut-trajectories.md
+++ b/docs/source/how-to/plotting/cut-trajectories.md
@@ -3,13 +3,26 @@
 # Cut trajectories
 
 Use a cut with calculated momentum coordinates to show its trajectory on a converted
-constant energy surface. Prepare `cut_path` and `constant_energy_map` with
-{ref}`how-to-python-convert-coordinates-only`. Both objects must use the same
+constant energy surface. Start with angle-resolved `data` that has the required
 experimental configuration, work function, and normal-emission position.
 
 ## Python
 
-Plot the calculated `kx` and `ky` coordinates over the constant energy surface:
+Select the cut in angle space. Calculate its momentum coordinates without interpolating
+its intensity. Convert the complete dataset for the constant energy surface:
+
+```python
+binding_energy = -0.3
+
+cut = data.qsel(beta=-10)
+cut_with_momentum = cut.kspace.convert_coords()
+converted = data.kspace.convert()
+
+cut_path = cut_with_momentum.qsel(eV=binding_energy)
+constant_energy_map = converted.qsel(eV=binding_energy)
+```
+
+Plot the calculated `kx` and `ky` coordinates over the converted intensity:
 
 ```python
 import matplotlib.pyplot as plt
@@ -34,17 +47,35 @@ ax.plot(cut_path.kx, cut_path.ky, color="tab:red")
 ```
 
 The line must remain inside the measured momentum coverage. A mismatch usually means
-that the cut and surface use different momentum-conversion parameters.
+that the cut and surface use different momentum-conversion parameters. See
+{ref}`how-to-python-convert-coordinates-only` for the difference between calculating
+coordinates and interpolating intensity.
 
 ## Figure Composer
 
-1. Add `constant_energy_map` and `cut_path` in {guilabel}`Sources`.
-2. Use one axes in {guilabel}`Layout`.
-3. Add an {guilabel}`Image Plot` step for `constant_energy_map`. Set
-   {guilabel}`Aspect` to `equal`.
-4. Add an {guilabel}`Axes Method` step after the image. Select
+Start with the same angle-resolved `data` used in the Python procedure:
+
+1. Open `data` in ImageTool Manager.
+2. Choose {menuselection}`Edit --> Select Data…`. Select `beta=-10` with `qsel`, and
+   set {guilabel}`Result Placement` to {guilabel}`Open Child Window`.
+3. In the original ImageTool, choose {menuselection}`Edit --> Convert to kspace…`.
+   Configure the conversion and open the result as a child window.
+4. Convert the angular-cut child. Re-enter the same configuration, work function,
+   normal-emission offsets, bounds, and resolution. Open the result as another child
+   window.
+5. Add the converted volume and converted cut in {guilabel}`Sources`. Give them the
+   aliases `converted` and `converted_cut`.
+6. Select each source in {guilabel}`Sources`. Enable the `eV` selection row, select
+   `qsel`, and enter the same binding energy for both sources.
+7. Use one axes in {guilabel}`Layout`.
+8. Add an {guilabel}`Image Plot` step for `converted`. Set {guilabel}`Aspect` to
+   `equal`.
+9. Add an {guilabel}`Axes Method` step after the image. Select
    {meth}`plot <matplotlib.axes.Axes.plot>` and target the same axes.
-5. Set {guilabel}`Plot data` to {guilabel}`Pick from data`.
-6. For X, select `cut_path` as the {guilabel}`DataArray` and `kx` as the coordinate.
-   For Y, select `cut_path` and `ky`.
-7. Set the line color and style as required.
+10. Set {guilabel}`Plot data` to {guilabel}`Pick from data`. For X, select
+    `converted_cut` and `kx`. For Y, select `converted_cut` and `ky`.
+11. Set the line color and style as required.
+
+ImageTool interpolates the angular cut during momentum conversion. The Python procedure
+uses {meth}`convert_coords <xarray.DataArray.kspace.convert_coords>` because only the
+trajectory coordinates are required.

--- a/docs/source/how-to/plotting/high-symmetry-cuts.md
+++ b/docs/source/how-to/plotting/high-symmetry-cuts.md
@@ -3,20 +3,39 @@
 # High-symmetry cuts
 
 Use this guide to show a selected reciprocal-space path beside its energy–momentum cut.
-Start with converted `momentum_data`. You can extract the cut with Python or with a
-polygonal ROI in ImageTool.
+Start with converted `momentum_data`.
 
 ## Python
 
-Prepare `high_symmetry_vertices` and `high_symmetry_cut` with
-{ref}`how-to-python-extract-path`.
+Define the path vertices in the coordinates of `momentum_data`. Then interpolate the
+complete data volume along the path:
+
+```python
+import numpy as np
+
+import erlab.analysis as era
+
+lattice_constant = 6.97
+high_symmetry_vertices = {
+    "kx": [
+        0.0,
+        2 * np.pi / (np.sqrt(3) * lattice_constant),
+        2 * np.pi / (np.sqrt(3) * lattice_constant),
+        0.0,
+    ],
+    "ky": [0.0, 0.0, 2 * np.pi / (3 * lattice_constant), 0.0],
+}
+high_symmetry_cut = era.interpolate.slice_along_path(
+    momentum_data,
+    vertices=high_symmetry_vertices,
+    step_size=0.005,
+)
+```
 
 Calculate the path positions of the vertices. Use them for the x-axis ticks and the
 internal guide lines:
 
 ```python
-import numpy as np
-
 path_vertices = np.column_stack(
     [high_symmetry_vertices["kx"], high_symmetry_vertices["ky"]]
 )
@@ -82,11 +101,14 @@ axes[1].set(
 ```
 
 The interpolation follows an ideal line. It does not average intensity over a finite
-width perpendicular to the path.
+width perpendicular to the path. See {ref}`how-to-python-extract-path` for sampling and
+path checks.
 
 ## Figure Composer
 
-### ImageTool preparation
+### ImageTool calculation
+
+Start with the same converted `momentum_data` used in the Python procedure:
 
 1. Open `momentum_data` in a managed ImageTool.
 2. Display the $k_x$-$k_y$ plane. Move the energy cursor to the required binding
@@ -116,9 +138,9 @@ record the `path` value where the associated `kx` and `ky` coordinates match tha
 vertex. Use these values for the guide lines and tick labels below. The
 `path_vertex_positions` calculation in the Python section gives the same values.
 
-If the map and cut already exist as Python variables, prepare `path_energy_map` and
-`high_symmetry_cut` with the Python procedures above and in
-{ref}`how-to-python-extract-path`. Add both arrays in {guilabel}`Sources`:
+If you used the Python procedure above to prepare `path_energy_map` and
+`high_symmetry_cut`, open both arrays in ImageTool Manager and add them in
+{guilabel}`Sources`:
 
 1. Use a $1 \times 2$ layout.
 2. Add an {guilabel}`Image Plot` step for `path_energy_map` on the left axes. Set

--- a/docs/source/how-to/plotting/index.md
+++ b/docs/source/how-to/plotting/index.md
@@ -11,6 +11,7 @@ For figure creation, export, and recipe reuse, see {doc}`../gui/plotting`.
 colorbars
 maps-and-cuts
 two-dimensional-colormaps
+polygon-masking
 cut-trajectories
 high-symmetry-cuts
 annotations
@@ -70,8 +71,8 @@ figure-styles
 ::::
 
 ::::{grid-item-card} Polygon masking
-:link: how-to-python-mask-polygon
-:link-type: ref
+:link: polygon-masking
+:link-type: doc
 :class-card: plotting-gallery-card
 
 ```{eval-rst}

--- a/docs/source/how-to/plotting/polygon-masking.md
+++ b/docs/source/how-to/plotting/polygon-masking.md
@@ -1,0 +1,172 @@
+(how-to-plotting-polygon-masking)=
+
+# Polygon masking
+
+Use a polygon mask to retain measured intensity inside a selected momentum-space
+region. This example starts with a converted three-dimensional `data` array and uses
+the first Brillouin zone as the boundary.
+
+## Python
+
+Select the constant energy surface. Then calculate the ordered zone vertices from the
+real-space lattice and apply the polygon mask:
+
+```python
+import numpy as np
+
+import erlab
+import erlab.analysis as era
+
+binding_energy = -0.2
+energy_width = 0.02
+lattice_constant = 6.97
+
+constant_energy_map = data.qsel(
+    eV=binding_energy,
+    eV_width=energy_width,
+)
+real_space_basis = lattice_constant * np.array(
+    [
+        [1.0, 0.0],
+        [-0.5, np.sqrt(3) / 2],
+    ]
+)
+first_bz_vertices = erlab.lattice.get_2d_vertices(
+    real_space_basis,
+    reciprocal=False,
+    rotate=30.0,
+)
+masked_map = era.mask.mask_with_polygon(
+    constant_energy_map,
+    first_bz_vertices,
+    dims=("kx", "ky"),
+)
+```
+
+Plot the source map and masked result with common color limits. Close the vertex list
+only for drawing the boundary. {func}`erlab.analysis.mask.mask_with_polygon` closes the
+mask polygon automatically:
+
+```python
+import matplotlib.pyplot as plt
+import erlab.plotting as eplt
+
+closed_vertices = np.vstack([first_bz_vertices, first_bz_vertices[0]])
+_, axes = plt.subplots(
+    1,
+    2,
+    figsize=(6.4, 3.0),
+    layout="compressed",
+    sharex=True,
+    sharey=True,
+)
+for ax, map_data in zip(
+    axes,
+    (constant_energy_map, masked_map),
+    strict=True,
+):
+    eplt.plot_array(
+        map_data,
+        ax=ax,
+        cmap="Greys",
+        gamma=0.5,
+        aspect="equal",
+    )
+axes[0].plot(
+    closed_vertices[:, 0],
+    closed_vertices[:, 1],
+    color="tab:red",
+)
+eplt.unify_clim(axes)
+eplt.clean_labels(axes)
+eplt.set_titles(axes, ["First Brillouin zone", "Masked data"])
+```
+
+```{eval-rst}
+.. plot:: how_to/inspection_and_selection.py mask_momentum_region
+   :include-source: false
+   :alt: Repeated-zone constant energy surface with the first Brillouin-zone boundary beside the intensity retained inside that zone
+```
+
+The 30° rotation aligns the Γ–M direction with $k_x$ for this model. Points outside the
+first Brillouin zone become missing values. Use `invert=True` to mask the zone instead.
+Use `drop=True` to remove coordinate labels for rows and columns that contain no
+retained values. See {ref}`how-to-plotting-brillouin-zone-overlay` for other zone
+overlays.
+
+## Figure Composer
+
+Start with the same three-dimensional `data` array, binding energy, energy width, and
+lattice constant used in the Python procedure. Figure Composer does not calculate a
+polygon mask. Create the derived array in ImageTool before you assemble the figure.
+
+### ImageTool calculation
+
+1. Open `data` in a managed ImageTool.
+2. Choose {menuselection}`Edit --> Select Data…`. For `eV`, select `qsel`, enter
+   `-0.2`, enable {guilabel}`Width`, and enter `0.02`. Set
+   {guilabel}`Result Placement` to {guilabel}`Open Child Window`.
+3. Calculate `first_bz_vertices` with the lattice calculation in the Python section.
+4. In the constant-energy-map child, right-click the image and choose
+   {guilabel}`Add Polygon ROI`.
+5. Right-click the ROI and choose {guilabel}`Edit ROI…`. Enter the calculated vertices
+   in the `kx` and `ky` columns in their listed order. Turn on {guilabel}`Closed`.
+6. Right-click the ROI and choose {guilabel}`Mask Data with ROI`.
+7. Leave {guilabel}`Invert Mask` and {guilabel}`Drop Masked Values` off. Set
+   {guilabel}`Result Placement` to {guilabel}`Open Child Window`, and create the masked
+   map.
+
+For other polygon boundaries, move the ROI handles or enter different coordinates.
+See {ref}`how-to-gui-mask-polygon` for the mask controls and result behavior.
+
+### Figure assembly
+
+1. In the constant-energy-map ImageTool, right-click the image and choose
+   {guilabel}`New Figure`.
+2. Set {guilabel}`Layout` to a $1 \times 2$ grid. Target the existing
+   {guilabel}`Image Plot` step to the left axes. Set {guilabel}`Gamma` to `0.5` and
+   {guilabel}`Aspect` to `equal`.
+3. In the masked-map child, right-click the image and choose
+   {guilabel}`Append to Figure`. Select the same figure and the right axes. Set the new
+   {guilabel}`Image Plot` step to the same gamma and aspect.
+
+The single polygon boundary does not have an editable Figure Composer step.
+
+```{include} ../../_includes/figure-composer-planned-step.md
+```
+
+4. Add a {guilabel}`Python` step after the left image. Review this code, then enter it
+   in {guilabel}`Code`:
+
+```python
+import numpy as np
+
+import erlab
+
+lattice_constant = 6.97
+real_space_basis = lattice_constant * np.array(
+    [
+        [1.0, 0.0],
+        [-0.5, np.sqrt(3) / 2],
+    ]
+)
+first_bz_vertices = erlab.lattice.get_2d_vertices(
+    real_space_basis,
+    reciprocal=False,
+    rotate=30.0,
+)
+closed_vertices = np.vstack([first_bz_vertices, first_bz_vertices[0]])
+axs[0, 0].plot(
+    closed_vertices[:, 0],
+    closed_vertices[:, 1],
+    color="tab:red",
+)
+```
+
+5. Add an {guilabel}`ERLab Method` step for
+   {func}`unify_clim <erlab.plotting.unify_clim>` and target both axes.
+6. Add an {guilabel}`ERLab Method` step for
+   {func}`clean_labels <erlab.plotting.clean_labels>` and target both axes.
+7. Add an {guilabel}`ERLab Method` step for
+   {func}`set_titles <erlab.plotting.set_titles>` and target both axes. Enter
+   `First Brillouin zone` and `Masked data` on separate lines in {guilabel}`Text`.

--- a/docs/source/how-to/python/inspection-and-selection.md
+++ b/docs/source/how-to/python/inspection-and-selection.md
@@ -7,49 +7,8 @@ ranges, follow a path through momentum space, or compare several slices.
 
 ## Polygon masking
 
-Define polygon vertices in the coordinate order given by `dims`, then apply
-{func}`mask_with_polygon <erlab.analysis.mask.mask_with_polygon>`:
-
-This example uses the first Brillouin zone as a physically meaningful boundary for a
-repeated-zone constant energy surface. Construct the real-space basis and obtain the
-ordered zone vertices:
-
-```python
-import numpy as np
-
-import erlab
-import erlab.analysis as era
-
-constant_energy_map = data.qsel(eV=-0.2, eV_width=0.02)
-lattice_constant = 6.97
-real_space_basis = lattice_constant * np.array(
-    [
-        [1.0, 0.0],
-        [-0.5, np.sqrt(3) / 2],
-    ]
-)
-first_bz_vertices = erlab.lattice.get_2d_vertices(
-    real_space_basis,
-    reciprocal=False,
-    rotate=30.0,
-)
-masked_map = era.mask.mask_with_polygon(
-    constant_energy_map,
-    first_bz_vertices,
-    dims=("kx", "ky"),
-)
-```
-
-```{eval-rst}
-.. plot:: how_to/inspection_and_selection.py mask_momentum_region
-   :include-source: false
-   :alt: Repeated-zone constant energy surface with the first Brillouin-zone boundary beside the intensity retained inside that zone
-```
-
-The 30° rotation aligns the Γ–M direction with $k_x$ for this model. Points outside the
-first Brillouin zone become missing values. Use `invert=True` to mask the zone instead.
-Use `drop=True` to remove coordinate labels for rows and columns that contain no
-retained values.
+See {doc}`../plotting/polygon-masking` to calculate a polygon from lattice parameters,
+apply it to a constant energy surface, and reproduce the result in Figure Composer.
 
 (how-to-python-select-average-data)=
 

--- a/docs/source/pyplots/how_to/inspection_and_selection.py
+++ b/docs/source/pyplots/how_to/inspection_and_selection.py
@@ -9,9 +9,9 @@ from erlab.io.exampledata import generate_data
 
 
 def mask_momentum_region() -> None:
-    data = generate_data(seed=1).T
-    constant_energy_map = data.qsel(eV=-0.2, eV_width=0.02)
     lattice_constant = 6.97
+    data = generate_data(a=lattice_constant, seed=1).T
+    constant_energy_map = data.qsel(eV=-0.2, eV_width=0.02)
     real_space_basis = lattice_constant * np.array(
         [
             [1.0, 0.0],

--- a/docs/source/pyplots/how_to/plotting.py
+++ b/docs/source/pyplots/how_to/plotting.py
@@ -240,6 +240,7 @@ def draw_brillouin_zone_overlay() -> None:
     eplt.plot_bz(
         avec,
         ax=ax,
+        rotate=30.0,
         edgecolor="tab:purple",
         linestyle="--",
         linewidth=1.2,


### PR DESCRIPTION
## Summary

- Add the calculation steps required before plotting cut trajectories and high-symmetry paths.
- Add a dedicated polygon-masking guide with Python, ImageTool, and Figure Composer workflows that start from the same source data.
- Rotate the Brillouin-zone overlay by 30 degrees in the Python example, Figure Composer example, and shared renderer.

## Validation

- `uv run ruff check .`
- `git diff --name-only -z origin/main...HEAD | xargs -0 uv run ruff format --check`
- `uv run mypy src`
- `uv run --directory docs make html SPHINXOPTS="-E -W --keep-going"`
- Executed the polygon-masking calculation and the affected gallery render helpers.
- Checked the gallery, polygon-masking page, and rotated overlay in a browser.

The full test suite was not run because this change only modifies documentation and documentation renderers.

`make linkcheck` completed with 11 external HTTP 403 responses from existing DOI and Stack Overflow links. It found no other warnings and changed no files.

The repository-wide format check still reports the unchanged `docs/source/contributing/interactive-tools.md`. All eight changed files pass the format check.
