### PR TITLE
fix(interactive.ftool): preserve fits after model changes

### DIFF
--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -4016,13 +4016,14 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
 
     def _cache_fit_result_payload(self) -> None:
         """Cache the current result payload for save and deferred restore."""
+        self._serialized_fit_result_blob = None
+        self._pending_persisted_fit_is_current = None
         result = self._fit_result_dataset_for_persistence()
         self._serialized_fit_result_blob = (
             None
             if result is None
             else erlab.interactive.utils._serialize_fit_dataset_blob(result)
         )
-        self._pending_persisted_fit_is_current = None
 
     def _invalidate_fit_result_payload(self) -> None:
         """Discard all saved and deferred state for replaced fit results."""
@@ -4466,22 +4467,30 @@ class Fit1DTool(erlab.interactive.utils.ToolWindow):
             self._finish_multi_fit()
 
     def _finish_multi_fit(self) -> None:
-        self._sync_multi_fit_view(full=True)
-        if self._serialized_fit_result_blob is None:
-            self._cache_fit_result_payload()
-        self._set_fit_running(False, multi=True)
-        self._fit_running_multi = False
-        self._fit_multi_total = None
-        self._fit_multi_step = 0
-        self._fit_multi_fit_data = None
-        self._fit_multi_weights = None
-        self._fit_multi_params = None
-        self._fit_multi_revision = None
-        self._fit_multi_generation = None
-        self._fit_multi_live_refresh_pending = False
-        self._fit_multi_refresh_pending = False
-        self._fit_multi_last_elapsed = None
-        self._finish_fit_multi_history()
+        try:
+            try:
+                self._sync_multi_fit_view(full=True)
+                if self._serialized_fit_result_blob is None:
+                    self._cache_fit_result_payload()
+            finally:
+                self._fit_running_multi = False
+                self._fit_multi_total = None
+                self._fit_multi_step = 0
+                self._fit_multi_fit_data = None
+                self._fit_multi_weights = None
+                self._fit_multi_params = None
+                self._fit_multi_revision = None
+                self._fit_multi_generation = None
+                self._fit_multi_live_refresh_pending = False
+                self._fit_multi_refresh_pending = False
+                self._fit_multi_last_elapsed = None
+                self._set_fit_running(False, multi=True)
+        except Exception:
+            self._fit_errored(
+                erlab.interactive.utils._format_traceback(traceback.format_exc())
+            )
+        finally:
+            self._finish_fit_multi_history()
 
     def _set_fit_running(
         self,

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import dis
 import enum
 import functools
+import json
 import logging
 import os
 import time
+import traceback
+import types
 import typing
 import urllib.parse
 
@@ -54,7 +58,7 @@ from erlab.interactive.imagetool._provenance._operations import (
 )
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable, Hashable, Mapping
+    from collections.abc import Callable, Hashable, Iterable, Mapping
 
     import lmfit
     import varname
@@ -396,6 +400,7 @@ class Fit2DTool(Fit1DTool):
     _PERSISTED_FIT_CURRENT_ATTR: typing.ClassVar[str] = "__ftool_fit_is_current__"
     _FIT_RANGE_MIN_COORD: typing.ClassVar[str] = "__ftool_fit_range_min__"
     _FIT_RANGE_MAX_COORD: typing.ClassVar[str] = "__ftool_fit_range_max__"
+    _FIT_PARAMETER_AXES_VAR: typing.ClassVar[str] = "__ftool_fit_parameter_axes__"
     _PARAMETER_OUTPUT_SEPARATOR: typing.ClassVar[str] = ":"
     _direct_weights_full: xr.DataArray | None
 
@@ -874,6 +879,25 @@ class Fit2DTool(Fit1DTool):
             return result_ds
         return result_ds.reindex({self._coord_name: ordered})
 
+    def _restore_fit_parameter_axes(self, result_ds: xr.Dataset) -> xr.Dataset:
+        """Remove alignment padding and recover each slice's parameter order."""
+        if self._FIT_PARAMETER_AXES_VAR in result_ds:
+            axes = json.loads(result_ds[self._FIT_PARAMETER_AXES_VAR].item())
+            result_ds = result_ds.drop_vars(self._FIT_PARAMETER_AXES_VAR)
+        else:
+            if not any(name in result_ds.dims for name in ("param", "cov_i", "cov_j")):
+                return result_ds
+            # Older payloads do not record the pre-alignment order. Recover the
+            # native parameter order, including parameters with missing errors.
+            names = list(self._extract_fit_result(result_ds).params)
+            axes = {
+                name: [param for param in names if param in result_ds.get_index(name)]
+                for name in ("param", "cov_i", "cov_j")
+                if name in result_ds.dims
+                and any(param not in names for param in result_ds.get_index(name))
+            }
+        return result_ds.sel(axes)
+
     def _concat_fit_results(
         self,
         results: list[xr.Dataset],
@@ -881,7 +905,7 @@ class Fit2DTool(Fit1DTool):
         dim: Hashable,
         fit_ranges: list[tuple[float, float]] | None = None,
     ) -> xr.Dataset:
-        """Combine fit results without aligning identical fit coordinates."""
+        """Align different result indexes and retain the identical-index fast path."""
         if fit_ranges is None:
             range_coord_names = (
                 self._FIT_RANGE_MIN_COORD,
@@ -920,16 +944,55 @@ class Fit2DTool(Fit1DTool):
                 self._fit_result_with_explicit_range(result, fit_ranges[0])
                 for result in results
             ]
+        indexes = [
+            {name: index for name, index in result.xindexes.items() if name != dim}
+            for result in results
+        ]
+        identical_indexes = all(
+            other.keys() == indexes[0].keys()
+            and all(index.equals(other[name]) for name, index in indexes[0].items())
+            for other in indexes[1:]
+        )
+        mixed_parameter_axes = any(
+            (name in indexes[0]) != (name in other)
+            or (
+                name in indexes[0]
+                and name in other
+                and not indexes[0][name].equals(other[name])
+            )
+            for other in indexes[1:]
+            for name in ("param", "cov_i", "cov_j")
+        )
+        if mixed_parameter_axes:
+            # Parameter output axes can be reordered or restricted independently
+            # of ModelResult.params. Record their exact labels before alignment.
+            results = [
+                result.assign(
+                    {
+                        self._FIT_PARAMETER_AXES_VAR: xr.DataArray(
+                            json.dumps(
+                                {
+                                    name: result.get_index(name).tolist()
+                                    for name in ("param", "cov_i", "cov_j")
+                                    if name in result.dims
+                                }
+                            )
+                        )
+                    }
+                )
+                for result in results
+            ]
+        align_results = mixed_ranges or not identical_indexes
         combined = xr.concat(
             results,
             dim=dim,
             data_vars="all",
-            coords="all" if mixed_ranges else "minimal",
+            coords="all" if align_results else "minimal",
             compat="override",
-            join="outer" if mixed_ranges else "override",
+            join="outer" if align_results else "override",
             combine_attrs="override",
         )
-        if mixed_ranges:
+        if align_results:
             return self._restore_fit_coord_order(combined)
         return combined
 
@@ -2330,6 +2393,7 @@ class Fit2DTool(Fit1DTool):
         slice_states: list[tuple[_FitRestoreState, xr.Dataset]] = []
         for idx in range(results_da.sizes[y_dim]):
             slice_ds = fit_ds.isel({y_dim: idx}).copy()
+            slice_ds = self._restore_fit_parameter_axes(slice_ds)
             slice_ds = self._trim_fit_result_to_range(slice_ds)
             restore = self._parse_fit_dataset_for_restore(slice_ds, model=model)
             if restore.data.ndim != 1:
@@ -2339,18 +2403,13 @@ class Fit2DTool(Fit1DTool):
             slice_states.append((restore, slice_ds))
 
         base_model = slice_states[0][0].model
-        base_param_names = list(base_model.param_names)
-        base_indep = list(base_model.independent_vars)
-        for restore, _ in slice_states:
-            result_model = restore.result.model or restore.model
-            if (
-                type(result_model) is not type(base_model)
-                or list(result_model.param_names) != base_param_names
-                or list(result_model.independent_vars) != base_indep
-            ):
-                raise ValueError(
-                    "Fit dataset contains mixed model definitions across slices."
-                )
+        if not self._models_match(
+            base_model,
+            (restore.result.model or restore.model for restore, _ in slice_states),
+        ):
+            raise ValueError(
+                "Fit dataset contains mixed model definitions across slices."
+            )
 
         self._model = base_model
         self._serialized_model_state = self._serialize_model_state(base_model)
@@ -2412,6 +2471,7 @@ class Fit2DTool(Fit1DTool):
                         }
                     )
                 result_ds = self._trim_fit_result_to_range(result_ds)
+                result_ds = self._restore_fit_parameter_axes(result_ds)
                 self._result_ds_full[idx] = self._fit_result_with_range(result_ds)
         self._refresh_contents_from_index(mark_fit_stale=not fit_is_current)
         self._update_param_plot_options()
@@ -2884,30 +2944,38 @@ class Fit2DTool(Fit1DTool):
             self._finish_fit_2d_sequence()
 
     def _finish_fit_2d_sequence(self) -> None:
-        final_idx = self._fit_2d_last_completed_idx
-        if final_idx is None and self._data_full.sizes[self._y_dim_name] > 0:
-            final_idx = self._current_idx
-        if final_idx is not None:
-            self._sync_fit_2d_sequence_view(
-                final_idx,
-                mark_fit_stale=self._result_ds_full[final_idx] is None,
+        try:
+            final_idx = self._fit_2d_last_completed_idx
+            if final_idx is None and self._data_full.sizes[self._y_dim_name] > 0:
+                final_idx = self._current_idx
+            try:
+                if final_idx is not None:
+                    self._sync_fit_2d_sequence_view(
+                        final_idx,
+                        mark_fit_stale=self._result_ds_full[final_idx] is None,
+                    )
+                if self._serialized_fit_result_blob is None:
+                    self._cache_fit_result_payload()
+            finally:
+                self._fit_running_multi = False
+                self._fit_2d_indices = []
+                self._fit_2d_total = 0
+                self._fit_2d_direction = None
+                self._fit_2d_initial_range = None
+                self._fit_2d_last_completed_idx = None
+                self._fit_2d_last_completed_elapsed = None
+                self._fit_2d_revision = None
+                self._fit_2d_generation = None
+                self._fit_2d_live_refresh_pending = False
+                self._set_fit_running(False, multi=True)
+                self._update_full_fit_saveable()
+                self._flush_fit_2d_sequence_param_plot(force=True)
+        except Exception:
+            self._fit_errored(
+                erlab.interactive.utils._format_traceback(traceback.format_exc())
             )
-        self._set_fit_running(False, multi=True)
-        self._fit_running_multi = False
-        self._fit_2d_indices = []
-        self._fit_2d_total = 0
-        self._fit_2d_direction = None
-        self._fit_2d_initial_range = None
-        self._fit_2d_last_completed_idx = None
-        self._fit_2d_last_completed_elapsed = None
-        self._fit_2d_revision = None
-        self._fit_2d_generation = None
-        self._fit_2d_live_refresh_pending = False
-        if self._serialized_fit_result_blob is None:
-            self._cache_fit_result_payload()
-        self._update_full_fit_saveable()
-        self._flush_fit_2d_sequence_param_plot(force=True)
-        self._finish_fit_2d_sequence_history()
+        finally:
+            self._finish_fit_2d_sequence_history()
 
     def _y_values(self) -> np.ndarray:
         if self._y_values_cache is not None:
@@ -3084,6 +3152,21 @@ class Fit2DTool(Fit1DTool):
             if warn:
                 self._show_warning(title, text)
 
+        if not self._models_match(
+            self._model,
+            (
+                self._extract_fit_result(result).model
+                for result in self._result_ds_full[self._y_range_slice()]
+                if result is not None
+            ),
+        ):
+            _warn_user(
+                "Inconsistent Models",
+                "Stored fits use different model definitions. Refit the selected "
+                "slices with the current model before generating combined fit code.",
+            )
+            return None
+
         param_names: list[str] = []
         param_names_all: list[str] = []
         params_expr: dict[str, str] = {}
@@ -3192,6 +3275,244 @@ class Fit2DTool(Fit1DTool):
                 vary=vary,
             )
         return parameter_specs
+
+    @classmethod
+    def _models_match(
+        cls, model: lmfit.Model, candidates: Iterable[lmfit.Model | None]
+    ) -> bool:
+        """Check fit definitions, including functions, options, and expressions."""
+        checked = {model}
+        model_state: dict[str, typing.Any] | None = None
+        with _patch_encode4js():
+            for candidate in candidates:
+                if candidate in checked:
+                    continue
+                if candidate is None:
+                    return False
+                if model_state is None:
+                    model_state = cls._model_definition(model)
+                if not cls._model_state_equal(
+                    model_state, cls._model_definition(candidate), {}
+                ):
+                    return False
+                checked.add(candidate)
+        return True
+
+    @classmethod
+    def _model_definition(cls, model: lmfit.Model) -> dict[str, typing.Any]:
+        """Describe a model without serializing its callable definition."""
+        if isinstance(model, lmfit.model.CompositeModel):
+            # lmfit persists the operands and operator. Composite-level hints
+            # are not restored; per-slice Parameters retain their constraints.
+            return {
+                "left": cls._model_definition(model.left),
+                "right": cls._model_definition(model.right),
+                "op": model.op,
+            }
+        state, _, _ = model._get_state()
+        func = model.func
+        if isinstance(func, erlab.analysis.fit.functions.dynamic.DynamicFunction):
+            state["funcdef"] = {
+                "class": type(func),
+                "state": {
+                    name: value
+                    for name, value in vars(func).items()
+                    if not isinstance(
+                        getattr(type(func), name, None), functools.cached_property
+                    )
+                },
+            }
+        return state
+
+    @staticmethod
+    def _model_function_state(func: types.FunctionType) -> tuple[typing.Any, ...]:
+        """Keep values read by a function, including globals in nested code."""
+        names: set[str] = set()
+        codes = [func.__code__]
+        while codes:
+            code = codes.pop()
+            names.update(
+                instruction.argval
+                for instruction in dis.get_instructions(code)
+                if instruction.opname in {"LOAD_GLOBAL", "LOAD_NAME"}
+            )
+            codes.extend(
+                const for const in code.co_consts if isinstance(const, types.CodeType)
+            )
+        builtin_namespace: dict[str, typing.Any] = typing.cast(
+            "typing.Any", func
+        ).__builtins__
+        namespace = {
+            name: func.__globals__[name]
+            if name in func.__globals__
+            else builtin_namespace[name]
+            for name in names
+            if name in func.__globals__ or name in builtin_namespace
+        }
+        closure = {}
+        for name, cell in zip(
+            func.__code__.co_freevars, func.__closure__ or (), strict=True
+        ):
+            with contextlib.suppress(ValueError):  # An empty cell has no bound value.
+                closure[name] = cell.cell_contents
+        return func.__defaults__, func.__kwdefaults__, closure, namespace, vars(func)
+
+    @classmethod
+    def _model_state_equal(
+        cls,
+        left: typing.Any,
+        right: typing.Any,
+        seen: dict[tuple[int, int], tuple[typing.Any, typing.Any]],
+    ) -> bool:
+        """Compare model state without pickle identity for Python functions."""
+        if left is right:
+            return True
+        same_type = type(left) is type(right)
+        pair = (id(left), id(right))
+        if pair in seen:
+            return True
+        # Keep temporary function-state objects alive to prevent ID reuse.
+        seen[pair] = (left, right)
+        if same_type and isinstance(left, types.FunctionType):
+            # Code equality survives dill round trips. Pickle bytes do not: memo
+            # references and globals dictionaries can change during restoration.
+            return left.__code__ == right.__code__ and cls._model_state_equal(
+                cls._model_function_state(left), cls._model_function_state(right), seen
+            )
+        if same_type and isinstance(left, types.MethodType):
+            return cls._model_state_equal(
+                (left.__func__, left.__self__),
+                (right.__func__, right.__self__),
+                seen,
+            )
+        if same_type and type(left) is functools.partial:
+            return cls._model_state_equal(
+                (left.func, left.args, left.keywords, vars(left)),
+                (right.func, right.args, right.keywords, vars(right)),
+                seen,
+            )
+        if same_type and type(left) in {staticmethod, classmethod}:
+            return cls._model_state_equal(left.__func__, right.__func__, seen)
+        if same_type and type(left) is property:
+            return cls._model_state_equal(
+                (left.fget, left.fset, left.fdel),
+                (right.fget, right.fset, right.fdel),
+                seen,
+            )
+        if same_type and type(left) is dict:
+            return left.keys() == right.keys() and all(
+                cls._model_state_equal(value, right[key], seen)
+                for key, value in left.items()
+            )
+        if same_type and type(left) in {list, tuple}:
+            return len(left) == len(right) and all(
+                cls._model_state_equal(a, b, seen)
+                for a, b in zip(left, right, strict=True)
+            )
+        if same_type and type(left) in {set, frozenset}:
+            remaining = list(right)
+            for value in left:
+                for index, candidate in enumerate(remaining):
+                    candidate_seen = seen.copy()
+                    if cls._model_state_equal(value, candidate, candidate_seen):
+                        seen.update(candidate_seen)
+                        remaining.pop(index)
+                        break
+                else:
+                    return False
+            return not remaining
+        if type(left) is np.ndarray and type(right) is np.ndarray:
+            if left.dtype != right.dtype or left.shape != right.shape:
+                return False
+            if left.dtype.names is not None:
+                return all(
+                    cls._model_state_equal(left[name], right[name], seen)
+                    for name in left.dtype.names
+                )
+            if left.dtype.hasobject:
+                return cls._model_state_equal(left.tolist(), right.tolist(), seen)
+            if left.dtype.kind == "c":
+                return cls._model_state_equal(left.real, right.real, seen) and (
+                    cls._model_state_equal(left.imag, right.imag, seen)
+                )
+            return bool(
+                np.array_equal(left, right, equal_nan=left.dtype.kind in "fmM")
+                and (
+                    left.dtype.kind != "f"
+                    or np.array_equal(
+                        np.signbit(left[left == 0]), np.signbit(right[right == 0])
+                    )
+                )
+            )
+        if same_type and type(left) in {bytes, bytearray}:
+            return left == right
+        if isinstance(left, type) and isinstance(right, type):
+            # dill can reconstruct locally defined classes. Compare their
+            # definitions as well as instance state, including __call__ methods.
+            return (
+                left.__module__ == right.__module__
+                and left.__qualname__ == right.__qualname__
+                and cls._model_state_equal(type(left), type(right), seen)
+                and cls._model_state_equal(left.__bases__, right.__bases__, seen)
+                and cls._model_state_equal(
+                    {
+                        key: value
+                        for key, value in vars(left).items()
+                        if key not in {"__slotnames__", "__firstlineno__"}
+                        and not (
+                            key in {"__dict__", "__weakref__"}
+                            and isinstance(value, types.GetSetDescriptorType)
+                        )
+                    },
+                    {
+                        key: value
+                        for key, value in vars(right).items()
+                        if key not in {"__slotnames__", "__firstlineno__"}
+                        and not (
+                            key in {"__dict__", "__weakref__"}
+                            and isinstance(value, types.GetSetDescriptorType)
+                        )
+                    },
+                    seen,
+                )
+            )
+        if (
+            not callable(left)
+            and not callable(right)
+            and not isinstance(left, (dict, list, tuple, np.ndarray))
+            and not isinstance(right, (dict, list, tuple, np.ndarray))
+        ):
+            try:
+                return json.dumps(
+                    lmfit.jsonutils.encode4js(left), sort_keys=True
+                ) == json.dumps(lmfit.jsonutils.encode4js(right), sort_keys=True)
+            except (TypeError, ValueError):
+                pass
+        # An opaque object has identity but no state that establishes equivalence.
+        if type(left) is object or type(right) is object:
+            return False
+        try:
+            left_state = cls._model_object_state(left)
+            right_state = cls._model_object_state(right)
+        except (AttributeError, TypeError, ValueError):
+            # Unsupported state cannot establish equivalence for combined code.
+            return False
+        return cls._model_state_equal(left_state, right_state, seen)
+
+    @staticmethod
+    def _model_object_state(value: typing.Any) -> tuple[typing.Any, ...]:
+        """Read pickle reconstruction state without executing its constructor."""
+        reduced = value.__reduce_ex__(4)
+        if isinstance(reduced, str):
+            return type(value), value.__module__, reduced
+        fields = list(reduced)
+        # Reducers can provide iterators for sequence and mapping contents.
+        # Materialize those contents once, while retaining cyclic references.
+        if len(fields) > 3 and fields[3] is not None:
+            fields[3] = list(fields[3])
+        if len(fields) > 4 and fields[4] is not None:
+            fields[4] = dict(fields[4])
+        return type(value), tuple(fields)
 
     def _build_full_copy_prelude(
         self, *, warn: bool = True, input_name: str | None = None

--- a/tests/interactive/imagetool/manager/provenance/_common.py
+++ b/tests/interactive/imagetool/manager/provenance/_common.py
@@ -203,16 +203,12 @@ def _set_provenance_steps_clipboard(
     QtWidgets.QApplication.clipboard().setMimeData(mime_data)
 
 
-def _fit2d_param_result_dataset(params: typing.Any) -> xr.Dataset:
+def _fit2d_param_result_dataset(
+    model: lmfit.Model, params: lmfit.Parameters
+) -> xr.Dataset:
     params = params.copy()
-    param_args = ", ".join(("x", *params.keys()))
-    namespace = {"np": np}
-    exec(  # noqa: S102
-        f"def _model_func({param_args}):\n    return np.zeros_like(x, dtype=float)\n",
-        namespace,
-    )
     result = lmfit.model.ModelResult(
-        lmfit.Model(namespace["_model_func"]),
+        model,
         params,
         data=np.zeros(3),
         fcn_args=(np.arange(3, dtype=float),),
@@ -223,10 +219,12 @@ def _fit2d_param_result_dataset(params: typing.Any) -> xr.Dataset:
     return xr.Dataset({"modelfit_results": xr.DataArray(result, dims=())})
 
 
-def _seed_fit2d_param_results(child: Fit2DTool, params_list: list[typing.Any]) -> None:
+def _seed_fit2d_param_results(
+    child: Fit2DTool, params_list: list[lmfit.Parameters]
+) -> None:
     child._params_full = [params.copy() for params in params_list]
     child._result_ds_full = [
-        _fit2d_param_result_dataset(params) for params in params_list
+        _fit2d_param_result_dataset(child._model, params) for params in params_list
     ]
     child._fit_is_current = True
     child._update_full_fit_saveable()

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -5627,6 +5627,84 @@ def test_fit1d_finalize_fit_thread_action_error_restores_idle(
     assert not win.cancel_fit_button.isEnabled()
 
 
+@pytest.mark.parametrize("failure", ["serialize", "sync"])
+def test_fit1d_multi_fit_completion_failure_allows_refit(
+    qtbot, monkeypatch, failure
+) -> None:
+    tool, _data, _model, _params = _make_linear_fit1d_tool(qtbot)
+    tool.nfev_spin.setValue(0)
+    tool.timeout_spin.setValue(30.0)
+    errors = []
+    monkeypatch.setattr(
+        tool,
+        "_show_error",
+        lambda title, text, detailed_text=None: errors.append(detailed_text),
+    )
+    original_sync = tool._sync_multi_fit_view
+
+    def fail_sync(*, full=False):
+        original_sync(full=full)
+        if full:
+            raise RuntimeError("completion sync failed")
+
+    def fail_serialize(_dataset):
+        raise RuntimeError("completion serialization failed")
+
+    with monkeypatch.context() as patch:
+        if failure == "serialize":
+            patch.setattr(
+                erlab.interactive.utils, "_serialize_fit_dataset_blob", fail_serialize
+            )
+        else:
+            patch.setattr(tool, "_sync_multi_fit_view", fail_sync)
+        tool._run_fit_multiple(2)
+        qtbot.waitUntil(
+            lambda: tool._fit_multi_total is None and not tool._fit_running(),
+            timeout=10000,
+        )
+    assert len(errors) == 1
+    assert "completion" in errors[0]
+    assert tool._last_result_ds is not None
+    assert tool._serialized_fit_result_blob is None
+    assert tool._pending_persisted_fit_is_current is None
+    assert tool._fit_multi_generation is None
+    assert tool._fit_multi_sequence_write_history is None
+    assert tool._write_history
+    assert not tool._fit_running_multi
+    assert tool.fit_button.isEnabled()
+    assert tool.fit_multi_button.isEnabled()
+    assert not tool.cancel_fit_button.isEnabled()
+    assert not tool._fit_worker_callbacks
+
+    tool._run_fit_multiple(2)
+    qtbot.waitUntil(
+        lambda: tool._fit_multi_total is None and not tool._fit_running(),
+        timeout=10000,
+    )
+    assert len(errors) == 1
+    assert tool._serialized_fit_result_blob is not None
+    assert tool._fit_is_current
+
+
+def test_fit1d_failed_cache_discards_previous_payload(qtbot, monkeypatch) -> None:
+    tool, data, model, params = _make_linear_fit1d_tool(qtbot)
+    tool._last_result_ds = data.xlm.modelfit("x", model=model, params=params).load()
+    tool._cache_fit_result_payload()
+    assert tool._serialized_fit_result_blob is not None
+
+    def fail_serialize(_dataset):
+        raise RuntimeError("serialization failed")
+
+    monkeypatch.setattr(
+        erlab.interactive.utils, "_serialize_fit_dataset_blob", fail_serialize
+    )
+    with pytest.raises(RuntimeError, match="serialization failed"):
+        tool._cache_fit_result_payload()
+    assert tool._serialized_fit_result_blob is None
+    assert tool._pending_persisted_fit_is_current is None
+    assert tool._last_result_ds is not None
+
+
 def test_snap_cursor_line_value(qtbot) -> None:
     line = fit1d._SnapCursorLine(pos=1.5, angle=90, movable=True)
     qtbot.addWidget(QtWidgets.QWidget())

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -1,4 +1,6 @@
+import collections
 import contextlib
+import functools
 import json
 import os
 import re
@@ -14,6 +16,7 @@ import lmfit
 import numpy as np
 import pyqtgraph as pg
 import pytest
+import scipy.interpolate
 import xarray as xr
 from qtpy import QtCore, QtWidgets
 
@@ -253,15 +256,17 @@ def _assert_fit_result_dataset_equivalent(
         assert actual_param.vary == expected_param.vary
 
 
-def _fit_result_dataset(params, *, nfev: int = 1) -> xr.Dataset:
+def _fit_result_dataset(params, *, nfev: int = 1, model=None) -> xr.Dataset:
     params = params.copy()
-    param_args = ", ".join(("x", *params.keys()))
-    namespace = {"np": np}
-    exec(  # noqa: S102
-        f"def _model_func({param_args}):\n    return np.zeros_like(x, dtype=float)\n",
-        namespace,
-    )
-    model = lmfit.Model(namespace["_model_func"])
+    if model is None:
+        param_args = ", ".join(("x", *params.keys()))
+        namespace = {"np": np}
+        exec(  # noqa: S102
+            f"def _model_func({param_args}):\n"
+            "    return np.zeros_like(x, dtype=float)\n",
+            namespace,
+        )
+        model = lmfit.Model(namespace["_model_func"])
     result = lmfit.model.ModelResult(
         model,
         params,
@@ -355,7 +360,7 @@ def _seed_fit2d_full_results(win: Fit2DTool, model, params) -> None:
 def _seed_fit2d_param_results(win: Fit2DTool, params_list) -> None:
     win._params_full = [params.copy() for params in params_list]
     win._result_ds_full = [
-        win._fit_result_with_range(_fit_result_dataset(params))
+        win._fit_result_with_range(_fit_result_dataset(params, model=win._model))
         for params in params_list
     ]
     win._fit_is_current = True
@@ -1015,7 +1020,9 @@ def test_fit2d_full_provenance_handles_spaced_fit_axis(qtbot) -> None:
         params["p0_center"].set(value=value)
         params_full.append(params)
     win._params_full = params_full
-    win._result_ds_full = [xr.Dataset() for _ in params_full]
+    win._result_ds_full = [
+        _fit_result_dataset(params, model=win._model) for params in params_full
+    ]
     win.y_min_spin.setValue(0)
     win.y_max_spin.setValue(len(params_full) - 1)
 
@@ -3196,6 +3203,717 @@ def test_fit2d_concat_strategy_depends_on_recorded_ranges(
 
 
 @pytest.mark.parametrize("descending", [False, True])
+@pytest.mark.parametrize("mixed_ranges", [False, True])
+@pytest.mark.parametrize("change", ["names", "degree", "order", "subset"])
+def test_fit2d_concat_preserves_parameter_axes(
+    qtbot, monkeypatch, change, mixed_ranges, descending
+) -> None:
+    x = np.linspace(0.0, 2.0, 41)
+    if descending:
+        x = x[::-1]
+    data = xr.DataArray(
+        np.stack([3 * np.exp(-x / 4) + 0.01 * np.sin(12 * x)] * 2),
+        dims=("y", "x"),
+        coords={"y": [0, 1], "x": x},
+    )
+    model = lmfit.models.LinearModel()
+    other_model = {
+        "names": lmfit.models.ExponentialModel(),
+        "degree": lmfit.models.PolynomialModel(2),
+    }.get(change, model)
+    tool = erlab.interactive.ftool(data, model=model, execute=False)
+    qtbot.addWidget(tool)
+    results = []
+    for index, fit_model in enumerate((model, other_model)):
+        fit_data = data.isel(y=index)
+        if mixed_ranges and index == 1:
+            fit_data = fit_data.where(fit_data.x >= 0.5, drop=True)
+        params = fit_model.guess(fit_data.values, x=fit_data.x.values)
+        result = fit_data.xlm.modelfit("x", model=fit_model, params=params).load()
+        if index == 1:
+            if change == "order":
+                result = result.isel(param=[1, 0], cov_i=[0, 1], cov_j=[1, 0])
+            elif change == "subset":
+                result = result.sel(param=["slope"], cov_i=["slope"], cov_j=["slope"])
+        results.append(tool._fit_result_with_range(result))
+    originals = [result.copy(deep=True) for result in results]
+    tool._result_ds_full = results
+    joins = []
+    concat = xr.concat
+
+    def tracked_concat(*args, **kwargs):
+        joins.append(kwargs["join"])
+        return concat(*args, **kwargs)
+
+    monkeypatch.setattr(fit2d_module.xr, "concat", tracked_concat)
+    combined = tool._fit_result_dataset_for_persistence()
+    assert combined is not None
+    assert joins == ["outer"]
+    np.testing.assert_array_equal(combined.x, x)
+    for index, result in enumerate(results):
+        selected = combined.isel({tool._PERSISTED_FIT_INDEX_DIM: index})
+        selected = tool._fit_result_with_range(selected)
+        for variable in (
+            "modelfit_coefficients",
+            "modelfit_stderr",
+            "modelfit_covariance",
+        ):
+            array = result[variable]
+            assert np.isfinite(array).all()
+            actual = selected[variable].sel({dim: array[dim] for dim in array.dims})
+            xr.testing.assert_identical(
+                actual.drop_vars(tool._PERSISTED_FIT_INDEX_DIM), array
+            )
+        missing = combined.param.to_index().difference(result.param.to_index())
+        assert selected.modelfit_coefficients.sel(param=missing).isnull().all()
+    _assert_fit_result_list_equivalent(results, originals)
+
+    blob = erlab.interactive.utils._serialize_fit_dataset_blob(combined)
+    decoded = erlab.interactive.utils._deserialize_fit_dataset_blob(blob)
+    tool._apply_restored_fit_result(decoded, fit_is_current=False)
+    _assert_fit_result_list_equivalent(
+        tool._result_ds_full, originals, require_model_type=False
+    )
+    assert all(
+        tool._FIT_PARAMETER_AXES_VAR not in result
+        for result in tool._result_ds_full
+        if result is not None
+    )
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_fit2d_mixed_parameter_axes_preserve_sparse_results_without_errors(
+    qtbot, legacy
+) -> None:
+    tool, model, _params = _make_linear_fit2d_tool(qtbot)
+    other_model = lmfit.models.PolynomialModel(2)
+    results = [None] * 3
+    for index, fit_model in ((0, model), (2, other_model)):
+        data = tool._data_full.isel(y=index)
+        params = fit_model.guess(data.values, x=data.x.values)
+        results[index] = data.xlm.modelfit(
+            "x", model=fit_model, params=params, method="nelder", calc_covar=False
+        ).load()
+        assert np.isfinite(results[index].modelfit_coefficients).all()
+        assert results[index].modelfit_stderr.isnull().all()
+        assert results[index].modelfit_covariance.isnull().all()
+    tool._result_ds_full = results
+    originals = [
+        None if result is None else result.copy(deep=True) for result in results
+    ]
+    if legacy:
+        # Payloads written before parameter-axis metadata was introduced can
+        # already contain outer-aligned results when their fit ranges differ.
+        combined = xr.concat(
+            [
+                result.expand_dims({tool._PERSISTED_FIT_INDEX_DIM: [index]})
+                for index, result in enumerate(results)
+                if result is not None
+            ],
+            dim=tool._PERSISTED_FIT_INDEX_DIM,
+            coords="all",
+            join="outer",
+        )
+        tool._serialized_fit_result_blob = (
+            erlab.interactive.utils._serialize_fit_dataset_blob(combined)
+        )
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        tool.to_dataset(), _code_trust=new_document_trust()
+    )
+    qtbot.addWidget(restored)
+    _assert_fit_result_list_equivalent(
+        restored._result_ds_full, originals, require_model_type=False
+    )
+    values, errors = restored._param_plot_dataarrays("c2")
+    values = values.reindex(y=tool._data_full.y)
+    errors = errors.reindex(y=tool._data_full.y)
+    assert values.isel(y=slice(0, 2)).isnull().all()
+    assert np.isfinite(values.isel(y=2))
+    assert errors.isnull().all()
+
+
+def test_fit2d_restore_results_without_parameter_arrays(qtbot) -> None:
+    tool, model, params = _make_linear_fit2d_tool(qtbot)
+    result = (
+        tool._data_full.isel(y=0).xlm.modelfit("x", model=model, params=params).load()
+    )
+    # These are the required saved-fit fields. Parameter plots can obtain the
+    # parameters and uncertainties directly from the ModelResult object.
+    result = result[["modelfit_data", "modelfit_results"]]
+    tool._result_ds_full[0] = result
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        tool.to_dataset(), _code_trust=new_document_trust()
+    )
+    qtbot.addWidget(restored)
+    _assert_fit_result_list_equivalent(
+        restored._result_ds_full, [result, None, None], require_model_type=False
+    )
+    assert restored._param_plot_names() == list(result.modelfit_results.item().params)
+
+
+@pytest.mark.parametrize("operation", ["fit", "fit-20", "fit-up", "fit-down"])
+def test_fit2d_refit_after_peak_shape_change(qtbot, monkeypatch, operation) -> None:
+    model = erlab.analysis.fit.models.MultiPeakModel(
+        2, "voigt", fd=False, convolve=False, background="none"
+    )
+    params = model.make_params(
+        p0_center=-0.4,
+        p1_center=0.4,
+        p0_sigma=0.12,
+        p1_sigma=0.15,
+        p0_gamma=0.08,
+        p1_gamma=0.1,
+        p0_amplitude=1.0,
+        p1_amplitude=0.7,
+    )
+    x = np.linspace(-1.5, 1.5, 81)
+    data = xr.DataArray(
+        np.stack([model.eval(params, x=x)] * 3),
+        dims=("y", "x"),
+        coords={"y": [0, 1, 2], "x": x},
+        name="mdcs",
+    )
+    tool = erlab.interactive.ftool(
+        data, model=model, params=params, data_name="data", execute=False
+    )
+    qtbot.addWidget(tool)
+    warnings, errors = _configure_fit2d_for_tests(tool, monkeypatch)
+    tool.nfev_spin.setValue(0)
+    tool._result_ds_full = [
+        data.isel(y=index).xlm.modelfit("x", model=model, params=params).load()
+        for index in range(3)
+    ]
+    originals = [result.copy(deep=True) for result in tool._result_ds_full]
+    tool._set_current_index(1)
+    tool.peak_shape_combo.setCurrentText("lorentzian")
+    assert tool._model.func._peak_shapes == ["lorentzian", "lorentzian"]
+    completed = []
+    tool.sigFitFinished.connect(lambda _: completed.append(tool._current_idx))
+    if operation == "fit":
+        assert tool._run_fit()
+    elif operation == "fit-20":
+        tool._run_fit_multiple(20)
+    else:
+        tool._run_fit_2d("up" if operation == "fit-up" else "down")
+    qtbot.waitUntil(
+        lambda: (
+            not tool._fit_running()
+            and tool._fit_multi_total is None
+            and tool._fit_2d_total == 0
+        ),
+        timeout=30000,
+    )
+    assert not warnings
+    assert not errors
+    expected_indices = {
+        "fit": [1],
+        "fit-20": [1] * 20,
+        "fit-up": [1, 2],
+        "fit-down": [1, 0],
+    }[operation]
+    assert completed == expected_indices
+    for index, result in enumerate(tool._result_ds_full):
+        fitted = result.modelfit_results.item()
+        assert fitted.success
+        if index in completed:
+            assert fitted.model.func._peak_shapes == ["lorentzian", "lorentzian"]
+        else:
+            _assert_fit_result_dataset_equivalent(result, originals[index])
+
+    # Editable parameters already use the new model at every slice. They must
+    # not make historical results appear reproducible with that one model.
+    assert all("p0_sigma" not in p for p in tool._params_full if p is not None)
+    assert tool._build_full_copy_prelude(warn=False) == ""
+    assert tool._parameter_model_fit_operation("p0_center", stderr=False) is None
+    assert "p0_sigma" in tool._param_plot_names()
+    expected = [result.copy(deep=True) for result in tool._result_ds_full]
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        tool.to_dataset(), _code_trust=new_document_trust()
+    )
+    qtbot.addWidget(restored)
+    _assert_fit_result_list_equivalent(
+        restored._result_ds_full, expected, require_model_type=False
+    )
+    for original, result in zip(expected, restored._result_ds_full, strict=True):
+        assert tool._models_match(
+            original.modelfit_results.item().model,
+            [result.modelfit_results.item().model],
+        )
+    assert restored._model.func._peak_shapes == ["lorentzian", "lorentzian"]
+
+    saved = []
+    monkeypatch.setattr(
+        erlab.interactive.utils, "wait_dialog", lambda *_args: contextlib.nullcontext()
+    )
+    monkeypatch.setattr(
+        erlab.interactive.utils,
+        "save_fit_ui",
+        lambda dataset, *, parent: saved.append(dataset),
+    )
+    tool._save_fit_full()
+    assert len(saved) == 1
+    for index, result in enumerate(expected):
+        actual = tool._restore_fit_parameter_axes(saved[0].isel(y=index))
+        _assert_fit_result_dataset_equivalent(actual, result)
+    tool._set_current_index(0)
+    tool._run_fit_2d("up")
+    qtbot.waitUntil(
+        lambda: tool._fit_2d_total == 0 and not tool._fit_running(), timeout=30000
+    )
+    assert not errors
+    # Full-fit code deliberately shares nearly equal starting values. Use one
+    # exact seed for every slice so both executions have identical inputs.
+    seed_params = tool._params.copy()
+    tool._params_full = [seed_params.copy() for _ in tool._params_full]
+    code = tool._copy_code_full()
+    namespace = _exec_generated_code(
+        code, data=data, erlab=erlab, era=erlab.analysis, np=np, xr=xr, lmfit=lmfit
+    )
+    expected_fit = data.xlm.modelfit(
+        "x",
+        model=tool._model,
+        params=seed_params,
+        method=tool.method_combo.currentText(),
+        scale_covar=tool.scale_covar_check.isChecked(),
+    )
+    xr.testing.assert_identical(
+        namespace["result"].drop_vars("modelfit_results"),
+        expected_fit.drop_vars("modelfit_results"),
+    )
+
+    closed = []
+    original_close = Fit2DTool.close
+
+    def record_close(window):
+        closed.append(window)
+        return original_close(window)
+
+    # Keep rejected-window wrappers alive through teardown on both bindings.
+    with monkeypatch.context() as patch:
+        patch.setattr(Fit2DTool, "close", record_close)
+        with pytest.raises(ValueError, match="mixed model definitions"):
+            erlab.interactive.ftool(saved[0], execute=False)
+    assert len(closed) == 1
+
+
+@pytest.mark.parametrize("failure", ["serialize", "sync"])
+@pytest.mark.parametrize("operation", ["fit-20", "fit-up", "fit-down"])
+def test_fit2d_completion_failure_allows_refit(
+    qtbot, monkeypatch, failure, operation
+) -> None:
+    tool, _model, _params = _make_linear_fit2d_tool(qtbot)
+    warnings, errors = _configure_fit2d_for_tests(tool, monkeypatch)
+    tool.nfev_spin.setValue(0)
+    tool._set_current_index(1)
+    sync_method = (
+        "_sync_multi_fit_view"
+        if operation == "fit-20"
+        else "_sync_fit_2d_sequence_view"
+    )
+    original_sync = getattr(tool, sync_method)
+
+    def fail_sync(*args, **kwargs):
+        original_sync(*args, **kwargs)
+        if kwargs.get("full", operation != "fit-20"):
+            raise RuntimeError("completion sync failed")
+
+    def fail_serialize(_dataset):
+        raise RuntimeError("completion serialization failed")
+
+    with monkeypatch.context() as patch:
+        if failure == "serialize":
+            patch.setattr(
+                erlab.interactive.utils, "_serialize_fit_dataset_blob", fail_serialize
+            )
+        else:
+            patch.setattr(tool, sync_method, fail_sync)
+        if operation == "fit-20":
+            tool._run_fit_multiple(2)
+        else:
+            tool._run_fit_2d("up" if operation == "fit-up" else "down")
+        qtbot.waitUntil(
+            lambda: (
+                not tool._fit_running()
+                and tool._fit_multi_total is None
+                and tool._fit_2d_total == 0
+            ),
+            timeout=10000,
+        )
+    assert not warnings
+    assert len(errors) == 1
+    assert "completion" in errors[0][2]
+    assert tool._result_ds_full[tool._current_idx] is not None
+    assert tool._last_result_ds is not None
+    assert tool._serialized_fit_result_blob is None
+    assert tool._pending_persisted_fit_is_current is None
+    assert tool._fit_multi_generation is None
+    assert tool._fit_2d_generation is None
+    assert tool._fit_multi_sequence_write_history is None
+    assert tool._fit_2d_sequence_write_history is None
+    assert tool._write_history
+    assert not tool._fit_running_multi
+    assert tool.fit_button.isEnabled()
+    assert tool.fit_multi_button.isEnabled()
+    assert tool.fit_up_button.isEnabled()
+    assert tool.fit_down_button.isEnabled()
+    assert not tool.cancel_fit_button.isEnabled()
+    assert not tool._fit_worker_callbacks
+
+    tool._run_fit_multiple(2)
+    qtbot.waitUntil(
+        lambda: tool._fit_multi_total is None and not tool._fit_running(),
+        timeout=10000,
+    )
+    assert len(errors) == 1
+    assert tool._serialized_fit_result_blob is not None
+    assert tool._fit_is_current
+
+
+class _ModelComparisonLine:
+    __slots__ = ("scale",)
+
+    def __init__(self, scale):
+        self.scale = scale
+
+    def line(self, x, slope=1.0, intercept=0.0):
+        return self.scale * slope * x + intercept
+
+    def __call__(self, x):
+        return self.scale * x
+
+    @classmethod
+    def class_line(cls, x, slope=1.0, intercept=0.0):
+        return slope * x + intercept
+
+
+_MODEL_COMPARISON_REFERENCES = (
+    "interp1d",
+    "spline",
+    "slots",
+    "local",
+    "object-array",
+    "namespace",
+    "set",
+    "sequence",
+    "mapping",
+)
+
+
+def _make_model_comparison_reference(kind, scale=1.0):
+    knots = [-1.0, 0.0, 1.0]
+    values = [0.0, scale, 0.0]
+    if kind == "interp1d":
+        return scipy.interpolate.interp1d(knots, values)
+    if kind == "spline":
+        return scipy.interpolate.CubicSpline(knots, values)
+    if kind == "slots":
+        return _ModelComparisonLine(scale)
+    if kind == "local":
+
+        class Reference:
+            __slots__ = ("cycle", "scale")
+
+            def __init__(self):
+                self.scale = scale
+                self.cycle = self
+
+            def __call__(self, x):
+                return self.evaluate(x, self.value)
+
+            @property
+            def value(self):
+                return self.configured_scale(self.cycle.scale)
+
+            @staticmethod
+            def evaluate(x, value):
+                return value * x
+
+            @classmethod
+            def configured_scale(cls, value):
+                return value
+
+        return Reference()
+    if kind == "object-array":
+        references = np.array([scipy.interpolate.interp1d(knots, values)], dtype=object)
+        return lambda x: references[0](x)
+    if kind == "namespace":
+        namespace = types.SimpleNamespace(knots=knots, values=values)
+        return lambda x: np.interp(x, namespace.knots, namespace.values)
+    if kind == "set":
+        factors = frozenset({scale, scale + 1.0})
+        return lambda x: sum(factors) * x
+    if kind == "sequence":
+        factors = collections.deque([scale, scale + 1.0])
+        return lambda x: sum(factors) * x
+    if kind == "mapping":
+        offsets = collections.defaultdict(functools.partial(float, scale), x=scale)
+        return lambda x: offsets.default_factory() * x + offsets["x"]
+    raise ValueError(kind)
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "local",
+        "closure",
+        "polynomial",
+        "partial",
+        "method",
+        "classmethod",
+        "composite",
+        *[f"reference-{kind}" for kind in _MODEL_COMPARISON_REFERENCES],
+    ],
+)
+def test_fit2d_saved_custom_model_accepts_original_and_copies_code(qtbot, kind) -> None:
+    scale = 2.0
+
+    def line(x, slope=1.0, intercept=0.0):
+        return slope * x + intercept
+
+    def scaled_line(x, slope=1.0, intercept=0.0):
+        return scale * slope * x + intercept
+
+    if kind.startswith("reference-"):
+        reference = _make_model_comparison_reference(kind.removeprefix("reference-"))
+
+        def reference_model(x, amplitude=1.0):
+            return amplitude * reference(x)
+
+        model = lmfit.Model(reference_model)
+    elif kind == "polynomial":
+        model = lmfit.models.PolynomialModel(2)
+    elif kind == "composite":
+        model = lmfit.Model(line, prefix="line_") + lmfit.models.ConstantModel(
+            prefix="constant_"
+        )
+        model.set_param_hint("constant_c", expr="2 * line_intercept")
+    elif kind == "method":
+        model = lmfit.Model(_ModelComparisonLine(2.0).line)
+    elif kind == "classmethod":
+        model = lmfit.Model(_ModelComparisonLine.class_line)
+    elif kind == "partial":
+        func = functools.partial(line, intercept=1.0)
+        func.__name__ = "line"
+        model = lmfit.Model(func, independent_vars=["x"], param_names=["slope"])
+    else:
+        model = lmfit.Model(scaled_line if kind == "closure" else line)
+    model.set_param_hint(model.param_names[0], min=np.float64(-10.0))
+    params = model.make_params(**dict.fromkeys(model.param_names, 1.0))
+    x = np.linspace(-1.0, 1.0, 21)
+    values = model.eval(params, x=x) + 0.01 * np.sin(12 * x)
+    data = xr.DataArray(
+        np.stack([values] * 2),
+        dims=("y", "x"),
+        coords={"y": [0, 1], "x": x},
+    )
+    result = data.xlm.modelfit("x", model=model, params=params).load()
+    decoded = erlab.interactive.utils._deserialize_fit_dataset_blob(
+        erlab.interactive.utils._serialize_fit_dataset_blob(result)
+    )
+    inferred = erlab.interactive.ftool(decoded, execute=False)
+    qtbot.addWidget(inferred)
+    tool = erlab.interactive.ftool(
+        decoded, model=model, model_name="model", data_name="saved", execute=False
+    )
+    qtbot.addWidget(tool)
+    for index, restored in enumerate(tool._result_ds_full):
+        _assert_fit_result_dataset_equivalent(
+            restored, result.isel(y=index), require_model_type=False
+        )
+    assert tool._models_match(
+        model, [slice_result.model for slice_result in decoded.modelfit_results.values]
+    )
+    # Keep the model reconstructed by history separate from its live fit results.
+    tool.tool_status = tool.tool_status
+    assert tool._build_full_copy_prelude(warn=False)
+    seed = tool._params.copy()
+    tool._params_full = [seed.copy() for _ in range(2)]
+    code = tool._copy_code_full()
+    namespace = _exec_generated_code(code, saved=decoded, model=model, np=np, xr=xr)
+    expected = data.xlm.modelfit(
+        "x",
+        model=model,
+        params=seed,
+        method=tool.method_combo.currentText(),
+        scale_covar=tool.scale_covar_check.isChecked(),
+    )
+    xr.testing.assert_identical(
+        namespace["result"].drop_vars("modelfit_results"),
+        expected.drop_vars("modelfit_results"),
+    )
+
+
+@pytest.mark.parametrize("kind", _MODEL_COMPARISON_REFERENCES)
+def test_fit2d_model_comparison_detects_changed_reference_state(kind) -> None:
+    def make_model(scale):
+        reference = _make_model_comparison_reference(kind, scale)
+
+        def model_function(x, amplitude=1.0):
+            return amplitude * reference(x)
+
+        return lmfit.Model(model_function)
+
+    original = make_model(1.0)
+    equivalent = make_model(1.0)
+    changed = make_model(2.0)
+    assert Fit2DTool._models_match(original, [equivalent])
+    assert not Fit2DTool._models_match(original, [changed])
+    x = np.linspace(-1.0, 1.0, 21)
+    np.testing.assert_array_equal(original.eval(x=x), equivalent.eval(x=x))
+    assert not np.array_equal(original.eval(x=x), changed.eval(x=x))
+
+
+def test_fit2d_model_comparison_checks_local_class_code_and_container_state() -> None:
+    def make_reference(quadratic):
+        class Reference:
+            def __call__(self, x):
+                return x
+
+        if quadratic:
+            Reference.__call__ = lambda self, x: x**2
+        return Reference()
+
+    def make_model(reference):
+        def model_function(x, amplitude=1.0):
+            return amplitude * reference(x)
+
+        return lmfit.Model(model_function)
+
+    assert not Fit2DTool._models_match(
+        make_model(make_reference(False)), [make_model(make_reference(True))]
+    )
+    # Matching items alone do not establish equal default factories or attributes.
+    left = collections.defaultdict(int, x=1)
+    right = collections.defaultdict(float, x=1)
+    assert not Fit2DTool._model_state_equal(left, right, {})
+
+    class Values(list):
+        pass
+
+    first, second = Values([1]), Values([1])
+    first.scale, second.scale = 1.0, 2.0
+    assert not Fit2DTool._model_state_equal(first, second, {})
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ({1, 2}, {1}),
+        ({1}, {1, 2}),
+        (b"first", b"second"),
+        (np.array([1]), np.array([[1]])),
+        (np.array([1]), np.array([1.0])),
+        (np.array([0.0]), np.array([-0.0])),
+        (np.array([complex(1, np.nan)]), np.array([complex(2, np.nan)])),
+        (np.array([complex(np.nan, 1)]), np.array([complex(np.nan, 2)])),
+        (abs, len),
+        (types.ModuleType("first"), types.ModuleType("second")),
+    ],
+)
+def test_fit2d_model_comparison_rejects_different_or_unsupported_state(left, right):
+    assert not Fit2DTool._model_state_equal(left, right, {})
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.array([complex(1, np.nan), complex(np.nan, 1)]),
+        np.array([np.nan, -0.0, 0.0]),
+        np.array(["NaT", "2026-09-07"], dtype="datetime64[D]"),
+        np.array([(np.nan, 1.0)], dtype=[("a", float), ("b", float)]),
+    ],
+)
+def test_fit2d_model_comparison_accepts_array_state_with_missing_values(value):
+    assert Fit2DTool._model_state_equal(value, value.copy(), {})
+
+
+@pytest.mark.parametrize("change", ["code", "default", "keyword", "closure"])
+def test_fit2d_model_comparison_detects_changed_function_state(change) -> None:
+    def make_function(scale, default, keyword):
+        def line(x, slope=default, *, intercept=keyword):
+            return scale * slope * x + intercept
+
+        return line
+
+    function = make_function(2.0, 1.0, 0.0)
+    changed = make_function(
+        3.0 if change == "closure" else 2.0,
+        2.0 if change == "default" else 1.0,
+        1.0 if change == "keyword" else 0.0,
+    )
+    if change == "code":
+
+        def changed(x, slope=1.0, *, intercept=0.0):
+            return 2.0 * slope * x**2 + intercept
+
+    model = lmfit.Model(function)
+    assert Fit2DTool._models_match(model, [lmfit.Model(make_function(2.0, 1.0, 0.0))])
+    assert not Fit2DTool._models_match(model, [lmfit.Model(changed)])
+
+
+def test_fit2d_model_comparison_checks_nested_globals_and_recursive_helpers() -> None:
+    namespace = {"offset": 1.0, "np": np}
+    exec(  # noqa: S102
+        "def helper(x):\n"
+        "    return helper(x - 1) if x > 1 else x\n"
+        "def line(x, slope=1.0):\n"
+        "    return slope * x + np.array(list(offset + helper(0) for _ in x))\n",
+        namespace,
+    )
+    original = lmfit.Model(namespace["line"])
+    restored = lmfit.Model(lambda x: x).loads(original.dumps())
+    assert Fit2DTool._models_match(original, [restored])
+    x = np.linspace(0.0, 1.0, 3)
+    np.testing.assert_array_equal(original.eval(x=x), restored.eval(x=x))
+    restored.func.__globals__["offset"] = 2.0
+    assert not Fit2DTool._models_match(original, [restored])
+    np.testing.assert_array_equal(restored.eval(x=x), original.eval(x=x) + 1.0)
+
+
+def test_fit2d_model_comparison_checks_bound_state_and_unknown_values() -> None:
+    model = lmfit.Model(_ModelComparisonLine(2.0).line)
+    assert not Fit2DTool._models_match(
+        model, [lmfit.Model(_ModelComparisonLine(3.0).line)]
+    )
+
+    def make_function(marker):
+        def line(x, slope=1.0):
+            return slope * x if marker is not None else x
+
+        return line
+
+    assert not Fit2DTool._models_match(
+        lmfit.Model(make_function(object())), [lmfit.Model(make_function(object()))]
+    )
+    assert not Fit2DTool._models_match(
+        lmfit.Model(make_function(1)), [lmfit.Model(make_function(1.0))]
+    )
+
+
+def test_fit2d_model_definitions_include_expressions_options_and_operators() -> None:
+    expression = lmfit.models.ExpressionModel("slope * x + intercept")
+    equivalent = lmfit.models.ExpressionModel("slope * x + intercept")
+    different = lmfit.models.ExpressionModel("slope * x**2 + intercept")
+    assert expression.param_names == different.param_names
+    assert Fit2DTool._models_match(expression, [expression, equivalent, equivalent])
+    assert not Fit2DTool._models_match(expression, [different])
+    assert not Fit2DTool._models_match(expression, [None])
+    equivalent.set_param_hint("slope", min=0.0)
+    assert not Fit2DTool._models_match(expression, [equivalent])
+
+    left = lmfit.models.LinearModel(prefix="line_")
+    right = lmfit.models.ConstantModel(prefix="constant_")
+    composite = left + right
+    assert Fit2DTool._models_match(composite, [left + right])
+    assert not Fit2DTool._models_match(composite, [left - right])
+
+    model = erlab.analysis.fit.models.MultiPeakModel(1, "lorentzian")
+    changed = erlab.analysis.fit.models.MultiPeakModel(1, "lorentzian", oversample=5)
+    assert model.param_names == changed.param_names
+    assert not Fit2DTool._models_match(model, [changed])
+
+
+@pytest.mark.parametrize("descending", [False, True])
 @pytest.mark.parametrize("slice_dim", ["slice", "bound"])
 def test_fit2d_mixed_slice_ranges_copy_and_output_provenance(
     qtbot, descending, slice_dim
@@ -3439,7 +4157,9 @@ def test_fit2d_copy_code_full_inconsistent_expr_warning(qtbot, monkeypatch) -> N
     win._params["p0_center"].set(expr="p0_width / 2")
 
     win._params_full = [params1, params2]
-    win._result_ds_full = [xr.Dataset(), xr.Dataset()]
+    win._result_ds_full = [
+        _fit_result_dataset(params, model=win._model) for params in (params1, params2)
+    ]
     win.y_min_spin.setValue(0)
     win.y_max_spin.setValue(1)
 
@@ -3461,7 +4181,7 @@ def test_fit2d_copy_code_full_missing_fit_warning(qtbot, monkeypatch) -> None:
     assert isinstance(win, Fit2DTool)
 
     win._params_full = [win._params.copy(), win._params.copy()]
-    win._result_ds_full = [xr.Dataset(), None]
+    win._result_ds_full = [_fit_result_dataset(win._params, model=win._model), None]
     win.y_min_spin.setValue(0)
     win.y_max_spin.setValue(1)
 
@@ -3487,7 +4207,9 @@ def test_fit2d_copy_code_full_inconsistent_params_warning(qtbot, monkeypatch) ->
     del params2["p0_center"]
 
     win._params_full = [params1, params2]
-    win._result_ds_full = [xr.Dataset(), xr.Dataset()]
+    win._result_ds_full = [
+        _fit_result_dataset(params, model=win._model) for params in (params1, params2)
+    ]
     win.y_min_spin.setValue(0)
     win.y_max_spin.setValue(1)
 


### PR DESCRIPTION
Changing fitted MDC peaks from Voigt to Lorentzian could make Fit ×20 fail when it combined stored results with different parameter axes. Align different indexes by label and keep the fast path for identical indexes. Preserve each slice's parameter order, covariance axes, and fit range through save and restore.

Always restore idle controls and history state when repeated-fit completion fails. Clear obsolete cached payloads before serialization. Block combined fit code when stored slices use different model definitions. Compare custom functions and captured object state without relying on unstable serialized bytes, so compatible saved models still open and produce executable code.

Validation:

- `uv run ruff format .` and `uv run ruff check --fix .`
- `uv run mypy src`
- `uv run python -m scripts.ci_test_groups --check-partition`
- `QT_QPA_PLATFORM=offscreen QT_API=pyqt6 PYTEST_QT_API=pyqt6 uv run pytest -q tests/interactive/test_fit1d.py tests/interactive/test_fit2d.py --cov=erlab` — 492 passed; all changed runtime statements covered.
- Fit1D/Fit2D suite under PySide6 — 485 passed before the final array-state cases; 39 focused cases passed after those changes.
- Final review regression set under PyQt6 — 53 passed.
- `git diff --check` and commit hooks.

Regression coverage includes Fit, Fit ×20, Fit Up, and Fit Down after changing peak shape; sparse and mixed-range persistence; reordered parameter axes; completion failures followed by a successful refit; and saved custom models with interpolation objects, closures, bound methods, and callable instances. Generated fit code is executed and its numerical output is compared with a direct fit.


Manager provenance test fixtures use the active polynomial model so their synthetic results satisfy model consistency checks. The distinct-output-ID integration test passes under both PyQt6 and PySide6.
