### PR TITLE
perf(interactive): speed up repeated Fit2D fitting

### DIFF
--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -772,6 +772,7 @@ class _FitJob:
 
     revision: int
     target_index: int | None
+    fit_range: tuple[float, float] | None = None
 
 
 class _FitWorker(threading.Thread):
@@ -4225,7 +4226,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         if outcome.kind == "success":
             if outcome.result is None:
                 raise RuntimeError("Fit worker returned no result.")
-            return functools.partial(callbacks.on_success, outcome.result)
+            result_ds = self._fit_result_for_job(outcome.result, callbacks.job)
+            return functools.partial(callbacks.on_success, result_ds)
         if outcome.kind == "timed_out":
             return callbacks.on_timeout
         if outcome.kind == "error":
@@ -4238,6 +4240,10 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         if outcome.kind == "cancelled":
             return self._fit_cancelled
         raise RuntimeError("Fit worker stopped without a terminal outcome.")
+
+    def _fit_result_for_job(self, result_ds: xr.Dataset, job: _FitJob) -> xr.Dataset:
+        """Attach immutable job context to a completed fit result."""
+        return result_ds
 
     def _finalize_fit_thread(self, thread: _FitWorker) -> None:
         try:

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -3791,9 +3791,9 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._replace_current_params(result.params.copy())
         self._fit_is_current = True
         # Fit2D copies the current slice into its full result state in this hook.
-        # Update subclass-owned state before serializing the shared result payload.
+        # Update subclass-owned state now, but defer payload serialization until the
+        # sequence finishes. An explicit save can still populate the cache on demand.
         self._sync_fit_result_state(notify=False)
-        self._cache_fit_result_payload()
         self._fit_multi_last_elapsed = time.perf_counter() - t0
         self._fit_multi_live_refresh_pending = True
         self._fit_multi_refresh_pending = True
@@ -4430,6 +4430,8 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     def _finish_multi_fit(self) -> None:
         self._sync_multi_fit_view(full=True)
+        if self._serialized_fit_result_blob is None:
+            self._cache_fit_result_payload()
         self._set_fit_running(False, multi=True)
         self._fit_running_multi = False
         self._fit_multi_total = None

--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -787,6 +787,7 @@ class _FitWorker(threading.Thread):
         max_nfev: int,
         method: str,
         timeout: float,
+        completion_callback: Callable[[object], None] | None = None,
     ) -> None:
         # The application registry owns every worker through completion. A
         # non-daemon thread prevents Python from finalizing a live fit payload.
@@ -800,6 +801,7 @@ class _FitWorker(threading.Thread):
         self._max_nfev = max_nfev
         self._method = method
         self._timeout = timeout
+        self._completion_callback = completion_callback
         self._cancel = threading.Event()
         self._outcome = _FitWorkerOutcome("not_finished")
 
@@ -807,6 +809,17 @@ class _FitWorker(threading.Thread):
         self._cancel.set()
 
     def run(self) -> None:
+        try:
+            self._run_fit()
+        finally:
+            if self._outcome.kind == "not_finished":
+                self._outcome = _FitWorkerOutcome("error", error=traceback.format_exc())
+            completion_callback = self._completion_callback
+            if completion_callback is not None:
+                with contextlib.suppress(RuntimeError):
+                    completion_callback(self)
+
+    def _run_fit(self) -> None:
         self._outcome = _FitWorkerOutcome("not_finished")
         t0 = time.perf_counter()
         timed_out = False
@@ -865,6 +878,7 @@ class _FitWorker(threading.Thread):
         self._model = None
         self._params = None
         self._weights = None
+        self._completion_callback = None
         self._outcome = _FitWorkerOutcome("not_finished")
 
 
@@ -878,13 +892,16 @@ class _FitWorkerCallbacks(typing.NamedTuple):
 class _FitWorkerRegistry(QtCore.QObject):
     """Own fit workers until their payloads can be released on the GUI thread."""
 
+    sigWorkerFinished = QtCore.Signal(object)
+
     def __init__(self, app: QtWidgets.QApplication) -> None:
         super().__init__(app)
         self._workers: dict[_FitWorker, QtWidgets.QWidget | None] = {}
         self._owner_destroy_callbacks: dict[_FitWorker, Callable[..., None]] = {}
-        self._reap_timer = QtCore.QTimer(self)
-        self._reap_timer.setInterval(25)
-        self._reap_timer.timeout.connect(self.reap)
+        self.sigWorkerFinished.connect(
+            self._worker_finished,
+            QtCore.Qt.ConnectionType.QueuedConnection,
+        )
         app.aboutToQuit.connect(self.shutdown)
 
     @property
@@ -902,8 +919,6 @@ class _FitWorkerRegistry(QtCore.QObject):
         owner_destroyed = functools.partial(self._owner_destroyed, thread, owner)
         self._owner_destroy_callbacks[thread] = owner_destroyed
         owner.destroyed.connect(owner_destroyed)
-        if not any(owner is None for owner in self._workers.values()):
-            self._reap_timer.stop()
 
     def detach(self, thread: _FitWorker) -> None:
         if thread not in self._workers:
@@ -911,14 +926,10 @@ class _FitWorkerRegistry(QtCore.QObject):
         owner = self._workers[thread]
         self._disconnect_owner(thread, owner)
         self._workers[thread] = None
-        if not self._reap_timer.isActive():
-            self._reap_timer.start()
 
     def remove(self, thread: _FitWorker) -> None:
         owner = self._workers.pop(thread, None)
         self._disconnect_owner(thread, owner)
-        if not any(owner is None for owner in self._workers.values()):
-            self._reap_timer.stop()
 
     def _disconnect_owner(
         self, thread: _FitWorker, owner: QtWidgets.QWidget | None
@@ -940,25 +951,25 @@ class _FitWorkerRegistry(QtCore.QObject):
             return
         self._owner_destroy_callbacks.pop(thread, None)
         self._workers[thread] = None
-        if not self._reap_timer.isActive():
-            self._reap_timer.start()
 
-    @QtCore.Slot()
-    def reap(self) -> None:
-        """Release stopped detached workers on the GUI thread."""
-        for thread, owner in tuple(self._workers.items()):
-            if owner is not None and erlab.interactive.utils.qt_is_valid(owner):
-                continue
-            if thread.is_alive():
-                continue
-            thread.join()
-            thread.release_payload()
-            self.remove(thread)
+    @QtCore.Slot(object)
+    def _worker_finished(self, thread: _FitWorker) -> None:
+        """Finalize one registered worker on the GUI thread."""
+        if thread not in self._workers:
+            return
+        owner = self._workers[thread]
+        thread.join()
+        if thread not in self._workers or self._workers[thread] is not owner:
+            return
+        if owner is not None and erlab.interactive.utils.qt_is_valid(owner):
+            typing.cast("Fit1DTool", owner)._finalize_fit_thread(thread)
+            return
+        thread.release_payload()
+        self.remove(thread)
 
     @QtCore.Slot()
     def shutdown(self) -> None:
         """Cancel and join all workers before Qt and Python start teardown."""
-        self._reap_timer.stop()
         workers = tuple(self._workers)
         for thread in workers:
             thread.cancel()
@@ -1266,9 +1277,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         self._fit_config_revision = 0
         self._fit_sequence_generation = 0
         self._fit_worker_registry = _fit_worker_registry()
-        self._fit_poll_timer = QtCore.QTimer(self)
-        self._fit_poll_timer.setInterval(25)
-        self._fit_poll_timer.timeout.connect(self._poll_fit_worker)
         for model_class in (
             *_library_lmfit_model_classes(),
             *self.MODEL_CHOICES.values(),
@@ -3790,10 +3798,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         result = self._last_result_ds.modelfit_results.compute().item()
         self._replace_current_params(result.params.copy())
         self._fit_is_current = True
-        # Fit2D copies the current slice into its full result state in this hook.
-        # Update subclass-owned state now, but defer payload serialization until the
-        # sequence finishes. An explicit save can still populate the cache on demand.
-        self._sync_fit_result_state(notify=False)
         self._fit_multi_last_elapsed = time.perf_counter() - t0
         self._fit_multi_live_refresh_pending = True
         self._fit_multi_refresh_pending = True
@@ -4127,7 +4131,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self.finalize_source_refresh()
 
     def _fit_start_errored(self, *, multi: bool) -> None:
-        self._fit_poll_timer.stop()
         self._fit_thread = None
         self._fit_cancel_requested = False
         self._fit_running_multi = False
@@ -4171,6 +4174,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
                 max_nfev=self.nfev_spin.value(),
                 method=self.method_combo.currentText(),
                 timeout=self.timeout_spin.value(),
+                completion_callback=self._fit_worker_registry.sigWorkerFinished.emit,
             )
         except Exception:
             self._fit_start_errored(multi=multi)
@@ -4208,19 +4212,7 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self._fit_thread = None
             self._fit_start_errored(multi=multi)
             return False
-        self._fit_poll_timer.start()
         return True
-
-    @QtCore.Slot()
-    def _poll_fit_worker(self) -> None:
-        thread = self._fit_thread
-        if thread is None:
-            self._fit_poll_timer.stop()
-            return
-        if thread.is_alive():
-            return
-        thread.join()
-        self._finalize_fit_thread(thread)
 
     def _fit_worker_completion_action(self, thread: _FitWorker) -> Callable[[], None]:
         callbacks = self._fit_worker_callbacks.get(thread)
@@ -4251,7 +4243,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         try:
             if self._fit_thread is not thread:
                 return
-            self._fit_poll_timer.stop()
             self._fit_thread = None
             cancel_requested = self._fit_cancel_requested
             self._fit_cancel_requested = False
@@ -5424,8 +5415,6 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
         """Remove one worker from this window without releasing its payload."""
         if self._fit_thread is not thread:
             return
-        if erlab.interactive.utils.qt_is_valid(self._fit_poll_timer):
-            self._fit_poll_timer.stop()
         self._fit_thread = None
         self._fit_cancel_requested = False
         self._fit_worker_callbacks.pop(thread, None)

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -896,6 +896,23 @@ class Fit2DTool(Fit1DTool):
         self._update_param_plot_options()
         self._update_param_plot(notify=notify)
 
+    def _sync_active_multi_fit_result_state(self) -> None:
+        """Sync the newest Fit ×20 result at an explicit persistence boundary."""
+        if (
+            self._fit_multi_sequence_active()
+            and self._last_result_ds is not None
+            and self._result_ds_full[self._current_idx] is not self._last_result_ds
+        ):
+            self._sync_fit_result_state(notify=False)
+
+    def _flush_restore_work_for_save(self) -> None:
+        super()._flush_restore_work_for_save()
+        self._sync_active_multi_fit_result_state()
+
+    def _fit_result_blob_for_persistence(self) -> np.ndarray | None:
+        self._sync_active_multi_fit_result_state()
+        return super()._fit_result_blob_for_persistence()
+
     def _fit_2d_sequence_active(self) -> bool:
         return self._fit_2d_total > 0
 
@@ -2940,6 +2957,7 @@ class Fit2DTool(Fit1DTool):
     @QtCore.Slot()
     def _save_fit_full(self) -> None:
         self._flush_restore_work()
+        self._sync_active_multi_fit_result_state()
         results = []
         for i, ds in enumerate(self._result_ds_full[self._y_range_slice()]):
             if ds is None:

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -640,6 +640,7 @@ class Fit2DTool(Fit1DTool):
         direct_weights: xr.DataArray | None = None,
         data_name: str,
     ) -> None:
+        data = self._without_fit_range_coords(data)
         self._data_full: xr.DataArray = data
         if uncertainty is not None and direct_weights is not None:
             raise ValueError("Only one of `uncertainty` and direct weights can be set")
@@ -651,6 +652,8 @@ class Fit2DTool(Fit1DTool):
         )
         self._y_dim_name: Hashable = data.dims[0]
         self._y_values_cache: np.ndarray | None = None
+        self._data_fit_range_cache: tuple[float, float] | None = None
+        self._current_fit_range_cache: tuple[int, tuple[float, float]] | None = None
         y_size = int(self._data_full.sizes[self._y_dim_name])
         self._current_idx: int = y_size // 2
         self._params_full = [None] * y_size
@@ -671,6 +674,17 @@ class Fit2DTool(Fit1DTool):
         self._fit_2d_sequence_write_history: bool | None = None
         self._fit_2d_revision: int | None = None
         self._fit_2d_generation: int | None = None
+
+    def _without_fit_range_coords(self, data: xr.DataArray) -> xr.DataArray:
+        """Remove private result metadata from a numerical fit input."""
+        range_coords = [
+            name
+            for name in (self._FIT_RANGE_MIN_COORD, self._FIT_RANGE_MAX_COORD)
+            if name in data.coords
+        ]
+        if range_coords:
+            return data.drop_vars(range_coords)
+        return data
 
     @staticmethod
     def _data_with_saved_dims(
@@ -741,6 +755,8 @@ class Fit2DTool(Fit1DTool):
         self._update_param_plot()
 
     def _data_fit_range(self, data: xr.DataArray) -> tuple[float, float]:
+        if data is self._data_full and self._data_fit_range_cache is not None:
+            return self._data_fit_range_cache
         if self._coord_name in data.coords:
             values = np.asarray(data.coords[self._coord_name].values, dtype=float)
         elif self._coord_name in data.dims:
@@ -752,36 +768,43 @@ class Fit2DTool(Fit1DTool):
         finite = values[np.isfinite(values)]
         if finite.size == 0:
             raise ValueError("Fit coordinate does not contain any finite values.")
-        return float(np.min(finite)), float(np.max(finite))
+        fit_range = float(np.min(finite)), float(np.max(finite))
+        if data is self._data_full:
+            self._data_fit_range_cache = fit_range
+        return fit_range
 
     def _current_fit_range(self) -> tuple[float, float]:
+        revision = getattr(self, "_fit_config_revision", -1)
+        if (
+            self._current_fit_range_cache is not None
+            and self._current_fit_range_cache[0] == revision
+        ):
+            return self._current_fit_range_cache[1]
         fit_domain = self._fit_domain()
         if fit_domain is None:
-            return self._data_fit_range(self._data_full)
-        return self._canonical_fit_range(fit_domain)
+            fit_range = self._data_fit_range(self._data_full)
+        else:
+            fit_range = self._canonical_fit_range(fit_domain)
+        self._current_fit_range_cache = revision, fit_range
+        return fit_range
 
-    def _fit_data(self) -> xr.DataArray:
-        fit_min, fit_max = self._current_fit_range()
-        return (
-            super()
-            ._fit_data()
-            .assign_coords(
-                {
-                    self._FIT_RANGE_MIN_COORD: fit_min,
-                    self._FIT_RANGE_MAX_COORD: fit_max,
-                }
-            )
-        )
+    def _fit_weights(self) -> xr.DataArray | None:
+        weights = super()._fit_weights()
+        if weights is None:
+            return None
+        return self._without_fit_range_coords(weights)
 
     def _fit_result_range(self, result_ds: xr.Dataset) -> tuple[float, float]:
         if (
             self._FIT_RANGE_MIN_COORD in result_ds.coords
             and self._FIT_RANGE_MAX_COORD in result_ds.coords
         ):
-            return (
+            fit_range = (
                 float(result_ds.coords[self._FIT_RANGE_MIN_COORD].item()),
                 float(result_ds.coords[self._FIT_RANGE_MAX_COORD].item()),
             )
+            if all(np.isfinite(fit_range)):
+                return fit_range
 
         if "modelfit_data" in result_ds:
             fit_data = result_ds["modelfit_data"]
@@ -801,12 +824,22 @@ class Fit2DTool(Fit1DTool):
         fit_range: tuple[float, float] | None = None,
     ) -> xr.Dataset:
         if fit_range is None:
-            if (
-                self._FIT_RANGE_MIN_COORD in result_ds.coords
-                and self._FIT_RANGE_MAX_COORD in result_ds.coords
-            ):
-                return result_ds
             fit_range = self._fit_result_range(result_ds)
+        if fit_range == self._data_fit_range(self._data_full):
+            range_coords = [
+                name
+                for name in (self._FIT_RANGE_MIN_COORD, self._FIT_RANGE_MAX_COORD)
+                if name in result_ds.coords
+            ]
+            if range_coords:
+                return result_ds.drop_vars(range_coords)
+            return result_ds
+        return self._fit_result_with_explicit_range(result_ds, fit_range)
+
+    def _fit_result_with_explicit_range(
+        self, result_ds: xr.Dataset, fit_range: tuple[float, float]
+    ) -> xr.Dataset:
+        """Attach finite range coordinates, including for a full-range result."""
         fit_min, fit_max = fit_range
         return result_ds.assign_coords(
             {
@@ -840,6 +873,65 @@ class Fit2DTool(Fit1DTool):
         if ordered.size != result_coord.size:
             return result_ds
         return result_ds.reindex({self._coord_name: ordered})
+
+    def _concat_fit_results(
+        self,
+        results: list[xr.Dataset],
+        *,
+        dim: Hashable,
+        fit_ranges: list[tuple[float, float]] | None = None,
+    ) -> xr.Dataset:
+        """Combine fit results without aligning identical fit coordinates."""
+        if fit_ranges is None:
+            range_coord_names = (
+                self._FIT_RANGE_MIN_COORD,
+                self._FIT_RANGE_MAX_COORD,
+            )
+            # Canonical live results omit both coordinates only for the full range.
+            if all(
+                all(name not in result.coords for name in range_coord_names)
+                for result in results
+            ):
+                fit_ranges = [self._data_fit_range(self._data_full)] * len(results)
+            else:
+                fit_ranges = [self._fit_result_range(result) for result in results]
+        mixed_ranges = any(fit_range != fit_ranges[0] for fit_range in fit_ranges[1:])
+        if mixed_ranges:
+            results = [
+                self._fit_result_with_explicit_range(result, fit_range)
+                for result, fit_range in zip(results, fit_ranges, strict=True)
+            ]
+        elif fit_ranges[0] == self._data_fit_range(self._data_full):
+            if any(
+                self._FIT_RANGE_MIN_COORD in result.coords
+                or self._FIT_RANGE_MAX_COORD in result.coords
+                for result in results
+            ):
+                results = [
+                    self._fit_result_with_range(result, fit_ranges[0])
+                    for result in results
+                ]
+        elif any(
+            self._FIT_RANGE_MIN_COORD not in result.coords
+            or self._FIT_RANGE_MAX_COORD not in result.coords
+            for result in results
+        ):
+            results = [
+                self._fit_result_with_explicit_range(result, fit_ranges[0])
+                for result in results
+            ]
+        combined = xr.concat(
+            results,
+            dim=dim,
+            data_vars="all",
+            coords="all" if mixed_ranges else "minimal",
+            compat="override",
+            join="outer" if mixed_ranges else "override",
+            combine_attrs="override",
+        )
+        if mixed_ranges:
+            return self._restore_fit_coord_order(combined)
+        return combined
 
     def _selected_fit_ranges(self) -> list[tuple[float, float]] | None:
         results = self._result_ds_full[self._y_range_slice()]
@@ -879,8 +971,6 @@ class Fit2DTool(Fit1DTool):
         return slice(fit_min, fit_max)
 
     def _sync_fit_result_state(self, *, notify: bool = True) -> None:
-        if self._last_result_ds is not None:
-            self._last_result_ds = self._fit_result_with_range(self._last_result_ds)
         previous = self._params_full[self._current_idx]
         expressions_changed = (
             () if previous is None else self._live_parameter_expressions(previous)
@@ -2278,7 +2368,9 @@ class Fit2DTool(Fit1DTool):
             restore.params.copy() for restore, _ in slice_states
         ]
         self._params_from_coord_full = [{} for _ in range(y_size)]
-        self._result_ds_full = [slice_ds for _, slice_ds in slice_states]
+        self._result_ds_full = [
+            self._fit_result_with_range(slice_ds) for _, slice_ds in slice_states
+        ]
         self._fit_is_current = True
         self._refresh_fit_code_entries()
         self._cache_fit_result_payload()
@@ -2288,24 +2380,16 @@ class Fit2DTool(Fit1DTool):
     def _fit_result_dataset_for_persistence(self) -> xr.Dataset | None:
         """Return all current slice results before opaque serialization."""
         saved_results = [
-            self._fit_result_with_range(result_ds).expand_dims(
-                {self._PERSISTED_FIT_INDEX_DIM: [idx]}
-            )
+            result_ds.expand_dims({self._PERSISTED_FIT_INDEX_DIM: [idx]})
             for idx, result_ds in enumerate(self._result_ds_full)
             if result_ds is not None
         ]
         if not saved_results:
             return None
-        sparse = xr.concat(
+        return self._concat_fit_results(
             saved_results,
             dim=self._PERSISTED_FIT_INDEX_DIM,
-            data_vars="all",
-            coords="all",
-            compat="override",
-            join="outer",
-            combine_attrs="override",
         )
-        return self._restore_fit_coord_order(sparse)
 
     def _apply_restored_fit_result(
         self, sparse: xr.Dataset, *, fit_is_current: bool
@@ -2328,7 +2412,7 @@ class Fit2DTool(Fit1DTool):
                         }
                     )
                 result_ds = self._trim_fit_result_to_range(result_ds)
-                self._result_ds_full[idx] = result_ds
+                self._result_ds_full[idx] = self._fit_result_with_range(result_ds)
         self._refresh_contents_from_index(mark_fit_stale=not fit_is_current)
         self._update_param_plot_options()
         self._update_param_plot()
@@ -2592,7 +2676,19 @@ class Fit2DTool(Fit1DTool):
 
     def _fit_job(self) -> _FitJob:
         """Identify the Fit2D slice submitted to a new worker."""
-        return _FitJob(self._fit_config_revision, int(self._current_idx))
+        return _FitJob(
+            self._fit_config_revision,
+            int(self._current_idx),
+            self._current_fit_range(),
+        )
+
+    def _fit_result_for_job(self, result_ds: xr.Dataset, job: _FitJob) -> xr.Dataset:
+        """Attach the submitted Fit2D range after xarray-lmfit completes."""
+        if job.fit_range is None:  # pragma: no cover - Fit2D always records a range.
+            raise RuntimeError("Fit2D job does not contain a fit range.")
+        if job.fit_range == self._data_fit_range(self._data_full):
+            return result_ds
+        return self._fit_result_with_explicit_range(result_ds, job.fit_range)
 
     def _fit_job_is_current(self, job: _FitJob) -> bool:
         """Reject an outcome if its configuration or target slice changed."""
@@ -2672,7 +2768,7 @@ class Fit2DTool(Fit1DTool):
     def _store_fit_2d_sequence_result(
         self, idx: int, result_ds: xr.Dataset, t0: float
     ) -> lmfit.model.ModelResult:
-        self._last_result_ds = self._fit_result_with_range(result_ds.copy())
+        self._last_result_ds = result_ds.copy()
         result = self._last_result_ds.modelfit_results.compute().item()
         self._replace_current_params(result.params.copy())
         previous = self._params_full[idx]
@@ -2968,19 +3064,12 @@ class Fit2DTool(Fit1DTool):
                     "in the range before saving the full fit.",
                 )
                 return
-            results.append(self._fit_result_with_range(ds))
+            results.append(ds)
         fit_ranges = [self._fit_result_range(result) for result in results]
         with erlab.interactive.utils.wait_dialog(self, "Combining fit results..."):
-            full_ds = xr.concat(
-                results,
-                dim=self._y_dim_name,
-                data_vars="all",
-                coords="all",
-                compat="override",
-                join="outer",
-                combine_attrs="override",
+            full_ds = self._concat_fit_results(
+                results, dim=self._y_dim_name, fit_ranges=fit_ranges
             )
-            full_ds = self._restore_fit_coord_order(full_ds)
             direct_weights = self._direct_weights_for_full_fit_results(fit_ranges)
             if direct_weights is not None:
                 full_ds["modelfit_weights"] = direct_weights

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -2284,7 +2284,9 @@ def test_fit1d_update_inputs_keeps_fit_finished_receivers_constant(qtbot) -> Non
         )
 
 
-def test_fit1d_direct_update_discards_and_reaps_old_worker(qtbot, monkeypatch) -> None:
+def test_fit1d_direct_update_discards_and_releases_old_worker(
+    qtbot, monkeypatch
+) -> None:
     data = _make_1d_data()
     win = erlab.interactive.ftool(data, execute=False)
     qtbot.addWidget(win)
@@ -4067,7 +4069,6 @@ def test_fit1d_start_worker_start_exception_resets_buttons(qtbot, monkeypatch) -
     assert worker not in win._fit_worker_callbacks
     assert not fit1d._fit_worker_registry().workers
     assert win._fit_thread is None
-    assert not win._fit_poll_timer.isActive()
     assert win._fit_start_time is None
     assert not win._fit_running_multi
     assert win._fit_cancel_requested is False
@@ -4112,7 +4113,6 @@ def test_fit1d_workers_use_one_scale_covar_snapshot(qtbot, monkeypatch) -> None:
     second_worker = win._fit_thread
 
     assert captured == [False, False]
-    win._fit_poll_timer.stop()
     for worker in (first_worker, second_worker):
         if worker is not None:
             fit1d._release_running_fit_worker(worker)
@@ -4333,7 +4333,9 @@ def test_fit1d_cancel_fit_without_thread_restores_idle_state(qtbot) -> None:
     assert not win.cancel_fit_button.isEnabled()
 
 
-def test_fit1d_cancel_fit_without_wait_leaves_worker_for_polling(qtbot) -> None:
+def test_fit1d_cancel_fit_without_wait_leaves_worker_for_queued_completion(
+    qtbot,
+) -> None:
     win = erlab.interactive.ftool(_make_1d_data(), execute=False)
     qtbot.addWidget(win)
 
@@ -4765,6 +4767,9 @@ def test_fit_worker_records_loaded_result(qtbot, exp_decay_model, monkeypatch) -
     data = xr.DataArray(np.exp(-t), dims=("t",), coords={"t": t}, name="decay")
     params = exp_decay_model.make_params(n0=1.0, tau=1.0)
 
+    def _deleted_emitter(_worker) -> None:
+        raise RuntimeError("wrapped C/C++ object has been deleted")
+
     worker = fit1d._FitWorker(
         data,
         "t",
@@ -4773,6 +4778,7 @@ def test_fit_worker_records_loaded_result(qtbot, exp_decay_model, monkeypatch) -
         max_nfev=5,
         method="least_squares",
         timeout=1.0,
+        completion_callback=_deleted_emitter,
     )
 
     class _DummyResult:
@@ -4811,6 +4817,7 @@ def test_fit_worker_rejects_payload_release_while_alive(
         max_nfev=5,
         method="least_squares",
         timeout=1.0,
+        completion_callback=lambda _worker: None,
     )
     payload = (worker._fit_data, worker._model, worker._params, worker._weights)
     monkeypatch.setattr(worker, "is_alive", lambda: True)
@@ -4827,6 +4834,7 @@ def test_fit_worker_rejects_payload_release_while_alive(
     assert worker._model is None
     assert worker._params is None
     assert worker._weights is None
+    assert worker._completion_callback is None
     assert worker._outcome.kind == "not_finished"
 
 
@@ -4893,12 +4901,11 @@ def test_fit1d_published_outcome_is_rejected_after_configuration_change(
     )
     thread = win._fit_thread
     assert thread is not None
-    win._fit_poll_timer.stop()
     thread.join()
     assert thread._outcome.kind == "success"
 
     win.normalize_check.toggle()
-    win._poll_fit_worker()
+    qtbot.waitUntil(lambda: win._fit_thread is None, timeout=5000)
 
     assert completed == []
     assert win._fit_thread is None
@@ -4986,11 +4993,12 @@ def test_fit_worker_cancel_during_result_load_discards_result(
     assert worker._outcome.result is None
 
 
-@pytest.mark.parametrize("outcome", ["error", "cancelled", "timed_out"])
+@pytest.mark.parametrize("outcome", ["success", "error", "cancelled", "timed_out"])
 def test_fit_worker_records_each_terminal_outcome(
     qtbot, exp_decay_model, monkeypatch, outcome
 ) -> None:
     data = _make_1d_data()
+    published_outcomes: list[str] = []
     worker = fit1d._FitWorker(
         data,
         "x",
@@ -4999,6 +5007,9 @@ def test_fit_worker_records_each_terminal_outcome(
         max_nfev=5,
         method="least_squares",
         timeout=1.0,
+        completion_callback=lambda completed: published_outcomes.append(
+            completed._outcome.kind
+        ),
     )
 
     class _Result:
@@ -5022,6 +5033,35 @@ def test_fit_worker_records_each_terminal_outcome(
 
     assert worker._outcome.kind == outcome
     assert (worker._outcome.error is not None) is (outcome == "error")
+    assert published_outcomes == [outcome]
+
+
+def test_fit_worker_publishes_unexpected_failure(exp_decay_model, monkeypatch) -> None:
+    data = _make_1d_data()
+    published_workers: list[fit1d._FitWorker] = []
+    worker = fit1d._FitWorker(
+        data,
+        "x",
+        exp_decay_model,
+        exp_decay_model.make_params(n0=1.0, tau=1.0),
+        max_nfev=5,
+        method="least_squares",
+        timeout=1.0,
+        completion_callback=published_workers.append,
+    )
+
+    def _fail() -> None:
+        raise RuntimeError("unexpected worker failure")
+
+    monkeypatch.setattr(worker, "_run_fit", _fail)
+
+    with pytest.raises(RuntimeError, match="unexpected worker failure"):
+        worker.run()
+
+    assert worker._outcome.kind == "error"
+    assert worker._outcome.error is not None
+    assert "unexpected worker failure" in worker._outcome.error
+    assert published_workers == [worker]
 
 
 def test_running_fit_worker_registry_tracks_concurrent_workers(
@@ -5105,13 +5145,11 @@ def test_fit_worker_registry_transfers_exact_owner(qtbot) -> None:
         second_owner.destroyed.emit()
         assert registry.workers[worker] is None  # type: ignore[index]
         assert worker not in registry._owner_destroy_callbacks
-        assert registry._reap_timer.isActive()
 
         registry.register(other_worker, other_owner)  # type: ignore[arg-type]
         other_callback = registry._owner_destroy_callbacks[other_worker]  # type: ignore[index]
         other_owner.destroyed.emit()
         assert registry.workers[other_worker] is None  # type: ignore[index]
-        assert registry._reap_timer.isActive()
     finally:
         if second_callback is not None:
             with contextlib.suppress(TypeError, RuntimeError):
@@ -5123,57 +5161,33 @@ def test_fit_worker_registry_transfers_exact_owner(qtbot) -> None:
         registry.remove(other_worker)  # type: ignore[arg-type]
 
 
-def test_fit_worker_registry_reaps_only_safe_workers(qtbot) -> None:
+def test_fit_worker_registry_releases_detached_worker_once(qtbot) -> None:
     registry = fit1d._fit_worker_registry()
     events: list[str] = []
 
     class _Thread:
-        def __init__(self, name: str, *, alive: bool) -> None:
-            self.name = name
-            self.alive = alive
-
-        def is_alive(self) -> bool:
-            return self.alive
-
         def join(self) -> None:
-            assert not self.alive
-            events.append(f"{self.name}:join")
+            events.append("join")
 
         def release_payload(self) -> None:
-            events.append(f"{self.name}:release")
+            events.append("release")
 
-    owned = _Thread("owned", alive=False)
-    detached_alive = _Thread("alive", alive=True)
-    detached_stopped = _Thread("stopped", alive=False)
-    owners = [QtWidgets.QWidget() for _ in range(3)]
-    for owner in owners:
-        qtbot.addWidget(owner)
+    thread = _Thread()
+    owner = QtWidgets.QWidget()
+    qtbot.addWidget(owner)
 
     try:
         assert not registry.workers
-        registry.register(owned, owners[0])  # type: ignore[arg-type]
-        registry.register(detached_alive, owners[1])  # type: ignore[arg-type]
-        registry.detach(detached_alive)  # type: ignore[arg-type]
-        registry.register(detached_stopped, owners[2])  # type: ignore[arg-type]
-        registry.detach(detached_stopped)  # type: ignore[arg-type]
+        registry.register(thread, owner)  # type: ignore[arg-type]
+        registry.detach(thread)  # type: ignore[arg-type]
 
-        registry.reap()
-        assert registry.workers == {owned: owners[0], detached_alive: None}
-        assert events == ["stopped:join", "stopped:release"]
+        registry._worker_finished(thread)  # type: ignore[arg-type]
+        registry._worker_finished(thread)  # type: ignore[arg-type]
 
-        detached_alive.alive = False
-        registry.reap()
-        assert registry.workers == {owned: owners[0]}
-        assert events == [
-            "stopped:join",
-            "stopped:release",
-            "alive:join",
-            "alive:release",
-        ]
-        assert not registry._reap_timer.isActive()
+        assert not registry.workers
+        assert events == ["join", "release"]
     finally:
-        for thread in (owned, detached_alive, detached_stopped):
-            registry.remove(thread)  # type: ignore[arg-type]
+        registry.remove(thread)  # type: ignore[arg-type]
 
 
 def test_fit_worker_is_registered_before_python_thread_start(
@@ -5199,7 +5213,6 @@ def test_fit_worker_is_registered_before_python_thread_start(
         win._finalize_fit_thread(thread)
         assert not fit1d._fit_worker_registry().workers
     finally:
-        win._fit_poll_timer.stop()
         if win._fit_thread is not None:
             fit1d._release_running_fit_worker(win._fit_thread)
             win._fit_thread = None
@@ -5208,7 +5221,6 @@ def test_fit_worker_is_registered_before_python_thread_start(
 def test_fit_worker_completion_is_finalized_on_gui_thread(qtbot, monkeypatch) -> None:
     win = erlab.interactive.ftool(_make_1d_data(), execute=False)
     qtbot.addWidget(win)
-    win._poll_fit_worker()
     completion_threads: list[QtCore.QThread] = []
     original_completion_action = win._fit_worker_completion_action
 
@@ -5224,8 +5236,7 @@ def test_fit_worker_completion_is_finalized_on_gui_thread(qtbot, monkeypatch) ->
     assert completion_threads == [QtWidgets.QApplication.instance().thread()]
 
 
-@pytest.mark.parametrize("alive", [True, False])
-def test_fit_worker_poll_uses_current_worker(qtbot, alive) -> None:
+def test_fit_worker_completion_signal_is_queued_without_polling(qtbot) -> None:
     win = erlab.interactive.ftool(_make_1d_data(), execute=False)
     qtbot.addWidget(win)
     results: list[xr.Dataset] = []
@@ -5233,13 +5244,10 @@ def test_fit_worker_poll_uses_current_worker(qtbot, alive) -> None:
     class _DummyThread:
         def __init__(self) -> None:
             self._outcome = fit1d._FitWorkerOutcome("success", result=xr.Dataset())
-            self.joined = False
-
-        def is_alive(self) -> bool:
-            return alive
+            self.join_calls = 0
 
         def join(self) -> None:
-            self.joined = True
+            self.join_calls += 1
 
         def release_payload(self) -> None:
             pass
@@ -5254,16 +5262,18 @@ def test_fit_worker_poll_uses_current_worker(qtbot, alive) -> None:
     )
     fit1d._register_running_fit_worker(thread, win)  # type: ignore[arg-type]
     try:
-        win._fit_poll_timer.start()
-        win._poll_fit_worker()
+        win._fit_worker_registry.sigWorkerFinished.emit(thread)
+        win._fit_worker_registry.sigWorkerFinished.emit(thread)
+        assert results == []
+        assert thread.join_calls == 0
+        qtbot.waitUntil(lambda: win._fit_thread is None, timeout=1000)
+        QtWidgets.QApplication.processEvents()
 
-        assert len(results) == int(not alive)
-        assert thread.joined is (not alive)
-        assert (win._fit_thread is None) is (not alive)
-        assert (thread not in fit1d._fit_worker_registry().workers) is (not alive)
-        assert win._fit_poll_timer.isActive() is alive
+        assert len(results) == 1
+        xr.testing.assert_identical(results[0], xr.Dataset())
+        assert thread.join_calls == 1
+        assert thread not in fit1d._fit_worker_registry().workers
     finally:
-        win._fit_poll_timer.stop()
         fit1d._release_running_fit_worker(thread)  # type: ignore[arg-type]
         win._fit_thread = None
 
@@ -5488,26 +5498,40 @@ def test_fit_worker_survives_forced_collection_while_running(
             retained_owner.close()
 
 
-def test_fit1d_finalize_stale_and_idle_threads(qtbot) -> None:
+def test_fit_worker_registry_rejects_stale_owner_and_finalizes_current(qtbot) -> None:
     win = erlab.interactive.ftool(_make_1d_data(), execute=False)
     qtbot.addWidget(win)
 
     class _DummyThread:
         def __init__(self) -> None:
             self._outcome = fit1d._FitWorkerOutcome("success", result=xr.Dataset())
+            self.join_calls = 0
+            self.release_calls = 0
+
+        def join(self) -> None:
+            self.join_calls += 1
 
         def release_payload(self) -> None:
-            pass
+            self.release_calls += 1
 
     current = _DummyThread()
     stale = _DummyThread()
     win._fit_thread = current  # type: ignore[assignment]
     win._fit_cancel_requested = True
+    win._fit_worker_callbacks[stale] = fit1d._FitWorkerCallbacks(  # type: ignore[index]
+        on_success=lambda _result: None,
+        on_timeout=lambda: None,
+        on_error=lambda _message: None,
+        job=win._fit_job(),
+    )
     fit1d._register_running_fit_worker(stale, win)  # type: ignore[arg-type]
     try:
-        win._finalize_fit_thread(stale)  # type: ignore[arg-type]
+        win._fit_worker_registry._worker_finished(stale)  # type: ignore[arg-type]
         assert win._fit_thread is current
         assert win._fit_cancel_requested
+        assert stale.join_calls == 1
+        assert stale.release_calls == 1
+        assert stale not in win._fit_worker_callbacks
         assert stale not in fit1d._fit_worker_registry().workers
 
         fit1d._register_running_fit_worker(current, win)  # type: ignore[arg-type]
@@ -5518,8 +5542,10 @@ def test_fit1d_finalize_stale_and_idle_threads(qtbot) -> None:
             job=win._fit_job(),
         )
         win._fit_cancel_requested = False
-        win._finalize_fit_thread(current)  # type: ignore[arg-type]
+        win._fit_worker_registry._worker_finished(current)  # type: ignore[arg-type]
         assert win._fit_thread is None
+        assert current.join_calls == 1
+        assert current.release_calls == 1
         assert current not in fit1d._fit_worker_registry().workers
     finally:
         fit1d._release_running_fit_worker(stale)  # type: ignore[arg-type]
@@ -5542,17 +5568,12 @@ def test_fit1d_stale_multi_revision_finishes_sequence(qtbot, monkeypatch) -> Non
     assert finished == [True]
 
 
-def test_fit1d_forget_worker_skips_invalid_timer(qtbot, monkeypatch) -> None:
+def test_fit1d_forget_worker_clears_current_worker(qtbot) -> None:
     win = erlab.interactive.ftool(_make_1d_data(), execute=False)
     qtbot.addWidget(win)
     thread = object()
     win._fit_thread = thread  # type: ignore[assignment]
     win._fit_cancel_requested = True
-    monkeypatch.setattr(
-        erlab.interactive.utils,
-        "qt_is_valid",
-        lambda obj: obj is not win._fit_poll_timer,
-    )
 
     win._forget_fit_worker(thread)  # type: ignore[arg-type]
 

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -5394,6 +5394,73 @@ def test_fit2d_sequence_serializes_full_results_once(qtbot, monkeypatch) -> None
     assert invalidation_calls == data.sizes["y"]
 
 
+@pytest.mark.parametrize("persist_during_sequence", [False, True])
+def test_fit2d_multi_fit_serializes_full_results_once_at_completion(
+    qtbot, monkeypatch, *, persist_during_sequence
+) -> None:
+    tool, _model, _params = _make_linear_fit2d_tool(qtbot)
+    deferred: list[Callable[[], None]] = []
+    started_steps: list[int] = []
+    serialized_after_steps: list[int] = []
+    serialized_slice_counts: list[int] = []
+    invalidation_calls = 0
+    original_invalidate = tool._invalidate_fit_result_payload
+
+    def tracked_invalidate() -> None:
+        nonlocal invalidation_calls
+        invalidation_calls += 1
+        original_invalidate()
+
+    def tracked_serialize(dataset: xr.Dataset) -> np.ndarray:
+        serialized_after_steps.append(len(started_steps))
+        serialized_slice_counts.append(dataset.sizes[tool._PERSISTED_FIT_INDEX_DIM])
+        return np.array([len(started_steps)], dtype=np.uint8)
+
+    def _start_fit_worker(
+        fit_data,
+        params,
+        *,
+        multi,
+        step=0,
+        total=0,
+        on_success,
+        on_timeout,
+        on_error,
+    ) -> bool:
+        del fit_data, params, multi, total, on_timeout, on_error
+        started_steps.append(step)
+        tool._fit_start_time = fit1d_module.time.perf_counter()
+        on_success(_fit_result_dataset(tool._params, nfev=step))
+        return True
+
+    monkeypatch.setattr(tool, "_defer_next_fit_step", deferred.append)
+    monkeypatch.setattr(tool, "_start_fit_worker", _start_fit_worker)
+    monkeypatch.setattr(tool, "_invalidate_fit_result_payload", tracked_invalidate)
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "_serialize_fit_dataset_blob",
+        tracked_serialize,
+    )
+
+    tool._run_fit_multiple(20)
+    assert started_steps == [1]
+    if persist_during_sequence:
+        assert tool._fit_result_blob_for_persistence() is not None
+
+    while deferred:
+        deferred.pop(0)()
+
+    expected_serializations = [1, 20] if persist_during_sequence else [20]
+    assert started_steps == list(range(1, 21))
+    assert invalidation_calls == 20
+    assert serialized_after_steps == expected_serializations
+    assert serialized_slice_counts == [1] * len(expected_serializations)
+    assert tool._fit_multi_total is None
+    assert tool._result_ds_full[tool._current_idx] is not None
+    result = tool._result_ds_full[tool._current_idx].modelfit_results.compute().item()
+    assert result.nfev == 20
+
+
 def test_fit2d_multi_fit_caches_updated_full_result(qtbot) -> None:
     tool, model, params = _make_linear_fit2d_tool(qtbot)
     data = tool.tool_data

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -5403,8 +5403,12 @@ def test_fit2d_multi_fit_serializes_full_results_once_at_completion(
     started_steps: list[int] = []
     serialized_after_steps: list[int] = []
     serialized_slice_counts: list[int] = []
+    synced_after_steps: list[int] = []
+    saved_state_nfev: list[int | None] = []
     invalidation_calls = 0
     original_invalidate = tool._invalidate_fit_result_payload
+    original_sync = tool._sync_fit_result_state
+    original_saved_tool_data_dataset = tool._saved_tool_data_dataset
 
     def tracked_invalidate() -> None:
         nonlocal invalidation_calls
@@ -5415,6 +5419,19 @@ def test_fit2d_multi_fit_serializes_full_results_once_at_completion(
         serialized_after_steps.append(len(started_steps))
         serialized_slice_counts.append(dataset.sizes[tool._PERSISTED_FIT_INDEX_DIM])
         return np.array([len(started_steps)], dtype=np.uint8)
+
+    def tracked_sync(*, notify=True) -> None:
+        synced_after_steps.append(len(started_steps))
+        original_sync(notify=notify)
+
+    def tracked_saved_tool_data_dataset() -> xr.Dataset:
+        result_ds = tool._result_ds_full[tool._current_idx]
+        saved_state_nfev.append(
+            None
+            if result_ds is None
+            else result_ds.modelfit_results.compute().item().nfev
+        )
+        return original_saved_tool_data_dataset()
 
     def _start_fit_worker(
         fit_data,
@@ -5436,6 +5453,12 @@ def test_fit2d_multi_fit_serializes_full_results_once_at_completion(
     monkeypatch.setattr(tool, "_defer_next_fit_step", deferred.append)
     monkeypatch.setattr(tool, "_start_fit_worker", _start_fit_worker)
     monkeypatch.setattr(tool, "_invalidate_fit_result_payload", tracked_invalidate)
+    monkeypatch.setattr(tool, "_sync_fit_result_state", tracked_sync)
+    monkeypatch.setattr(
+        tool,
+        "_saved_tool_data_dataset",
+        tracked_saved_tool_data_dataset,
+    )
     monkeypatch.setattr(
         erlab.interactive.utils,
         "_serialize_fit_dataset_blob",
@@ -5445,7 +5468,8 @@ def test_fit2d_multi_fit_serializes_full_results_once_at_completion(
     tool._run_fit_multiple(20)
     assert started_steps == [1]
     if persist_during_sequence:
-        assert tool._fit_result_blob_for_persistence() is not None
+        persisted = tool.to_dataset()
+        assert tool._PERSISTED_FIT_RESULT_VAR in persisted
 
     while deferred:
         deferred.pop(0)()
@@ -5455,6 +5479,8 @@ def test_fit2d_multi_fit_serializes_full_results_once_at_completion(
     assert invalidation_calls == 20
     assert serialized_after_steps == expected_serializations
     assert serialized_slice_counts == [1] * len(expected_serializations)
+    assert synced_after_steps == expected_serializations
+    assert saved_state_nfev == ([1] if persist_during_sequence else [])
     assert tool._fit_multi_total is None
     assert tool._result_ds_full[tool._current_idx] is not None
     result = tool._result_ds_full[tool._current_idx].modelfit_results.compute().item()

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -370,6 +370,7 @@ def _fit_slices_with_ranges(
         win._set_current_index(index)
         win.domain_min_spin.setValue(fit_range[0])
         win.domain_max_spin.setValue(fit_range[1])
+        job = win._fit_job()
         fit_ds = (
             win._fit_data()
             .xlm.modelfit(
@@ -380,7 +381,7 @@ def _fit_slices_with_ranges(
             )
             .load()
         )
-        win._last_result_ds = fit_ds
+        win._last_result_ds = win._fit_result_for_job(fit_ds, job)
         result = fit_ds.modelfit_results.compute().item()
         win._params = result.params.copy()
         win._sync_fit_result_state()
@@ -3023,6 +3024,10 @@ def test_fit2d_records_range_from_dispatched_fit_data(qtbot) -> None:
     win.domain_min_spin.setValue(-0.6)
     win.domain_max_spin.setValue(0.6)
     dispatched_data = win._fit_data()
+    job = win._fit_job()
+    assert job.fit_range == (-0.6, 0.6)
+    assert Fit2DTool._FIT_RANGE_MIN_COORD not in dispatched_data.coords
+    assert Fit2DTool._FIT_RANGE_MAX_COORD not in dispatched_data.coords
     result_ds = dispatched_data.xlm.modelfit(
         win._coord_name,
         model=win._model,
@@ -3031,13 +3036,163 @@ def test_fit2d_records_range_from_dispatched_fit_data(qtbot) -> None:
 
     win.domain_min_spin.setValue(-1.0)
     win.domain_max_spin.setValue(0.0)
-    win._set_fit_ds(result_ds, 0.0)
+    assert win._current_fit_range() == (-1.0, 0.0)
+    win._set_fit_ds(win._fit_result_for_job(result_ds, job), 0.0)
 
     assert win._last_result_ds is not None
     assert win._fit_result_range(win._last_result_ds) == (-0.6, 0.6)
 
     overwritten = win._fit_result_with_range(win._last_result_ds, (-0.5, 0.5))
     assert win._fit_result_range(overwritten) == (-0.5, 0.5)
+
+
+def test_fit2d_fit_range_cache_resets_for_replacement_and_transpose(qtbot) -> None:
+    data = _make_2d_data()
+    win = erlab.interactive.ftool(data, execute=False)
+    qtbot.addWidget(win)
+    assert isinstance(win, Fit2DTool)
+
+    assert win._current_fit_range() == (-1.0, 1.0)
+    assert win._current_fit_range() == (-1.0, 1.0)
+
+    updated = data.assign_coords(x=np.linspace(-3.0, 3.0, data.sizes["x"]))
+    win.update_inputs({"data": updated})
+    assert win._current_fit_range() == (-3.0, 3.0)
+
+    win._do_transpose()
+    assert win._current_fit_range() == (0.0, 2.0)
+
+
+@pytest.mark.parametrize("full_range", [False, True], ids=["cropped", "full"])
+@pytest.mark.parametrize("operation", ["fit", "fit-20", "fit-up", "fit-down"])
+def test_fit2d_worker_inputs_exclude_fit_range_coordinates(
+    qtbot, monkeypatch, operation, full_range
+) -> None:
+    win, _model, _params = _make_linear_fit2d_tool(qtbot)
+    if not full_range:
+        win.domain_min_spin.setValue(-0.5)
+        win.domain_max_spin.setValue(0.5)
+    win.nfev_spin.setValue(0)
+
+    submitted: list[xr.DataArray] = []
+    original_init = fit1d_module._FitWorker.__init__
+
+    def tracked_init(worker, fit_data, *args, **kwargs) -> None:
+        submitted.append(fit_data)
+        original_init(worker, fit_data, *args, **kwargs)
+
+    monkeypatch.setattr(fit1d_module._FitWorker, "__init__", tracked_init)
+    monkeypatch.setattr(threading.Thread, "start", lambda _thread: None)
+
+    if operation == "fit":
+        assert win._run_fit()
+    elif operation == "fit-20":
+        win._run_fit_multiple(20)
+    elif operation == "fit-up":
+        win.y_index_spin.setValue(win.y_min_spin.value())
+        win._run_fit_2d("up")
+    else:
+        win.y_index_spin.setValue(win.y_max_spin.value())
+        win._run_fit_2d("down")
+
+    while win._fit_thread is not None:
+        thread = win._fit_thread
+        thread._run_fit()
+        win._finalize_fit_thread(thread)
+        QtWidgets.QApplication.processEvents()
+
+    expected_count = {
+        "fit": 1,
+        "fit-20": 20,
+        "fit-up": win.tool_data.sizes[win._y_dim_name],
+        "fit-down": win.tool_data.sizes[win._y_dim_name],
+    }[operation]
+    assert len(submitted) == expected_count
+    for fit_data in submitted:
+        assert Fit2DTool._FIT_RANGE_MIN_COORD not in fit_data.coords
+        assert Fit2DTool._FIT_RANGE_MAX_COORD not in fit_data.coords
+
+    stored_results = [result for result in win._result_ds_full if result is not None]
+    assert stored_results
+    expected_range = (-1.0, 1.0) if full_range else (-0.5, 0.5)
+    for result in stored_results:
+        assert win._fit_result_range(result) == expected_range
+        for coord in (
+            Fit2DTool._FIT_RANGE_MIN_COORD,
+            Fit2DTool._FIT_RANGE_MAX_COORD,
+        ):
+            assert (coord in result.coords) is not full_range
+
+
+@pytest.mark.parametrize(
+    (
+        "fit_ranges",
+        "expected_coords",
+        "expected_join",
+        "expected_reorders",
+        "expect_range_coords",
+    ),
+    [
+        ([(-1.0, 1.0), (-1.0, 1.0)], "minimal", "override", 0, False),
+        ([(-1.0, 1.0), (0.0, 1.0)], "all", "outer", 2, True),
+    ],
+)
+def test_fit2d_concat_strategy_depends_on_recorded_ranges(
+    qtbot,
+    monkeypatch,
+    fit_ranges,
+    expected_coords,
+    expected_join,
+    expected_reorders,
+    expect_range_coords,
+) -> None:
+    win, _model, _params = _make_linear_fit2d_tool(qtbot)
+    win.y_max_spin.setValue(1)
+    _fit_slices_with_ranges(win, fit_ranges)
+
+    concat_options: list[tuple[str, str]] = []
+    reorder_calls = 0
+    original_concat = xr.concat
+    original_restore_order = win._restore_fit_coord_order
+
+    def tracked_concat(*args, **kwargs):
+        concat_options.append((kwargs["coords"], kwargs["join"]))
+        return original_concat(*args, **kwargs)
+
+    def tracked_restore_order(result_ds):
+        nonlocal reorder_calls
+        reorder_calls += 1
+        return original_restore_order(result_ds)
+
+    @contextlib.contextmanager
+    def wait_stub(_parent, _message):
+        yield None
+
+    saved: list[xr.Dataset] = []
+    monkeypatch.setattr(fit2d_module.xr, "concat", tracked_concat)
+    monkeypatch.setattr(win, "_restore_fit_coord_order", tracked_restore_order)
+    monkeypatch.setattr(erlab.interactive.utils, "wait_dialog", wait_stub)
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "save_fit_ui",
+        lambda fit_ds, *, parent: saved.append(fit_ds),
+    )
+
+    persisted = win._fit_result_dataset_for_persistence()
+    assert persisted is not None
+    win._save_fit_full()
+
+    assert len(saved) == 1
+    assert concat_options == [(expected_coords, expected_join)] * 2
+    assert reorder_calls == expected_reorders
+    for combined in (persisted, saved[0]):
+        for coord in (
+            Fit2DTool._FIT_RANGE_MIN_COORD,
+            Fit2DTool._FIT_RANGE_MAX_COORD,
+        ):
+            assert (coord in combined.coords) is expect_range_coords
+            if expect_range_coords:
+                assert np.isfinite(combined.coords[coord]).all()
 
 
 @pytest.mark.parametrize("descending", [False, True])
@@ -3135,8 +3290,16 @@ def test_fit2d_mixed_slice_ranges_copy_and_output_provenance(
 
 
 @pytest.mark.parametrize("descending", [False, True])
+@pytest.mark.parametrize(
+    "fit_ranges",
+    [
+        [(-1.0, 0.0), (0.0, 1.0)],
+        [(-1.0, 1.0), (0.0, 1.0)],
+    ],
+    ids=["cropped-cropped", "full-cropped"],
+)
 def test_fit2d_mixed_slice_ranges_persistence_roundtrip(
-    qtbot, monkeypatch, descending
+    qtbot, monkeypatch, descending, fit_ranges
 ) -> None:
     x = np.linspace(-1.0, 1.0, 9)
     if descending:
@@ -3158,13 +3321,20 @@ def test_fit2d_mixed_slice_ranges_persistence_roundtrip(
     qtbot.addWidget(win)
     assert isinstance(win, Fit2DTool)
 
-    fit_ranges = [(-1.0, 0.0), (0.0, 1.0)]
     _fit_slices_with_ranges(win, fit_ranges)
     expected_results = [
         result_ds.copy(deep=True)
         for result_ds in win._result_ds_full
         if result_ds is not None
     ]
+
+    sparse = win._fit_result_dataset_for_persistence()
+    assert sparse is not None
+    for coord in (
+        Fit2DTool._FIT_RANGE_MIN_COORD,
+        Fit2DTool._FIT_RANGE_MAX_COORD,
+    ):
+        assert np.isfinite(sparse.coords[coord]).all()
 
     restored = erlab.interactive.utils.ToolWindow.from_dataset(
         win.to_dataset(), _code_trust=new_document_trust()
@@ -3215,6 +3385,11 @@ def test_fit2d_mixed_slice_ranges_persistence_roundtrip(
     )
     win._save_fit_full()
     assert len(saved_fits) == 1
+    for coord in (
+        Fit2DTool._FIT_RANGE_MIN_COORD,
+        Fit2DTool._FIT_RANGE_MAX_COORD,
+    ):
+        assert np.isfinite(saved_fits[0].coords[coord]).all()
 
     reopened = erlab.interactive.ftool(saved_fits[0], execute=False)
     qtbot.addWidget(reopened)
@@ -3228,19 +3403,25 @@ def test_fit2d_mixed_slice_ranges_persistence_roundtrip(
         assert result_ds is not None
         expected_x = x[(x >= fit_ranges[index][0]) & (x <= fit_ranges[index][1])]
         np.testing.assert_allclose(result_ds["x"], expected_x)
+        for coord in (
+            Fit2DTool._FIT_RANGE_MIN_COORD,
+            Fit2DTool._FIT_RANGE_MAX_COORD,
+        ):
+            assert (coord in result_ds.coords) is (fit_ranges[index] != (-1.0, 1.0))
 
     reopened._set_current_index(0)
     reopened.domain_min_spin.setValue(-0.5)
     reopened.domain_max_spin.setValue(0.0)
     refit_data = reopened._fit_data()
-    assert float(refit_data.coords[Fit2DTool._FIT_RANGE_MIN_COORD]) == -0.5
-    assert float(refit_data.coords[Fit2DTool._FIT_RANGE_MAX_COORD]) == 0.0
+    refit_job = reopened._fit_job()
+    assert Fit2DTool._FIT_RANGE_MIN_COORD not in refit_data.coords
+    assert Fit2DTool._FIT_RANGE_MAX_COORD not in refit_data.coords
     refit_ds = refit_data.xlm.modelfit(
         reopened._coord_name,
         model=reopened._model,
         params=reopened._params,
     ).load()
-    reopened._set_fit_ds(refit_ds, 0.0)
+    reopened._set_fit_ds(reopened._fit_result_for_job(refit_ds, refit_job), 0.0)
     assert reopened._last_result_ds is not None
     assert reopened._fit_result_range(reopened._last_result_ds) == (-0.5, 0.0)
 


### PR DESCRIPTION
## Summary

- Replace 25 ms fit-worker polling with queued completion signals.
- Defer repeated Fit x20 state synchronization and serialize the final result once.
- Capture each Fit2D range in immutable job state instead of attaching private coordinates to numerical worker inputs.
- Cache invariant range calculations.
- Use override alignment for uniform fit ranges and retain outer alignment for mixed ranges.
- Preserve mixed-range persistence, descending coordinates, direct weights, and generated-code provenance.

## Benchmarks

The benchmark fits synthetic 20 x 51 linear data under PyQt6 with the offscreen Qt backend. Values are median wall times.

| Build | Fit x20 | Fit up |
|---|---:|---:|
| 3.23.2 | 522.6 ms | 907.6 ms |
| 3.25.1 | 187.3 ms | 230.3 ms |
| 3.26.0 | 204.3 ms | 280.4 ms |
| 3.26.1 | 204.1 ms | 269.2 ms |
| This branch | 196.5 ms | 230.5 ms |

The current values use 15 timed repetitions after warm-up. Their interquartile ranges are 193.9-200.6 ms for Fit x20 and 229.2-234.3 ms for Fit up.

A 100-slice profiled comparison against the signal-only commit produced:

| Metric | Signal-only | This branch |
|---|---:|---:|
| Total Fit up | 1100.0 ms | 986.6 ms |
| Input preparation | 38.9 ms | 7.3 ms |
| Persistence assembly | 69.0 ms | 28.9 ms |
| Final completion gap | 131.7 ms | 87.5 ms |

## Validation

- `uv run --group pyqt6 pytest tests/interactive/test_fit1d.py` - 257 passed
- `QT_API=pyqt6 uv run pytest tests/interactive/test_fit2d.py -q` - 156 passed
- `QT_API=pyside6 uv run --group pyside6 pytest tests/interactive/test_fit2d.py` - 156 passed
- `uv run ruff format --check src/erlab/interactive/_fit1d.py src/erlab/interactive/_fit2d.py tests/interactive/test_fit2d.py`
- `uv run ruff check src/erlab/interactive/_fit1d.py src/erlab/interactive/_fit2d.py tests/interactive/test_fit2d.py`
- `uv run mypy src/erlab/interactive/_fit1d.py src/erlab/interactive/_fit2d.py`
- `git diff --check`
