### PR TITLE
fix(manager): preserve restored window sizes

### DIFF
--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -4874,20 +4874,16 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     def _queue_post_restore_redraw_if_needed(self, ds: xr.Dataset) -> None:
         if not self._saved_tool_window_visible(ds) or not self._auto_redraw_enabled():
             return
-        if self._defer_restore_work(
+        self._run_or_defer_restore_work(
             self._redraw_restored_plot,
             key=_RESTORE_REDRAW_KEY,
             run_on_show=True,
-        ):
-            return
-        erlab.interactive.utils.single_shot(
-            self,
-            0,
-            functools.partial(self._redraw_plot, show_window=True),
         )
 
     def _redraw_restored_plot(self) -> None:
-        self._redraw_plot(show_window=True)
+        # Size the owned display after the composer show event. This request
+        # coalesces with the normal show request, so restoration renders once.
+        self._request_show_figure_window(activate=False)
 
     def _flush_restore_work_for_save(self) -> None:
         self._flush_restore_work(

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -65,7 +65,13 @@ class BaseImageTool(QtWidgets.QMainWindow):
     """
 
     def __init__(
-        self, data=None, parent: QtWidgets.QWidget | None = None, **kwargs
+        self,
+        data=None,
+        parent: QtWidgets.QWidget | None = None,
+        *,
+        _saved_window_state: object = None,
+        _legacy_window_rect: object = None,
+        **kwargs,
     ) -> None:
         super().__init__(parent=parent)
         state = kwargs.pop("state", None)
@@ -98,6 +104,15 @@ class BaseImageTool(QtWidgets.QMainWindow):
         central_layout.addWidget(self.controls_bar)
         central_layout.addWidget(self.slicer_area, 1)
         self.setCentralWidget(central_widget)
+
+        # Restore geometry before applying the slicer state. Some state updates create
+        # the native window and queue its initial resize on the window system backend.
+        restored_window_state = (
+            _saved_window_state is not None
+            and _qt_state.restore_qt_window_state(self, _saved_window_state)
+        )
+        if not restored_window_state and _legacy_window_rect is not None:
+            _qt_state.restore_qt_window_state(self, {"rect": _legacy_window_rect})
 
         try:
             if state is not None:
@@ -271,6 +286,8 @@ class BaseImageTool(QtWidgets.QMainWindow):
         tool = cls(
             ds[_ITOOL_DATA_NAME].rename(name),
             state=json.loads(ds.attrs["itool_state"]),
+            _saved_window_state=ds.attrs.get("itool_window_state"),
+            _legacy_window_rect=ds.attrs.get("itool_rect"),
             **kwargs,
         )
         migrated_file_selection = tool._migrate_legacy_file_load_selection()
@@ -308,13 +325,6 @@ class BaseImageTool(QtWidgets.QMainWindow):
                     "Ignoring invalid saved ImageTool provenance metadata.",
                 )
         tool.setWindowTitle(ds.attrs["itool_title"])
-        if (
-            not _qt_state.restore_qt_window_state(
-                tool, ds.attrs.get("itool_window_state")
-            )
-            and "itool_rect" in ds.attrs
-        ):
-            _qt_state.restore_qt_window_state(tool, {"rect": ds.attrs["itool_rect"]})
         return tool
 
     @classmethod

--- a/tests/interactive/imagetool/manager/figurecomposer/test_core.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_core.py
@@ -1142,6 +1142,12 @@ def test_figure_composer_redraw_and_preview_cache_edges(qtbot, monkeypatch) -> N
         "single_shot",
         lambda _owner, delay, callback: single_shot_calls.append((delay, callback)),
     )
+    show_requests: list[bool] = []
+    monkeypatch.setattr(
+        tool,
+        "_request_show_figure_window",
+        lambda *, activate: show_requests.append(activate),
+    )
 
     tool.auto_redraw_check.setChecked(False)
     assert not tool._maybe_redraw_plot(show_window=True)
@@ -1173,10 +1179,10 @@ def test_figure_composer_redraw_and_preview_cache_edges(qtbot, monkeypatch) -> N
     tool._queue_post_restore_redraw_if_needed(visible_ds)
     assert single_shot_calls == []
     tool.auto_redraw_check.setChecked(True)
+    render_count = len(render_calls)
     tool._queue_post_restore_redraw_if_needed(visible_ds)
-    assert single_shot_calls[-1][0] == 0
-    single_shot_calls[-1][1]()
-    assert render_calls[-1] == {"show_window": True}
+    assert show_requests == [False]
+    assert len(render_calls) == render_count
 
     assert tool._persisted_preview_cache_pixmap() is None
     preview = QtGui.QPixmap(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -22,6 +22,7 @@ from erlab.interactive._figurecomposer import (
     FigureOperationState,
     FigureRecipeState,
     FigureSourceState,
+    FigureSubplotsState,
 )
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
@@ -791,6 +792,11 @@ def test_figure_composer_visible_restore_queues_auto_redraw(
 
     restored = erlab.interactive.utils.ToolWindow.from_dataset(ds)
     qtbot.addWidget(restored)
+    assert isinstance(restored, FigureComposerTool)
+
+    qtbot.wait(20)
+    assert render_calls == []
+    restored.show()
 
     qtbot.wait_until(lambda: bool(render_calls), timeout=5000)
     assert render_calls == [((restored,), {"show_window": True})]
@@ -810,18 +816,26 @@ def test_figure_composer_deferred_restore_delays_visible_redraw(
         {"line": data},
         sources=(FigureSourceState(name="line", label="line"),),
         operations=(FigureOperationState.line(label="line", source="line"),),
+        setup=FigureSubplotsState(
+            figsize=(3.1333, 4.38),
+            dpi=150.0,
+            layout="constrained",
+        ),
         primary_source="line",
     )
     qtbot.addWidget(tool)
+    tool.resize(514, 632)
     ds = tool.to_dataset()
     window_state = json.loads(ds.attrs["tool_window_state"])
     window_state["visible"] = True
     ds.attrs["tool_window_state"] = json.dumps(window_state)
 
     render_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    original_render = figurecomposer_tool_module._render_preview
 
     def record_render(*args, **kwargs) -> None:
         render_calls.append((args, kwargs))
+        original_render(*args, **kwargs)
 
     monkeypatch.setattr(figurecomposer_tool_module, "_render_preview", record_render)
 
@@ -832,11 +846,32 @@ def test_figure_composer_deferred_restore_delays_visible_redraw(
     qtbot.addWidget(restored)
     assert isinstance(restored, FigureComposerTool)
     assert render_calls == []
+    assert restored.tool_status.setup.figsize == (3.1333, 4.38)
 
     restored.show()
 
-    qtbot.wait_until(lambda: bool(render_calls), timeout=5000)
+    qtbot.wait_until(
+        lambda: (
+            restored._figure_window is not None
+            and restored._figure_window.isVisible()
+            and bool(render_calls)
+        ),
+        timeout=5000,
+    )
+    figure_window = restored._figure_window
+    assert figure_window is not None
+    target_width = round(3.1333 * 150.0)
+    target_height = round(4.38 * 150.0)
+    qtbot.wait_until(
+        lambda: (
+            abs(figure_window.canvas.width() - target_width) <= 2
+            and abs(figure_window.canvas.height() - target_height) <= 2
+        ),
+        timeout=5000,
+    )
+    qtbot.wait(50)
     assert render_calls == [((restored,), {"show_window": True})]
+    assert restored.tool_status.setup.figsize == (3.1333, 4.38)
 
 
 def _line_figure_composer_restore_dataset(qtbot):

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -18,6 +18,7 @@ import xarray as xr
 from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
+import erlab.interactive.imagetool._mainwindow as imagetool_mainwindow
 import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager as manager_module
 import erlab.interactive.imagetool.manager._desktop as manager_desktop
@@ -222,7 +223,7 @@ def test_manager_added_time_display_uses_zone_name_and_offset(
 
 
 def test_imagetool_dataset_uses_window_state_and_restores_legacy_size(
-    qtbot, test_data
+    qtbot, monkeypatch, test_data
 ) -> None:
     tool = erlab.interactive.imagetool.ImageTool(test_data, _in_manager=True)
     qtbot.addWidget(tool)
@@ -236,8 +237,34 @@ def test_imagetool_dataset_uses_window_state_and_restores_legacy_size(
     assert "itool_qt_geometry" not in ds.attrs
     assert "itool_rect" not in ds.attrs
 
+    restore_order: list[str] = []
+    restore_qt_window_state = imagetool_mainwindow._qt_state.restore_qt_window_state
+    restore_slicer_state = imagetool_viewer.ImageSlicerArea._restore_state
+
+    def _record_restore_order(widget, state) -> bool:
+        restore_order.append("window")
+        return restore_qt_window_state(widget, state)
+
+    def _record_slicer_state_restore(self, state, **kwargs) -> None:
+        restore_order.append("slicer")
+        restore_slicer_state(self, state, **kwargs)
+
+    monkeypatch.setattr(
+        imagetool_mainwindow._qt_state,
+        "restore_qt_window_state",
+        _record_restore_order,
+    )
+    monkeypatch.setattr(
+        imagetool_viewer.ImageSlicerArea,
+        "_restore_state",
+        _record_slicer_state_restore,
+    )
     restored = erlab.interactive.imagetool.ImageTool.from_dataset(ds, _in_manager=True)
     qtbot.addWidget(restored)
+    assert restore_order == ["window", "slicer"]
+    assert restored.size() == tool.size()
+    restored.show()
+    QtWidgets.QApplication.processEvents()
     assert restored.size() == tool.size()
 
     legacy_ds = ds.copy(deep=False)
@@ -246,12 +273,17 @@ def test_imagetool_dataset_uses_window_state_and_restores_legacy_size(
         (5000, 6000, tool.width(), tool.height())
     )
     legacy_ds.attrs["itool_visible"] = True
+    restore_order.clear()
     legacy = erlab.interactive.imagetool.ImageTool.from_dataset(
         legacy_ds, _in_manager=True
     )
     qtbot.addWidget(legacy)
+    assert restore_order == ["window", "slicer"]
     assert legacy.size() == tool.size()
     assert legacy.pos() != QtCore.QPoint(5000, 6000)
+    legacy.show()
+    QtWidgets.QApplication.processEvents()
+    assert legacy.size() == tool.size()
 
 
 def test_imagetool_dataset_preserves_never_shown_size_hint(qtbot, test_data) -> None:

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -2924,8 +2924,10 @@ def test_manager_workspace_show_materializes_hidden_memory_payload(
         root = itool(data, manager=False, execute=False)
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         root.slicer_area.set_index(1, 3)
+        root.resize(533, 477)
         manager.add_imagetool(root, show=False)
         root.hide()
+        saved_size = root.size()
 
         fname = tmp_path / "show-hidden-memory.itws"
         manager._workspace_controller.saving._save_workspace_document(fname)
@@ -2937,8 +2939,11 @@ def test_manager_workspace_show_materializes_hidden_memory_payload(
         assert wrapper.pending_workspace_memory_payload is not None
         manager.show_imagetool(0)
         qtbot.wait_until(lambda: manager.get_imagetool(0).isVisible())
+        QtWidgets.QApplication.processEvents()
 
-        loaded = manager.get_imagetool(0).slicer_area
+        restored = manager.get_imagetool(0)
+        assert restored.size() == saved_size
+        loaded = restored.slicer_area
         assert wrapper.pending_workspace_memory_payload is None
         assert loaded.data_loadable is False
         assert workspace_arrays.dataarray_is_numpy_backed(loaded._data)


### PR DESCRIPTION
## Summary

- Restore ImageTool geometry before slicer-state restoration can create the native window.
- Defer Figure Composer redraw until its owned figure window uses the saved size.
- Add regression coverage for restore ordering, legacy geometry, deferred ImageTool materialization, and deferred Figure Composer redraw.

## Verification

- `uv run ruff format --check` on all changed files
- `uv run ruff check` on all changed files
- `uv run mypy src/erlab/interactive/_figurecomposer/_tool.py src/erlab/interactive/imagetool/_mainwindow.py`
- Focused regression set with PyQt6: 8 passed
- Focused regression set with PySide6: 8 passed
- Native macOS validation with `workspace_screenshots.itws`: deferred tool[1] remained at 739 x 699 after materialization, first show, event processing, and a 500 ms delay