### PR TITLE
fix(figurecomposer): isolate step section scrolling

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_ui/_operation_editor.py
+++ b/src/erlab/interactive/_figurecomposer/_ui/_operation_editor.py
@@ -107,6 +107,25 @@ class OperationEditorBinding:
 class _FigureComposerStepEditorScroll(QtWidgets.QScrollArea):
     """Scroll vertically without allowing editor content to clip horizontally."""
 
+    def __init__(
+        self,
+        page: QtWidgets.QWidget,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName(f"{page.objectName()}Scroll")
+        self.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+        self.setWidgetResizable(True)
+        self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        self.setAutoFillBackground(False)
+        viewport = typing.cast("QtWidgets.QWidget", self.viewport())
+        viewport.setObjectName(f"{page.objectName()}Viewport")
+        viewport.setAutoFillBackground(False)
+        self.setWidget(page)
+        page.setAutoFillBackground(False)
+
     def minimumSizeHint(self) -> QtCore.QSize:
         hint = super().minimumSizeHint()
         content = self.widget()
@@ -243,26 +262,10 @@ class FigureOperationEditor(QtWidgets.QWidget):
         self.navigator_layout.addStretch(1)
         layout.addWidget(self.navigator)
 
-        self.scroll_area = _FigureComposerStepEditorScroll(self)
-        self.scroll_area.setObjectName("figureComposerStepEditorScroll")
-        self.scroll_area.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
-        self.scroll_area.setWidgetResizable(True)
-        self.scroll_area.setHorizontalScrollBarPolicy(
-            QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
-        )
-        self.scroll_area.setVerticalScrollBarPolicy(
-            QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded
-        )
-        self.scroll_area.setAutoFillBackground(False)
-        viewport = typing.cast("QtWidgets.QWidget", self.scroll_area.viewport())
-        viewport.setObjectName("figureComposerStepEditorViewport")
-        viewport.setAutoFillBackground(False)
-        layout.addWidget(self.scroll_area, 1)
-
-        self.stack = QtWidgets.QStackedWidget()
+        self.stack = QtWidgets.QStackedWidget(self)
         self.stack.setObjectName("figureComposerStepSectionStack")
         self.stack.setAutoFillBackground(False)
-        self.scroll_area.setWidget(self.stack)
+        layout.addWidget(self.stack, 1)
 
         self._source_page = self.create_page("figureComposerStepSourcesPage")
         source_page_layout = QtWidgets.QVBoxLayout(self._source_page)
@@ -314,7 +317,7 @@ class FigureOperationEditor(QtWidgets.QWidget):
         self, object_name: str, *, transient: bool = False
     ) -> QtWidgets.QWidget:
         """Create a page whose lifetime is owned by this editor."""
-        page = _FigureComposerStepEditorPage(self._editor_tabs, self.stack)
+        page = _FigureComposerStepEditorPage(self._editor_tabs, self)
         page.setObjectName(object_name)
         if transient:
             self._transient_pages.append(page)
@@ -325,12 +328,25 @@ class FigureOperationEditor(QtWidgets.QWidget):
         """Keys of the currently mounted editor sections."""
         return tuple(section.key for section in self._sections)
 
-    def _current_page(self) -> QtWidgets.QWidget | None:
-        return self.stack.currentWidget()
+    @property
+    def current_scroll_area(self) -> _FigureComposerStepEditorScroll | None:
+        """Scroll area for the visible editor section."""
+        current = self.stack.currentWidget()
+        if isinstance(current, _FigureComposerStepEditorScroll):
+            return current
+        return None
+
+    @property
+    def current_page(self) -> QtWidgets.QWidget | None:
+        """Content page for the visible editor section."""
+        scroll_area = self.current_scroll_area
+        if scroll_area is None:
+            return None
+        return scroll_area.widget()
 
     def refresh_current_background(self) -> None:
         """Refresh the current page after a palette or window change."""
-        current_page = self._current_page()
+        current_page = self.current_page
         if isinstance(current_page, _FigureComposerStepEditorPage):
             current_page.refresh_background()
 
@@ -339,14 +355,30 @@ class FigureOperationEditor(QtWidgets.QWidget):
         self.flush_pending_commits()
         self._generation += 1
         self._section_tab_stop_refs.clear()
+        transient_pages = self._transient_pages
+        mounted_transient_pages: list[QtWidgets.QWidget] = []
         while self.stack.count():
-            page = typing.cast("QtWidgets.QWidget", self.stack.widget(0))
-            page.hide()
-            self.stack.removeWidget(page)
-        pages = self._transient_pages
+            scroll_area = typing.cast(
+                "_FigureComposerStepEditorScroll", self.stack.widget(0)
+            )
+            page = scroll_area.widget()
+            if page is not None and any(
+                page is transient_page for transient_page in transient_pages
+            ):
+                self._clear_object_names_recursive(page)
+                self._retire_widget(page)
+                mounted_transient_pages.append(page)
+            elif (page := scroll_area.takeWidget()) is not None:
+                page.hide()
+                page.setParent(self)
+            self.stack.removeWidget(scroll_area)
+            self._clear_object_names_recursive(scroll_area)
+            self._retire_widget(scroll_area)
         self._transient_pages = []
-        for page in pages:
-            self._retire_widget(page)
+        for page in transient_pages:
+            if not any(page is mounted for mounted in mounted_transient_pages):
+                self._clear_object_names_recursive(page)
+                self._retire_widget(page)
 
     def flush_pending_commits(self, *, render: bool = False) -> None:
         """Commit debounced editor content before pages are replaced or saved."""
@@ -376,7 +408,9 @@ class FigureOperationEditor(QtWidgets.QWidget):
         self._sections = tuple(sections)
 
         for index, section in enumerate(self._sections):
-            self.stack.addWidget(section.page)
+            self.stack.addWidget(
+                _FigureComposerStepEditorScroll(section.page, self.stack)
+            )
             button = QtWidgets.QToolButton(self.navigator)
             button.setText(self._section_button_text(section, summaries))
             button.setToolButtonStyle(QtCore.Qt.ToolButtonStyle.ToolButtonTextOnly)
@@ -400,7 +434,11 @@ class FigureOperationEditor(QtWidgets.QWidget):
         key = existing_key if existing_key in keys else keys[0] if keys else ""
         if key:
             self.select_section(key)
-        self.scroll_area.updateGeometry()
+        for index in range(self.stack.count()):
+            scroll_area = typing.cast(
+                "_FigureComposerStepEditorScroll", self.stack.widget(index)
+            )
+            scroll_area.updateGeometry()
         self.updateGeometry()
 
     def select_section(self, key: str) -> None:
@@ -443,6 +481,13 @@ class FigureOperationEditor(QtWidgets.QWidget):
         for child in widget.findChildren(QtCore.QObject):
             if erlab.interactive.utils.qt_is_valid(child):
                 child.blockSignals(True)
+
+    @staticmethod
+    def _clear_object_names_recursive(widget: QtWidgets.QWidget) -> None:
+        widget.setObjectName("")
+        for child in widget.findChildren(QtCore.QObject):
+            if erlab.interactive.utils.qt_is_valid(child):
+                child.setObjectName("")
 
     def _retire_widget(self, widget: QtWidgets.QWidget) -> None:
         """Disable and defer deletion of a replaced editor widget safely."""
@@ -905,7 +950,7 @@ class FigureOperationEditor(QtWidgets.QWidget):
         parent: QtWidgets.QWidget | None = None,
         completions: Sequence[str] = (),
     ) -> QtWidgets.QLineEdit:
-        edit_parent = parent or self._current_page() or self
+        edit_parent = parent or self.current_page or self
         edit: QtWidgets.QLineEdit
         if completions:
             edit = CompletingLineEdit(
@@ -948,7 +993,7 @@ class FigureOperationEditor(QtWidgets.QWidget):
         mixed: bool = False,
         enabled: bool = True,
     ) -> QtWidgets.QComboBox:
-        combo = QtWidgets.QComboBox(parent or self._current_page() or self)
+        combo = QtWidgets.QComboBox(parent or self.current_page or self)
         self.mark_control(combo)
         combo.addItems(list(values))
         adapter = ComboBoxControlAdapter(combo)
@@ -973,7 +1018,7 @@ class FigureOperationEditor(QtWidgets.QWidget):
     ) -> QtWidgets.QComboBox:
         if len(values) != len(labels):
             raise ValueError("combo values and labels must have the same length")
-        combo = QtWidgets.QComboBox(parent or self._current_page() or self)
+        combo = QtWidgets.QComboBox(parent or self.current_page or self)
         self.mark_control(combo)
         adapter = ComboBoxDataControlAdapter(combo)
         if mixed:
@@ -1001,7 +1046,7 @@ class FigureOperationEditor(QtWidgets.QWidget):
         mixed: bool = False,
         enabled: bool = True,
     ) -> QtWidgets.QComboBox:
-        combo = QtWidgets.QComboBox(parent or self._current_page() or self)
+        combo = QtWidgets.QComboBox(parent or self.current_page or self)
         self.mark_control(combo)
         adapter = ComboBoxDataControlAdapter(combo)
         if mixed:
@@ -1048,7 +1093,7 @@ class FigureOperationEditor(QtWidgets.QWidget):
         mixed: bool = False,
         enabled: bool = True,
     ) -> QtWidgets.QComboBox:
-        combo = QtWidgets.QComboBox(parent or self._current_page() or self)
+        combo = QtWidgets.QComboBox(parent or self.current_page or self)
         self.mark_control(combo)
         adapter = ComboBoxDataControlAdapter(combo)
         if mixed:
@@ -1083,7 +1128,7 @@ class FigureOperationEditor(QtWidgets.QWidget):
         parent: QtWidgets.QWidget | None = None,
         mixed: bool = False,
     ) -> QtWidgets.QCheckBox:
-        check = QtWidgets.QCheckBox(parent or self._current_page() or self)
+        check = QtWidgets.QCheckBox(parent or self.current_page or self)
         self.mark_control(check)
         adapter = CheckBoxControlAdapter(check)
         if mixed:
@@ -1278,7 +1323,7 @@ class FigureOperationEditor(QtWidgets.QWidget):
         return bool(widget.focusPolicy() & QtCore.Qt.FocusPolicy.TabFocus)
 
     def _first_tab_stop(self) -> QtWidgets.QWidget | None:
-        current_page = self._current_page()
+        current_page = self.current_page
         if current_page is None:
             return None
         cache_key = self._current_section_key

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -1455,7 +1455,7 @@ def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
 
     _select_operation_rows(tool, (2,))
     tool.operation_editor.select_section("selection")
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     profile_coordinate_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileCoordinateCombo"
     )
@@ -1476,14 +1476,14 @@ def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
     assert tool.tool_status.operations[2].line_x is None
     _activate_combo_index(profile_values_combo, profile_values_combo.findData("kx"))
     assert tool.tool_status.operations[2].line_y == "kx"
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     profile_values_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileValuesCombo"
     )
     assert profile_values_combo is not None
     _activate_combo_index(profile_values_combo, 0)
     assert tool.tool_status.operations[2].line_y is None
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     profile_coordinate_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileCoordinateCombo"
     )
@@ -1501,7 +1501,7 @@ def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
         widget.toolTip() for widget in selection_page.findChildren(QtWidgets.QCheckBox)
     )
     tool.operation_editor.select_section("view")
-    view_page = tool.operation_editor.stack.currentWidget()
+    view_page = tool.operation_editor.current_page
     data_values_axis_combo = view_page.findChild(
         QtWidgets.QComboBox, "figureComposerDataValuesAxisCombo"
     )
@@ -1517,7 +1517,7 @@ def test_figure_composer_pipeline_codegen_executes(qtbot) -> None:
     _select_operation_rows(tool, (3,))
     assert tool.tool_status.operations[3].method_name == "clean_labels"
     tool.operation_editor.select_section("method")
-    erlab_method_page = tool.operation_editor.stack.currentWidget()
+    erlab_method_page = tool.operation_editor.current_page
     assert all(
         widget.toolTip()
         for widget in erlab_method_page.findChildren(QtWidgets.QComboBox)

--- a/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_custom_code.py
@@ -582,7 +582,7 @@ def test_figure_composer_custom_code_editor_is_multiline_and_debounced(
     )
     tool.operation_editor.select_section("code")
 
-    current_page = tool.operation_editor.stack.currentWidget()
+    current_page = tool.operation_editor.current_page
     assert current_page is not None
     code_edit = current_page.findChild(
         erlab.interactive.utils.PythonCodeEditor, "figureComposerCustomCodeEdit"
@@ -641,7 +641,7 @@ def test_figure_composer_custom_code_editor_skips_render_until_valid_python(
     )
     tool.operation_editor.select_section("code")
 
-    current_page = tool.operation_editor.stack.currentWidget()
+    current_page = tool.operation_editor.current_page
     assert current_page is not None
     code_edit = current_page.findChild(
         erlab.interactive.utils.PythonCodeEditor, "figureComposerCustomCodeEdit"
@@ -705,7 +705,7 @@ def test_figure_composer_custom_code_pending_edit_survives_step_switch(
     )
     tool.operation_editor.select_section("code")
 
-    current_page = tool.operation_editor.stack.currentWidget()
+    current_page = tool.operation_editor.current_page
     assert current_page is not None
     code_edit = current_page.findChild(
         erlab.interactive.utils.PythonCodeEditor, "figureComposerCustomCodeEdit"
@@ -745,7 +745,7 @@ def test_figure_composer_custom_code_pending_edit_flushes_on_close(qtbot) -> Non
     )
     tool.operation_editor.select_section("code")
 
-    current_page = tool.operation_editor.stack.currentWidget()
+    current_page = tool.operation_editor.current_page
     assert current_page is not None
     code_edit = current_page.findChild(
         erlab.interactive.utils.PythonCodeEditor, "figureComposerCustomCodeEdit"

--- a/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_helpers.py
@@ -229,7 +229,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
     )
     tool._update_operation_editor()
     tool.operation_editor.select_section("selection")
-    line_selection_page = tool.operation_editor.stack.currentWidget()
+    line_selection_page = tool.operation_editor.current_page
     assert line_selection_page is not None
     _assert_step_editor_section(
         line_selection_page, "figureComposerLineSelectionDataSection"
@@ -238,7 +238,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
         line_selection_page, "figureComposerLineSelectionProfilesSection"
     )
     tool.operation_editor.select_section("view")
-    line_view_page = tool.operation_editor.stack.currentWidget()
+    line_view_page = tool.operation_editor.current_page
     assert line_view_page is not None
     assert (
         line_view_page.findChild(
@@ -247,14 +247,14 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
         is None
     )
     tool.operation_editor.select_section("style")
-    line_style_page = tool.operation_editor.stack.currentWidget()
+    line_style_page = tool.operation_editor.current_page
     assert line_style_page is not None
     _assert_step_editor_section(line_style_page, "figureComposerLineStyleLegendSection")
     _assert_step_editor_section(line_style_page, "figureComposerLineStyleColorSection")
     _assert_step_editor_section(line_style_page, "figureComposerLineStyleLineSection")
     _assert_step_editor_section(line_style_page, "figureComposerLineStyleFillSection")
     tool.operation_editor.select_section("other")
-    line_other_page = tool.operation_editor.stack.currentWidget()
+    line_other_page = tool.operation_editor.current_page
     assert line_other_page is not None
     assert (
         _operation_section_button(tool, "other").property("section_title")
@@ -272,7 +272,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
     )
     tool._update_operation_editor()
     tool.operation_editor.select_section("selection")
-    line_slices_selection_page = tool.operation_editor.stack.currentWidget()
+    line_slices_selection_page = tool.operation_editor.current_page
     assert line_slices_selection_page is not None
     _assert_step_editor_section(
         line_slices_selection_page,
@@ -283,7 +283,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
         "figureComposerPlotSlicesSelectionValuesSection",
     )
     tool.operation_editor.select_section("view")
-    line_slices_view_page = tool.operation_editor.stack.currentWidget()
+    line_slices_view_page = tool.operation_editor.current_page
     assert line_slices_view_page is not None
     _assert_step_editor_section(
         line_slices_view_page, "figureComposerPlotSlicesViewPanelsSection"
@@ -292,7 +292,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
         line_slices_view_page, "figureComposerPlotSlicesViewAxesSection"
     )
     tool.operation_editor.select_section("colors")
-    line_slices_colors_page = tool.operation_editor.stack.currentWidget()
+    line_slices_colors_page = tool.operation_editor.current_page
     assert line_slices_colors_page is not None
     _assert_step_editor_section(
         line_slices_colors_page,
@@ -311,7 +311,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
         "figureComposerPlotSlicesStylePanelOverridesSection",
     )
     tool.operation_editor.select_section("transform")
-    line_slices_transform_page = tool.operation_editor.stack.currentWidget()
+    line_slices_transform_page = tool.operation_editor.current_page
     assert line_slices_transform_page is not None
     assert (
         line_slices_transform_page.objectName()
@@ -329,7 +329,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
     )
     tool._update_operation_editor()
     tool.operation_editor.select_section("colors")
-    image_slices_colors_page = tool.operation_editor.stack.currentWidget()
+    image_slices_colors_page = tool.operation_editor.current_page
     assert image_slices_colors_page is not None
     _assert_step_editor_section(
         image_slices_colors_page,
@@ -349,7 +349,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
     )
     tool._update_operation_editor()
     tool.operation_editor.select_section("method")
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     assert method_page is not None
     _assert_step_editor_section(method_page, "figureComposerMethodCallSection")
     _assert_step_editor_section(method_page, "figureComposerMethodValuesSection")
@@ -360,7 +360,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
     )
     tool._update_operation_editor()
     tool.operation_editor.select_section("view")
-    plot_array_view_page = tool.operation_editor.stack.currentWidget()
+    plot_array_view_page = tool.operation_editor.current_page
     assert plot_array_view_page is not None
     _assert_step_editor_section(
         plot_array_view_page, "figureComposerPlotArrayViewImageSection"
@@ -369,7 +369,7 @@ def test_figure_composer_step_editor_section_headers_are_native_subgroups(
         plot_array_view_page, "figureComposerPlotArrayViewAxesSection"
     )
     tool.operation_editor.select_section("colors")
-    plot_array_colors_page = tool.operation_editor.stack.currentWidget()
+    plot_array_colors_page = tool.operation_editor.current_page
     assert plot_array_colors_page is not None
     _assert_step_editor_section(
         plot_array_colors_page,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_line_profile.py
@@ -351,7 +351,7 @@ def test_figure_composer_line_profile_operation_uses_semantic_sections(
         == "Transform"
     )
     assert [
-        tool.operation_editor.stack.widget(index).objectName()
+        tool.operation_editor.stack.widget(index).widget().objectName()
         for index in range(tool.operation_editor.stack.count())
     ] == [
         "figureComposerStepSourcesPage",
@@ -437,7 +437,7 @@ def test_figure_composer_line_profile_operation_uses_semantic_sections(
         ("other", other_page),
     ):
         tool.operation_editor.select_section(key)
-        assert tool.operation_editor.stack.currentWidget() is page
+        assert tool.operation_editor.current_page is page
         assert tool.tool_status.operations[0] == operation
 
 
@@ -719,7 +719,7 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     profiles = figurecomposer_line_profile._line_data_items(tool, operation)
 
     tool.operation_editor.select_section("selection")
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     reduce_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileReduceCombo"
     )
@@ -733,14 +733,14 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     _activate_combo_text(reduce_combo, "Both")
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QSpinBox, "figureComposerProfileReduceCoarsenSpin"
             )
             is not None
         ),
         timeout=1000,
     )
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     coarsen_spin = selection_page.findChild(
         QtWidgets.QSpinBox, "figureComposerProfileReduceCoarsenSpin"
     )
@@ -755,7 +755,7 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     assert tool.tool_status.operations[0].line_reduce_thin == 3
     tool._replace_operation(0, operation)
     tool.operation_editor.select_section("other")
-    other_page = tool.operation_editor.stack.currentWidget()
+    other_page = tool.operation_editor.current_page
     offset_source_combo = other_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineOffsetSourceCombo"
     )
@@ -777,7 +777,7 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
         is None
     )
     tool.operation_editor.select_section("style")
-    style_page = tool.operation_editor.stack.currentWidget()
+    style_page = tool.operation_editor.current_page
     line_style_combo = style_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineStyleCombo"
     )
@@ -849,7 +849,7 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     operation = tool.tool_status.operations[0]
 
     tool.operation_editor.select_section("other")
-    other_page = tool.operation_editor.stack.currentWidget()
+    other_page = tool.operation_editor.current_page
     offset_source_combo = other_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineOffsetSourceCombo"
     )
@@ -857,14 +857,14 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     _activate_combo_text(offset_source_combo, "manual")
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QComboBox, "figureComposerLineOffsetCoordinateCombo"
             )
             is None
         ),
         timeout=1000,
     )
-    other_page = tool.operation_editor.stack.currentWidget()
+    other_page = tool.operation_editor.current_page
     assert tool.tool_status.operations[0].line_offset_source == "manual"
     assert tool.tool_status.operations[0].line_offset_scale == 1.0
     assert (
@@ -891,14 +891,14 @@ def test_figure_composer_profile_lines_support_per_profile_style_and_offsets(
     _activate_combo_text(offset_source_combo, "index")
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QDoubleSpinBox, "figureComposerLineOffsetScaleEdit"
             )
             is not None
         ),
         timeout=1000,
     )
-    other_page = tool.operation_editor.stack.currentWidget()
+    other_page = tool.operation_editor.current_page
     assert tool.tool_status.operations[0].line_offset_source == "index"
     assert (
         other_page.findChild(
@@ -1228,7 +1228,7 @@ def test_figure_composer_line_profile_coordinate_colormap_render_and_codegen(
     )
 
     tool.operation_editor.select_section("style")
-    style_page = tool.operation_editor.stack.currentWidget()
+    style_page = tool.operation_editor.current_page
     assert (
         style_page.findChild(QtWidgets.QComboBox, "figureComposerLineColorModeCombo")
         is not None
@@ -1663,7 +1663,7 @@ def test_figure_composer_line_label_help_button_opens_structured_dialog(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("style")
-    editor = tool.operation_editor.stack.currentWidget()
+    editor = tool.operation_editor.current_page
     labels_edit = editor.findChild(QtWidgets.QLineEdit, "figureComposerLineLabelsEdit")
     help_button = editor.findChild(
         QtWidgets.QToolButton, "figureComposerLineLabelsHelpButton"
@@ -2519,7 +2519,7 @@ def test_figure_composer_line_labels_auto_add_axes_legend_step(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("style")
-    labels_edit = tool.operation_editor.stack.currentWidget().findChild(
+    labels_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineLabelsEdit"
     )
     assert labels_edit is not None
@@ -2582,7 +2582,7 @@ def test_figure_composer_disabled_line_labels_do_not_add_legend_or_render(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("style")
-    labels_edit = tool.operation_editor.stack.currentWidget().findChild(
+    labels_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineLabelsEdit"
     )
     assert labels_edit is not None
@@ -2646,7 +2646,7 @@ def test_figure_composer_batch_line_labels_add_one_legend_per_axes_group(
 
     _select_operation_rows(tool, (0, 1, 2))
     tool.operation_editor.select_section("style")
-    labels_edit = tool.operation_editor.stack.currentWidget().findChild(
+    labels_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineLabelsEdit"
     )
     assert labels_edit is not None
@@ -3116,13 +3116,13 @@ def test_figure_composer_line_action_seeds_from_selected_slice_step(
     assert operation.axes.axes == ((0, 0), (0, 1), (0, 2))
 
     tool.operation_editor.select_section("view")
-    placement_combo = tool.operation_editor.stack.currentWidget().findChild(
+    placement_combo = tool.operation_editor.current_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfilePlacementCombo"
     )
     assert placement_combo is not None
 
     tool.operation_editor.select_section("other")
-    normalize_combo = tool.operation_editor.stack.currentWidget().findChild(
+    normalize_combo = tool.operation_editor.current_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineNormalizeCombo"
     )
     assert normalize_combo is not None
@@ -3169,7 +3169,7 @@ def test_figure_composer_batch_line_edits_update_selected_steps(qtbot) -> None:
 
     _select_operation_rows(tool, (0, 1, 2))
     tool.operation_editor.select_section("other")
-    other_page = tool.operation_editor.stack.currentWidget()
+    other_page = tool.operation_editor.current_page
     normalize_combo = other_page.findChild(
         QtWidgets.QComboBox, "figureComposerLineNormalizeCombo"
     )
@@ -3213,7 +3213,7 @@ def test_figure_composer_batch_line_mixed_values_do_not_overwrite_on_blur(
 
     _select_operation_rows(tool, (0, 1))
     tool.operation_editor.select_section("style")
-    style_page = tool.operation_editor.stack.currentWidget()
+    style_page = tool.operation_editor.current_page
     color_edit = style_page.findChild(
         QtWidgets.QLineEdit, "figureComposerLineColorsEdit"
     )

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method.py
@@ -180,7 +180,7 @@ def test_figure_composer_method_docs_button_opens_current_url(
             tool.operation_panel.operation_list.topLevelItem(row)
         )
         tool.operation_editor.select_section("method")
-        button = tool.operation_editor.stack.currentWidget().findChild(
+        button = tool.operation_editor.current_page.findChild(
             QtWidgets.QToolButton, "figureComposerMethodDocsButton"
         )
         assert button is not None
@@ -818,7 +818,7 @@ def test_figure_composer_tick_params_controls_update_state(qtbot) -> None:
 
     _select_operation_rows(tool, (0,))
     tool.operation_editor.select_section("method")
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     assert method_page is not None
     editor = method_page.findChild(
         figurecomposer_tick_params.TickParamsEditorWidget,
@@ -937,14 +937,14 @@ def test_figure_composer_limit_methods_default_to_current_axis_limits(qtbot) -> 
     tool.operation_editor.select_section("method")
     qtbot.wait_until(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QLineEdit, "figureComposerAxesMethodLimitsEdit"
             )
             is not None
         ),
         timeout=5000,
     )
-    limits_edit = tool.operation_editor.stack.currentWidget().findChild(
+    limits_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerAxesMethodLimitsEdit"
     )
     assert limits_edit is not None
@@ -956,14 +956,14 @@ def test_figure_composer_limit_methods_default_to_current_axis_limits(qtbot) -> 
     tool.operation_editor.select_section("method")
     qtbot.wait_until(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QLineEdit, "figureComposerAxesMethodLimitsEdit"
             )
             is not None
         ),
         timeout=5000,
     )
-    limits_edit = tool.operation_editor.stack.currentWidget().findChild(
+    limits_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerAxesMethodLimitsEdit"
     )
     assert limits_edit is not None
@@ -1008,7 +1008,7 @@ def test_figure_composer_method_selector_preserves_compatible_values(qtbot) -> N
     )
     tool.operation_editor.select_section("method")
 
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     method_combo = method_page.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodCombo"
     )
@@ -1078,7 +1078,7 @@ def test_figure_composer_erlab_label_method_selector_maps_location(
     qtbot.addWidget(tool)
     tool.operation_editor.select_section("method")
 
-    method_combo = tool.operation_editor.stack.currentWidget().findChild(
+    method_combo = tool.operation_editor.current_page.findChild(
         QtWidgets.QComboBox, "figureComposerERLabMethodCombo"
     )
     assert method_combo is not None
@@ -1520,7 +1520,7 @@ def test_figure_composer_batch_same_method_edits_selected_steps(qtbot) -> None:
 
     _select_operation_rows(tool, (0, 1))
     tool.operation_editor.select_section("method")
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     title_edit = method_page.findChild(
         QtWidgets.QPlainTextEdit, "figureComposerAxesMethodTitleEdit"
     )
@@ -1580,7 +1580,7 @@ def test_figure_composer_method_text_args_accept_real_newlines(qtbot) -> None:
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("method")
-    label_input = tool.operation_editor.stack.currentWidget().findChild(
+    label_input = tool.operation_editor.current_page.findChild(
         completion_widgets.CompletingPlainTextEdit,
         "figureComposerAxesMethodXLabelEdit",
     )
@@ -1747,7 +1747,7 @@ def test_figure_composer_label_methods_offer_curated_manual_input(
     qtbot.addWidget(tool)
 
     tool.operation_editor.select_section("method")
-    label_input = tool.operation_editor.stack.currentWidget().findChild(
+    label_input = tool.operation_editor.current_page.findChild(
         completion_widgets.CompletingPlainTextEdit
     )
     assert label_input is not None
@@ -1799,7 +1799,7 @@ def test_figure_composer_plural_label_methods_offer_completion(qtbot, name) -> N
     qtbot.addWidget(tool)
 
     tool.operation_editor.select_section("method")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     label_input = page.findChild(
         completion_widgets.CompletingPlainTextEdit,
         "figureComposerMethodTextValuesEdit",
@@ -2007,7 +2007,7 @@ def test_figure_composer_set_titles_default_location_uses_stylesheet(qtbot) -> N
     qtbot.addWidget(tool)
 
     tool.operation_editor.select_section("method")
-    location_combo = tool.operation_editor.stack.currentWidget().findChild(
+    location_combo = tool.operation_editor.current_page.findChild(
         QtWidgets.QComboBox,
         "figureComposerERLabSetTitlesLocCombo",
     )
@@ -2051,7 +2051,7 @@ def test_figure_composer_text_controls_handle_constructor_aliases(qtbot) -> None
     )
     qtbot.addWidget(tool)
     tool.operation_editor.select_section("method")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     color_edit = page.findChild(
         QtWidgets.QLineEdit, "figureComposerAxesMethodTextColorEdit"
     )
@@ -2114,8 +2114,8 @@ def test_figure_composer_text_controls_handle_constructor_aliases(qtbot) -> None
         "rotation_mode": "anchor",
         "fontsize": 9,
     }
-    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
-    rebuilt_page = tool.operation_editor.stack.currentWidget()
+    qtbot.waitUntil(lambda: tool.operation_editor.current_page is not page)
+    rebuilt_page = tool.operation_editor.current_page
     rebuilt_horizontal_combo = rebuilt_page.findChild(
         QtWidgets.QComboBox,
         "figureComposerAxesMethodTextHorizontalAlignmentCombo",
@@ -2173,7 +2173,7 @@ def test_figure_composer_loaded_text_none_alignments_are_unset(
 
     operation = tool.tool_status.operations[0]
     assert operation.method_kwargs == {"fontsize": 8}
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     horizontal_combo = page.findChild(
         QtWidgets.QComboBox,
         "figureComposerAxesMethodTextHorizontalAlignmentCombo",
@@ -2223,7 +2223,7 @@ def test_figure_composer_constructor_method_controls_handle_aliases(qtbot) -> No
     )
     qtbot.addWidget(tool)
     tool.operation_editor.select_section("method")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     color_edit = page.findChild(
         QtWidgets.QLineEdit, "figureComposerAxesMethodVLineColorEdit"
     )
@@ -2262,7 +2262,7 @@ def test_figure_composer_extra_method_kwargs_canonicalize_aliases(qtbot) -> None
     )
     qtbot.addWidget(tool)
     tool.operation_editor.select_section("method")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     extra_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
     assert extra_edit is not None
 
@@ -2274,8 +2274,8 @@ def test_figure_composer_extra_method_kwargs_canonicalize_aliases(qtbot) -> None
         "linestyle": ":",
         "alpha": 0.5,
     }
-    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
-    rebuilt_page = tool.operation_editor.stack.currentWidget()
+    qtbot.waitUntil(lambda: tool.operation_editor.current_page is not page)
+    rebuilt_page = tool.operation_editor.current_page
     color_edit = rebuilt_page.findChild(
         QtWidgets.QLineEdit, "figureComposerAxesMethodVLineColorEdit"
     )
@@ -2313,7 +2313,7 @@ def test_figure_composer_axis_label_position_controls_are_exclusive(qtbot) -> No
     qtbot.addWidget(tool)
     tool.operation_editor.select_section("method")
 
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     horizontal_combo = page.findChild(
         QtWidgets.QComboBox,
         "figureComposerAxesMethodXLabelHorizontalAlignmentCombo",
@@ -2325,8 +2325,8 @@ def test_figure_composer_axis_label_position_controls_are_exclusive(qtbot) -> No
         "fontsize": 8,
     }
 
-    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
-    page = tool.operation_editor.stack.currentWidget()
+    qtbot.waitUntil(lambda: tool.operation_editor.current_page is not page)
+    page = tool.operation_editor.current_page
     location_combo = page.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodXLabelLocCombo"
     )
@@ -2337,8 +2337,8 @@ def test_figure_composer_axis_label_position_controls_are_exclusive(qtbot) -> No
         "fontsize": 8,
     }
 
-    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
-    page = tool.operation_editor.stack.currentWidget()
+    qtbot.waitUntil(lambda: tool.operation_editor.current_page is not page)
+    page = tool.operation_editor.current_page
     extra_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodKwEdit")
     font_size_edit = page.findChild(
         QtWidgets.QLineEdit, "figureComposerAxesMethodXLabelFontSizeEdit"
@@ -2356,8 +2356,8 @@ def test_figure_composer_axis_label_position_controls_are_exclusive(qtbot) -> No
         "fontsize": 9,
     }
 
-    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
-    page = tool.operation_editor.stack.currentWidget()
+    qtbot.waitUntil(lambda: tool.operation_editor.current_page is not page)
+    page = tool.operation_editor.current_page
     horizontal_combo = page.findChild(
         QtWidgets.QComboBox,
         "figureComposerAxesMethodXLabelHorizontalAlignmentCombo",
@@ -2383,8 +2383,8 @@ def test_figure_composer_axis_label_position_controls_are_exclusive(qtbot) -> No
     extra_edit.editingFinished.emit()
     assert tool.tool_status.operations[0].method_kwargs == {"fontsize": 10}
 
-    qtbot.waitUntil(lambda: tool.operation_editor.stack.currentWidget() is not page)
-    page = tool.operation_editor.stack.currentWidget()
+    qtbot.waitUntil(lambda: tool.operation_editor.current_page is not page)
+    page = tool.operation_editor.current_page
     horizontal_combo = page.findChild(
         QtWidgets.QComboBox,
         "figureComposerAxesMethodXLabelHorizontalAlignmentCombo",
@@ -2531,7 +2531,7 @@ def test_figure_composer_method_controls_restore_literal_kwargs(qtbot) -> None:
             tool.operation_panel.operation_list.topLevelItem(row)
         )
         tool.operation_editor.select_section("method")
-        page = tool.operation_editor.stack.currentWidget()
+        page = tool.operation_editor.current_page
         assert page is not None
         return page
 
@@ -2757,7 +2757,7 @@ def test_figure_composer_batch_minor_tick_control_updates_selected_steps(
 
     _select_operation_rows(tool, (0, 1))
     tool.operation_editor.select_section("method")
-    minor_check = tool.operation_editor.stack.currentWidget().findChild(
+    minor_check = tool.operation_editor.current_page.findChild(
         QtWidgets.QCheckBox, "figureComposerAxesMethodXTickMinorCheck"
     )
     assert minor_check is not None
@@ -2800,11 +2800,11 @@ def test_figure_composer_batch_incompatible_methods_disable_editor(qtbot) -> Non
 
     _select_operation_rows(tool, (0, 1))
 
-    assert tool.operation_editor.stack.currentWidget().objectName() == (
+    assert tool.operation_editor.current_page.objectName() == (
         "figureComposerIncompatibleBatchPage"
     )
     assert (
-        tool.operation_editor.stack.currentWidget().findChild(
+        tool.operation_editor.current_page.findChild(
             QtWidgets.QPlainTextEdit, "figureComposerAxesMethodTitleEdit"
         )
         is None
@@ -2921,7 +2921,7 @@ def test_figure_composer_label_subplots_preserves_empty_text_rows(qtbot) -> None
     qtbot.addWidget(tool)
 
     tool.operation_editor.select_section("method")
-    text_edit = tool.operation_editor.stack.currentWidget().findChild(
+    text_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QPlainTextEdit,
         "figureComposerMethodTextValuesEdit",
     )
@@ -2981,7 +2981,7 @@ def test_figure_composer_legacy_method_order_normalizes_to_c(
     )
 
     tool.operation_editor.select_section("method")
-    order_combo = tool.operation_editor.stack.currentWidget().findChild(
+    order_combo = tool.operation_editor.current_page.findChild(
         QtWidgets.QComboBox,
         "figureComposerERLabLabelSubplotsOrderCombo",
     )
@@ -3100,7 +3100,7 @@ def test_figure_composer_erlab_method_controls_update_recipe(qtbot) -> None:
             tool.operation_panel.operation_list.topLevelItem(row)
         )
         tool.operation_editor.select_section("method")
-        page = tool.operation_editor.stack.currentWidget()
+        page = tool.operation_editor.current_page
         assert page is not None
         return page
 
@@ -3524,9 +3524,7 @@ def test_figure_composer_erlab_method_allows_empty_text_values(qtbot) -> None:
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("method")
-    title_edit = tool.operation_editor.stack.currentWidget().findChild(
-        QtWidgets.QPlainTextEdit
-    )
+    title_edit = tool.operation_editor.current_page.findChild(QtWidgets.QPlainTextEdit)
     assert title_edit is not None
     title_edit.setPlainText("Left\n")
     assert tool.tool_status.operations[0].text_values == ("Left", "")
@@ -3535,9 +3533,7 @@ def test_figure_composer_erlab_method_allows_empty_text_values(qtbot) -> None:
         tool.operation_panel.operation_list.topLevelItem(1)
     )
     tool.operation_editor.select_section("method")
-    xlabel_edit = tool.operation_editor.stack.currentWidget().findChild(
-        QtWidgets.QPlainTextEdit
-    )
+    xlabel_edit = tool.operation_editor.current_page.findChild(QtWidgets.QPlainTextEdit)
     assert xlabel_edit is not None
     xlabel_edit.setPlainText("")
     assert tool.tool_status.operations[1].text_values == ("",)

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method_execution.py
@@ -931,7 +931,7 @@ def test_figure_composer_figure_layout_methods_render_and_codegen(qtbot) -> None
         adjust_tool.operation_panel.operation_list.topLevelItem(0)
     )
     adjust_tool.operation_editor.select_section("method")
-    adjust_page = adjust_tool.operation_editor.stack.currentWidget()
+    adjust_page = adjust_tool.operation_editor.current_page
     left_spin = adjust_page.findChild(
         QtWidgets.QDoubleSpinBox, "figureComposerFigureSubplotsAdjustLeftEdit"
     )
@@ -968,7 +968,7 @@ def test_figure_composer_figure_layout_methods_render_and_codegen(qtbot) -> None
         default_tool.operation_panel.operation_list.topLevelItem(0)
     )
     default_tool.operation_editor.select_section("method")
-    default_page = default_tool.operation_editor.stack.currentWidget()
+    default_page = default_tool.operation_editor.current_page
     default_left_spin = default_page.findChild(
         QtWidgets.QDoubleSpinBox, "figureComposerFigureSubplotsAdjustLeftEdit"
     )
@@ -1019,7 +1019,7 @@ def test_figure_composer_figure_layout_methods_render_and_codegen(qtbot) -> None
         engine_tool.operation_panel.operation_list.topLevelItem(0)
     )
     engine_tool.operation_editor.select_section("method")
-    engine_page = engine_tool.operation_editor.stack.currentWidget()
+    engine_page = engine_tool.operation_editor.current_page
     engine_combo = engine_page.findChild(
         QtWidgets.QComboBox, "figureComposerFigureLayoutEngineCombo"
     )
@@ -1038,7 +1038,7 @@ def test_figure_composer_figure_layout_methods_render_and_codegen(qtbot) -> None
     _activate_combo_text(engine_combo, "compressed")
     qtbot.waitUntil(
         lambda: (
-            engine_tool.operation_editor.stack.currentWidget().findChild(
+            engine_tool.operation_editor.current_page.findChild(
                 QtWidgets.QDoubleSpinBox, "figureComposerFigureLayoutEngineHspaceEdit"
             )
             is not None
@@ -1049,7 +1049,7 @@ def test_figure_composer_figure_layout_methods_render_and_codegen(qtbot) -> None
     assert operation.method_args == ("compressed",)
     assert operation.method_kwargs == {"hspace": 0.2}
 
-    engine_page = engine_tool.operation_editor.stack.currentWidget()
+    engine_page = engine_tool.operation_editor.current_page
     assert (
         engine_page.findChild(
             QtWidgets.QDoubleSpinBox, "figureComposerFigureLayoutEnginePadEdit"

--- a/tests/interactive/imagetool/manager/figurecomposer/test_method_plot_data.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_method_plot_data.py
@@ -145,7 +145,7 @@ def test_figure_composer_axes_plot_method_render_and_codegen(qtbot) -> None:
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("method")
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     method_combo = method_page.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodCombo"
     )
@@ -217,7 +217,7 @@ def test_figure_composer_axes_plot_method_render_and_codegen(qtbot) -> None:
         tool.operation_panel.operation_list.topLevelItem(1)
     )
     tool.operation_editor.select_section("method")
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     custom_transform_edit = method_page.findChild(
         QtWidgets.QLineEdit, "figureComposerMethodTransformExpressionEdit"
     )
@@ -311,7 +311,7 @@ def test_figure_composer_axes_errorbar_method_render_and_codegen(qtbot) -> None:
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("method")
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     method_combo = method_page.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodCombo"
     )
@@ -477,7 +477,7 @@ def test_figure_composer_axes_plot_data_mode_switches_editor(qtbot) -> None:
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("method")
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     mode_combo = method_page.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodPlotDataModeCombo"
     )
@@ -495,7 +495,7 @@ def test_figure_composer_axes_plot_data_mode_switches_editor(qtbot) -> None:
     _activate_combo_index(mode_combo, mode_combo.findData("from_data"))
     qtbot.wait_until(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QComboBox, "figureComposerAxesMethodPlotYSourceCombo"
             )
             is not None
@@ -508,7 +508,7 @@ def test_figure_composer_axes_plot_data_mode_switches_editor(qtbot) -> None:
     assert operation.method_plot_y == FigureMethodPlotValueState(
         source="data", kind="data"
     )
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     assert (
         method_page.findChild(QtWidgets.QLineEdit, "figureComposerAxesMethodPlotXEdit")
         is None
@@ -559,7 +559,7 @@ def test_figure_composer_axes_plot_data_mode_switches_editor(qtbot) -> None:
     tool.operation_editor.select_section("method")
     qtbot.wait_until(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QComboBox,
                 "figureComposerAxesMethodErrorbarXErrorSourceCombo",
             )
@@ -573,7 +573,7 @@ def test_figure_composer_axes_plot_data_mode_switches_editor(qtbot) -> None:
     assert operation.method_plot_y == FigureMethodPlotValueState(
         source="data", kind="data"
     )
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     xerr_source_combo = method_page.findChild(
         QtWidgets.QComboBox, "figureComposerAxesMethodErrorbarXErrorSourceCombo"
     )
@@ -1444,7 +1444,7 @@ def test_figure_composer_batch_same_plot_method_edits_selected_steps(qtbot) -> N
 
     _select_operation_rows(tool, (0, 1))
     tool.operation_editor.select_section("method")
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     color_edit = method_page.findChild(
         QtWidgets.QLineEdit, "figureComposerAxesMethodPlotColorEdit"
     )

--- a/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_overlays.py
@@ -59,7 +59,7 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     )
 
     tool.operation_editor.select_section("slice")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
     mode_combo = page.findChild(QtWidgets.QComboBox, "figureComposerBZModeCombo")
     angle_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZAngleSpin")
@@ -101,7 +101,7 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     bounds_edit.editingFinished.emit()
 
     tool.operation_editor.select_section("lattice")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
     a_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZAEdit")
     b_spin = page.findChild(QtWidgets.QDoubleSpinBox, "figureComposerBZBEdit")
@@ -129,7 +129,7 @@ def test_figure_composer_bz_overlay_editor_updates_state(qtbot) -> None:
     _activate_combo_text(centering_combo, "F")
 
     tool.operation_editor.select_section("style")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
     color_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerBZColorEdit")
     line_style_combo = page.findChild(
@@ -202,7 +202,7 @@ def test_figure_composer_bz_overlay_restores_mode_control_visibility(
     )
 
     tool.operation_editor.select_section("slice")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
     layout = page.layout()
     assert isinstance(layout, QtWidgets.QFormLayout)
@@ -252,7 +252,7 @@ def test_figure_composer_batch_bz_overlay_line_kwargs_preserve_controls(qtbot) -
 
     _select_operation_rows(tool, (0, 1))
     tool.operation_editor.select_section("style")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     line_kw_edit = page.findChild(QtWidgets.QLineEdit, "figureComposerBZLineKwEdit")
     assert line_kw_edit is not None
     assert line_kw_edit.text() == ""
@@ -775,7 +775,7 @@ def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> No
     _activate_combo_index(source_combo, other_index)
 
     tool.operation_editor.select_section("photon")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
     energies_edit = page.findChild(
         QtWidgets.QLineEdit, "figureComposerPhotonEnergyValuesEdit"
@@ -792,7 +792,7 @@ def test_figure_composer_photon_energy_overlay_editor_updates_state(qtbot) -> No
     binding_edit.editingFinished.emit()
 
     tool.operation_editor.select_section("style")
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
     color_edit = page.findChild(
         QtWidgets.QLineEdit, "figureComposerPhotonEnergyColorEdit"

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_array.py
@@ -1122,7 +1122,7 @@ def test_figure_composer_plot_array_aspect_control_shows_mixed_batch_value(
 
     _select_operation_rows(tool, (0, 1))
     tool.operation_editor.select_section("view")
-    combo = tool.operation_editor.stack.currentWidget().findChild(
+    combo = tool.operation_editor.current_page.findChild(
         QtWidgets.QComboBox, "figureComposerPlotArrayAspectCombo"
     )
     assert combo is not None

--- a/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_plot_slices.py
@@ -1491,7 +1491,7 @@ def test_figure_composer_plot_slices_all_coordinate_values_with_thin(
     )
     tool._update_operation_editor()
     tool.operation_editor.select_section("selection")
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     assert selection_page is not None
     values_edit = selection_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesValuesEdit"
@@ -2053,8 +2053,12 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
         tool.operation_panel.splitter.widget(0) is tool.operation_panel.operation_list
     )
     assert tool.operation_panel.splitter.widget(1) is tool.operation_editor
-    assert tool.operation_editor.scroll_area.widget() is tool.operation_editor.stack
-    assert not tool.operation_editor.scroll_area.isAncestorOf(
+    assert tool.operation_editor.current_scroll_area is not None
+    assert (
+        tool.operation_editor.current_scroll_area.widget()
+        is tool.operation_editor.current_page
+    )
+    assert not tool.operation_editor.current_scroll_area.isAncestorOf(
         tool.operation_editor.navigator
     )
     editor_tabs = tool.findChild(QtWidgets.QTabWidget, "figureComposerEditorTabs")
@@ -2183,7 +2187,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
         "advanced",
     )
     assert [
-        tool.operation_editor.stack.widget(index).objectName()
+        tool.operation_editor.stack.widget(index).widget().objectName()
         for index in range(tool.operation_editor.stack.count())
     ] == [
         "figureComposerStepSourcesPage",
@@ -2291,11 +2295,11 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     tool.operation_editor.request_update(axis="equal")
     assert tool.findChild(QtWidgets.QToolBox) is None
     assert (
-        tool.operation_editor.stack.currentWidget().objectName()
+        tool.operation_editor.current_page.objectName()
         == "figureComposerPlotSlicesColorsPage"
     )
     tool.operation_editor.select_section("view")
-    view_page = tool.operation_editor.stack.currentWidget()
+    view_page = tool.operation_editor.current_page
     xlim_edit = view_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesXLimEdit"
     )
@@ -2320,27 +2324,27 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     assert restored_status.operations[0].ylim == 2.5
     assert "ylim=2.5" in tool.generated_code()
     assert (
-        tool.operation_editor.stack.currentWidget().objectName()
+        tool.operation_editor.current_page.objectName()
         == "figureComposerPlotSlicesViewPage"
     )
     qtbot.mouseClick(
         _operation_section_button(tool, "colors"), QtCore.Qt.MouseButton.LeftButton
     )
     assert (
-        tool.operation_editor.stack.currentWidget().objectName()
+        tool.operation_editor.current_page.objectName()
         == "figureComposerPlotSlicesColorsPage"
     )
     operation_item = tool.operation_panel.operation_list.topLevelItem(0)
     operation_item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
     assert tool.tool_status.operations[0].enabled is False
     assert (
-        tool.operation_editor.stack.currentWidget().objectName()
+        tool.operation_editor.current_page.objectName()
         == "figureComposerPlotSlicesColorsPage"
     )
     operation_item.setCheckState(0, QtCore.Qt.CheckState.Checked)
     assert tool.tool_status.operations[0].enabled is True
     assert (
-        tool.operation_editor.stack.currentWidget().objectName()
+        tool.operation_editor.current_page.objectName()
         == "figureComposerPlotSlicesColorsPage"
     )
     tool.operation_editor.select_section("axes")
@@ -2350,7 +2354,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     qtbot.wait(1)
     assert tool.tool_status.operations[0].axes.expression == "axs[:, 0]"
     assert (
-        tool.operation_editor.stack.currentWidget().objectName()
+        tool.operation_editor.current_page.objectName()
         == "figureComposerTargetAxesPage"
     )
     tool._target_current_operation_all_axes()
@@ -2387,7 +2391,7 @@ def test_figure_composer_plot_slices_operation_uses_separate_window(
     qtbot.wait(1)
     assert tool.tool_status.operations[0].axes.axes == ((0, 0), (0, 1))
     assert (
-        tool.operation_editor.stack.currentWidget().objectName()
+        tool.operation_editor.current_page.objectName()
         == "figureComposerTargetAxesPage"
     )
     tool._target_current_operation_all_axes()
@@ -2864,7 +2868,7 @@ def test_figure_composer_plot_slices_line_coordinate_colormap_codegen(
     assert rendered_lines[1].get_linewidth() == 2.5
 
     tool.operation_editor.select_section("colors")
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     assert (
         colors_page.findChild(
             QtWidgets.QComboBox, "figureComposerPlotSlicesLineColorModeCombo"
@@ -3327,7 +3331,7 @@ def test_figure_composer_plot_slices_qsel_kwargs_display_in_selection(qtbot) -> 
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("selection")
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     dimension_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerPlotSlicesDimensionCombo"
     )
@@ -3349,7 +3353,7 @@ def test_figure_composer_plot_slices_qsel_kwargs_display_in_selection(qtbot) -> 
     assert slice_kwargs_edit.text() == "beta=slice(-0.5, 0.5)"
 
     tool.operation_editor.select_section("advanced")
-    extra_kwargs_edit = tool.operation_editor.stack.currentWidget().findChild(
+    extra_kwargs_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerExtraKwEdit"
     )
     assert extra_kwargs_edit is not None
@@ -3383,7 +3387,7 @@ def test_figure_composer_plot_slices_advanced_qsel_kwargs_move_to_selection(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("advanced")
-    extra_kwargs_edit = tool.operation_editor.stack.currentWidget().findChild(
+    extra_kwargs_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerExtraKwEdit"
     )
     assert extra_kwargs_edit is not None
@@ -3406,7 +3410,7 @@ def test_figure_composer_plot_slices_advanced_qsel_kwargs_move_to_selection(
         timeout=1000,
     )
     tool.operation_editor.select_section("selection")
-    slice_kwargs_edit = tool.operation_editor.stack.currentWidget().findChild(
+    slice_kwargs_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesSliceKwargsEdit"
     )
     assert slice_kwargs_edit is not None
@@ -3457,7 +3461,7 @@ def test_figure_composer_plot_slices_color_controls_do_not_commit_on_rebuild(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("colors")
-    first_page = tool.operation_editor.stack.currentWidget()
+    first_page = tool.operation_editor.current_page
     first_cmap_combo = first_page.findChild(
         erlab.interactive.colors.ColorMapComboBox, "figureComposerCmapCombo"
     )
@@ -3474,7 +3478,7 @@ def test_figure_composer_plot_slices_color_controls_do_not_commit_on_rebuild(
 
     _select_operation_rows(tool, (0, 1))
     tool.operation_editor.select_section("colors")
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     cmap_combo = colors_page.findChild(
         erlab.interactive.colors.ColorMapComboBox, "figureComposerCmapCombo"
     )
@@ -3501,7 +3505,7 @@ def test_figure_composer_plot_slices_color_controls_do_not_commit_on_rebuild(
         "plasma",
         "plasma_r",
     ]
-    halfrange_edit = tool.operation_editor.stack.currentWidget().findChild(
+    halfrange_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerHalfrangeNormEdit"
     )
     assert halfrange_edit is not None
@@ -3611,7 +3615,7 @@ def test_figure_composer_plot_slices_line_panels_use_line_controls(qtbot) -> Non
     assert order_combo is not None
 
     tool.operation_editor.select_section("colors")
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     line_color_edit = colors_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesLineColorEdit"
     )
@@ -3664,7 +3668,7 @@ def test_figure_composer_plot_slices_line_panels_use_line_controls(qtbot) -> Non
     )
 
     tool.operation_editor.select_section("colors")
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     assert (
         colors_page.findChild(QtWidgets.QComboBox, "figureComposerSameLimitsCombo")
         is None
@@ -3732,7 +3736,7 @@ def test_figure_composer_plot_slices_line_transforms_codegen_executes(
 
     assert "transform" in tool.operation_editor.section_keys
     tool.operation_editor.select_section("transform")
-    transform_page = tool.operation_editor.stack.currentWidget()
+    transform_page = tool.operation_editor.current_page
     assert transform_page.objectName() == "figureComposerPlotSlicesTransformPage"
     assert (
         transform_page.findChild(
@@ -3755,7 +3759,7 @@ def test_figure_composer_plot_slices_line_transforms_codegen_executes(
     )
 
     tool.operation_editor.select_section("colors")
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     assert (
         colors_page.findChild(
             QtWidgets.QComboBox, "figureComposerPlotSlicesLineNormalizeCombo"
@@ -3852,7 +3856,7 @@ def test_figure_composer_plot_slices_line_panels_ignore_image_cmap(qtbot) -> Non
     qtbot.addWidget(tool)
 
     tool.operation_editor.select_section("colors")
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     line_color_edit = colors_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesLineColorEdit"
     )
@@ -3907,7 +3911,7 @@ def test_figure_composer_plot_slices_mixed_image_line_batch_hides_color_controls
 
     _select_operation_rows(tool, (0, 1))
     tool.operation_editor.select_section("colors")
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
 
     assert (
         colors_page.findChild(
@@ -3932,17 +3936,17 @@ def test_figure_composer_plot_slices_mixed_image_line_batch_hides_color_controls
     assert mixed_label is not None
 
     tool.operation_editor.select_section("view")
-    view_page = tool.operation_editor.stack.currentWidget()
+    view_page = tool.operation_editor.current_page
     assert view_page.findChild(QtWidgets.QComboBox, "figureComposerAxisCombo")
     tool.operation_editor.select_section("colors")
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     assert (
         colors_page.findChild(QtWidgets.QComboBox, "figureComposerSameLimitsCombo")
         is None
     )
 
     tool.operation_editor.select_section("selection")
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     assert selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerPlotSlicesDimensionCombo"
     )
@@ -3982,7 +3986,7 @@ def test_figure_composer_plot_slices_image_panels_hide_line_transforms(
 
     assert "transform" not in tool.operation_editor.section_keys
     tool.operation_editor.select_section("colors")
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     assert (
         colors_page.findChild(
             QtWidgets.QComboBox, "figureComposerPlotSlicesLineNormalizeCombo"
@@ -4155,7 +4159,7 @@ def test_figure_composer_plot_slices_line_panel_style_editor_updates_recipe(
     qtbot.addWidget(tool)
     tool.operation_editor.select_section("colors")
 
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     panel_check = colors_page.findChild(
         QtWidgets.QCheckBox, "figureComposerPlotSlicesPanelStylesCheck"
     )
@@ -4163,14 +4167,14 @@ def test_figure_composer_plot_slices_line_panel_style_editor_updates_recipe(
     panel_check.setChecked(True)
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QWidget, "figureComposerPlotSlicesPanelLineStyleEditor"
             )
             is not None
         ),
         timeout=1000,
     )
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     panel_list = colors_page.findChild(
         QtWidgets.QListWidget, "figureComposerPlotSlicesPanelLineStyleList"
     )
@@ -4283,7 +4287,7 @@ def test_figure_composer_dict_inputs_prefer_keyword_form(qtbot) -> None:
 
     _select_operation_rows(tool, (2,))
     tool.operation_editor.select_section("selection")
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     assert (
         selection_page.findChild(
             QtWidgets.QComboBox, "figureComposerProfileReduceCombo"
@@ -4526,7 +4530,7 @@ def test_figure_composer_norm_controls_are_dynamic_and_split_kwargs(qtbot) -> No
     tool._update_operation_editor()
     tool.operation_editor.select_section("colors")
 
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     norm_combo = colors_page.findChild(QtWidgets.QComboBox, "figureComposerNormCombo")
     assert norm_combo is not None
     assert norm_combo.currentIndex() == figurecomposer_norms._NORM_CHOICES.index(
@@ -4557,14 +4561,14 @@ def test_figure_composer_norm_controls_are_dynamic_and_split_kwargs(qtbot) -> No
     assert tool.tool_status.operations[0].norm_name == "CenteredInversePowerNorm"
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QLineEdit, "figureComposerVcenterNormEdit"
             )
             is not None
         ),
         timeout=1000,
     )
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     vcenter_edit = colors_page.findChild(
         QtWidgets.QLineEdit, "figureComposerVcenterNormEdit"
     )
@@ -4578,14 +4582,14 @@ def test_figure_composer_norm_controls_are_dynamic_and_split_kwargs(qtbot) -> No
     assert tool.tool_status.operations[0].norm_name == "CenteredPowerNorm"
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QLineEdit, "figureComposerHalfrangeNormEdit"
             )
             is not None
         ),
         timeout=1000,
     )
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     assert (
         colors_page.findChild(
             erlab.interactive.colors.ColorMapGammaWidget,
@@ -4615,7 +4619,7 @@ def test_figure_composer_norm_controls_are_dynamic_and_split_kwargs(qtbot) -> No
     assert tool.tool_status.operations[0].norm_kwargs == {"custom": "extra"}
 
     def norm_kwargs_text_updated() -> bool:
-        refreshed_edit = tool.operation_editor.stack.currentWidget().findChild(
+        refreshed_edit = tool.operation_editor.current_page.findChild(
             QtWidgets.QLineEdit, "figureComposerNormKwargsEdit"
         )
         return refreshed_edit is not None and refreshed_edit.text() == 'custom="extra"'
@@ -4624,32 +4628,32 @@ def test_figure_composer_norm_controls_are_dynamic_and_split_kwargs(qtbot) -> No
         norm_kwargs_text_updated,
         timeout=1000,
     )
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     norm_kwargs_edit = colors_page.findChild(
         QtWidgets.QLineEdit, "figureComposerNormKwargsEdit"
     )
     assert norm_kwargs_edit is not None
     assert norm_kwargs_edit.text() == 'custom="extra"'
 
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     norm_combo = colors_page.findChild(QtWidgets.QComboBox, "figureComposerNormCombo")
     assert norm_combo is not None
     _activate_combo_text(norm_combo, "Normalize")
     assert tool.tool_status.operations[0].norm_name == "Normalize"
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page.findChild(
                 QtWidgets.QLineEdit, "figureComposerVminNormEdit"
             )
             is not None
-            and tool.operation_editor.stack.currentWidget().findChild(
+            and tool.operation_editor.current_page.findChild(
                 QtWidgets.QLineEdit, "figureComposerHalfrangeNormEdit"
             )
             is None
         ),
         timeout=1000,
     )
-    colors_page = tool.operation_editor.stack.currentWidget()
+    colors_page = tool.operation_editor.current_page
     assert (
         colors_page.findChild(
             erlab.interactive.colors.ColorMapGammaWidget,

--- a/tests/interactive/imagetool/manager/figurecomposer/test_set_palette.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_set_palette.py
@@ -50,7 +50,7 @@ def _set_palette_tool(qtbot, operation: FigureOperationState) -> FigureComposerT
 
 
 def _set_palette_page(tool: FigureComposerTool) -> QtWidgets.QWidget:
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
     return page
 
@@ -138,7 +138,7 @@ def test_figure_composer_set_palette_editor_preview_and_controls(
     tool.operation_panel.operation_list.setCurrentItem(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
 
     combo = page.findChild(QtWidgets.QComboBox, "figureComposerSetPaletteNameCombo")
@@ -251,7 +251,7 @@ def test_figure_composer_set_palette_custom_colors_editor_and_codegen(
     tool.operation_panel.operation_list.setCurrentItem(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
 
     mode_combo = page.findChild(
@@ -324,7 +324,7 @@ def test_figure_composer_set_palette_mode_switch_seeds_custom_colors(qtbot) -> N
     tool.operation_panel.operation_list.setCurrentItem(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
     mode_combo = page.findChild(
         QtWidgets.QComboBox, "figureComposerSetPaletteModeCombo"
@@ -341,8 +341,8 @@ def test_figure_composer_set_palette_mode_switch_seeds_custom_colors(qtbot) -> N
     assert len(operation.palette_colors) == 3
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget() is not None
-            and tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page is not None
+            and tool.operation_editor.current_page.findChild(
                 color_widgets._ColorListEditorWidget,
                 "figureComposerSetPaletteColorsWidget",
             )
@@ -350,7 +350,7 @@ def test_figure_composer_set_palette_mode_switch_seeds_custom_colors(qtbot) -> N
         ),
         timeout=1000,
     )
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
     colors_widget = page.findChild(
         color_widgets._ColorListEditorWidget,
@@ -387,8 +387,8 @@ def test_figure_composer_generated_palette_switch_to_custom_colors(
     assert len(current.palette_colors) == expected_count
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget() is not None
-            and tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page is not None
+            and tool.operation_editor.current_page.findChild(
                 color_widgets._ColorListEditorWidget,
                 "figureComposerSetPaletteColorsWidget",
             )
@@ -492,8 +492,8 @@ def test_figure_composer_set_palette_cubehelix_editor_and_custom_seed(qtbot) -> 
     assert current.palette_colors == expected_hex
     qtbot.waitUntil(
         lambda: (
-            tool.operation_editor.stack.currentWidget() is not None
-            and tool.operation_editor.stack.currentWidget().findChild(
+            tool.operation_editor.current_page is not None
+            and tool.operation_editor.current_page.findChild(
                 color_widgets._ColorListEditorWidget,
                 "figureComposerSetPaletteColorsWidget",
             )
@@ -647,7 +647,7 @@ def test_figure_composer_set_palette_diverging_color_picker(
     assert getattr(state, other_field) == pytest.approx(expected_other)
 
     qtbot.waitUntil(
-        lambda: tool.operation_editor.stack.currentWidget() is not page,
+        lambda: tool.operation_editor.current_page is not page,
         timeout=1000,
     )
     rebuilt_page = _set_palette_page(tool)
@@ -849,7 +849,7 @@ def test_figure_composer_set_palette_seed_color_picker(
     np.testing.assert_allclose(updated.color, expected)
 
     qtbot.waitUntil(
-        lambda: tool.operation_editor.stack.currentWidget() is not page,
+        lambda: tool.operation_editor.current_page is not page,
         timeout=1000,
     )
     rebuilt_page = _set_palette_page(tool)
@@ -1371,7 +1371,7 @@ def test_figure_composer_set_palette_editor_disables_without_seaborn(
     tool.operation_panel.operation_list.setCurrentItem(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
-    page = tool.operation_editor.stack.currentWidget()
+    page = tool.operation_editor.current_page
     assert page is not None
 
     combo = page.findChild(QtWidgets.QComboBox, "figureComposerSetPaletteNameCombo")

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -4827,7 +4827,7 @@ def test_figure_composer_batch_line_source_dependent_combos_disable(
 
     _select_operation_rows(tool, (0, 1))
     tool.operation_editor.select_section("selection")
-    selection_page = tool.operation_editor.stack.currentWidget()
+    selection_page = tool.operation_editor.current_page
     coordinate_combo = selection_page.findChild(
         QtWidgets.QComboBox, "figureComposerProfileCoordinateCombo"
     )

--- a/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_window_layout.py
@@ -64,6 +64,8 @@ from erlab.interactive._figurecomposer._ui import (
     _toolbar_dialogs as figurecomposer_toolbar_dialogs,
 )
 from erlab.interactive._figurecomposer._ui._operation_editor import (
+    FigureOperationEditor,
+    StepSection,
     _FigureComposerStepEditorPage,
     _FigureComposerStepEditorScroll,
 )
@@ -3941,9 +3943,10 @@ def test_figure_composer_operation_table_presents_targets_and_selects_rows(
         operation_list.setCurrentItem(operation_list.topLevelItem(row))
         QtWidgets.QApplication.processEvents()
         assert operation_list.height() == initial_list_height
+        assert tool.operation_editor.current_scroll_area is not None
         assert (
-            tool.operation_editor.scroll_area.minimumSizeHint().width()
-            >= tool.operation_editor.stack.minimumSizeHint().width()
+            tool.operation_editor.current_scroll_area.minimumSizeHint().width()
+            >= tool.operation_editor.current_page.minimumSizeHint().width()
         )
     operation_list.setCurrentItem(palette_item)
     QtWidgets.QApplication.processEvents()
@@ -3953,7 +3956,7 @@ def test_figure_composer_operation_table_presents_targets_and_selects_rows(
     )
     target_rect = operation_list.visualRect(target_index)
     assert not target_rect.isEmpty()
-    current_page = tool.operation_editor.stack.currentWidget()
+    current_page = tool.operation_editor.current_page
     assert current_page is not None
     current_control = next(
         widget
@@ -5266,11 +5269,56 @@ def test_figure_composer_operation_list_keypress_defensive_paths(qtbot) -> None:
     operation_list.keyPressEvent(fallback_event)
 
 
+def test_figure_composer_step_sections_scroll_independently(qtbot) -> None:
+    tabs = QtWidgets.QTabWidget()
+    qtbot.addWidget(tabs)
+    editor = FigureOperationEditor(tabs, (), tabs)
+    tabs.addTab(editor, "Recipe")
+
+    long_page = editor.create_page("longPage")
+    long_layout = QtWidgets.QVBoxLayout(long_page)
+    for index in range(30):
+        long_layout.addWidget(QtWidgets.QLabel(f"Control {index}", long_page))
+    short_page = editor.create_page("shortPage")
+    short_layout = QtWidgets.QVBoxLayout(short_page)
+    short_layout.addWidget(QtWidgets.QLabel("Control", short_page))
+    editor.replace_sections(
+        (
+            StepSection("long", "Long", long_page, "Long section"),
+            StepSection("short", "Short", short_page, "Short section"),
+        ),
+        summaries={},
+    )
+
+    tabs.resize(480, 260)
+    tabs.show()
+    editor.select_section("long")
+    long_scroll = editor.current_scroll_area
+    assert long_scroll is not None
+    qtbot.waitUntil(lambda: long_scroll.verticalScrollBar().maximum() > 0)
+    long_position = long_scroll.verticalScrollBar().maximum()
+    long_scroll.verticalScrollBar().setValue(long_position)
+
+    editor.select_section("short")
+    short_scroll = editor.current_scroll_area
+    assert short_scroll is not None
+    assert short_scroll is not long_scroll
+    assert short_scroll.widget() is short_page
+    assert short_scroll.verticalScrollBar().value() == 0
+
+    editor.select_section("long")
+    assert editor.current_scroll_area is long_scroll
+    assert long_scroll.verticalScrollBar().value() == long_position
+
+
 def test_figure_composer_step_editor_and_reorder_defensive_paths(
     qtbot, monkeypatch
 ) -> None:
-    scroll = _FigureComposerStepEditorScroll()
+    initial_content = QtWidgets.QWidget()
+    initial_content.setObjectName("initialContent")
+    scroll = _FigureComposerStepEditorScroll(initial_content)
     qtbot.addWidget(scroll)
+    scroll.takeWidget()
     empty_hint = scroll.minimumSizeHint()
 
     class _HintWidget(QtWidgets.QWidget):
@@ -5278,6 +5326,7 @@ def test_figure_composer_step_editor_and_reorder_defensive_paths(
             return QtCore.QSize(220, 20)
 
     content = _HintWidget()
+    content.setObjectName("hintContent")
     scroll.setWidget(content)
     scroll.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
     assert scroll.minimumSizeHint().width() > empty_hint.width()
@@ -7435,7 +7484,7 @@ def test_figure_composer_subplots_adjust_pairs_stay_valid(qtbot) -> None:
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("method")
-    method_page = tool.operation_editor.stack.currentWidget()
+    method_page = tool.operation_editor.current_page
     left_spin = method_page.findChild(
         QtWidgets.QDoubleSpinBox, "figureComposerFigureSubplotsAdjustLeftEdit"
     )
@@ -9324,7 +9373,7 @@ def test_figure_composer_editor_widget_rebuilds_are_deferred(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("selection")
-    values_edit = tool.operation_editor.stack.currentWidget().findChild(
+    values_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesValuesEdit"
     )
     assert values_edit is not None
@@ -9351,7 +9400,7 @@ def test_figure_composer_editor_widget_rebuilds_are_deferred(
         staticmethod(lambda: active_popup[0]),
     )
     rebuild_calls.clear()
-    values_edit = tool.operation_editor.stack.currentWidget().findChild(
+    values_edit = tool.operation_editor.current_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesValuesEdit"
     )
     assert values_edit is not None
@@ -9367,7 +9416,7 @@ def test_figure_composer_editor_widget_rebuilds_are_deferred(
     qtbot.waitUntil(lambda: rebuild_calls == [None], timeout=1000)
     assert tool._operation_editor_update_pending is False
 
-    dimension_combo = tool.operation_editor.stack.currentWidget().findChild(
+    dimension_combo = tool.operation_editor.current_page.findChild(
         QtWidgets.QComboBox, "figureComposerPlotSlicesDimensionCombo"
     )
     assert dimension_combo is not None
@@ -9385,7 +9434,7 @@ def test_figure_composer_editor_widget_rebuilds_are_deferred(
     qtbot.waitUntil(lambda: rebuild_calls == [None], timeout=1000)
     assert tool._operation_editor_update_pending is False
 
-    dimension_combo = tool.operation_editor.stack.currentWidget().findChild(
+    dimension_combo = tool.operation_editor.current_page.findChild(
         QtWidgets.QComboBox, "figureComposerPlotSlicesDimensionCombo"
     )
     assert dimension_combo is not None
@@ -9428,7 +9477,7 @@ def test_figure_composer_retired_editor_widgets_drain_after_popup(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("selection")
-    old_page = tool.operation_editor.stack.currentWidget()
+    old_page = tool.operation_editor.current_page
     active_popup: list[QtWidgets.QWidget | None] = [None]
     monkeypatch.setattr(
         QtWidgets.QApplication,
@@ -9492,7 +9541,7 @@ def test_figure_composer_retired_editor_control_signal_is_ignored(
         tool.operation_panel.operation_list.topLevelItem(0)
     )
     tool.operation_editor.select_section("selection")
-    old_page = tool.operation_editor.stack.currentWidget()
+    old_page = tool.operation_editor.current_page
     old_values_edit = old_page.findChild(
         QtWidgets.QLineEdit, "figureComposerPlotSlicesValuesEdit"
     )
@@ -9622,9 +9671,7 @@ def test_figure_composer_layout_change_marks_removed_axes(qtbot, monkeypatch) ->
     assert tool.tool_status.setup.nrows == 1
     assert tool.tool_status.operations[0].axes.axes == ((1, 1),)
     assert tool._operation_has_invalid_axes(tool.tool_status.operations[0])
-    assert (
-        tool.operation_editor.stack.currentWidget() is tool.operation_editor.source_page
-    )
+    assert tool.operation_editor.current_page is tool.operation_editor.source_page
     tool.operation_editor.select_section("axes")
     assert tool.keep_valid_axes_button.isEnabled()
     with pytest.raises(ValueError, match="Cannot generate code"):


### PR DESCRIPTION
## Summary

- give each recipe-step section its own vertical scroll area
- preserve each section scroll position when users switch sections
- keep persistent editor pages alive during rebuilds and retire transient pages safely
- keep scroll containers out of the keyboard focus chain

## Validation

- QT_API=pyqt6 PYTEST_QT_API=pyqt6 QT_QPA_PLATFORM=offscreen uv run pytest -q tests/interactive/imagetool/manager/figurecomposer (820 passed)
- focused PySide6 ownership, rebuild, focus, and scroll tests (8 passed)
- post-rebase focused PyQt6 tests (8 passed)
- uv run ruff format --check on the changed module and Figure Composer tests
- uv run ruff check on the changed module and Figure Composer tests
- uv run mypy src/erlab/interactive/_figurecomposer/_ui/_operation_editor.py
- git diff --check origin/main...HEAD