### PR TITLE
fix(interactive): improve workspace restoration and metadata persistence

### DIFF
--- a/src/erlab/interactive/_code_trust/_payloads.py
+++ b/src/erlab/interactive/_code_trust/_payloads.py
@@ -6,12 +6,13 @@ import hashlib
 import json
 import typing
 
+from erlab.interactive import _persistence_constants
 from erlab.interactive._code_trust._core import CodeTrustEntry
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, MutableMapping
 
-CODE_PAYLOAD_ENTRIES_ATTR = "erlab_code_trust_payload_entries"
+
 _PAYLOAD_SHA256_KEY = "payload_sha256"
 
 
@@ -56,7 +57,7 @@ def code_payload_entries_from_metadata(
     attrs: Mapping[str, typing.Any],
 ) -> tuple[CodeTrustEntry, ...]:
     """Read validated opaque-payload entries from saved document metadata."""
-    raw = attrs.get(CODE_PAYLOAD_ENTRIES_ATTR)
+    raw = attrs.get(_persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR)
     if raw is None:
         return ()
     if isinstance(raw, bytes):
@@ -95,9 +96,9 @@ def store_code_payload_entries(
     """Store opaque-payload entries as deterministic document metadata."""
     validated = _validated_entries(entries)
     if not validated:
-        attrs.pop(CODE_PAYLOAD_ENTRIES_ATTR, None)
+        attrs.pop(_persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR, None)
         return
-    attrs[CODE_PAYLOAD_ENTRIES_ATTR] = json.dumps(
+    attrs[_persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR] = json.dumps(
         [entry.payload() for entry in validated],
         ensure_ascii=False,
         allow_nan=False,

--- a/src/erlab/interactive/_figurecomposer/_tool.py
+++ b/src/erlab/interactive/_figurecomposer/_tool.py
@@ -18,6 +18,7 @@ import unicodedata
 import uuid
 import weakref
 
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool._provenance._model import (
     ScriptInput,
     ToolProvenanceOperation,
@@ -4580,7 +4581,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
         self, variable_name: str, data: xr.DataArray
     ) -> dict[str, typing.Any] | None:
         del data
-        if variable_name == erlab.interactive.utils._SAVED_TOOL_DATA_NAME:
+        if variable_name == _persistence_constants.SAVED_TOOL_DATA_NAME:
             return self._source_reference_payload(self._document.recipe.primary_source)
         return self._source_reference_payload(variable_name)
 
@@ -4593,7 +4594,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
     ) -> bool:
         del ds
         return (
-            variable_name != erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+            variable_name != _persistence_constants.SAVED_TOOL_DATA_NAME
             and reference.get("kind") == "manager_node"
         )
 
@@ -4605,11 +4606,11 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             )
         else:
             primary_data = self.tool_data
-        items = {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: primary_data}
+        items = {_persistence_constants.SAVED_TOOL_DATA_NAME: primary_data}
         for source_name in self._document.source_data:
             if source_name == self._document.recipe.primary_source:
                 continue
-            if source_name == erlab.interactive.utils._SAVED_TOOL_DATA_NAME:
+            if source_name == _persistence_constants.SAVED_TOOL_DATA_NAME:
                 raise ValueError(
                     "Figure source names cannot use the reserved saved-tool data name"
                 )
@@ -4642,7 +4643,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
                 continue
             _data, already_selected = self._persistence_source_data(source.name)
             variable_name = (
-                erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+                _persistence_constants.SAVED_TOOL_DATA_NAME
                 if source.name == self._document.recipe.primary_source
                 else source.name
             )
@@ -4702,7 +4703,7 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
 
         def persisted_data(source: FigureSourceState) -> xr.DataArray | None:
             variable_name = (
-                erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+                _persistence_constants.SAVED_TOOL_DATA_NAME
                 if source.name == self._document.recipe.primary_source
                 else source.name
             )
@@ -4714,8 +4715,10 @@ class FigureComposerTool(erlab.interactive.utils.ToolWindow[FigureRecipeState]):
             current_primary = source_data.get(source.name)
             if current_primary is not None:
                 return data.rename(current_primary.name)
-            tool_data_name = ds.attrs.get("tool_data_name", "<none-value>")
-            if tool_data_name == "<none-value>":
+            tool_data_name = ds.attrs.get(
+                "tool_data_name", _persistence_constants.NONE_TOOL_DATA_NAME
+            )
+            if tool_data_name == _persistence_constants.NONE_TOOL_DATA_NAME:
                 tool_data_name = None
             return data.rename(tool_data_name)
 

--- a/src/erlab/interactive/_persistence_constants.py
+++ b/src/erlab/interactive/_persistence_constants.py
@@ -1,0 +1,52 @@
+"""Names and versions shared by interactive persistence code.
+
+Keep this module free of imports so tools and workspace readers can share the
+saved-file contract without importing each other's implementation.
+"""
+
+# Data variables, coordinates, and encoded attributes.
+ITOOL_DATA_NAME: str = "<erlab-itool-data>"
+SAVED_TOOL_DATA_NAME: str = "<saved-tool-data>"
+TOOL_DATA_BLOB_NAME_ATTR: str = "tool_data_blob_name"
+SAVED_TOOL_DATA_REFERENCE_DIM: str = "<saved-tool-data-reference>"
+SAVED_TOOL_DATA_BLOB_DIM_PREFIX: str = "<saved-tool-data-blob-"
+TOOL_ATTRS_VERSION_ATTR = "_erlab_tool_attrs_version"
+TOOL_ENCODED_ATTRS_ATTR = "_erlab_tool_encoded_attrs"
+TOOL_ATTRS_VERSION = 1
+TOOL_ATTR_TRANSPORT_KEYS = frozenset((TOOL_ATTRS_VERSION_ATTR, TOOL_ENCODED_ATTRS_ATTR))
+
+# Tool input and provenance metadata.
+TOOL_SOURCE_SPEC_ATTR = "tool_source_spec"
+TOOL_SOURCE_BINDING_ATTR = "tool_source_binding"
+TOOL_SOURCE_STATE_ATTR = "tool_source_state"
+TOOL_SOURCE_AUTO_UPDATE_ATTR = "tool_source_auto_update"
+TOOL_INPUT_PROVENANCE_SPEC_ATTR = "tool_input_provenance_spec"
+TOOL_SCRIPT_INPUTS_ATTR = "tool_script_inputs"
+TOOL_PRIMARY_INPUT_ATTR = "tool_primary_input"
+TOOL_DATA_REFERENCES_ATTR = "tool_data_references"
+NONE_TOOL_DATA_NAME = "<none-value>"
+
+# ImageTool and Manager provenance metadata.
+MANAGER_LIVE_SOURCE_SPEC_ATTR = "manager_node_live_source_spec"
+MANAGER_PROVENANCE_SPEC_ATTR = "manager_node_provenance_spec"
+ITOOL_PROVENANCE_SPEC_ATTR = "itool_provenance_spec"
+
+# Opaque executable-payload metadata.
+CODE_PAYLOAD_ENTRIES_ATTR = "erlab_code_trust_payload_entries"
+
+# Workspace document formats and legacy transactions.
+WORKSPACE_SCHEMA_VERSION = 6
+WORKSPACE_LEGACY_SCHEMA_VERSION = 3
+WORKSPACE_MANIFEST_ATTR = "imagetool_workspace_manifest"
+WORKSPACE_LEGACY_TEMP_GROUP_PREFIXES = ("__itws_pending_", "__itws_backup_")
+WORKSPACE_TRANSACTION_GROUP_PREFIX = "__itws_txn_"
+WORKSPACE_ENCODED_ATTRS_ATTR = "_erlab_workspace_encoded_attrs"
+WORKSPACE_ENCODED_ATTRS_VERSION = 1
+WORKSPACE_REPLAY_SOURCE_BLOB_NAME = "<manager-replay-source-data>"
+
+# Immutable workspace storage.
+WORKSPACE_OBJECTS_GROUP = "__itws_objects"
+WORKSPACE_STAGING_GROUP = "__itws_staging"
+WORKSPACE_GENERATIONS_GROUP = "__itws_generations"
+WORKSPACE_GENERATION_WIDTH = 20
+WORKSPACE_ID_ATTR = "imagetool_workspace_id"

--- a/src/erlab/interactive/_plot_state.py
+++ b/src/erlab/interactive/_plot_state.py
@@ -21,8 +21,7 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-TOOL_VIEW_STATE_ATTR = "tool_view_state"
-_TOOL_VIEW_STATE_VERSION = 1
+
 _MAX_SAVED_COLORMAP_STOPS = 256
 
 
@@ -126,7 +125,7 @@ def _parse_tool_view_state(payload: object) -> ToolViewState:
     raw = json.loads(payload)
     if not isinstance(raw, dict):
         raise TypeError("saved tool view state must be a JSON object")
-    if raw.get("version", _TOOL_VIEW_STATE_VERSION) != _TOOL_VIEW_STATE_VERSION:
+    if raw.get("version", 1) != 1:
         raise ValueError("unsupported saved tool view state version")
     raw_plots = raw.get("plots", {})
     if not isinstance(raw_plots, dict):

--- a/src/erlab/interactive/imagetool/_mainwindow.py
+++ b/src/erlab/interactive/imagetool/_mainwindow.py
@@ -7,6 +7,7 @@ functionality of the ImageTool window, including GUI controls and keyboard short
 
 from __future__ import annotations
 
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     ReplayStep,
@@ -36,9 +37,6 @@ if typing.TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
     from erlab.interactive.imagetool.slicer import ArraySlicer
-
-_ITOOL_DATA_NAME: str = _serialization.ITOOL_DATA_NAME
-#: Name to use for the data variable in cached datasets
 
 
 class BaseImageTool(QtWidgets.QMainWindow):
@@ -231,7 +229,9 @@ class BaseImageTool(QtWidgets.QMainWindow):
         name = data.name
         if name is None:
             name = ""
-        ds = data.to_dataset(name=_ITOOL_DATA_NAME, promote_attrs=False)
+        ds = data.to_dataset(
+            name=_persistence_constants.ITOOL_DATA_NAME, promote_attrs=False
+        )
         attrs = {
             "itool_state": json.dumps(state),
             "itool_title": self.windowTitle(),
@@ -240,7 +240,7 @@ class BaseImageTool(QtWidgets.QMainWindow):
             "erlab_version": erlab.__version__,
         }
         if self._provenance_spec is not None:
-            attrs["itool_provenance_spec"] = json.dumps(
+            attrs[_persistence_constants.ITOOL_PROVENANCE_SPEC_ATTR] = json.dumps(
                 self._provenance_spec.model_dump(mode="json")
             )
         return ds.assign_attrs(attrs)
@@ -258,7 +258,7 @@ class BaseImageTool(QtWidgets.QMainWindow):
 
         """
         _serialization.encode_private_coords(
-            self.to_dataset(), _ITOOL_DATA_NAME
+            self.to_dataset(), _persistence_constants.ITOOL_DATA_NAME
         ).to_netcdf(filename, engine="h5netcdf", invalid_netcdf=True)
 
     @classmethod
@@ -273,7 +273,9 @@ class BaseImageTool(QtWidgets.QMainWindow):
             Additional keyword arguments passed to the constructor.
 
         """
-        ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
+        ds = _serialization.restore_private_coords(
+            ds, _persistence_constants.ITOOL_DATA_NAME
+        )
         saved_version = ds.attrs.get("erlab_version", "0.0.0")
         if erlab.utils.misc.is_newer_version(saved_version):  # pragma: no cover
             erlab.utils.misc.emit_user_level_warning(
@@ -284,7 +286,7 @@ class BaseImageTool(QtWidgets.QMainWindow):
         name = ds.attrs["itool_name"]
         name = None if name == "" else name
         tool = cls(
-            ds[_ITOOL_DATA_NAME].rename(name),
+            ds[_persistence_constants.ITOOL_DATA_NAME].rename(name),
             state=json.loads(ds.attrs["itool_state"]),
             _saved_window_state=ds.attrs.get("itool_window_state"),
             _legacy_window_rect=ds.attrs.get("itool_rect"),
@@ -295,7 +297,9 @@ class BaseImageTool(QtWidgets.QMainWindow):
             tool._sync_file_load_provenance()
         migrated_file_provenance = tool.provenance_spec
 
-        provenance_spec = ds.attrs.get("itool_provenance_spec")
+        provenance_spec = ds.attrs.get(
+            _persistence_constants.ITOOL_PROVENANCE_SPEC_ATTR
+        )
         if provenance_spec is not None:
             try:
                 saved_provenance = parse_tool_provenance_spec(

--- a/src/erlab/interactive/imagetool/_serialization.py
+++ b/src/erlab/interactive/imagetool/_serialization.py
@@ -2,26 +2,220 @@
 
 from __future__ import annotations
 
+import base64
+import collections.abc
 import contextlib
 import json
+import math
+import numbers
 import typing
 
+import numpy as np
 import xarray as xr
+
+from erlab.interactive import _persistence_constants
 
 if typing.TYPE_CHECKING:
     from collections.abc import Hashable, Mapping
 
-ITOOL_DATA_NAME: str = "<erlab-itool-data>"
-SAVED_TOOL_DATA_NAME: str = "<saved-tool-data>"
-TOOL_DATA_BLOB_NAME_ATTR: str = "tool_data_blob_name"
-SAVED_TOOL_DATA_REFERENCE_DIM: str = "<saved-tool-data-reference>"
-SAVED_TOOL_DATA_BLOB_DIM_PREFIX: str = "<saved-tool-data-blob-"
 
-# NetCDF stores non-dimension coordinate names in a whitespace-delimited
-# ``coordinates`` attribute.  A coord named "Fake Motor" cannot round-trip there,
-# so ImageTool stores those associated coords as private variables plus this map.
-_PRIVATE_COORDS_ATTR = "_erlab_imagetool_private_coords"
-_PRIVATE_COORD_VAR_PREFIX = "__erlab_imagetool_coord_"
+# Coordinates with whitespace in their names use private variables plus a name map.
+PRIVATE_COORDS_ATTR = "_erlab_imagetool_private_coords"
+
+_STALE_BACKEND_ENCODING_KEYS = frozenset(
+    (
+        "chunksizes",
+        "compression",
+        "compression_opts",
+        "contiguous",
+        "fletcher32",
+        "original_shape",
+        "preferred_chunks",
+        "shuffle",
+        "source",
+    )
+)
+
+
+def _tool_attr_writes_natively(value: typing.Any) -> bool:
+    if isinstance(value, str):
+        return "\x00" not in value
+    if isinstance(value, np.generic) and value.dtype.kind in "Mm":
+        return False
+    if isinstance(value, np.ndarray):
+        if value.dtype.kind == "U":
+            return False
+        # Let HDF5 retain its existing handling of compound and special dtypes.
+        # These dtypes must not pass through the typed codec's raw-byte encoding.
+        if value.dtype.kind == "V" or value.dtype.metadata is not None:
+            return True
+        if value.dtype.kind == "O":
+            return bool(value.size) and all(
+                isinstance(item, str | bytes) and _tool_attr_writes_natively(item)
+                for item in value.flat
+            )
+    if isinstance(value, list | tuple):
+        if _structured_attr_sequence(value):
+            return True
+        return all(_tool_attr_writes_natively(item) for item in value) and (
+            attr_value_writes_natively(value)
+        )
+    return attr_value_writes_natively(value)
+
+
+def _structured_attr_sequence(value: typing.Any) -> bool:
+    return isinstance(value, np.void) or (
+        isinstance(value, list | tuple)
+        and bool(value)
+        and all(_structured_attr_sequence(item) for item in value)
+    )
+
+
+def _validate_tool_attr_value(value: typing.Any) -> None:
+    """Reject NumPy metadata that the shared workspace codec cannot preserve."""
+    if isinstance(value, np.ndarray | np.generic):
+        if (
+            value.dtype.kind == "V"
+            or (value.dtype.hasobject and value.dtype.kind != "O")
+            or value.dtype.metadata is not None
+        ):
+            raise TypeError(
+                "structured or variable-width NumPy attributes and dtype metadata "
+                "are unsupported"
+            )
+        if value.dtype.kind == "O":
+            for item in np.asarray(value).flat:
+                if isinstance(item, list | tuple | np.ndarray):
+                    raise TypeError(
+                        "sequence elements in object array attributes are unsupported"
+                    )
+                _validate_tool_attr_value(item)
+    elif isinstance(value, collections.abc.Mapping):
+        for key, item in value.items():
+            _validate_tool_attr_value(key)
+            _validate_tool_attr_value(item)
+    elif isinstance(value, list | tuple):
+        for item in value:
+            _validate_tool_attr_value(item)
+
+
+def _encode_tool_attrs(
+    attrs: Mapping[Hashable, typing.Any], *, root: bool
+) -> tuple[dict[str, typing.Any], list[list[dict[str, typing.Any]]]]:
+    native: dict[str, typing.Any] = {}
+    encoded: list[list[dict[str, typing.Any]]] = []
+    for key, value in attrs.items():
+        if not isinstance(key, str) or not key:
+            raise TypeError("Tool attribute names must be non-empty strings")
+        try:
+            writes_natively = not (
+                root and key in _persistence_constants.TOOL_ATTR_TRANSPORT_KEYS
+            ) and (_tool_attr_writes_natively(value))
+        except RecursionError as exc:
+            raise TypeError(
+                f"Cannot serialize tool attribute {key!r}: unsupported cyclic sequence"
+            ) from exc
+        if writes_natively:
+            native[key] = value
+            continue
+        if root and key.startswith(("tool_", "erlab_")):
+            raise TypeError(f"Tool control attribute {key!r} must use native metadata")
+        try:
+            _validate_tool_attr_value(value)
+            encoded.append([encode_attr_key(key), encode_attr_value(value)])
+        except (TypeError, RecursionError) as exc:
+            raise TypeError(f"Cannot serialize tool attribute {key!r}: {exc}") from exc
+    return native, encoded
+
+
+def prepare_tool_dataset(
+    ds: xr.Dataset, *, strip_backend_encoding: bool = False
+) -> xr.Dataset:
+    """Prepare tool file metadata without copying or computing array values."""
+    prepared = ds.copy(deep=False)
+    prepared.attrs, root_attrs = _encode_tool_attrs(ds.attrs, root=True)
+    variable_attrs: dict[str, list[list[dict[str, typing.Any]]]] = {}
+    for name, variable in prepared.variables.items():
+        variable.attrs, encoded = _encode_tool_attrs(variable.attrs, root=False)
+        if encoded:
+            if not isinstance(name, str):
+                raise TypeError("Saved tool variable names must be strings")
+            variable_attrs[name] = encoded
+        if strip_backend_encoding:
+            variable.encoding = {
+                key: value
+                for key, value in variable.encoding.items()
+                if key not in _STALE_BACKEND_ENCODING_KEYS
+            }
+    if root_attrs or variable_attrs:
+        prepared.attrs[_persistence_constants.TOOL_ATTRS_VERSION_ATTR] = (
+            _persistence_constants.TOOL_ATTRS_VERSION
+        )
+        prepared.attrs[_persistence_constants.TOOL_ENCODED_ATTRS_ATTR] = json.dumps(
+            {"dataset": root_attrs, "variables": variable_attrs},
+            separators=(",", ":"),
+        )
+    return prepared
+
+
+def _decode_tool_attrs(
+    attrs: dict[Hashable, typing.Any], entries: object, *, root: bool
+) -> None:
+    if not isinstance(entries, list):
+        raise TypeError("Encoded tool attributes must be a list")
+    for entry in entries:
+        if not isinstance(entry, list) or len(entry) != 2:
+            raise ValueError("Invalid encoded tool attribute entry")
+        try:
+            key = decode_attr_key(entry[0])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("Invalid encoded tool attribute name") from exc
+        if not isinstance(key, str) or not key or encode_attr_key(key) != entry[0]:
+            raise ValueError("Invalid encoded tool attribute name")
+        if key in attrs or (root and key.startswith(("tool_", "erlab_"))):
+            raise ValueError(f"Encoded tool attribute cannot replace metadata {key!r}")
+        try:
+            value = decode_attr_value(entry[1])
+            _validate_tool_attr_value(value)
+            encoded = encode_attr_value(value)
+        except (KeyError, TypeError, ValueError, OverflowError, RecursionError) as exc:
+            raise ValueError(
+                f"Invalid encoded tool attribute value for {key!r}"
+            ) from exc
+        if encoded != entry[1]:
+            raise ValueError(f"Invalid encoded tool attribute value for {key!r}")
+        attrs[key] = value
+
+
+def restore_tool_dataset_attrs(ds: xr.Dataset) -> xr.Dataset:
+    """Decode a marked tool file once, before restoring private coordinates."""
+    if _persistence_constants.TOOL_ATTRS_VERSION_ATTR not in ds.attrs:
+        return ds
+    version = ds.attrs[_persistence_constants.TOOL_ATTRS_VERSION_ATTR]
+    if (
+        isinstance(version, bool)
+        or not isinstance(version, int | np.integer)
+        or version != _persistence_constants.TOOL_ATTRS_VERSION
+    ):
+        raise ValueError(f"Unsupported tool attribute encoding version: {version!r}")
+    try:
+        payload = json.loads(ds.attrs[_persistence_constants.TOOL_ENCODED_ATTRS_ATTR])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid encoded tool attributes: {exc}") from exc
+    if not isinstance(payload, dict) or set(payload) != {"dataset", "variables"}:
+        raise ValueError("Invalid tool attribute envelope")
+    variables = payload["variables"]
+    if not isinstance(variables, dict):
+        raise TypeError("Encoded tool variable attributes must be a mapping")
+    restored = ds.copy(deep=False)
+    for key in _persistence_constants.TOOL_ATTR_TRANSPORT_KEYS:
+        restored.attrs.pop(key)
+    _decode_tool_attrs(restored.attrs, payload["dataset"], root=True)
+    for name, entries in variables.items():
+        if name not in restored.variables:
+            raise ValueError(f"Encoded attributes refer to missing variable {name!r}")
+        _decode_tool_attrs(restored[name].attrs, entries, root=False)
+    return restored
 
 
 def coord_name_needs_private_storage(name: Hashable) -> bool:
@@ -30,7 +224,7 @@ def coord_name_needs_private_storage(name: Hashable) -> bool:
 
 def _private_coord_variable_name(existing: set[Hashable], index: int) -> str:
     while True:
-        name = f"{_PRIVATE_COORD_VAR_PREFIX}{index}"
+        name = f"__erlab_imagetool_coord_{index}"
         if name not in existing:
             return name
         index += 1
@@ -46,7 +240,7 @@ def _decode_attr(value: object) -> object:
 def private_coord_records_from_attrs(
     attrs: Mapping[Hashable, object],
 ) -> tuple[dict[str, typing.Any], ...] | None:
-    raw = _decode_attr(attrs.get(_PRIVATE_COORDS_ATTR))
+    raw = _decode_attr(attrs.get(PRIVATE_COORDS_ATTR))
     if raw is None:
         return None
     if not isinstance(raw, str):
@@ -81,7 +275,7 @@ def private_coord_records_from_attrs(
 
 def private_coord_variable_names(
     ds: xr.Dataset,
-    data_name: Hashable = ITOOL_DATA_NAME,
+    data_name: Hashable = _persistence_constants.ITOOL_DATA_NAME,
 ) -> tuple[str, ...]:
     if data_name not in ds.data_vars:
         return ()
@@ -98,7 +292,7 @@ def _coord_dims_fit_data(coord: xr.DataArray, data_array: xr.DataArray) -> bool:
 
 def encode_private_coords(
     ds: xr.Dataset,
-    data_name: Hashable = ITOOL_DATA_NAME,
+    data_name: Hashable = _persistence_constants.ITOOL_DATA_NAME,
 ) -> xr.Dataset:
     if data_name not in ds.data_vars:
         return ds
@@ -143,7 +337,7 @@ def encode_private_coords(
         encoded[variable_name] = private_coord
 
     data_attrs = dict(encoded[data_name].attrs)
-    data_attrs[_PRIVATE_COORDS_ATTR] = json.dumps(records, separators=(",", ":"))
+    data_attrs[PRIVATE_COORDS_ATTR] = json.dumps(records, separators=(",", ":"))
     encoded[data_name].attrs = data_attrs
     return encoded
 
@@ -173,7 +367,7 @@ def _legacy_spaced_coord_records(
 
 def restore_private_coords(
     ds: xr.Dataset,
-    data_name: Hashable = ITOOL_DATA_NAME,
+    data_name: Hashable = _persistence_constants.ITOOL_DATA_NAME,
 ) -> xr.Dataset:
     if data_name not in ds.data_vars:
         return ds
@@ -184,7 +378,7 @@ def restore_private_coords(
     if records is None:
         records = _legacy_spaced_coord_records(restored, data_name)
     else:
-        data_attrs.pop(_PRIVATE_COORDS_ATTR, None)
+        data_attrs.pop(PRIVATE_COORDS_ATTR, None)
         restored[data_name].attrs = data_attrs
 
     drop_names: list[Hashable] = []
@@ -215,3 +409,245 @@ def restore_private_coords(
     if drop_names:
         restored = restored.drop_vars(drop_names)
     return restored
+
+
+def attr_value_writes_natively(value: typing.Any) -> bool:
+    if isinstance(value, str):
+        return True
+    if isinstance(value, bytes):
+        return b"\x00" not in value and _bytes_are_utf8(value)
+    if isinstance(value, np.ndarray):
+        return value.dtype.kind in "biufcSU"
+    if isinstance(value, np.generic):
+        return isinstance(value, (np.number, np.bool_))
+    if isinstance(value, bool | int | float | complex):
+        return True
+    if isinstance(value, list | tuple):
+        return _attr_sequence_writes_natively(value)
+    return False
+
+
+def _attr_sequence_writes_natively(
+    value: list[typing.Any] | tuple[typing.Any, ...],
+) -> bool:
+    if not value:
+        return True
+    if all(isinstance(item, str) for item in value):
+        return True
+    if all(
+        isinstance(item, bytes) and b"\x00" not in item and _bytes_are_utf8(item)
+        for item in value
+    ):
+        return True
+    return all(_attr_numeric_scalar_writes_natively(item) for item in value)
+
+
+def _attr_numeric_scalar_writes_natively(value: typing.Any) -> bool:
+    if isinstance(value, np.generic):
+        return isinstance(value, (np.number, np.bool_))
+    return isinstance(value, bool | int | float | complex)
+
+
+def _bytes_are_utf8(value: bytes) -> bool:
+    try:
+        value.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def encode_attr_key(value: typing.Any) -> dict[str, typing.Any]:
+    if isinstance(value, np.generic):
+        if value.dtype.kind in "SUMm":
+            return encode_attr_value(value)
+        value = value.item()
+    if value is None:
+        return {"kind": "none"}
+    if isinstance(value, bool):
+        return {"kind": "bool", "value": value}
+    if isinstance(value, int):
+        return {"kind": "int", "value": value}
+    if isinstance(value, float):
+        return {"kind": "float", **_encode_float(value)}
+    if isinstance(value, complex):
+        return {
+            "kind": "complex",
+            "real": _encode_float(value.real),
+            "imag": _encode_float(value.imag),
+        }
+    if isinstance(value, str):
+        return {"kind": "str", "value": value}
+    if isinstance(value, bytes):
+        return {
+            "kind": "bytes",
+            "value": base64.b64encode(value).decode("ascii"),
+        }
+    if isinstance(value, tuple):
+        return {
+            "kind": "tuple",
+            "items": [encode_attr_key(item) for item in value],
+        }
+    raise TypeError(f"unsupported attr key type {type(value).__name__!r}")
+
+
+def decode_attr_key(value: typing.Any) -> typing.Hashable:
+    decoded = decode_attr_value(value)
+    if not isinstance(decoded, collections.abc.Hashable):
+        raise TypeError(f"decoded attr key is not hashable: {type(decoded).__name__!r}")
+    return decoded
+
+
+def encode_attr_value(value: typing.Any) -> dict[str, typing.Any]:
+    if isinstance(value, np.ndarray):
+        return _encode_array(value, kind="ndarray")
+    if isinstance(value, np.str_ | np.bytes_):
+        array = np.asarray(value)
+        if value.dtype.itemsize == 0:
+            # np.asarray expands an empty string scalar to one NUL code unit.
+            array = np.ndarray((), dtype=value.dtype)
+        # Legacy numpy_scalar records do not distinguish empty strings from NULs.
+        return _encode_array(array, kind="numpy_string")
+    if isinstance(value, np.generic):
+        return _encode_array(np.asarray(value), kind="numpy_scalar")
+    if value is None:
+        return {"kind": "none"}
+    if isinstance(value, bool):
+        return {"kind": "bool", "value": value}
+    if isinstance(value, int):
+        return {"kind": "int", "value": value}
+    if isinstance(value, float):
+        return {"kind": "float", **_encode_float(value)}
+    if isinstance(value, complex):
+        return {
+            "kind": "complex",
+            "real": _encode_float(value.real),
+            "imag": _encode_float(value.imag),
+        }
+    if isinstance(value, str):
+        return {"kind": "str", "value": value}
+    if isinstance(value, bytes):
+        return {
+            "kind": "bytes",
+            "value": base64.b64encode(value).decode("ascii"),
+        }
+    if isinstance(value, list):
+        return {
+            "kind": "list",
+            "items": [encode_attr_value(item) for item in value],
+        }
+    if isinstance(value, tuple):
+        return {
+            "kind": "tuple",
+            "items": [encode_attr_value(item) for item in value],
+        }
+    if isinstance(value, collections.abc.Mapping):
+        return {
+            "kind": "dict",
+            "items": [
+                [encode_attr_key(key), encode_attr_value(item)]
+                for key, item in value.items()
+            ],
+        }
+    if isinstance(value, numbers.Number):
+        raise TypeError(f"unsupported numeric attr type {type(value).__name__!r}")
+    raise TypeError(f"unsupported attr value type {type(value).__name__!r}")
+
+
+def decode_attr_value(value: typing.Any) -> typing.Any:
+    if not isinstance(value, collections.abc.Mapping):
+        raise TypeError("encoded workspace attr value must be a mapping")
+    kind = value.get("kind")
+    match kind:
+        case "none":
+            return None
+        case "bool":
+            return bool(value["value"])
+        case "int":
+            return int(value["value"])
+        case "float":
+            return _decode_float(value)
+        case "complex":
+            return complex(
+                _decode_float(value["real"]),
+                _decode_float(value["imag"]),
+            )
+        case "str":
+            return str(value["value"])
+        case "bytes":
+            return base64.b64decode(str(value["value"]).encode("ascii"))
+        case "list":
+            return [decode_attr_value(item) for item in value["items"]]
+        case "tuple":
+            return tuple(decode_attr_value(item) for item in value["items"])
+        case "dict":
+            return {
+                decode_attr_key(key): decode_attr_value(item)
+                for key, item in value["items"]
+            }
+        case "ndarray":
+            return _decode_array(value)
+        case "numpy_scalar" | "numpy_string":
+            array = _decode_array(value)
+            if array.ndim != 0:
+                raise ValueError("encoded NumPy scalar must have an empty shape")
+            if kind == "numpy_scalar":
+                # Retain the decoding semantics of existing workspace records.
+                return array[()]
+            # Indexing a string array strips trailing NULs from the scalar.
+            if array.dtype.kind == "S":
+                return np.bytes_(array.tobytes())
+            if array.dtype.kind == "U":
+                data = array.astype(array.dtype.newbyteorder("<"), copy=False).tobytes()
+                return np.str_(data.decode("utf-32-le", errors="surrogatepass"))
+            raise TypeError("encoded NumPy string must have a string dtype")
+        case _:
+            raise TypeError(f"unknown workspace attr value kind {kind!r}")
+
+
+def _encode_float(value: float) -> dict[str, typing.Any]:
+    if math.isnan(value):
+        return {"special": "nan"}
+    if math.isinf(value):
+        return {"special": "inf" if value > 0 else "-inf"}
+    return {"value": value}
+
+
+def _decode_float(value: Mapping[str, typing.Any]) -> float:
+    special = value.get("special")
+    if special == "nan":
+        # Distinct NaN mapping keys must not share the same object identity.
+        return float("nan")
+    if special == "inf":
+        return math.inf
+    if special == "-inf":
+        return -math.inf
+    return float(value["value"])
+
+
+def _encode_array(value, *, kind: str) -> dict[str, typing.Any]:
+    array = np.asarray(value)
+    payload: dict[str, typing.Any] = {
+        "kind": kind,
+        "dtype": array.dtype.str,
+        "shape": list(array.shape),
+    }
+    if array.dtype.kind == "O":
+        payload["items"] = encode_attr_value(array.tolist())
+        return payload
+    contiguous = np.ascontiguousarray(array)
+    payload["data"] = base64.b64encode(contiguous.tobytes()).decode("ascii")
+    return payload
+
+
+def _decode_array(value: Mapping[str, typing.Any]):
+    dtype = np.dtype(typing.cast("str", value["dtype"]))
+    shape = tuple(int(size) for size in typing.cast("list[typing.Any]", value["shape"]))
+    if "items" in value:
+        items = decode_attr_value(value["items"])
+        return np.asarray(items, dtype=object).reshape(shape)
+    data = base64.b64decode(str(value["data"]).encode("ascii"))
+    if dtype.kind in "SU" and dtype.itemsize == 0:
+        if data:
+            raise ValueError("encoded zero-width string array must have no data")
+        return np.ndarray(shape, dtype=dtype)
+    return np.frombuffer(data, dtype=dtype).copy().reshape(shape)

--- a/src/erlab/interactive/imagetool/manager/_lineage.py
+++ b/src/erlab/interactive/imagetool/manager/_lineage.py
@@ -14,6 +14,7 @@ from qtpy import QtCore, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool.slicer
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool._provenance._execution import (
     _memoized_live_input_resolver,
@@ -1469,7 +1470,7 @@ class _LineageController:
                     )
                 if attrs is not None:
                     raw_references = attrs.get(
-                        erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR
+                        _persistence_constants.TOOL_DATA_REFERENCES_ATTR
                     )
                     if isinstance(raw_references, (str, bytes, bytearray)):
                         try:
@@ -1491,7 +1492,7 @@ class _LineageController:
                                 if updated_attrs is None:
                                     updated_attrs = dict(attrs)
                                 updated_attrs[
-                                    erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR
+                                    _persistence_constants.TOOL_DATA_REFERENCES_ATTR
                                 ] = json.dumps(rebased_references)
                 if updated_attrs is not None:
                     node.update_pending_workspace_payload_attrs(updated_attrs)

--- a/src/erlab/interactive/imagetool/manager/_server.py
+++ b/src/erlab/interactive/imagetool/manager/_server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from erlab.interactive import _persistence_constants
+
 __all__ = [
     "HOST_IP",
     "PORT",
@@ -47,7 +49,6 @@ import zmq.utils.monitor
 from qtpy import QtCore
 
 import erlab
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool.manager._registry import (
     ImageToolManagerAmbiguousError,
     ImageToolManagerNotFoundError,
@@ -1144,7 +1145,7 @@ def show_in_manager(
 
     direct_manager = _direct_manager_for_target(target)
 
-    if isinstance(data, xr.Dataset) and _ITOOL_DATA_NAME in data:
+    if isinstance(data, xr.Dataset) and _persistence_constants.ITOOL_DATA_NAME in data:
         # Dataset created with ImageTool.to_dataset()
         input_data: list[xr.DataArray] | list[xr.Dataset] = [data]
     elif data is None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_arrays.py
@@ -20,6 +20,7 @@ from xarray.backends.locks import SerializableLock
 from xarray.core import indexing
 
 import erlab
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool import _serialization
 from erlab.interactive.imagetool.manager._workspace import _store as workspace_store
 
@@ -35,7 +36,6 @@ else:
     h5py = _lazy.load("h5py")
 
 from erlab.interactive.imagetool.manager._workspace._format import (
-    _WORKSPACE_MANIFEST_ATTR,
     _restore_workspace_serialized_attrs,
     _sanitize_workspace_attr_names,
     _workspace_file_is_workspace,
@@ -46,9 +46,8 @@ from erlab.interactive.imagetool.manager._workspace._format import (
 _WORKSPACE_FILE_LOCKS: dict[str, threading.RLock] = {}
 _WORKSPACE_FILE_LOCKS_LOCK = threading.Lock()
 _WORKSPACE_COMPRESSION_MIN_BYTES = 1 << 20  # 1 MiB
-_TOOL_DATA_BLOB_NAME_ATTR = _serialization.TOOL_DATA_BLOB_NAME_ATTR
-_SAVED_TOOL_DATA_REFERENCE_DIM = _serialization.SAVED_TOOL_DATA_REFERENCE_DIM
-_SAVED_TOOL_DATA_BLOB_DIM_PREFIX = _serialization.SAVED_TOOL_DATA_BLOB_DIM_PREFIX
+
+
 _WORKSPACE_H5PY_DIMENSION_SCALE_ATTRS = frozenset(
     {"CLASS", "NAME", "DIMENSION_LIST", "REFERENCE_LIST"}
 )
@@ -361,6 +360,7 @@ class WorkspaceFileManager(CachingFileManager):
         self._group_path = None if group_path is None else f"/{group_path.strip('/')}"
         self._store_lease_released = True
         self._netcdf_file: h5netcdf.File | None = None
+        self._direct_read_datasets: dict[str, h5py.Dataset | None] = {}
         self._store_handle_generation = -1
         self._serialized_worker = False
         self._workspace_id: str | None = None
@@ -454,9 +454,8 @@ class WorkspaceFileManager(CachingFileManager):
             self._netcdf_file is None
             or self._store_handle_generation != store.handle_generation
         ):
-            if self._netcdf_file is not None:
-                with contextlib.suppress(Exception):
-                    self._netcdf_file.close()
+            with contextlib.suppress(Exception):
+                self._close_store_wrapper()
             self._netcdf_file = h5netcdf.File(
                 store.read_h5_file,
                 mode="r",
@@ -467,6 +466,38 @@ class WorkspaceFileManager(CachingFileManager):
             )
             self._store_handle_generation = store.handle_generation
         return self._netcdf_file
+
+    def _direct_read_dataset(
+        self, variable_name: str, variable: h5netcdf.Variable
+    ) -> h5py.Dataset | None:
+        """Cache numeric read eligibility while the store read session is held.
+
+        Immutable payloads with fixed, matching physical and netCDF dimensions
+        need neither netCDF padding nor type conversion. Other variables retain
+        h5netcdf's selection semantics. Closing the wrapper clears both positive
+        and negative decisions before the handle or payload binding changes.
+        """
+        store = self._store
+        if store is None or self._object_id is None:
+            return None
+        if variable_name not in self._direct_read_datasets:
+            # h5netcdf can expose a name different from the physical HDF5 name.
+            dataset = variable._h5ds
+            dtype = dataset.dtype
+            self._direct_read_datasets[variable_name] = (
+                dataset
+                if (
+                    dtype.kind in "iuf"
+                    and dtype.metadata is None
+                    and dataset.shape == dataset.maxshape == variable.shape
+                    and all(
+                        not variable._parent._all_dimensions[dim].isunlimited()
+                        for dim in variable.dimensions
+                    )
+                )
+                else None
+            )
+        return self._direct_read_datasets[variable_name]
 
     def _read_bounded_variable(self, variable_name: str, key: typing.Any) -> typing.Any:
         """Read one array selection through a worker-owned file handle."""
@@ -481,7 +512,9 @@ class WorkspaceFileManager(CachingFileManager):
                 decode_vlen_strings=True,
                 locking="best-effort",
             ) as netcdf_file:
-                workspace_id = netcdf_file.attrs.get(workspace_store._WORKSPACE_ID_ATTR)
+                workspace_id = netcdf_file.attrs.get(
+                    _persistence_constants.WORKSPACE_ID_ATTR
+                )
                 if isinstance(workspace_id, bytes):
                     workspace_id = workspace_id.decode()
                 if (
@@ -508,6 +541,7 @@ class WorkspaceFileManager(CachingFileManager):
             ) from exc
 
     def _close_store_wrapper(self) -> None:
+        self._direct_read_datasets.clear()
         netcdf_file = self._netcdf_file
         self._netcdf_file = None
         self._store_handle_generation = -1
@@ -517,7 +551,7 @@ class WorkspaceFileManager(CachingFileManager):
     def _remember_workspace_id(self, netcdf_file: h5netcdf.File) -> None:
         if self._workspace_id is not None:
             return
-        workspace_id = netcdf_file.attrs.get(workspace_store._WORKSPACE_ID_ATTR)
+        workspace_id = netcdf_file.attrs.get(_persistence_constants.WORKSPACE_ID_ATTR)
         if isinstance(workspace_id, bytes):
             workspace_id = workspace_id.decode()
         if isinstance(workspace_id, str) and workspace_id:
@@ -619,6 +653,7 @@ class WorkspaceFileManager(CachingFileManager):
         self._netcdf_file = None
         self._store_handle_generation = -1
         self._serialized_worker = True
+        self._direct_read_datasets = {}
         self.lock = SerializableLock(("erlab-workspace-reader", self.reader_path))
 
     def __dask_tokenize__(self) -> tuple[str, str, str | None, str | None]:
@@ -705,6 +740,14 @@ class _WorkspaceBackendArray(BackendArray):
             array = self.datastore._acquire(needs_lock=False).variables[
                 self.variable_name
             ]
+            dataset = manager._direct_read_dataset(self.variable_name, array)
+            if dataset is not None and all(
+                type(part) is int
+                or isinstance(part, np.integer)
+                or (isinstance(part, slice) and (part.step is None or part.step > 0))
+                for part in (key if isinstance(key, tuple) else (key,))
+            ):
+                return dataset[key]
             return array[key]
 
 
@@ -789,7 +832,7 @@ def open_workspace_dataset(
     object_id = (
         group_parts[1]
         if len(group_parts) >= 2
-        and group_parts[0] == workspace_store._WORKSPACE_OBJECTS_GROUP
+        and group_parts[0] == _persistence_constants.WORKSPACE_OBJECTS_GROUP
         else None
     )
     return _open_workspace_dataset_from_manager(
@@ -854,9 +897,10 @@ def _h5py_attrs_to_dict(
 ) -> dict[typing.Hashable, typing.Any]:
     excluded = set(exclude)
     out: dict[typing.Hashable, typing.Any] = {}
-    for key, value in attrs.items():
+    for key in attrs:
         if key in excluded:
             continue
+        value = attrs[key]
         if isinstance(value, bytes):
             value = value.decode()
         out[key] = value
@@ -874,7 +918,7 @@ def _read_workspace_root_attrs_h5py(
             if _workspace_schema_uses_immutable_generations(
                 int(attrs.get("imagetool_workspace_schema_version", 1))
             ):
-                attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(
+                attrs[_persistence_constants.WORKSPACE_MANIFEST_ATTR] = json.dumps(
                     active_store.current_generation().manifest
                 )
             return attrs
@@ -886,23 +930,25 @@ def _read_workspace_root_attrs_h5py(
         if _workspace_schema_uses_immutable_generations(
             int(attrs.get("imagetool_workspace_schema_version", 1))
         ):
-            generation_root = h5_file.get(workspace_store._WORKSPACE_GENERATIONS_GROUP)
+            generation_root = h5_file.get(
+                _persistence_constants.WORKSPACE_GENERATIONS_GROUP
+            )
             if generation_root is None:
                 raise ValueError("Workspace has no committed generation")
             for name in sorted(generation_root, reverse=True):
                 if (
-                    len(name) != workspace_store._WORKSPACE_GENERATION_WIDTH
+                    len(name) != _persistence_constants.WORKSPACE_GENERATION_WIDTH
                     or not name.isdigit()
                 ):
                     continue
                 with contextlib.suppress(Exception):
-                    attrs[_WORKSPACE_MANIFEST_ATTR] = json.dumps(
+                    attrs[_persistence_constants.WORKSPACE_MANIFEST_ATTR] = json.dumps(
                         workspace_store.WorkspaceStore._read_manifest(
                             generation_root[name]
                         )
                     )
                     break
-            if _WORKSPACE_MANIFEST_ATTR not in attrs:
+            if _persistence_constants.WORKSPACE_MANIFEST_ATTR not in attrs:
                 raise ValueError("Workspace has no valid committed generation")
         return attrs
 
@@ -1176,19 +1222,22 @@ def _workspace_h5py_create_dataset(
 
 
 def _workspace_h5py_tool_data_blob_dim(variable_name: str) -> str:
-    return f"{_SAVED_TOOL_DATA_BLOB_DIM_PREFIX}{variable_name.encode().hex()}>"
+    return (
+        f"{_persistence_constants.SAVED_TOOL_DATA_BLOB_DIM_PREFIX}"
+        f"{variable_name.encode().hex()}>"
+    )
 
 
 def _workspace_h5py_dataarray_is_tool_reference(data_array: xr.DataArray) -> bool:
     return (
         data_array.ndim == 1
-        and data_array.dims == (_SAVED_TOOL_DATA_REFERENCE_DIM,)
+        and data_array.dims == (_persistence_constants.SAVED_TOOL_DATA_REFERENCE_DIM,)
         and data_array.size == 0
     )
 
 
 def _workspace_h5py_dataarray_is_tool_blob(data_array: xr.DataArray) -> bool:
-    return _TOOL_DATA_BLOB_NAME_ATTR in data_array.attrs
+    return _persistence_constants.TOOL_DATA_BLOB_NAME_ATTR in data_array.attrs
 
 
 def _workspace_h5py_dataarray_is_independent_tool_item(
@@ -1209,10 +1258,10 @@ def _workspace_h5py_dataset_independent_tool_variable(
     if not _workspace_h5py_dataset_storage_supported(dataset):
         return None
     attrs = _h5py_attrs_to_dict(dataset.attrs, exclude=exclude_attrs)
-    if _TOOL_DATA_BLOB_NAME_ATTR in attrs:
+    if _persistence_constants.TOOL_DATA_BLOB_NAME_ATTR in attrs:
         dims = (_workspace_h5py_tool_data_blob_dim(variable_name),)
     elif dataset.ndim == 1 and dataset.size == 0:
-        dims = (_SAVED_TOOL_DATA_REFERENCE_DIM,)
+        dims = (_persistence_constants.SAVED_TOOL_DATA_REFERENCE_DIM,)
     else:
         return None
     return xr.Variable(dims, _workspace_h5py_read_values(dataset), attrs)
@@ -1222,8 +1271,8 @@ def _workspace_h5py_extra_tool_data_names(
     ds: xr.Dataset, data_name: typing.Hashable
 ) -> frozenset[typing.Hashable]:
     if data_name not in {
-        _serialization.ITOOL_DATA_NAME,
-        _serialization.SAVED_TOOL_DATA_NAME,
+        _persistence_constants.ITOOL_DATA_NAME,
+        _persistence_constants.SAVED_TOOL_DATA_NAME,
     }:
         return frozenset()
     return frozenset(
@@ -1238,7 +1287,7 @@ def _workspace_h5py_dataset_has_only_independent_tool_items(
     ds: xr.Dataset, data_name: typing.Hashable
 ) -> bool:
     return (
-        data_name == _serialization.SAVED_TOOL_DATA_NAME
+        data_name == _persistence_constants.SAVED_TOOL_DATA_NAME
         and not ds.coords
         and all(
             _workspace_h5py_dataarray_is_independent_tool_item(data_array)
@@ -1287,7 +1336,11 @@ def _read_workspace_dataset_group_h5py(
         else:
             return None
 
-        if preferred_data_name == data_name == _serialization.SAVED_TOOL_DATA_NAME:
+        if (
+            preferred_data_name
+            == data_name
+            == _persistence_constants.SAVED_TOOL_DATA_NAME
+        ):
             independent_data_vars: dict[typing.Hashable, xr.Variable] = {}
             for variable_name, dataset in datasets.items():
                 variable = _workspace_h5py_dataset_independent_tool_variable(
@@ -1299,7 +1352,7 @@ def _read_workspace_dataset_group_h5py(
                     break
                 independent_data_vars[variable_name] = variable
             else:
-                if _serialization.SAVED_TOOL_DATA_NAME in independent_data_vars:
+                if _persistence_constants.SAVED_TOOL_DATA_NAME in independent_data_vars:
                     return xr.Dataset(
                         independent_data_vars,
                         attrs=_h5py_attrs_to_dict(group.attrs),
@@ -1440,8 +1493,8 @@ def _read_workspace_dataset_group_h5py(
             data_vars[variable_name] = coord_variable
 
         if data_name in {
-            _serialization.ITOOL_DATA_NAME,
-            _serialization.SAVED_TOOL_DATA_NAME,
+            _persistence_constants.ITOOL_DATA_NAME,
+            _persistence_constants.SAVED_TOOL_DATA_NAME,
         }:
             for variable_name, dataset in datasets.items():
                 if (
@@ -1456,7 +1509,7 @@ def _read_workspace_dataset_group_h5py(
                     exclude_attrs=internal_attrs,
                 )
                 if variable is None:
-                    if data_name == _serialization.SAVED_TOOL_DATA_NAME:
+                    if data_name == _persistence_constants.SAVED_TOOL_DATA_NAME:
                         return None
                     continue
                 data_vars[variable_name] = variable
@@ -1472,10 +1525,10 @@ def _read_workspace_dataset_group_h5py(
 
 
 def _workspace_h5py_data_name(ds: xr.Dataset) -> typing.Hashable | None:
-    if _serialization.ITOOL_DATA_NAME in ds.data_vars:
-        return _serialization.ITOOL_DATA_NAME
-    if _serialization.SAVED_TOOL_DATA_NAME in ds.data_vars:
-        return _serialization.SAVED_TOOL_DATA_NAME
+    if _persistence_constants.ITOOL_DATA_NAME in ds.data_vars:
+        return _persistence_constants.ITOOL_DATA_NAME
+    if _persistence_constants.SAVED_TOOL_DATA_NAME in ds.data_vars:
+        return _persistence_constants.SAVED_TOOL_DATA_NAME
     if len(ds.data_vars) == 1:
         return next(iter(ds.data_vars))
     return None

--- a/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_controller.py
@@ -27,7 +27,7 @@ import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.manager._workspace._trust as workspace_trust
 import erlab.interactive.imagetool.slicer
 import erlab.interactive.imagetool.viewer_linking
-from erlab.interactive import _shortcut_sequences
+from erlab.interactive import _persistence_constants, _shortcut_sequences
 from erlab.interactive._code_trust import (
     approve_document_trust,
     bind_document_trust_manifest,
@@ -1495,7 +1495,7 @@ class _WorkspaceController:
                             opened
                         )
                         replace_ds = imagetool_serialization.restore_private_coords(
-                            replace_ds, erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+                            replace_ds, _persistence_constants.SAVED_TOOL_DATA_NAME
                         )
                         source_parent_data, reference_resolver = (
                             self.loading._workspace_tool_restore_references(
@@ -2232,7 +2232,7 @@ class _WorkspaceController:
             associated_lock = self._take_workspace_access_lock(workspace_access)
 
         associated_store = None
-        if schema_version >= workspace_format._WORKSPACE_LEGACY_SCHEMA_VERSION:
+        if schema_version >= _persistence_constants.WORKSPACE_LEGACY_SCHEMA_VERSION:
             associated_store = workspace_store.WorkspaceStore.active(associated_fname)
             if associated_store is None:
                 associated_store = workspace_store.WorkspaceStore(associated_fname)

--- a/src/erlab/interactive/imagetool/manager/_workspace/_format.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_format.py
@@ -6,21 +6,18 @@ names identify payload locations; they do not define the complete workspace sche
 
 from __future__ import annotations
 
-import base64
 import collections.abc
 import contextlib
 import copy
 import json
 import logging
-import math
-import numbers
 import pathlib
 import typing
 
-import numpy as np
 import pydantic
 
 from erlab.extensions._models import _script_name_key, _validate_source_hash
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool import _serialization
 
 if typing.TYPE_CHECKING:
@@ -30,18 +27,6 @@ if typing.TYPE_CHECKING:
     import xarray as xr
 
 logger = logging.getLogger(__name__)
-
-_WORKSPACE_SCHEMA_VERSION = 6
-_WORKSPACE_MANIFEST_SCHEMA_VERSION = 4
-_WORKSPACE_LEGACY_SCHEMA_VERSION = 3
-_WORKSPACE_MANIFEST_ATTR = "imagetool_workspace_manifest"
-_WORKSPACE_TRANSACTION_PROTOCOL = "recoverable-delta-v1"
-_WORKSPACE_PENDING_GROUP_PREFIX = "__itws_pending_"
-_WORKSPACE_BACKUP_GROUP_PREFIX = "__itws_backup_"
-_WORKSPACE_TRANSACTION_GROUP_PREFIX = "__itws_txn_"
-_WORKSPACE_ENCODED_ATTRS_ATTR = "_erlab_workspace_encoded_attrs"
-_WORKSPACE_ENCODED_ATTRS_VERSION = 1
-_WORKSPACE_REPLAY_SOURCE_BLOB_NAME = "<manager-replay-source-data>"
 
 
 class _WorkspaceEmbeddedScriptEntry(pydantic.BaseModel):
@@ -113,7 +98,7 @@ class WorkspaceOptionOverridesState(pydantic.BaseModel):
 def _workspace_manifest_from_attrs(
     attrs: Mapping[typing.Any, typing.Any],
 ) -> dict[str, typing.Any]:
-    raw_manifest = attrs.get(_WORKSPACE_MANIFEST_ATTR)
+    raw_manifest = attrs.get(_persistence_constants.WORKSPACE_MANIFEST_ATTR)
     if isinstance(raw_manifest, bytes):
         raw_manifest = raw_manifest.decode()
     if isinstance(raw_manifest, str):
@@ -206,18 +191,19 @@ def _workspace_file_metadata_from_attrs(
 ) -> tuple[int, dict[str, typing.Any] | None]:
     schema_version = int(attrs.get("imagetool_workspace_schema_version", 1))
     manifest = None
-    if schema_version >= _WORKSPACE_MANIFEST_SCHEMA_VERSION:
+    # Schema 4 introduced the root manifest.
+    if schema_version >= 4:
         manifest = _workspace_manifest_from_attrs(attrs) or None
     return schema_version, manifest
 
 
 def _current_workspace_schema_version() -> int:
-    return _WORKSPACE_SCHEMA_VERSION
+    return _persistence_constants.WORKSPACE_SCHEMA_VERSION
 
 
 def _workspace_schema_uses_immutable_generations(schema_version: int) -> bool:
     """Return whether a readable schema uses immutable generation storage."""
-    return 5 <= schema_version <= _WORKSPACE_SCHEMA_VERSION
+    return 5 <= schema_version <= _persistence_constants.WORKSPACE_SCHEMA_VERSION
 
 
 def _workspace_path_is_itws(
@@ -234,11 +220,13 @@ def _require_itws_workspace_path(fname: str | os.PathLike[str], message: str) ->
 def _set_legacy_workspace_schema(
     attrs: MutableMapping[typing.Hashable, typing.Any],
 ) -> None:
-    attrs["imagetool_workspace_schema_version"] = _WORKSPACE_LEGACY_SCHEMA_VERSION
+    attrs["imagetool_workspace_schema_version"] = (
+        _persistence_constants.WORKSPACE_LEGACY_SCHEMA_VERSION
+    )
 
 
 def _workspace_schema_requires_conversion(schema_version: int) -> bool:
-    return schema_version < _WORKSPACE_LEGACY_SCHEMA_VERSION
+    return schema_version < _persistence_constants.WORKSPACE_LEGACY_SCHEMA_VERSION
 
 
 def _workspace_manifest_payload(
@@ -256,7 +244,7 @@ def _workspace_manifest_payload(
     embedded_extension_sources: Iterable[typing.Any] | None = None,
 ) -> dict[str, typing.Any]:
     manifest: dict[str, typing.Any] = {
-        "schema_version": _WORKSPACE_SCHEMA_VERSION,
+        "schema_version": _persistence_constants.WORKSPACE_SCHEMA_VERSION,
         "erlab_version": erlab_version,
         # HDF5 group order is not the manager's authoritative top-level order.
         "root_order": list(root_order),
@@ -295,12 +283,11 @@ def _workspace_manifest_payload(
 def _is_workspace_internal_group_name(name: typing.Any) -> bool:
     return str(name).startswith(
         (
-            "__itws_objects",
-            "__itws_staging",
-            "__itws_generations",
-            _WORKSPACE_PENDING_GROUP_PREFIX,
-            _WORKSPACE_BACKUP_GROUP_PREFIX,
-            _WORKSPACE_TRANSACTION_GROUP_PREFIX,
+            _persistence_constants.WORKSPACE_OBJECTS_GROUP,
+            _persistence_constants.WORKSPACE_STAGING_GROUP,
+            _persistence_constants.WORKSPACE_GENERATIONS_GROUP,
+            *_persistence_constants.WORKSPACE_LEGACY_TEMP_GROUP_PREFIXES,
+            _persistence_constants.WORKSPACE_TRANSACTION_GROUP_PREFIX,
         )
     )
 
@@ -313,7 +300,10 @@ def _workspace_manifest_attrs(
     for key, value in attrs.items():
         try:
             encoded.append(
-                [_workspace_encode_attr_key(key), _workspace_encode_attr_value(value)]
+                [
+                    _serialization.encode_attr_key(key),
+                    _serialization.encode_attr_value(value),
+                ]
             )
         except TypeError:
             logger.warning(
@@ -334,8 +324,8 @@ def _restore_workspace_manifest_attrs(
     for item in payload:
         if not isinstance(item, list) or len(item) != 2:
             raise TypeError("Workspace manifest attribute entry is invalid")
-        attrs[_workspace_decode_attr_key(item[0])] = _workspace_decode_attr_value(
-            item[1]
+        attrs[_serialization.decode_attr_key(item[0])] = (
+            _serialization.decode_attr_value(item[1])
         )
     return attrs
 
@@ -383,20 +373,23 @@ def _workspace_serializable_attrs(
     for key, value in attrs.items():
         if not isinstance(key, str) or not key:
             continue
-        if key == _WORKSPACE_ENCODED_ATTRS_ATTR:
+        if key == _persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR:
             existing_entries = _workspace_encoded_attr_entries(value)
             if existing_entries is not None:
                 encoded_entries.extend(existing_entries)
                 continue
         if (
-            key != _WORKSPACE_ENCODED_ATTRS_ATTR
-            and _workspace_attr_value_writes_natively(value)
+            key != _persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR
+            and _serialization.attr_value_writes_natively(value)
         ):
             serializable[key] = value
             continue
         try:
             encoded_entries.append(
-                [_workspace_encode_attr_key(key), _workspace_encode_attr_value(value)]
+                [
+                    _serialization.encode_attr_key(key),
+                    _serialization.encode_attr_value(value),
+                ]
             )
         except TypeError:
             logger.warning(
@@ -405,232 +398,14 @@ def _workspace_serializable_attrs(
                 type(value).__name__,
             )
     if encoded_entries:
-        serializable[_WORKSPACE_ENCODED_ATTRS_ATTR] = json.dumps(
+        serializable[_persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR] = json.dumps(
             {
-                "version": _WORKSPACE_ENCODED_ATTRS_VERSION,
+                "version": _persistence_constants.WORKSPACE_ENCODED_ATTRS_VERSION,
                 "attrs": encoded_entries,
             },
             separators=(",", ":"),
         )
     return serializable
-
-
-def _workspace_attr_value_writes_natively(value: typing.Any) -> bool:
-    if isinstance(value, str):
-        return True
-    if isinstance(value, bytes):
-        return b"\x00" not in value and _workspace_bytes_are_utf8(value)
-    if isinstance(value, np.ndarray):
-        return value.dtype.kind in "biufcSU"
-    if isinstance(value, np.generic):
-        return isinstance(value, (np.number, np.bool_))
-    if isinstance(value, bool | int | float | complex):
-        return True
-    if isinstance(value, list | tuple):
-        return _workspace_attr_sequence_writes_natively(value)
-    return False
-
-
-def _workspace_attr_sequence_writes_natively(
-    value: list[typing.Any] | tuple[typing.Any, ...],
-) -> bool:
-    if not value:
-        return True
-    if all(isinstance(item, str) for item in value):
-        return True
-    if all(
-        isinstance(item, bytes)
-        and b"\x00" not in item
-        and _workspace_bytes_are_utf8(item)
-        for item in value
-    ):
-        return True
-    return all(_workspace_attr_numeric_scalar_writes_natively(item) for item in value)
-
-
-def _workspace_attr_numeric_scalar_writes_natively(value: typing.Any) -> bool:
-    if isinstance(value, np.generic):
-        return isinstance(value, (np.number, np.bool_))
-    return isinstance(value, bool | int | float | complex)
-
-
-def _workspace_bytes_are_utf8(value: bytes) -> bool:
-    try:
-        value.decode("utf-8")
-    except UnicodeDecodeError:
-        return False
-    return True
-
-
-def _workspace_encode_attr_key(value: typing.Any) -> dict[str, typing.Any]:
-    if isinstance(value, np.generic):
-        value = value.item()
-    if value is None:
-        return {"kind": "none"}
-    if isinstance(value, bool):
-        return {"kind": "bool", "value": value}
-    if isinstance(value, int):
-        return {"kind": "int", "value": value}
-    if isinstance(value, float):
-        return {"kind": "float", **_workspace_encode_float(value)}
-    if isinstance(value, complex):
-        return {
-            "kind": "complex",
-            "real": _workspace_encode_float(value.real),
-            "imag": _workspace_encode_float(value.imag),
-        }
-    if isinstance(value, str):
-        return {"kind": "str", "value": value}
-    if isinstance(value, bytes):
-        return {
-            "kind": "bytes",
-            "value": base64.b64encode(value).decode("ascii"),
-        }
-    if isinstance(value, tuple):
-        return {
-            "kind": "tuple",
-            "items": [_workspace_encode_attr_key(item) for item in value],
-        }
-    raise TypeError(f"unsupported attr key type {type(value).__name__!r}")
-
-
-def _workspace_decode_attr_key(value: typing.Any) -> typing.Hashable:
-    decoded = _workspace_decode_attr_value(value)
-    if not isinstance(decoded, collections.abc.Hashable):
-        raise TypeError(f"decoded attr key is not hashable: {type(decoded).__name__!r}")
-    return decoded
-
-
-def _workspace_encode_attr_value(value: typing.Any) -> dict[str, typing.Any]:
-    if isinstance(value, np.ndarray):
-        return _workspace_encode_array(value, kind="ndarray")
-    if isinstance(value, np.generic):
-        return _workspace_encode_array(np.asarray(value), kind="numpy_scalar")
-    if value is None:
-        return {"kind": "none"}
-    if isinstance(value, bool):
-        return {"kind": "bool", "value": value}
-    if isinstance(value, int):
-        return {"kind": "int", "value": value}
-    if isinstance(value, float):
-        return {"kind": "float", **_workspace_encode_float(value)}
-    if isinstance(value, complex):
-        return {
-            "kind": "complex",
-            "real": _workspace_encode_float(value.real),
-            "imag": _workspace_encode_float(value.imag),
-        }
-    if isinstance(value, str):
-        return {"kind": "str", "value": value}
-    if isinstance(value, bytes):
-        return {
-            "kind": "bytes",
-            "value": base64.b64encode(value).decode("ascii"),
-        }
-    if isinstance(value, list):
-        return {
-            "kind": "list",
-            "items": [_workspace_encode_attr_value(item) for item in value],
-        }
-    if isinstance(value, tuple):
-        return {
-            "kind": "tuple",
-            "items": [_workspace_encode_attr_value(item) for item in value],
-        }
-    if isinstance(value, collections.abc.Mapping):
-        return {
-            "kind": "dict",
-            "items": [
-                [_workspace_encode_attr_key(key), _workspace_encode_attr_value(item)]
-                for key, item in value.items()
-            ],
-        }
-    if isinstance(value, numbers.Number):
-        raise TypeError(f"unsupported numeric attr type {type(value).__name__!r}")
-    raise TypeError(f"unsupported attr value type {type(value).__name__!r}")
-
-
-def _workspace_decode_attr_value(value: typing.Any) -> typing.Any:
-    if not isinstance(value, collections.abc.Mapping):
-        raise TypeError("encoded workspace attr value must be a mapping")
-    kind = value.get("kind")
-    match kind:
-        case "none":
-            return None
-        case "bool":
-            return bool(value["value"])
-        case "int":
-            return int(value["value"])
-        case "float":
-            return _workspace_decode_float(value)
-        case "complex":
-            return complex(
-                _workspace_decode_float(value["real"]),
-                _workspace_decode_float(value["imag"]),
-            )
-        case "str":
-            return str(value["value"])
-        case "bytes":
-            return base64.b64decode(str(value["value"]).encode("ascii"))
-        case "list":
-            return [_workspace_decode_attr_value(item) for item in value["items"]]
-        case "tuple":
-            return tuple(_workspace_decode_attr_value(item) for item in value["items"])
-        case "dict":
-            return {
-                _workspace_decode_attr_key(key): _workspace_decode_attr_value(item)
-                for key, item in value["items"]
-            }
-        case "ndarray":
-            return _workspace_decode_array(value)
-        case "numpy_scalar":
-            return _workspace_decode_array(value)[()]
-        case _:
-            raise TypeError(f"unknown workspace attr value kind {kind!r}")
-
-
-def _workspace_encode_float(value: float) -> dict[str, typing.Any]:
-    if math.isnan(value):
-        return {"special": "nan"}
-    if math.isinf(value):
-        return {"special": "inf" if value > 0 else "-inf"}
-    return {"value": value}
-
-
-def _workspace_decode_float(value: Mapping[str, typing.Any]) -> float:
-    special = value.get("special")
-    if special == "nan":
-        return math.nan
-    if special == "inf":
-        return math.inf
-    if special == "-inf":
-        return -math.inf
-    return float(value["value"])
-
-
-def _workspace_encode_array(value, *, kind: str) -> dict[str, typing.Any]:
-    array = np.asarray(value)
-    payload: dict[str, typing.Any] = {
-        "kind": kind,
-        "dtype": array.dtype.str,
-        "shape": list(array.shape),
-    }
-    if array.dtype.kind == "O":
-        payload["items"] = _workspace_encode_attr_value(array.tolist())
-        return payload
-    contiguous = np.ascontiguousarray(array)
-    payload["data"] = base64.b64encode(contiguous.tobytes()).decode("ascii")
-    return payload
-
-
-def _workspace_decode_array(value: Mapping[str, typing.Any]):
-    dtype = np.dtype(typing.cast("str", value["dtype"]))
-    shape = tuple(int(size) for size in typing.cast("list[typing.Any]", value["shape"]))
-    if "items" in value:
-        items = _workspace_decode_attr_value(value["items"])
-        return np.asarray(items, dtype=object).reshape(shape)
-    data = base64.b64decode(str(value["data"]).encode("ascii"))
-    return np.frombuffer(data, dtype=dtype).copy().reshape(shape)
 
 
 def _workspace_encoded_attr_entries(value: typing.Any) -> list[list[typing.Any]] | None:
@@ -647,7 +422,8 @@ def _workspace_encoded_attr_entries(value: typing.Any) -> list[list[typing.Any]]
         return None
     if (
         not isinstance(payload, dict)
-        or payload.get("version") != _WORKSPACE_ENCODED_ATTRS_VERSION
+        or payload.get("version")
+        != _persistence_constants.WORKSPACE_ENCODED_ATTRS_VERSION
         or not isinstance(payload.get("attrs"), list)
     ):
         return None
@@ -664,19 +440,19 @@ def _restore_workspace_serialized_attrs(
     attrs: Mapping[typing.Any, typing.Any],
 ) -> dict[typing.Any, typing.Any]:
     encoded_entries = _workspace_encoded_attr_entries(
-        attrs.get(_WORKSPACE_ENCODED_ATTRS_ATTR)
+        attrs.get(_persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR)
     )
     if encoded_entries is None:
         return dict(attrs)
     restored = {
         key: value
         for key, value in attrs.items()
-        if key != _WORKSPACE_ENCODED_ATTRS_ATTR
+        if key != _persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR
     }
     for key_payload, value_payload in encoded_entries:
         try:
-            key = _workspace_decode_attr_key(key_payload)
-            value = _workspace_decode_attr_value(value_payload)
+            key = _serialization.decode_attr_key(key_payload)
+            value = _serialization.decode_attr_value(value_payload)
         except (KeyError, TypeError, ValueError):
             logger.warning(
                 "Ignoring invalid encoded workspace attribute", exc_info=True

--- a/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_loading.py
@@ -28,12 +28,12 @@ import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.slicer
 import erlab.interactive.imagetool.viewer_linking
 from erlab.extensions._models import _script_name_key
-from erlab.interactive import _qt_state
+from erlab.interactive import _persistence_constants, _qt_state
 from erlab.interactive.imagetool._load_source import (
     _deserialize_loader_kwargs,
     _file_path_stem,
 )
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME, ImageTool
+from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool._provenance._model import (
     ScriptInputDataRole,
     ToolProvenanceSpec,
@@ -357,7 +357,7 @@ class _WorkspaceLoader:
         ds = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
             payload_path,
-            preferred_data_name=_ITOOL_DATA_NAME,
+            preferred_data_name=_persistence_constants.ITOOL_DATA_NAME,
         )
         if ds is not None:
             return ds
@@ -378,7 +378,7 @@ class _WorkspaceLoader:
         ds = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
             payload_path,
-            preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+            preferred_data_name=_persistence_constants.SAVED_TOOL_DATA_NAME,
         )
         if ds is not None:
             return ds
@@ -537,9 +537,9 @@ class _WorkspaceLoader:
 
     @staticmethod
     def _workspace_imagetool_payload_data(ds: xr.Dataset) -> xr.DataArray:
-        if _ITOOL_DATA_NAME not in ds:
+        if _persistence_constants.ITOOL_DATA_NAME not in ds:
             raise ValueError("Pending workspace payload has no ImageTool data")
-        return ds[_ITOOL_DATA_NAME]
+        return ds[_persistence_constants.ITOOL_DATA_NAME]
 
     def _workspace_tool_reference_source_data(
         self,
@@ -599,7 +599,7 @@ class _WorkspaceLoader:
                 reference.get("kind") == "parent_source"
                 for reference in tool_data_references.values()
             )
-            or erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR in ds.attrs
+            or _persistence_constants.TOOL_SOURCE_BINDING_ATTR in ds.attrs
         ):
             source_parent_data = _source_data_for_target(parent_target)
 
@@ -693,7 +693,7 @@ class _WorkspaceLoader:
         cls, attrs: Mapping[str, typing.Any]
     ) -> _ManagedWindowNode._source_state_type:
         source_state = workspace_format._decode_workspace_attr_text(
-            attrs.get(erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR)
+            attrs.get(_persistence_constants.TOOL_SOURCE_STATE_ATTR)
         )
         return erlab.interactive.utils._normalize_tool_source_state(source_state)
 
@@ -704,14 +704,14 @@ class _WorkspaceLoader:
         parent_target: int | str | None,
     ) -> xr.Dataset:
         """Convert released unary ToolWindow metadata to one canonical input."""
-        inputs_attr = erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR
+        inputs_attr = _persistence_constants.TOOL_SCRIPT_INPUTS_ATTR
         if parent_target is None or inputs_attr in ds.attrs:
             return ds
 
         legacy_attrs = (
-            erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR,
-            erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR,
-            erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR,
+            _persistence_constants.TOOL_SOURCE_SPEC_ATTR,
+            _persistence_constants.TOOL_SOURCE_BINDING_ATTR,
+            _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR,
         )
         if not any(key in ds.attrs for key in legacy_attrs):
             return ds
@@ -746,7 +746,7 @@ class _WorkspaceLoader:
             tool_cls._saved_script_input_attrs(updated_inputs, primary_input)
         )
         if source_spec is not None:
-            migrated.attrs.pop(erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR, None)
+            migrated.attrs.pop(_persistence_constants.TOOL_SOURCE_BINDING_ATTR, None)
         return migrated
 
     def _root_workspace_imagetool_kwargs(
@@ -932,8 +932,12 @@ class _WorkspaceLoader:
     ) -> int | str:
         with _workspace_load_stage(profiler, "imagetool metadata restore"):
             uid = ds.attrs.get("manager_node_uid")
-            provenance_spec = ds.attrs.get("manager_node_provenance_spec")
-            live_source_spec = ds.attrs.get("manager_node_live_source_spec")
+            provenance_spec = ds.attrs.get(
+                _persistence_constants.MANAGER_PROVENANCE_SPEC_ATTR
+            )
+            live_source_spec = ds.attrs.get(
+                _persistence_constants.MANAGER_LIVE_SOURCE_SPEC_ATTR
+            )
             live_source_binding = ds.attrs.get("manager_node_live_source_binding")
             parse_provenance_spec = parse_tool_provenance_spec
             parsed_provenance_spec = None
@@ -982,12 +986,12 @@ class _WorkspaceLoader:
                         exc_info=True,
                     )
             replay_source_pending = (
-                workspace_format._WORKSPACE_REPLAY_SOURCE_BLOB_NAME in ds
+                _persistence_constants.WORKSPACE_REPLAY_SOURCE_BLOB_NAME in ds
                 and pending_workspace_memory_payload is not None
             )
             replay_source_data = None
             if (
-                workspace_format._WORKSPACE_REPLAY_SOURCE_BLOB_NAME in ds
+                _persistence_constants.WORKSPACE_REPLAY_SOURCE_BLOB_NAME in ds
                 and not replay_source_pending
             ):
                 replay_source_data = self._workspace_replay_source_data(ds, uid=uid)
@@ -1028,7 +1032,10 @@ class _WorkspaceLoader:
             }
             if profiler is not None:
                 tool_kwargs["_workspace_load_profiler"] = profiler
-            if _ITOOL_DATA_NAME in ds and ds[_ITOOL_DATA_NAME].chunks is not None:
+            if (
+                _persistence_constants.ITOOL_DATA_NAME in ds
+                and ds[_persistence_constants.ITOOL_DATA_NAME].chunks is not None
+            ):
                 tool_kwargs["auto_compute"] = False
             legacy_name = _legacy_saved_title_data_name(ds, parsed_provenance_spec)
             if legacy_name is not None:
@@ -1108,7 +1115,7 @@ class _WorkspaceLoader:
         *,
         uid: object,
     ) -> xr.DataArray | None:
-        blob_name = workspace_format._WORKSPACE_REPLAY_SOURCE_BLOB_NAME
+        blob_name = _persistence_constants.WORKSPACE_REPLAY_SOURCE_BLOB_NAME
         if blob_name not in ds:
             return None
         try:
@@ -1247,7 +1254,7 @@ class _WorkspaceLoader:
     @staticmethod
     def _tool_dataset_without_saved_input_provenance(ds: xr.Dataset) -> xr.Dataset:
         """Remove the legacy duplicate input-provenance snapshot before restore."""
-        attr_name = erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
+        attr_name = _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR
         if attr_name not in ds.attrs:
             return ds
         restored = ds.copy(deep=False)
@@ -1894,14 +1901,12 @@ class _WorkspaceLoader:
                 opened.close()
 
         def _load_dataset(
-            payload_path: str, *, entry: Mapping[str, typing.Any], imagetool: bool
+            payload_path: str,
+            *,
+            entry: Mapping[str, typing.Any],
+            imagetool: bool,
+            current_attrs: dict[typing.Hashable, typing.Any] | None,
         ) -> tuple[xr.Dataset, tuple[str | os.PathLike[str], str] | None]:
-            manifest_attrs = entry.get("payload_attrs")
-            current_attrs = (
-                workspace_format._restore_workspace_manifest_attrs(manifest_attrs)
-                if manifest_attrs is not None
-                else None
-            )
             prefix = "itool" if imagetool else "tool"
             if current_attrs is None:
                 window_visible = _workspace_payload_window_visible_h5py(
@@ -1943,9 +1948,9 @@ class _WorkspaceLoader:
                     if attrs is not None:
                         return xr.Dataset(attrs=attrs), (fname, payload_path)
             preferred_data_name = (
-                _ITOOL_DATA_NAME
+                _persistence_constants.ITOOL_DATA_NAME
                 if imagetool
-                else erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+                else _persistence_constants.SAVED_TOOL_DATA_NAME
             )
             try:
                 ds = workspace_arrays._read_workspace_dataset_group_h5py(
@@ -1973,15 +1978,21 @@ class _WorkspaceLoader:
             if not isinstance(payload_path, str):
                 payload_path = f"{path}/{'imagetool' if is_imagetool else 'tool'}"
             with profiler.stage("payload read"):
+                manifest_attrs = entry.get("payload_attrs")
+                current_attrs = (
+                    workspace_format._restore_workspace_manifest_attrs(manifest_attrs)
+                    if manifest_attrs is not None
+                    else None
+                )
                 ds, pending_payload = _load_dataset(
-                    payload_path, entry=entry, imagetool=is_imagetool
+                    payload_path,
+                    entry=entry,
+                    imagetool=is_imagetool,
+                    current_attrs=current_attrs,
                 )
-            manifest_attrs = entry.get("payload_attrs")
-            if manifest_attrs is not None:
+            if current_attrs is not None:
                 ds = ds.copy(deep=False)
-                ds.attrs = workspace_format._restore_workspace_manifest_attrs(
-                    manifest_attrs
-                )
+                ds.attrs = current_attrs
             if is_imagetool:
                 target = self._load_workspace_imagetool_dataset(
                     ds,
@@ -2559,8 +2570,8 @@ class _WorkspaceLoader:
         try:
             ds = workspace_format._restore_workspace_dataset_attrs(ds)
             data_name: Hashable
-            if _ITOOL_DATA_NAME in ds.data_vars:
-                data_name = _ITOOL_DATA_NAME
+            if _persistence_constants.ITOOL_DATA_NAME in ds.data_vars:
+                data_name = _persistence_constants.ITOOL_DATA_NAME
             else:
                 data_name = next(iter(ds.data_vars))
             name = ds.attrs.get("itool_name", "")
@@ -2861,7 +2872,7 @@ class _WorkspaceLoader:
                 if (
                     associate
                     and schema_version
-                    >= workspace_format._WORKSPACE_LEGACY_SCHEMA_VERSION
+                    >= _persistence_constants.WORKSPACE_LEGACY_SCHEMA_VERSION
                 ):
                     fallback_store = workspace_store.WorkspaceStore.active(access.path)
                     if fallback_store is None:

--- a/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_pending.py
@@ -23,8 +23,9 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.slicer
 import erlab.interactive.imagetool.viewer_linking
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool import _serialization
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME, ImageTool
+from erlab.interactive.imagetool._mainwindow import ImageTool
 from erlab.interactive.imagetool._provenance._model import (
     ScriptInputDataRole,
     mark_promoted_1d_source,
@@ -290,7 +291,9 @@ class _PendingWorkspacePayloads:
     ) -> xr.DataArray:
         """Restore script-input data without requiring a live manager node."""
         ds = workspace_format._restore_workspace_dataset_attrs(opened.copy(deep=False))
-        ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
+        ds = _serialization.restore_private_coords(
+            ds, _persistence_constants.ITOOL_DATA_NAME
+        )
         data = self._loader._workspace_imagetool_payload_data(ds).rename(name)
         if attrs is None:
             attrs = ds.attrs
@@ -353,11 +356,13 @@ class _PendingWorkspacePayloads:
                 workspace_path, payload_path, load_data=False
             )
             try:
-                ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
-                if _ITOOL_DATA_NAME not in ds:
+                ds = _serialization.restore_private_coords(
+                    ds, _persistence_constants.ITOOL_DATA_NAME
+                )
+                if _persistence_constants.ITOOL_DATA_NAME not in ds:
                     return None, None
                 name = None if node.name == "" else node.name
-                data = ds[_ITOOL_DATA_NAME].rename(name)
+                data = ds[_persistence_constants.ITOOL_DATA_NAME].rename(name)
                 attrs = node.pending_workspace_payload_attrs
                 if attrs is None:
                     attrs = ds.attrs
@@ -409,10 +414,13 @@ class _PendingWorkspacePayloads:
         data_name = workspace_format._decode_workspace_attr_text(
             attrs.get("tool_data_name")
         )
-        if data_name is not None and data_name != "<none-value>":
+        if (
+            data_name is not None
+            and data_name != _persistence_constants.NONE_TOOL_DATA_NAME
+        ):
             lines.append(f"<p>Data: <code>{html.escape(data_name)}</code></p>")
         source_state = workspace_format._decode_workspace_attr_text(
-            attrs.get("tool_source_state")
+            attrs.get(_persistence_constants.TOOL_SOURCE_STATE_ATTR)
         )
         if source_state is not None:
             lines.append(f"<p>Source: {html.escape(source_state)}</p>")
@@ -564,7 +572,7 @@ class _PendingWorkspacePayloads:
                 group = h5_file.get(payload_path.strip("/"))
                 if not isinstance(group, h5py.Group):
                     return None
-                dataset = group.get(_ITOOL_DATA_NAME)
+                dataset = group.get(_persistence_constants.ITOOL_DATA_NAME)
                 if not isinstance(dataset, h5py.Dataset) or dataset.ndim != 1:
                     return None
                 if dataset.dtype.kind not in "biuf":
@@ -660,7 +668,7 @@ class _PendingWorkspacePayloads:
                 group = h5_file.get(payload_path.strip("/"))
                 if not isinstance(group, h5py.Group):
                     return None
-                dataset = group.get(_ITOOL_DATA_NAME)
+                dataset = group.get(_persistence_constants.ITOOL_DATA_NAME)
                 if not isinstance(dataset, h5py.Dataset):
                     return None
                 if dataset.dtype.kind not in "biuf":
@@ -981,7 +989,7 @@ class _PendingWorkspacePayloads:
                             )
                     else:
                         state = copy.deepcopy(node.slicer_area.state)
-                        data = ds[_ITOOL_DATA_NAME].rename(name)
+                        data = ds[_persistence_constants.ITOOL_DATA_NAME].rename(name)
                         node.slicer_area.set_data(data, auto_compute=False)
                         node.slicer_area.state = state
                     node._restore_replay_source_data(
@@ -1240,10 +1248,15 @@ class _PendingWorkspacePayloads:
                     workspace_path, payload_path, load_data=False
                 )
                 try:
-                    ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
-                    if _ITOOL_DATA_NAME not in ds:
+                    ds = _serialization.restore_private_coords(
+                        ds, _persistence_constants.ITOOL_DATA_NAME
+                    )
+                    if _persistence_constants.ITOOL_DATA_NAME not in ds:
                         return False
-                    valid_dims = tuple(str(dim) for dim in ds[_ITOOL_DATA_NAME].dims)
+                    valid_dims = tuple(
+                        str(dim)
+                        for dim in ds[_persistence_constants.ITOOL_DATA_NAME].dims
+                    )
                 finally:
                     ds.close()
             except Exception:
@@ -1320,10 +1333,12 @@ class _PendingWorkspacePayloads:
                     workspace_path, payload_path, load_data=False
                 )
                 try:
-                    ds = _serialization.restore_private_coords(ds, _ITOOL_DATA_NAME)
-                    if _ITOOL_DATA_NAME not in ds:
+                    ds = _serialization.restore_private_coords(
+                        ds, _persistence_constants.ITOOL_DATA_NAME
+                    )
+                    if _persistence_constants.ITOOL_DATA_NAME not in ds:
                         return False
-                    target_data = ds[_ITOOL_DATA_NAME]
+                    target_data = ds[_persistence_constants.ITOOL_DATA_NAME]
                     target_data = self._pending_workspace_data_with_saved_dim_order(
                         target_data, attrs
                     )
@@ -1641,7 +1656,7 @@ class _PendingWorkspacePayloads:
             payload_attrs=attrs,
         )
         node._source_auto_update = bool(
-            attrs.get(erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR)
+            attrs.get(_persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR)
         )
         source_state = self._loader._workspace_tool_source_state_from_attrs(attrs)
         node._source_state = source_state if node.tool_script_inputs else "fresh"

--- a/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_saving.py
@@ -22,7 +22,7 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
-from erlab.interactive import _qt_state
+from erlab.interactive import _persistence_constants, _qt_state
 from erlab.interactive._code_trust import document_trust_has_trusted_lineage
 from erlab.interactive.imagetool._load_source import _serialize_loader_kwargs
 from erlab.interactive.imagetool.manager._widgets import (
@@ -326,17 +326,17 @@ class _WorkspaceSaver:
         provenance_spec = persistence.provenance_spec
         if kind == "imagetool" and persistence.replay_source_data is not None:
             ds = ds.copy(deep=False)
-            blob_name = workspace_format._WORKSPACE_REPLAY_SOURCE_BLOB_NAME
+            blob_name = _persistence_constants.WORKSPACE_REPLAY_SOURCE_BLOB_NAME
             ds[blob_name] = erlab.interactive.utils._tool_data_to_blob(
                 persistence.replay_source_data,
                 blob_name,
             )
         if kind == "imagetool" and provenance_spec is not None:
-            ds.attrs["manager_node_provenance_spec"] = json.dumps(
+            ds.attrs[_persistence_constants.MANAGER_PROVENANCE_SPEC_ATTR] = json.dumps(
                 provenance_spec.model_dump(mode="json")
             )
         else:
-            ds.attrs.pop("manager_node_provenance_spec", None)
+            ds.attrs.pop(_persistence_constants.MANAGER_PROVENANCE_SPEC_ATTR, None)
         if isinstance(node, _ImageToolWrapper) and node.source_input_ndim is not None:
             ds.attrs["manager_node_source_input_ndim"] = int(node.source_input_ndim)
         if isinstance(node, _ImageToolWrapper) and node.watched:
@@ -366,7 +366,7 @@ class _WorkspaceSaver:
             ds.attrs["manager_node_output_id"] = output_id
         source_spec = persistence.source_spec
         if kind == "imagetool" and source_spec is not None:
-            ds.attrs["manager_node_live_source_spec"] = json.dumps(
+            ds.attrs[_persistence_constants.MANAGER_LIVE_SOURCE_SPEC_ATTR] = json.dumps(
                 source_spec.model_dump(mode="json")
             )
         if kind == "imagetool" and (source_spec is not None or output_id is not None):
@@ -427,7 +427,7 @@ class _WorkspaceSaver:
             ):
                 ds = tool.to_dataset()
             ds.attrs.pop(
-                erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR,
+                _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR,
                 None,
             )
             ds.attrs["tool_title"] = _strip_workspace_modified_placeholder(
@@ -859,9 +859,9 @@ class _WorkspaceSaver:
 
         provenance_spec = node.provenance_spec
         if provenance_spec is None:
-            attrs.pop("manager_node_provenance_spec", None)
+            attrs.pop(_persistence_constants.MANAGER_PROVENANCE_SPEC_ATTR, None)
         else:
-            attrs["manager_node_provenance_spec"] = json.dumps(
+            attrs[_persistence_constants.MANAGER_PROVENANCE_SPEC_ATTR] = json.dumps(
                 provenance_spec.model_dump(mode="json")
             )
 
@@ -913,9 +913,9 @@ class _WorkspaceSaver:
 
         source_spec = node.source_spec
         if source_spec is None:
-            attrs.pop("manager_node_live_source_spec", None)
+            attrs.pop(_persistence_constants.MANAGER_LIVE_SOURCE_SPEC_ATTR, None)
         else:
-            attrs["manager_node_live_source_spec"] = json.dumps(
+            attrs[_persistence_constants.MANAGER_LIVE_SOURCE_SPEC_ATTR] = json.dumps(
                 source_spec.model_dump(mode="json")
             )
         if source_spec is None and output_id is None:
@@ -958,32 +958,32 @@ class _WorkspaceSaver:
                 )
             )
             if not has_legacy_parent_reference:
-                attrs.pop(erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR, None)
+                attrs.pop(_persistence_constants.TOOL_SOURCE_SPEC_ATTR, None)
             if not any(
                 item.name == primary_input and item.source_spec is None
                 for item in script_inputs
             ):
-                attrs.pop(erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR, None)
-        elif erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR not in attrs:
-            attrs.pop(erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR, None)
+                attrs.pop(_persistence_constants.TOOL_SOURCE_BINDING_ATTR, None)
+        elif _persistence_constants.TOOL_SCRIPT_INPUTS_ATTR not in attrs:
+            attrs.pop(_persistence_constants.TOOL_PRIMARY_INPUT_ATTR, None)
         has_saved_inputs = bool(script_inputs) or any(
             key in attrs
             for key in (
-                erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR,
-                erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR,
-                erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR,
+                _persistence_constants.TOOL_SCRIPT_INPUTS_ATTR,
+                _persistence_constants.TOOL_SOURCE_SPEC_ATTR,
+                _persistence_constants.TOOL_SOURCE_BINDING_ATTR,
             )
         )
         if has_saved_inputs:
-            attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = node.source_state
-            attrs[erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR] = bool(
+            attrs[_persistence_constants.TOOL_SOURCE_STATE_ATTR] = node.source_state
+            attrs[_persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR] = bool(
                 node.source_auto_update
             )
         else:
-            attrs.pop(erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR, None)
-            attrs.pop(erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR, None)
-        attrs.pop(erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR, None)
-        attrs.pop("manager_node_provenance_spec", None)
+            attrs.pop(_persistence_constants.TOOL_SOURCE_STATE_ATTR, None)
+            attrs.pop(_persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR, None)
+        attrs.pop(_persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR, None)
+        attrs.pop(_persistence_constants.MANAGER_PROVENANCE_SPEC_ATTR, None)
         return attrs
 
     @staticmethod
@@ -992,7 +992,7 @@ class _WorkspaceSaver:
         previous: Mapping[str, typing.Any] | None,
     ) -> bool:
         """Return whether a reusable tool payload has legacy input provenance."""
-        attr_name = erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
+        attr_name = _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR
         pending_attrs = node.pending_workspace_payload_attrs
         if pending_attrs is not None and attr_name in pending_attrs:
             return True
@@ -1026,12 +1026,12 @@ class _WorkspaceSaver:
         if attrs is None:
             return {}
         payload = workspace_format._decode_workspace_attr_text(
-            attrs.get(erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR)
+            attrs.get(_persistence_constants.TOOL_DATA_REFERENCES_ATTR)
         )
         if payload is None:
             return (
                 {}
-                if erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR not in attrs
+                if _persistence_constants.TOOL_DATA_REFERENCES_ATTR not in attrs
                 else None
             )
         try:
@@ -1177,6 +1177,7 @@ class _WorkspaceSaver:
         object_writes: dict[str, workspace_storage._WorkspaceObjectWrite] = {}
         final_entries: list[dict[str, typing.Any]] = []
         serialized_datasets: list[xr.Dataset] = []
+        serialized_dataset_ids: set[int] = set()
         legacy_payload_rewrite_uids: set[str] = set()
         extension_object_ids = set(
             workspace_store.WorkspaceStore.manifest_extension_object_ids(manifest)
@@ -1248,6 +1249,7 @@ class _WorkspaceSaver:
                             dataset.attrs
                         )
                         serialized_datasets.append(dataset)
+                        serialized_dataset_ids.add(id(dataset))
             if attrs_payload is not None:
                 entry["payload_attrs"] = attrs_payload
 
@@ -1296,11 +1298,12 @@ class _WorkspaceSaver:
                         dataset = _serialize(uid)
                         if dataset is None:
                             continue
-                    if all(existing is not dataset for existing in serialized_datasets):
+                        entry["payload_attrs"] = (
+                            workspace_format._workspace_manifest_attrs(dataset.attrs)
+                        )
+                    if id(dataset) not in serialized_dataset_ids:
                         serialized_datasets.append(dataset)
-                    entry["payload_attrs"] = workspace_format._workspace_manifest_attrs(
-                        dataset.attrs
-                    )
+                        serialized_dataset_ids.add(id(dataset))
                     object_writes[object_id] = workspace_storage._WorkspaceObjectWrite(
                         object_id,
                         dataset=dataset,

--- a/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_storage.py
@@ -20,10 +20,8 @@ from qtpy import QtCore
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool.manager._workspace._format import (
-    _WORKSPACE_BACKUP_GROUP_PREFIX,
-    _WORKSPACE_PENDING_GROUP_PREFIX,
-    _WORKSPACE_TRANSACTION_GROUP_PREFIX,
     _workspace_file_is_workspace,
     _workspace_path_is_itws,
 )
@@ -860,18 +858,19 @@ def _recover_open_workspace_transaction(h5_file, txn_path: str) -> None:
 def _cleanup_orphan_workspace_internal_groups(h5_file) -> None:
     transaction_roots: set[str] = set()
     for name in list(h5_file):
-        if not name.startswith(_WORKSPACE_TRANSACTION_GROUP_PREFIX):
+        if not name.startswith(
+            _persistence_constants.WORKSPACE_TRANSACTION_GROUP_PREFIX
+        ):
             continue
         pending_root, backup_root = _workspace_transaction_roots(h5_file[name])
         transaction_roots.update(
             root for root in (pending_root, backup_root) if root is not None
         )
-    internal_prefixes = (
-        _WORKSPACE_PENDING_GROUP_PREFIX,
-        _WORKSPACE_BACKUP_GROUP_PREFIX,
-    )
     for name in list(h5_file):
-        if name.startswith(internal_prefixes) and name not in transaction_roots:
+        if (
+            name.startswith(_persistence_constants.WORKSPACE_LEGACY_TEMP_GROUP_PREFIXES)
+            and name not in transaction_roots
+        ):
             del h5_file[name]
 
 
@@ -893,7 +892,9 @@ def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
             transaction_names = {
                 name
                 for name in h5_file
-                if name.startswith(_WORKSPACE_TRANSACTION_GROUP_PREFIX)
+                if name.startswith(
+                    _persistence_constants.WORKSPACE_TRANSACTION_GROUP_PREFIX
+                )
             }
             transaction_roots: set[str] = set()
             for name in transaction_names:
@@ -903,7 +904,7 @@ def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
                 )
             has_orphan = any(
                 name.startswith(
-                    (_WORKSPACE_PENDING_GROUP_PREFIX, _WORKSPACE_BACKUP_GROUP_PREFIX)
+                    _persistence_constants.WORKSPACE_LEGACY_TEMP_GROUP_PREFIXES
                 )
                 and name not in transaction_roots
                 for name in h5_file
@@ -919,7 +920,9 @@ def _recover_workspace_transactions(fname: str | os.PathLike[str]) -> None:
             if not _workspace_file_is_workspace(h5_file):
                 return
             for name in list(h5_file):
-                if name.startswith(_WORKSPACE_TRANSACTION_GROUP_PREFIX):
+                if name.startswith(
+                    _persistence_constants.WORKSPACE_TRANSACTION_GROUP_PREFIX
+                ):
                     _recover_open_workspace_transaction(h5_file, name)
             _cleanup_orphan_workspace_internal_groups(h5_file)
             h5_file.flush()

--- a/src/erlab/interactive/imagetool/manager/_workspace/_store.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_store.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Self
 
 import erlab
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool.manager._workspace._format import (
     _current_workspace_schema_version,
     _workspace_schema_uses_immutable_generations,
@@ -34,12 +35,6 @@ else:
     h5py = _lazy.load("h5py")
 
 
-_WORKSPACE_OBJECTS_GROUP = "__itws_objects"
-_WORKSPACE_STAGING_GROUP = "__itws_staging"
-_WORKSPACE_GENERATIONS_GROUP = "__itws_generations"
-_WORKSPACE_MANIFEST_DATASET = "manifest"
-_WORKSPACE_GENERATION_WIDTH = 20
-_WORKSPACE_ID_ATTR = "imagetool_workspace_id"
 _FILE_ACCESS_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
 _HDF5_CONTENTION_RETRY_DELAYS = (0.02, 0.05, 0.1, 0.2, 0.4, 0.8, 1.0)
 _RETRYABLE_FILE_ACCESS_ERRNOS = frozenset(
@@ -486,19 +481,21 @@ class WorkspaceStore:
 
     @staticmethod
     def _ensure_workspace_id(h5_file: typing.Any, preferred: str | None = None) -> str:
-        workspace_id = preferred or h5_file.attrs.get(_WORKSPACE_ID_ATTR)
+        workspace_id = preferred or h5_file.attrs.get(
+            _persistence_constants.WORKSPACE_ID_ATTR
+        )
         if isinstance(workspace_id, bytes):
             workspace_id = workspace_id.decode()
         if not isinstance(workspace_id, str) or not workspace_id:
             workspace_id = uuid.uuid4().hex
-        if h5_file.attrs.get(_WORKSPACE_ID_ATTR) != workspace_id:
-            h5_file.attrs[_WORKSPACE_ID_ATTR] = workspace_id
+        if h5_file.attrs.get(_persistence_constants.WORKSPACE_ID_ATTR) != workspace_id:
+            h5_file.attrs[_persistence_constants.WORKSPACE_ID_ATTR] = workspace_id
             h5_file.flush()
         return workspace_id
 
     @staticmethod
     def _workspace_id_from_file(h5_file: typing.Any) -> str | None:
-        workspace_id = h5_file.attrs.get(_WORKSPACE_ID_ATTR)
+        workspace_id = h5_file.attrs.get(_persistence_constants.WORKSPACE_ID_ATTR)
         if isinstance(workspace_id, bytes):
             workspace_id = workspace_id.decode()
         if isinstance(workspace_id, str) and workspace_id:
@@ -535,9 +532,9 @@ class WorkspaceStore:
                 _current_workspace_schema_version()
             )
             h5_file.attrs["erlab_version"] = str(erlab.__version__)
-            h5_file.require_group(_WORKSPACE_OBJECTS_GROUP)
-            h5_file.require_group(_WORKSPACE_STAGING_GROUP)
-            h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
+            h5_file.require_group(_persistence_constants.WORKSPACE_OBJECTS_GROUP)
+            h5_file.require_group(_persistence_constants.WORKSPACE_STAGING_GROUP)
+            h5_file.require_group(_persistence_constants.WORKSPACE_GENERATIONS_GROUP)
             h5_file.flush()
             h5_file.close()
         else:
@@ -1178,7 +1175,7 @@ class WorkspaceStore:
             or object_id in {".", ".."}
         ):
             raise ValueError("Workspace object ID must be one path component")
-        return f"/{_WORKSPACE_OBJECTS_GROUP}/{object_id}"
+        return f"/{_persistence_constants.WORKSPACE_OBJECTS_GROUP}/{object_id}"
 
     @staticmethod
     def _manifest_text(manifest: Mapping[str, typing.Any]) -> str:
@@ -1192,7 +1189,7 @@ class WorkspaceStore:
     ) -> None:
         text = cls._manifest_text(manifest)
         dataset = group.create_dataset(
-            _WORKSPACE_MANIFEST_DATASET,
+            "manifest",
             data=text,
             dtype=h5py.string_dtype(encoding="utf-8"),
         )
@@ -1200,9 +1197,9 @@ class WorkspaceStore:
 
     @classmethod
     def _read_manifest(cls, group: typing.Any) -> dict[str, typing.Any]:
-        if _WORKSPACE_MANIFEST_DATASET not in group:
+        if "manifest" not in group:
             raise ValueError("Workspace generation has no manifest")
-        dataset = group[_WORKSPACE_MANIFEST_DATASET]
+        dataset = group["manifest"]
         raw = dataset.asstr()[()]
         if not isinstance(raw, str):
             raise TypeError("Workspace generation manifest is not text")
@@ -1238,12 +1235,15 @@ class WorkspaceStore:
     def generations(self) -> tuple[_WorkspaceGeneration, ...]:
         """Return all valid committed generations in ascending order."""
         with self.read_session() as h5_file:
-            root = h5_file.get(_WORKSPACE_GENERATIONS_GROUP)
+            root = h5_file.get(_persistence_constants.WORKSPACE_GENERATIONS_GROUP)
             if root is None:
                 return ()
             generations: list[_WorkspaceGeneration] = []
             for name in sorted(root):
-                if len(name) != _WORKSPACE_GENERATION_WIDTH or not name.isdigit():
+                if (
+                    len(name) != _persistence_constants.WORKSPACE_GENERATION_WIDTH
+                    or not name.isdigit()
+                ):
                     continue
                 with contextlib.suppress(Exception):
                     generations.append(
@@ -1254,10 +1254,13 @@ class WorkspaceStore:
     def current_generation(self) -> _WorkspaceGeneration:
         """Return the newest valid committed generation."""
         with self.read_session() as h5_file:
-            root = h5_file.get(_WORKSPACE_GENERATIONS_GROUP)
+            root = h5_file.get(_persistence_constants.WORKSPACE_GENERATIONS_GROUP)
             if root is not None:
                 for name in sorted(root, reverse=True):
-                    if len(name) != _WORKSPACE_GENERATION_WIDTH or not name.isdigit():
+                    if (
+                        len(name) != _persistence_constants.WORKSPACE_GENERATION_WIDTH
+                        or not name.isdigit()
+                    ):
                         continue
                     with contextlib.suppress(Exception):
                         return _WorkspaceGeneration(
@@ -1270,14 +1273,19 @@ class WorkspaceStore:
         with self.write_session():
             if self._workspace_id is None:
                 self._workspace_id = self._ensure_workspace_id(self.h5_file)
-            generation_root = self.h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
+            generation_root = self.h5_file.require_group(
+                _persistence_constants.WORKSPACE_GENERATIONS_GROUP
+            )
             existing_sequences = [
                 int(name)
                 for name in generation_root
-                if len(name) == _WORKSPACE_GENERATION_WIDTH and name.isdigit()
+                if len(name) == _persistence_constants.WORKSPACE_GENERATION_WIDTH
+                and name.isdigit()
             ]
             sequence = 1 if not existing_sequences else max(existing_sequences) + 1
-            staging_root = self.h5_file.require_group(_WORKSPACE_STAGING_GROUP)
+            staging_root = self.h5_file.require_group(
+                _persistence_constants.WORKSPACE_STAGING_GROUP
+            )
             staging_name = uuid.uuid4().hex
             staging = staging_root.create_group(staging_name)
             generation_manifest = dict(manifest)
@@ -1293,10 +1301,12 @@ class WorkspaceStore:
                     self.flush()
                 raise
 
-            generation_name = f"{sequence:0{_WORKSPACE_GENERATION_WIDTH}d}"
+            generation_name = (
+                f"{sequence:0{_persistence_constants.WORKSPACE_GENERATION_WIDTH}d}"
+            )
             self.h5_file.move(
-                f"/{_WORKSPACE_STAGING_GROUP}/{staging_name}",
-                f"/{_WORKSPACE_GENERATIONS_GROUP}/{generation_name}",
+                f"/{_persistence_constants.WORKSPACE_STAGING_GROUP}/{staging_name}",
+                f"/{_persistence_constants.WORKSPACE_GENERATIONS_GROUP}/{generation_name}",
             )
             self.h5_file.attrs["imagetool_workspace_schema_version"] = (
                 _current_workspace_schema_version()
@@ -1379,10 +1389,12 @@ class WorkspaceStore:
             generations = self.generations()
             retained = generations[-2:]
             retained_names = {
-                f"{generation.sequence:0{_WORKSPACE_GENERATION_WIDTH}d}"
+                f"{generation.sequence:0{_persistence_constants.WORKSPACE_GENERATION_WIDTH}d}"
                 for generation in retained
             }
-            generation_root = self.h5_file.require_group(_WORKSPACE_GENERATIONS_GROUP)
+            generation_root = self.h5_file.require_group(
+                _persistence_constants.WORKSPACE_GENERATIONS_GROUP
+            )
             for name in list(generation_root):
                 if name in retained_names:
                     continue
@@ -1393,7 +1405,9 @@ class WorkspaceStore:
             for generation in retained:
                 reachable.update(self.manifest_object_ids(generation.manifest))
 
-            object_root = self.h5_file.require_group(_WORKSPACE_OBJECTS_GROUP)
+            object_root = self.h5_file.require_group(
+                _persistence_constants.WORKSPACE_OBJECTS_GROUP
+            )
             obsolete = [name for name in object_root if name not in reachable]
             remove_count = len(obsolete) if not self._locking_supported else max_objects
             for name in obsolete[:remove_count]:
@@ -1404,11 +1418,13 @@ class WorkspaceStore:
     def clear_staging(self) -> None:
         """Remove unpublished staging groups left by interrupted saves."""
         with self.read_session() as h5_file:
-            staging_root = h5_file.get(_WORKSPACE_STAGING_GROUP)
+            staging_root = h5_file.get(_persistence_constants.WORKSPACE_STAGING_GROUP)
             if staging_root is None or not staging_root:
                 return
         with self.write_session():
-            staging_root = self.h5_file.require_group(_WORKSPACE_STAGING_GROUP)
+            staging_root = self.h5_file.require_group(
+                _persistence_constants.WORKSPACE_STAGING_GROUP
+            )
             for name in list(staging_root):
                 del staging_root[name]
             self.h5_file.flush()

--- a/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
+++ b/src/erlab/interactive/imagetool/manager/_workspace/_trust.py
@@ -10,15 +10,13 @@ from collections.abc import Mapping
 import erlab
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
+from erlab.interactive import _persistence_constants
 from erlab.interactive._code_trust import (
     create_manifest,
     document_path_is_trusted,
     relocate_manifest_entries,
 )
-from erlab.interactive._code_trust._payloads import (
-    CODE_PAYLOAD_ENTRIES_ATTR,
-    store_code_payload_entries,
-)
+from erlab.interactive._code_trust._payloads import store_code_payload_entries
 from erlab.interactive._saved_tools import resolve_saved_tool_class
 from erlab.interactive.imagetool._provenance._model import (
     ToolProvenanceSpec,
@@ -35,29 +33,27 @@ if typing.TYPE_CHECKING:
 WORKSPACE_CODE_TRUST_DOMAIN = "erlab.workspace"
 WORKSPACE_CODE_TRUST_POLICY_VERSION = 7
 _MANIFEST_ID = (WORKSPACE_CODE_TRUST_DOMAIN, WORKSPACE_CODE_TRUST_POLICY_VERSION)
-_MANAGER_LIVE_SOURCE_SPEC_ATTR = "manager_node_live_source_spec"
-_MANAGER_PROVENANCE_SPEC_ATTR = "manager_node_provenance_spec"
-_ITOOL_PROVENANCE_SPEC_ATTR = "itool_provenance_spec"
-_TOOL_SOURCE_SPEC_ATTR = "tool_source_spec"
-_TOOL_SCRIPT_INPUTS_ATTR = "tool_script_inputs"
-_TOOL_PRIMARY_INPUT_ATTR = "tool_primary_input"
-_TOOL_DATA_REFERENCES_ATTR = "tool_data_references"
-_PROVENANCE_ATTRS = (_MANAGER_PROVENANCE_SPEC_ATTR, _ITOOL_PROVENANCE_SPEC_ATTR)
+
+
+_PROVENANCE_ATTRS = (
+    _persistence_constants.MANAGER_PROVENANCE_SPEC_ATTR,
+    _persistence_constants.ITOOL_PROVENANCE_SPEC_ATTR,
+)
 _SOURCE_ATTRS = {
-    _MANAGER_LIVE_SOURCE_SPEC_ATTR: "source",
-    _TOOL_SOURCE_SPEC_ATTR: "tool-source",
+    _persistence_constants.MANAGER_LIVE_SOURCE_SPEC_ATTR: "source",
+    _persistence_constants.TOOL_SOURCE_SPEC_ATTR: "tool-source",
 }
 _ALL_SOURCE_ATTRS = tuple(_SOURCE_ATTRS.items())
 _CODE_TRUST_ATTRS = frozenset(
     (
         *_PROVENANCE_ATTRS,
         *_SOURCE_ATTRS,
-        CODE_PAYLOAD_ENTRIES_ATTR,
+        _persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR,
         "tool_cls_qualname",
         "tool_state",
-        _TOOL_SCRIPT_INPUTS_ATTR,
-        _TOOL_PRIMARY_INPUT_ATTR,
-        _TOOL_DATA_REFERENCES_ATTR,
+        _persistence_constants.TOOL_SCRIPT_INPUTS_ATTR,
+        _persistence_constants.TOOL_PRIMARY_INPUT_ATTR,
+        _persistence_constants.TOOL_DATA_REFERENCES_ATTR,
     )
 )
 
@@ -129,7 +125,7 @@ def _tool_code_trust_from_attrs(
         tool_cls = typing.cast("type[ToolWindow]", resolve_saved_tool_class(identifier))
         status = tool_cls.StateModel.model_validate_json(tool_state)
         manifest_attrs = dict(attrs)
-        manifest_attrs.pop(_TOOL_SOURCE_SPEC_ATTR, None)
+        manifest_attrs.pop(_persistence_constants.TOOL_SOURCE_SPEC_ATTR, None)
         return tool_cls._code_trust_manifest_from_saved_metadata(status, manifest_attrs)
     except Exception as exc:
         raise TypeError("Workspace tool trust metadata could not be inspected") from exc
@@ -206,14 +202,16 @@ def workspace_code_trust_manifest(
             node_entry.get("kind") == "imagetool" and "tool_cls_qualname" not in attrs
         )
         if not is_imagetool:
-            attrs.pop(_MANAGER_PROVENANCE_SPEC_ATTR, None)
+            attrs.pop(_persistence_constants.MANAGER_PROVENANCE_SPEC_ATTR, None)
         tool_manifest = _tool_code_trust_from_attrs(attrs)
         entries += _node_code_trust_entries(
             path,
             attrs,
             tool_manifest,
             saved_provenance_attrs=(
-                _PROVENANCE_ATTRS if is_imagetool else (_ITOOL_PROVENANCE_SPEC_ATTR,)
+                _PROVENANCE_ATTRS
+                if is_imagetool
+                else (_persistence_constants.ITOOL_PROVENANCE_SPEC_ATTR,)
             ),
         )
     return create_manifest(*_MANIFEST_ID, entries)
@@ -235,9 +233,9 @@ def current_workspace_code_trust_manifest(
             tool_manifest = _tool_code_trust_from_attrs(attrs)
         source_spec = node.source_spec
         source_attr, source_segment = (
-            (_MANAGER_LIVE_SOURCE_SPEC_ATTR, "source")
+            (_persistence_constants.MANAGER_LIVE_SOURCE_SPEC_ATTR, "source")
             if node.is_imagetool
-            else (_TOOL_SOURCE_SPEC_ATTR, "tool-source")
+            else (_persistence_constants.TOOL_SOURCE_SPEC_ATTR, "tool-source")
         )
         include_source = node.is_imagetool or tool is None or tool_manifest is None
         entries += _node_code_trust_entries(
@@ -272,15 +270,28 @@ def inspect_pending_workspace_code_payloads(manager: ImageToolManager) -> None:
             continue
         if attrs is None:
             raise TypeError("Workspace tool payload metadata is missing")
-        if CODE_PAYLOAD_ENTRIES_ATTR in attrs:
+        if _persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR in attrs:
             continue
         identifier = attrs.get("tool_cls_qualname")
         if not isinstance(identifier, str):
             raise TypeError("Workspace tool class identifier must be a string")
         tool_cls = resolve_saved_tool_class(identifier)
-        if not issubclass(tool_cls, erlab.interactive.utils.ToolWindow):
+        current_tool_base = erlab.interactive.utils.ToolWindow
+        # Match the reload-aware subclass check, but retain the inherited base:
+        # its default hooks can predate the current utils module.
+        base_tool_cls = next(
+            (
+                base
+                for base in tool_cls.__mro__
+                if (base.__module__, base.__qualname__)
+                == (current_tool_base.__module__, current_tool_base.__qualname__)
+            ),
+            None,
+        )
+        if base_tool_cls is None:
             raise TypeError("Workspace tool class is not a ToolWindow subclass")
-        base_tool_cls = erlab.interactive.utils.ToolWindow
+        tool_cls = typing.cast("type[ToolWindow]", tool_cls)
+        base_tool_cls = typing.cast("type[ToolWindow]", base_tool_cls)
         saved_inspector = tool_cls._code_trust_payload_entries_from_saved_dataset
         base_saved_inspector = (
             base_tool_cls._code_trust_payload_entries_from_saved_dataset

--- a/src/erlab/interactive/imagetool/manager/_wrapper.py
+++ b/src/erlab/interactive/imagetool/manager/_wrapper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool._provenance._code import _replace_code_identifiers
 from erlab.interactive.imagetool._provenance._model import (
     DerivationEntry,
@@ -168,10 +169,11 @@ def _preview_from_imagetool(
     if width <= 0 or height <= 0:
         return fallback_ratio, fallback_pixmap
 
-    if not main_image.slicer_data_items:
+    cursor = slicer_area.current_cursor
+    if not 0 <= cursor < len(main_image.slicer_data_items):
         return fallback_ratio, fallback_pixmap
 
-    image_item = main_image.slicer_data_items[0]
+    image_item = main_image.slicer_data_items[cursor]
     if not erlab.interactive.utils.qt_is_valid(image_item):
         return fallback_ratio, fallback_pixmap
 
@@ -200,10 +202,11 @@ def _preview_curve_from_imagetool(
 
     if not erlab.interactive.utils.qt_is_valid(main_image):
         return None
-    if not main_image.slicer_data_items:
+    cursor = slicer_area.current_cursor
+    if not 0 <= cursor < len(main_image.slicer_data_items):
         return None
 
-    data_item = main_image.slicer_data_items[0]
+    data_item = main_image.slicer_data_items[cursor]
     if not erlab.interactive.utils.qt_is_valid(data_item):
         return None
 
@@ -1713,10 +1716,10 @@ class _ManagedWindowNode(QtCore.QObject):
             or self._provenance_spec != snapshot.node_provenance_spec
         )
         provenance_attr_keys = (
-            erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR,
-            erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR,
-            erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR,
-            erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR,
+            _persistence_constants.TOOL_SOURCE_SPEC_ATTR,
+            _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR,
+            _persistence_constants.TOOL_SCRIPT_INPUTS_ATTR,
+            _persistence_constants.TOOL_PRIMARY_INPUT_ATTR,
         )
         current_attrs = self._pending_workspace_payload_attrs or {}
         replacement_attrs = snapshot.pending_payload_attrs or {}
@@ -1817,10 +1820,8 @@ class _ManagedWindowNode(QtCore.QObject):
                         remapped_pending_inputs, pending_primary_input
                     )
                 )
-                attrs.pop(erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR, None)
-                attrs.pop(
-                    erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR, None
-                )
+                attrs.pop(_persistence_constants.TOOL_SOURCE_SPEC_ATTR, None)
+                attrs.pop(_persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR, None)
                 pending_attrs_changed = True
 
         changed = (

--- a/src/erlab/interactive/imagetool/viewer.py
+++ b/src/erlab/interactive/imagetool/viewer.py
@@ -2286,6 +2286,9 @@ class ImageSlicerArea(QtWidgets.QWidget):
         """
         if self.array_slicer._obj.chunks is None:
             return
+        if self._state_refresh_deferred():
+            # The delayed initial update will compute all plots from the final state.
+            return
         if _workspace_write_in_progress(self._data):
             self._workspace_pending_dask_refresh = (cursor, axes)
             if not self._workspace_dask_refresh_scheduled:
@@ -2691,6 +2694,8 @@ class ImageSlicerArea(QtWidgets.QWidget):
         if self._update_delayed:
             self._update_delayed = False
             with self.history_suppressed(), self.link_sync_suppressed():
+                for ax in self._materialized_axes():
+                    ax.set_active_cursor(self.current_cursor)
                 self.sigDataChanged.emit()
                 logger.debug("Data refresh triggered (delayed)")
 

--- a/src/erlab/interactive/utils.py
+++ b/src/erlab/interactive/utils.py
@@ -43,7 +43,12 @@ import xarray as xr
 from qtpy import PYQT6, PYSIDE6, QtCore, QtGui, QtWidgets, uic
 
 import erlab
-from erlab.interactive import _qt_state, _saved_tools, _shortcut_sequences
+from erlab.interactive import (
+    _persistence_constants,
+    _qt_state,
+    _saved_tools,
+    _shortcut_sequences,
+)
 from erlab.interactive._code_trust import (
     approve_document_trust,
     commit_local_edit_trust,
@@ -71,7 +76,7 @@ from erlab.interactive._code_trust._ui import (
     create_code_trust_banner,
 )
 from erlab.interactive._file_loaders import BUILTIN_FILE_LOADER_SPECS
-from erlab.interactive._plot_state import TOOL_VIEW_STATE_ATTR, ToolPlotStateRegistry
+from erlab.interactive._plot_state import ToolPlotStateRegistry
 from erlab.interactive._widgets import _Separator
 from erlab.utils._code import (
     _parse_single_arg,
@@ -1177,16 +1182,6 @@ def copy_to_clipboard(content: str | list[str]) -> str:
     return content
 
 
-_TOOL_SOURCE_SPEC_ATTR = "tool_source_spec"
-_TOOL_SOURCE_BINDING_ATTR = "tool_source_binding"
-_TOOL_SOURCE_STATE_ATTR = "tool_source_state"
-_TOOL_SOURCE_AUTO_UPDATE_ATTR = "tool_source_auto_update"
-_TOOL_INPUT_PROVENANCE_SPEC_ATTR = "tool_input_provenance_spec"
-_TOOL_SCRIPT_INPUTS_ATTR = "tool_script_inputs"
-_TOOL_PRIMARY_INPUT_ATTR = "tool_primary_input"
-_TOOL_DATA_REFERENCES_ATTR = "tool_data_references"
-_TOOL_DATA_BLOB_NAME_ATTR = "tool_data_blob_name"
-_SAVED_TOOL_DATA_NAME = "<saved-tool-data>"
 _TOOL_INPUT_CODE_TRUST_DOMAIN = "erlab.tool-inputs"
 _TOOL_INPUT_CODE_TRUST_POLICY_VERSION = 1
 
@@ -1204,24 +1199,6 @@ def _normalize_tool_source_state(
     return "fresh"
 
 
-_SAVED_TOOL_DATA_REFERENCE_DIM = "<saved-tool-data-reference>"
-_SAVED_TOOL_DATA_BLOB_DIM_PREFIX = "<saved-tool-data-blob-"
-_NONE_TOOL_DATA_NAME = "<none-value>"
-_STALE_TOOL_DATA_ENCODING_KEYS = frozenset(
-    (
-        "chunksizes",
-        "compression",
-        "compression_opts",
-        "contiguous",
-        "fletcher32",
-        "original_shape",
-        "preferred_chunks",
-        "shuffle",
-        "source",
-    )
-)
-
-
 class _MissingSavedToolDataReferenceError(ValueError):
     """Raised when a saved tool-data reference cannot be resolved."""
 
@@ -1229,22 +1206,33 @@ class _MissingSavedToolDataReferenceError(ValueError):
 def _tool_data_placeholder() -> xr.DataArray:
     return xr.DataArray(
         np.empty((0,), dtype=np.uint8),
-        dims=(_SAVED_TOOL_DATA_REFERENCE_DIM,),
+        dims=(_persistence_constants.SAVED_TOOL_DATA_REFERENCE_DIM,),
     )
 
 
 def _tool_data_blob_dim(variable_name: str) -> str:
-    return f"{_SAVED_TOOL_DATA_BLOB_DIM_PREFIX}{variable_name.encode().hex()}>"
+    return (
+        f"{_persistence_constants.SAVED_TOOL_DATA_BLOB_DIM_PREFIX}"
+        f"{variable_name.encode().hex()}>"
+    )
 
 
 def _tool_data_to_blob(data: xr.DataArray, variable_name: str) -> xr.DataArray:
     from erlab.interactive.imagetool import _serialization
 
-    data_name = _NONE_TOOL_DATA_NAME if data.name is None else str(data.name)
-    ds = data.to_dataset(name=_SAVED_TOOL_DATA_NAME, promote_attrs=False)
-    ds.attrs[_TOOL_DATA_BLOB_NAME_ATTR] = data_name
-    encoded = _serialization.encode_private_coords(ds, _SAVED_TOOL_DATA_NAME)
-    encoded = _drop_stale_tool_data_encoding(encoded)
+    data_name = (
+        _persistence_constants.NONE_TOOL_DATA_NAME
+        if data.name is None
+        else str(data.name)
+    )
+    ds = data.to_dataset(
+        name=_persistence_constants.SAVED_TOOL_DATA_NAME, promote_attrs=False
+    )
+    ds.attrs[_persistence_constants.TOOL_DATA_BLOB_NAME_ATTR] = data_name
+    encoded = _serialization.encode_private_coords(
+        ds, _persistence_constants.SAVED_TOOL_DATA_NAME
+    )
+    encoded = _serialization.prepare_tool_dataset(encoded, strip_backend_encoding=True)
     blob = encoded.to_netcdf(
         path=None,
         engine="h5netcdf",
@@ -1253,19 +1241,8 @@ def _tool_data_to_blob(data: xr.DataArray, variable_name: str) -> xr.DataArray:
     return xr.DataArray(
         np.frombuffer(blob, dtype=np.uint8).copy(),
         dims=(_tool_data_blob_dim(variable_name),),
-        attrs={_TOOL_DATA_BLOB_NAME_ATTR: data_name},
+        attrs={_persistence_constants.TOOL_DATA_BLOB_NAME_ATTR: data_name},
     )
-
-
-def _drop_stale_tool_data_encoding(ds: xr.Dataset) -> xr.Dataset:
-    serialized = ds.copy(deep=False)
-    for variable in serialized.variables.values():
-        variable.encoding = {
-            key: value
-            for key, value in variable.encoding.items()
-            if key not in _STALE_TOOL_DATA_ENCODING_KEYS
-        }
-    return serialized
 
 
 def _tool_data_from_blob(blob: xr.DataArray) -> xr.DataArray:
@@ -1275,11 +1252,17 @@ def _tool_data_from_blob(blob: xr.DataArray) -> xr.DataArray:
         memoryview(np.asarray(blob.values, dtype=np.uint8).tobytes()),
         engine="h5netcdf",
     )
-    restored = _serialization.restore_private_coords(ds, _SAVED_TOOL_DATA_NAME)
-    data_name = restored.attrs.get(_TOOL_DATA_BLOB_NAME_ATTR, _NONE_TOOL_DATA_NAME)
-    if data_name == _NONE_TOOL_DATA_NAME:
+    ds = _serialization.restore_tool_dataset_attrs(ds)
+    restored = _serialization.restore_private_coords(
+        ds, _persistence_constants.SAVED_TOOL_DATA_NAME
+    )
+    data_name = restored.attrs.get(
+        _persistence_constants.TOOL_DATA_BLOB_NAME_ATTR,
+        _persistence_constants.NONE_TOOL_DATA_NAME,
+    )
+    if data_name == _persistence_constants.NONE_TOOL_DATA_NAME:
         data_name = None
-    return restored[_SAVED_TOOL_DATA_NAME].rename(data_name)
+    return restored[_persistence_constants.SAVED_TOOL_DATA_NAME].rename(data_name)
 
 
 class _ToolWindowMeta(type(QtWidgets.QMainWindow)):  # type: ignore[misc]
@@ -5229,7 +5212,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         self._flush_pending_history_write()
         data_name = self.tool_data.name
         if data_name is None:
-            data_name = "<none-value>"
+            data_name = _persistence_constants.NONE_TOOL_DATA_NAME
         attrs: dict[str, typing.Any] = {
             "tool_state": self._saved_tool_status().model_dump_json(),
             "tool_data_name": str(data_name),
@@ -5242,13 +5225,15 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         }
         view_state = self._plot_state_registry.state_json()
         if view_state is not None:
-            attrs[TOOL_VIEW_STATE_ATTR] = view_state
+            attrs["tool_view_state"] = view_state
         attrs.update(
             self._saved_script_input_attrs(self._script_inputs, self._primary_input)
         )
         if self._script_inputs:
-            attrs[_TOOL_SOURCE_STATE_ATTR] = self._source_state
-            attrs[_TOOL_SOURCE_AUTO_UPDATE_ATTR] = bool(self._source_auto_update)
+            attrs[_persistence_constants.TOOL_SOURCE_STATE_ATTR] = self._source_state
+            attrs[_persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR] = bool(
+                self._source_auto_update
+            )
         return attrs
 
     @staticmethod
@@ -5264,10 +5249,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         if primary_input not in {item.name for item in inputs}:
             raise ValueError("primary input must name a script input")
         return {
-            _TOOL_SCRIPT_INPUTS_ATTR: json.dumps(
+            _persistence_constants.TOOL_SCRIPT_INPUTS_ATTR: json.dumps(
                 [item.model_dump(mode="json") for item in inputs]
             ),
-            _TOOL_PRIMARY_INPUT_ATTR: primary_input,
+            _persistence_constants.TOOL_PRIMARY_INPUT_ATTR: primary_input,
         }
 
     def _saved_tool_status(self) -> M:
@@ -5329,7 +5314,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
         """Return named data artifacts that belong to this saved tool window."""
-        return {_SAVED_TOOL_DATA_NAME: self.tool_data}
+        return {_persistence_constants.SAVED_TOOL_DATA_NAME: self.tool_data}
 
     def _persistence_reference_node_uids(self) -> frozenset[str]:
         """Return manager node UIDs that saved data references may point to."""
@@ -5346,7 +5331,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Map canonical input names to their saved data item keys."""
         return {
             item.name: (
-                _SAVED_TOOL_DATA_NAME if item.name == self._primary_input else item.name
+                _persistence_constants.SAVED_TOOL_DATA_NAME
+                if item.name == self._primary_input
+                else item.name
             )
             for item in self._script_inputs
         }
@@ -5461,7 +5448,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         """Return a saved reference payload for a persistence data item."""
         if (
             not self._save_tool_data_references
-            or variable_name != _SAVED_TOOL_DATA_NAME
+            or variable_name != _persistence_constants.SAVED_TOOL_DATA_NAME
             or self.source_state != "fresh"
             or len(self._script_inputs) != 1
         ):
@@ -5528,7 +5515,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
 
     def _saved_tool_data_dataset(self) -> xr.Dataset:
         data_items = self._persistence_data_items()
-        required_items = {_SAVED_TOOL_DATA_NAME}
+        required_items = {_persistence_constants.SAVED_TOOL_DATA_NAME}
         required_items.update(self._persistence_input_item_keys().values())
         missing_items = required_items.difference(data_items)
         if missing_items:
@@ -5549,14 +5536,16 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             if reference is not None:
                 variables[variable_name] = _tool_data_placeholder()
                 references[variable_name] = reference
-            elif variable_name == _SAVED_TOOL_DATA_NAME:
+            elif variable_name == _persistence_constants.SAVED_TOOL_DATA_NAME:
                 variables[variable_name] = data
             else:
                 variables[variable_name] = _tool_data_to_blob(data, variable_name)
 
         ds = xr.Dataset(variables).assign_attrs(self._saved_tool_attrs)
         if references:
-            ds.attrs[_TOOL_DATA_REFERENCES_ATTR] = json.dumps(references)
+            ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR] = json.dumps(
+                references
+            )
         return ds
 
     def to_dataset(self) -> xr.Dataset:
@@ -5595,7 +5584,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     def _saved_tool_data_references_from_metadata(
         attrs: Mapping[str, typing.Any],
     ) -> dict[str, dict[str, typing.Any]]:
-        payload = attrs.get(_TOOL_DATA_REFERENCES_ATTR)
+        payload = attrs.get(_persistence_constants.TOOL_DATA_REFERENCES_ATTR)
         if payload is None:
             return {}
         if not isinstance(payload, str):
@@ -5654,11 +5643,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 )
                 return None
 
-        raw_script_inputs = attrs.get(_TOOL_SCRIPT_INPUTS_ATTR)
+        raw_script_inputs = attrs.get(_persistence_constants.TOOL_SCRIPT_INPUTS_ATTR)
         if raw_script_inputs is not None:
             try:
                 script_inputs = parse_script_inputs(raw_script_inputs)
-                raw_primary = attrs.get(_TOOL_PRIMARY_INPUT_ATTR)
+                raw_primary = attrs.get(_persistence_constants.TOOL_PRIMARY_INPUT_ATTR)
                 if isinstance(raw_primary, bytes):
                     raw_primary = raw_primary.decode()
                 primary_input = raw_primary if isinstance(raw_primary, str) else None
@@ -5671,7 +5660,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 if (
                     script_inputs
                     and source_parent_data is not None
-                    and _TOOL_SOURCE_BINDING_ATTR in attrs
+                    and _persistence_constants.TOOL_SOURCE_BINDING_ATTR in attrs
                 ):
                     primary_index = tuple(item.name for item in script_inputs).index(
                         primary_input
@@ -5679,7 +5668,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     if script_inputs[primary_index].source_spec is None:
                         source_spec = _materialized_source_spec(
                             _legacy_value(
-                                _TOOL_SOURCE_BINDING_ATTR,
+                                _persistence_constants.TOOL_SOURCE_BINDING_ATTR,
                                 ImageToolSelectionSourceBinding.model_validate,
                             )
                         )
@@ -5695,9 +5684,11 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                             script_inputs = tuple(updated)
                 return script_inputs, primary_input
 
-        raw_source_spec = attrs.get(_TOOL_SOURCE_SPEC_ATTR)
-        raw_source_binding = attrs.get(_TOOL_SOURCE_BINDING_ATTR)
-        raw_input_provenance = attrs.get(_TOOL_INPUT_PROVENANCE_SPEC_ATTR)
+        raw_source_spec = attrs.get(_persistence_constants.TOOL_SOURCE_SPEC_ATTR)
+        raw_source_binding = attrs.get(_persistence_constants.TOOL_SOURCE_BINDING_ATTR)
+        raw_input_provenance = attrs.get(
+            _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR
+        )
         if (
             raw_source_spec is None
             and raw_source_binding is None
@@ -5705,21 +5696,22 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         ):
             return (), None
         source_spec = _legacy_value(
-            _TOOL_SOURCE_SPEC_ATTR,
+            _persistence_constants.TOOL_SOURCE_SPEC_ATTR,
             lambda value: require_live_source_spec(parse_tool_provenance_spec(value)),
         )
         source_binding = (
             None
             if source_spec is not None
             else _legacy_value(
-                _TOOL_SOURCE_BINDING_ATTR,
+                _persistence_constants.TOOL_SOURCE_BINDING_ATTR,
                 ImageToolSelectionSourceBinding.model_validate,
             )
         )
         if source_spec is None:
             source_spec = _materialized_source_spec(source_binding)
         provenance_spec = _legacy_value(
-            _TOOL_INPUT_PROVENANCE_SPEC_ATTR, parse_tool_provenance_spec
+            _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR,
+            parse_tool_provenance_spec,
         )
         if source_spec is None and provenance_spec is None and source_binding is None:
             return (), None
@@ -5889,6 +5881,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         requested = None if variable_names is None else frozenset(variable_names)
         references = cls._saved_tool_data_references(ds)
         data_items: dict[str, xr.DataArray] = {}
+        materialized_references: dict[
+            int, tuple[xr.DataArray, xr.DataArray, bool, tuple[Hashable, ...]]
+        ] = {}
         for variable_name, reference in references.items():
             if requested is not None and variable_name not in requested:
                 continue
@@ -5903,7 +5898,42 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     entry_locator=entry_locator,
                 )
                 if materialize_references:
-                    resolved = resolved.copy(deep=False).load()
+                    cached = materialized_references.get(id(resolved))
+                    if cached is None:
+                        source_data = resolved
+                        # IndexVariable.load() is a no-op, even when its index
+                        # adapter reports that the expanded values are not in memory.
+                        lazy_data = (
+                            not isinstance(source_data.variable, xr.IndexVariable)
+                            and not source_data.variable._in_memory
+                        )
+                        lazy_coords = tuple(
+                            name
+                            for name, coord in source_data.coords.variables.items()
+                            if not isinstance(coord, xr.IndexVariable)
+                            and not coord._in_memory
+                        )
+                        resolved = resolved.copy(deep=False).load()
+                        # Keep the source alive so its identity cannot be reused.
+                        # Loading a copy leaves the resolver's source lazy.
+                        if lazy_data or lazy_coords:
+                            materialized_references[id(source_data)] = (
+                                source_data,
+                                resolved,
+                                lazy_data,
+                                lazy_coords,
+                            )
+                    else:
+                        _, loaded, lazy_data, lazy_coords = cached
+                        resolved = loaded.copy(deep=False)
+                        # Separate buffers created by loading. Keep existing eager
+                        # buffers shared, as shallow-copy/load does without caching.
+                        if lazy_data:
+                            resolved.data = loaded.data.copy()
+                        for name in lazy_coords:
+                            resolved.coords[name].variable.data = loaded.coords[
+                                name
+                            ].data.copy()
                 data_items[variable_name] = resolved
             except _MissingSavedToolDataReferenceError:
                 if cls._missing_saved_tool_data_reference_optional(
@@ -5917,17 +5947,20 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                 continue
             if variable_name in data_items:
                 continue
-            if _TOOL_DATA_BLOB_NAME_ATTR in data_array.attrs:
+            if _persistence_constants.TOOL_DATA_BLOB_NAME_ATTR in data_array.attrs:
                 if not isinstance(variable_name, str):
                     raise TypeError("Saved tool data variable names must be strings")
                 data_items[variable_name] = _tool_data_from_blob(data_array)
 
         if (
-            requested is None or _SAVED_TOOL_DATA_NAME in requested
-        ) and _SAVED_TOOL_DATA_NAME not in data_items:
-            if _SAVED_TOOL_DATA_NAME not in ds:
+            requested is None
+            or _persistence_constants.SAVED_TOOL_DATA_NAME in requested
+        ) and _persistence_constants.SAVED_TOOL_DATA_NAME not in data_items:
+            if _persistence_constants.SAVED_TOOL_DATA_NAME not in ds:
                 raise ValueError("Saved tool dataset is missing primary tool data")
-            data_items[_SAVED_TOOL_DATA_NAME] = ds[_SAVED_TOOL_DATA_NAME]
+            data_items[_persistence_constants.SAVED_TOOL_DATA_NAME] = ds[
+                _persistence_constants.SAVED_TOOL_DATA_NAME
+            ]
         return data_items
 
     @staticmethod
@@ -5984,7 +6017,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             "Callable[[Iterable[CodeTrustEntry]], tuple[CodeTrustEntry, ...]] | None",
             kwargs.pop("_code_trust_entry_locator", None),
         )
-        ds = _serialization.restore_private_coords(ds, _SAVED_TOOL_DATA_NAME)
+        ds = _serialization.restore_private_coords(
+            ds, _persistence_constants.SAVED_TOOL_DATA_NAME
+        )
 
         saved_version = ds.attrs.get("erlab_version", "0.0.0")
         if erlab.utils.misc.is_newer_version(saved_version):  # pragma: no cover
@@ -6018,13 +6053,17 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         )
 
         # Instantiate the class and set the status
-        tool_data_name: str | None = ds.attrs.get("tool_data_name", "<none-value>")
-        if tool_data_name == "<none-value>":
+        tool_data_name: str | None = ds.attrs.get(
+            "tool_data_name", _persistence_constants.NONE_TOOL_DATA_NAME
+        )
+        if tool_data_name == _persistence_constants.NONE_TOOL_DATA_NAME:
             tool_data_name = None
         token = _TOOL_WINDOW_RESTORE_DEFER.set(defer_restore_work)
         try:
             constructor_data = cls_obj._prepare_restored_tool_data_for_constructor(
-                data_items[_SAVED_TOOL_DATA_NAME].rename(tool_data_name),
+                data_items[_persistence_constants.SAVED_TOOL_DATA_NAME].rename(
+                    tool_data_name
+                ),
                 saved_status,
             )
             tool = cls_obj(
@@ -6068,10 +6107,12 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
                     script_inputs,
                     primary_input=primary_input,
                     auto_update=bool(
-                        ds.attrs.get(_TOOL_SOURCE_AUTO_UPDATE_ATTR, False)
+                        ds.attrs.get(
+                            _persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR, False
+                        )
                     ),
                     state=_normalize_tool_source_state(
-                        ds.attrs.get(_TOOL_SOURCE_STATE_ATTR)
+                        ds.attrs.get(_persistence_constants.TOOL_SOURCE_STATE_ATTR)
                     ),
                 )
             if script_inputs:
@@ -6080,7 +6121,7 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
             else:
                 tool._restore_persistence_payload(ds)
                 tool._restore_persistence_data_items(data_items, ds)
-            tool._plot_state_registry.restore_json(ds.attrs.get(TOOL_VIEW_STATE_ATTR))
+            tool._plot_state_registry.restore_json(ds.attrs.get("tool_view_state"))
             tool.setWindowTitle(ds.attrs["tool_title"])
             if (
                 not _qt_state.restore_qt_window_state(
@@ -6112,6 +6153,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         The saved netcdf dataset can be used to recreate the ImageTool with the class
         method :meth:`from_file`.
 
+        .. versionchanged:: 3.28.0
+           Nested attributes on data and coordinates are preserved in saved tool files.
+
         Parameters
         ----------
         filename
@@ -6125,7 +6169,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         manifest = self._code_trust_manifest_from_saved_metadata(
             saved_status, dataset.attrs
         )
-        _serialization.encode_private_coords(dataset, _SAVED_TOOL_DATA_NAME).to_netcdf(
+        encoded = _serialization.encode_private_coords(
+            dataset, _persistence_constants.SAVED_TOOL_DATA_NAME
+        )
+        _serialization.prepare_tool_dataset(encoded).to_netcdf(
             filename, engine="h5netcdf", invalid_netcdf=True
         )
         if manifest is not None:
@@ -6144,6 +6191,9 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
     def from_file(cls, filename: str | os.PathLike, **kwargs) -> typing.Self:
         """Restore a window from a file saved using :meth:`to_file`.
 
+        .. versionchanged:: 3.28.0
+           Restore typed attributes from new tool files. Older files remain supported.
+
         Parameters
         ----------
         filename
@@ -6151,7 +6201,10 @@ class ToolWindow(QtWidgets.QMainWindow, typing.Generic[M], metaclass=_ToolWindow
         **kwargs
             Additional keyword arguments passed to the constructor.
         """
+        from erlab.interactive.imagetool import _serialization
+
         with xr.open_dataset(filename, engine="h5netcdf") as opened:
+            opened = _serialization.restore_tool_dataset_attrs(opened)
             cls_obj = cls._saved_tool_class_from_dataset(opened)
             status = cls_obj.StateModel.model_validate_json(opened.attrs["tool_state"])
             manifest = cls_obj._code_trust_manifest_from_saved_metadata(

--- a/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_manager_gallery.py
@@ -17,6 +17,7 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 import erlab.interactive.imagetool.manager._workspace._saving as workspace_saving
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
+from erlab.interactive import _persistence_constants
 from erlab.interactive._figurecomposer import (
     FigureComposerTool,
     FigureOperationState,
@@ -25,7 +26,6 @@ from erlab.interactive._figurecomposer import (
     FigureSubplotsState,
 )
 from erlab.interactive.imagetool import itool
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._model import FileDataSelection
 from erlab.interactive.imagetool.manager._figurecomposer import _collection
 from tests.interactive.imagetool.manager.helpers import (
@@ -1615,17 +1615,17 @@ def test_manager_workspace_figure_sources_save_as_references(
                 "xr.DataTree", tree[f"figures/{figure_uid}/tool"]
             ).to_dataset(inherit=False)
             references = json.loads(
-                ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
+                ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR]
             )
 
-            assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in references
+            assert _persistence_constants.SAVED_TOOL_DATA_NAME in references
             assert "second" in references
-            assert ds[erlab.interactive.utils._SAVED_TOOL_DATA_NAME].size == 0
+            assert ds[_persistence_constants.SAVED_TOOL_DATA_NAME].size == 0
             assert ds["second"].size == 0
             assert workspace_arrays._workspace_dataset_can_write_h5py(ds)
 
             source_data_by_uid = {
-                references[erlab.interactive.utils._SAVED_TOOL_DATA_NAME][
+                references[_persistence_constants.SAVED_TOOL_DATA_NAME][
                     "node_uid"
                 ]: first,
                 references["second"]["node_uid"]: second,
@@ -1648,7 +1648,7 @@ def test_manager_workspace_figure_sources_save_as_references(
             saved_ds = workspace_arrays._read_workspace_dataset_group_h5py(
                 fname,
                 _current_workspace_payload_path(fname, f"figures/{figure_uid}"),
-                preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+                preferred_data_name=_persistence_constants.SAVED_TOOL_DATA_NAME,
             )
             assert saved_ds is not None
             assert "second" in saved_ds
@@ -1896,11 +1896,11 @@ def test_manager_workspace_embeds_figure_snapshot_after_source_transpose(
         saved_figure = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
             _current_workspace_payload_path(workspace_path, f"figures/{figure_uid}"),
-            preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+            preferred_data_name=_persistence_constants.SAVED_TOOL_DATA_NAME,
         )
         assert saved_figure is not None
         saved_references = FigureComposerTool._saved_tool_data_references(saved_figure)
-        assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in saved_references
+        assert _persistence_constants.SAVED_TOOL_DATA_NAME in saved_references
         assert (
             manager._child_node(figure_uid)._workspace_tool_data_references
             == saved_references
@@ -1917,15 +1917,15 @@ def test_manager_workspace_embeds_figure_snapshot_after_source_transpose(
         rewritten_figure = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
             _current_workspace_payload_path(workspace_path, f"figures/{figure_uid}"),
-            preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+            preferred_data_name=_persistence_constants.SAVED_TOOL_DATA_NAME,
         )
         assert rewritten_figure is not None
         rewritten_references = FigureComposerTool._saved_tool_data_references(
             rewritten_figure
         )
-        assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME not in rewritten_references
+        assert _persistence_constants.SAVED_TOOL_DATA_NAME not in rewritten_references
         assert (
-            rewritten_figure[erlab.interactive.utils._SAVED_TOOL_DATA_NAME].size
+            rewritten_figure[_persistence_constants.SAVED_TOOL_DATA_NAME].size
             == data.size
         )
         assert manager._workspace_controller.loading._load_workspace_file(
@@ -1981,7 +1981,7 @@ def test_manager_failed_save_keeps_last_saved_figure_references(
         manager._workspace_controller.saving._save_workspace_document(workspace_path)
         adopt_workspace_path(manager, workspace_path)
         saved_references = dict(figure_node._workspace_tool_data_references)
-        assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in saved_references
+        assert _persistence_constants.SAVED_TOOL_DATA_NAME in saved_references
         manager._workspace_controller._mark_workspace_clean()
 
         root.slicer_area.transpose_main_image()
@@ -2043,11 +2043,11 @@ def test_manager_save_as_preserves_figure_source_snapshot(
         saved_figure = workspace_arrays._read_workspace_dataset_group_h5py(
             target_path,
             _current_workspace_payload_path(target_path, f"figures/{figure_uid}"),
-            preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+            preferred_data_name=_persistence_constants.SAVED_TOOL_DATA_NAME,
         )
         assert saved_figure is not None
         assert (
-            erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+            _persistence_constants.SAVED_TOOL_DATA_NAME
             not in FigureComposerTool._saved_tool_data_references(saved_figure)
         )
         assert manager._child_node(figure_uid)._workspace_tool_data_references == {}
@@ -2109,11 +2109,11 @@ def test_manager_generation_save_preserves_pending_figure_snapshot(
         rewritten_figure = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
             _current_workspace_payload_path(workspace_path, f"figures/{figure_uid}"),
-            preferred_data_name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+            preferred_data_name=_persistence_constants.SAVED_TOOL_DATA_NAME,
         )
         assert rewritten_figure is not None
         assert (
-            erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+            _persistence_constants.SAVED_TOOL_DATA_NAME
             not in FigureComposerTool._saved_tool_data_references(rewritten_figure)
         )
 
@@ -2163,11 +2163,15 @@ def test_manager_pending_figure_source_reference_uses_saved_imagetool_dim_order(
         saved_ds = workspace_arrays._read_workspace_dataset_group_h5py(
             workspace_path,
             payload_path,
-            preferred_data_name=_ITOOL_DATA_NAME,
+            preferred_data_name=_persistence_constants.ITOOL_DATA_NAME,
         )
         assert saved_ds is not None
         stored = xr.Dataset(
-            {_ITOOL_DATA_NAME: saved_ds[_ITOOL_DATA_NAME].transpose("hv", "y", "x")},
+            {
+                _persistence_constants.ITOOL_DATA_NAME: saved_ds[
+                    _persistence_constants.ITOOL_DATA_NAME
+                ].transpose("hv", "y", "x")
+            },
             attrs=dict(saved_ds.attrs),
         )
         with h5py.File(workspace_path, "r+") as h5_file:
@@ -2236,7 +2240,7 @@ def test_manager_workspace_generation_rewrites_stale_figure_source_references(
                 "xr.DataTree", tree[f"figures/{figure_uid}/tool"]
             ).to_dataset(inherit=False)
             saved_refs = json.loads(
-                saved_ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
+                saved_ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR]
             )
             assert "second" in saved_refs
             assert saved_ds["second"].size == 0
@@ -2278,7 +2282,7 @@ def test_manager_workspace_generation_rewrites_stale_figure_source_references(
             rewritten_ds = object_write.dataset
             assert rewritten_ds is not None
             rewritten_refs = json.loads(
-                rewritten_ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
+                rewritten_ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR]
             )
             assert all(
                 reference.get("node_uid") != stale_uid

--- a/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
+++ b/tests/interactive/imagetool/manager/figurecomposer/test_sources.py
@@ -17,6 +17,7 @@ import erlab.interactive._figurecomposer._ui._editor_controls as _editor_control
 import erlab.interactive._figurecomposer._ui._figure_window as figure_window_ui
 import erlab.interactive._stylesheets
 import erlab.plotting as eplt
+from erlab.interactive import _persistence_constants
 from erlab.interactive._figurecomposer import (
     FigureAxesSelectionState,
     FigureComposerTool,
@@ -134,7 +135,7 @@ def test_figure_composer_source_alias_candidate_normalizes_usable_names() -> Non
     )
     assert (
         figurecomposer_sources._source_alias_error(
-            erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+            _persistence_constants.SAVED_TOOL_DATA_NAME
         )
         is not None
     )
@@ -335,6 +336,43 @@ def test_figure_composer_selected_source_reference_restores_from_base_data(
     )
 
 
+def test_figure_composer_duplicate_eager_reference_roundtrip_shares_buffers(
+    qtbot,
+) -> None:
+    source = xr.DataArray(
+        np.arange(42.0).reshape(6, 7),
+        dims=("x", "y"),
+        coords={"calibration": (("x", "y"), np.ones((6, 7)))},
+        name="source",
+    )
+    tool = FigureComposerTool(
+        source,
+        recipe=FigureRecipeState(
+            sources=(FigureSourceState(name="primary", node_uid="source-node"),),
+            primary_source="primary",
+        ),
+        source_data={"primary": source},
+    )
+    qtbot.addWidget(tool)
+    (duplicate,) = tool._document.duplicate_sources(("primary",))
+    with tool._save_tool_data_reference_context({"source-node"}):
+        saved = tool.to_dataset()
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        saved,
+        _tool_data_reference_resolver=lambda _reference: source,
+        _materialize_tool_data_references=True,
+        _defer_restore_work=True,
+    )
+    qtbot.addWidget(restored)
+    assert isinstance(restored, FigureComposerTool)
+    restored_sources = restored.source_data()
+    assert set(restored_sources) == {"primary", duplicate}
+    for item in restored_sources.values():
+        xr.testing.assert_identical(item, source)
+        assert np.shares_memory(item.data, source.data)
+        assert np.shares_memory(item.calibration.data, source.calibration.data)
+
+
 def test_figure_composer_selected_alias_roundtrip_uses_source_alias_base(
     qtbot,
 ) -> None:
@@ -419,7 +457,7 @@ def test_figure_composer_restore_recomputes_cached_selected_descendants(qtbot) -
 
     tool._restore_persistence_data_items(
         {
-            erlab.interactive.utils._SAVED_TOOL_DATA_NAME: replacement,
+            _persistence_constants.SAVED_TOOL_DATA_NAME: replacement,
             "selected_u": base,
             "selected_v": selected_u,
         },
@@ -526,7 +564,7 @@ def test_figure_composer_persistence_metadata_fallbacks(qtbot) -> None:
 
     items = tool._persistence_data_items()
     xr.testing.assert_identical(
-        items[erlab.interactive.utils._SAVED_TOOL_DATA_NAME], fallback
+        items[_persistence_constants.SAVED_TOOL_DATA_NAME], fallback
     )
     assert tool._embedded_selected_source_names(xr.Dataset()) == ()
 
@@ -1756,7 +1794,7 @@ def test_figure_composer_source_structure_edge_paths(qtbot) -> None:
     assert tool._document.source_alias_error("") is not None
     assert tool._document.source_alias_error("bad name") is not None
     assert tool._document.source_alias_error(
-        erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+        _persistence_constants.SAVED_TOOL_DATA_NAME
     )
     assert tool._document.source_alias_error("fig") is not None
     assert tool._document.source_alias_error("second", current="first") is not None
@@ -4866,9 +4904,7 @@ def test_figure_composer_restore_skips_missing_nonprimary_source_reference(
     with tool._save_tool_data_reference_context({"n-primary", "n-stale"}):
         ds = tool.to_dataset()
 
-    references = json.loads(
-        ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
-    )
+    references = json.loads(ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR])
     assert references["stale"]["node_uid"] == "n-stale"
     assert ds["stale"].size == 0
 
@@ -5164,7 +5200,7 @@ def test_figure_composer_restore_persisted_selection_failure_paths(qtbot) -> Non
     )
     primary_tool.set_source_data({})
     primary_tool._restore_persistence_data_items(
-        {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: data},
+        {_persistence_constants.SAVED_TOOL_DATA_NAME: data},
         xr.Dataset(attrs={"tool_data_name": "restored"}),
     )
     assert primary_tool.source_data()["primary"].name == "restored"
@@ -5184,7 +5220,7 @@ def test_figure_composer_restore_persisted_selection_failure_paths(qtbot) -> Non
     qtbot.addWidget(descendant_tool)
     descendant_tool.set_source_data({})
     descendant_tool._restore_persistence_data_items(
-        {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: data}, xr.Dataset()
+        {_persistence_constants.SAVED_TOOL_DATA_NAME: data}, xr.Dataset()
     )
     assert "root" in descendant_tool.source_data()
     assert "child" not in descendant_tool.source_data()

--- a/tests/interactive/imagetool/manager/provenance/test_dependencies.py
+++ b/tests/interactive/imagetool/manager/provenance/test_dependencies.py
@@ -17,11 +17,11 @@ import erlab
 import erlab.interactive.imagetool.manager._lineage as manager_lineage
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
+from erlab.interactive import _persistence_constants
 from erlab.interactive._fit2d import Fit2DTool
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.fermiedge import GoldTool
 from erlab.interactive.imagetool import itool
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._execution import rebuild_script_inputs
 from erlab.interactive.imagetool._provenance._model import (
     DerivationEntry,
@@ -1009,7 +1009,7 @@ def test_manager_operation_filter_preserves_output_binding(
         state = json.loads(saved.attrs["itool_state"])
         assert state["filter_operation"]["op"] == "gaussian_filter"
         xr.testing.assert_identical(
-            saved[_ITOOL_DATA_NAME].rename(initial_output.name),
+            saved[_persistence_constants.ITOOL_DATA_NAME].rename(initial_output.name),
             initial_output,
         )
 

--- a/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
+++ b/tests/interactive/imagetool/manager/provenance/test_watched_tools.py
@@ -12,7 +12,7 @@ import erlab
 import erlab.interactive.imagetool._highdim as imagetool_highdim
 import erlab.interactive.imagetool.manager._lineage as manager_lineage
 import erlab.interactive.imagetool.manager._widgets as manager_widgets
-import erlab.interactive.imagetool.manager._workspace._format as workspace_format
+from erlab.interactive import _persistence_constants
 from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
 from erlab.interactive._mesh import MeshTool
@@ -228,10 +228,10 @@ def test_manager_workspace_roundtrip_preserves_watched_binding(
         workspace_link_id = manager._workspace_state.link_id
         tree = manager._workspace_controller.saving._to_datatree()
         manifest = manager._workspace_controller.saving._workspace_manifest()
-        tree.attrs["imagetool_workspace_schema_version"] = (
-            workspace_format._WORKSPACE_MANIFEST_SCHEMA_VERSION
+        tree.attrs["imagetool_workspace_schema_version"] = 4
+        tree.attrs[_persistence_constants.WORKSPACE_MANIFEST_ATTR] = json.dumps(
+            manifest
         )
-        tree.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(manifest)
         assert manifest["workspace_link_id"] == workspace_link_id
         attrs = tree["0/imagetool"].attrs
         assert attrs["manager_node_watched_varname"] == "data"

--- a/tests/interactive/imagetool/manager/test_modelview.py
+++ b/tests/interactive/imagetool/manager/test_modelview.py
@@ -824,6 +824,15 @@ def test_imagetool_preview_image_is_cached_until_node_changes(
         assert node._preview_image[1].cacheKey() == pixmap.cacheKey()
         assert calls == [node.imagetool, node.imagetool, node.imagetool]
 
+        area = node.imagetool.slicer_area
+        area.add_cursor()
+        for cursor in (0, 1, 0):
+            previous_calls = len(calls)
+            area.set_current_cursor(cursor)
+            preview = node._preview_image
+            assert node._preview_image is preview
+            assert len(calls) == previous_calls + 1
+
         missing_calls: list[object] = []
 
         def _missing_preview(imagetool, fallback_ratio, fallback_pixmap):

--- a/tests/interactive/imagetool/manager/test_wrapper.py
+++ b/tests/interactive/imagetool/manager/test_wrapper.py
@@ -309,10 +309,15 @@ def test_wrapper_preview_fallback_branches(monkeypatch) -> None:
 
     class _FakeSlicerArea:
         def __init__(
-            self, main_image: object = None, *, raise_main: bool = False
+            self,
+            main_image: object = None,
+            *,
+            raise_main: bool = False,
+            current_cursor: int = 0,
         ) -> None:
             self._main_image = _FakeMainImage() if main_image is None else main_image
             self._raise_main = raise_main
+            self.current_cursor = current_cursor
 
         def _update_if_delayed(self) -> None:
             return
@@ -357,7 +362,14 @@ def test_wrapper_preview_fallback_branches(monkeypatch) -> None:
         fallback,
     )
     assert _preview(_FakeSlicerArea(_FakeMainImage(items=[]))) == (1.5, fallback)
+    for cursor in (-1, 1):
+        assert _preview(_FakeSlicerArea(current_cursor=cursor)) == (1.5, fallback)
     assert _preview(_FakeSlicerArea(_FakeMainImage(items=[invalid]))) == (1.5, fallback)
+    assert _preview(
+        _FakeSlicerArea(
+            _FakeMainImage(items=[_FakeImageItem(), invalid]), current_cursor=1
+        )
+    ) == (1.5, fallback)
     assert _preview(
         _FakeSlicerArea(_FakeMainImage(items=[_FakeImageItem(raise_pixmap=True)]))
     ) == (1.5, fallback)

--- a/tests/interactive/imagetool/manager/workspace/_support.py
+++ b/tests/interactive/imagetool/manager/workspace/_support.py
@@ -11,10 +11,10 @@ import pydantic
 import xarray as xr
 
 import erlab
-import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool._provenance._model import (
     FileLoadSource,
     FileReplayCall,
@@ -74,7 +74,7 @@ class _AddedTimeChildTool(erlab.interactive.utils.ToolWindow[_AddedTimeChildStat
 
     def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
         primary = self.primary_input or "data"
-        items = {imagetool_serialization.SAVED_TOOL_DATA_NAME: self._data}
+        items = {_persistence_constants.SAVED_TOOL_DATA_NAME: self._data}
         items.update(
             (name, value)
             for name, value in self._last_inputs.items()
@@ -141,7 +141,7 @@ class _WorkspaceSweepChildTool(
 
     def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
         return {
-            imagetool_serialization.SAVED_TOOL_DATA_NAME: self._data,
+            _persistence_constants.SAVED_TOOL_DATA_NAME: self._data,
             "auxiliary": self._extra_data,
         }
 
@@ -149,7 +149,7 @@ class _WorkspaceSweepChildTool(
         self, data_items: Mapping[str, xr.DataArray], ds: xr.Dataset
     ) -> None:
         del ds
-        self._data = data_items[imagetool_serialization.SAVED_TOOL_DATA_NAME].rename(
+        self._data = data_items[_persistence_constants.SAVED_TOOL_DATA_NAME].rename(
             self._data.name
         )
         self._extra_data = data_items["auxiliary"]
@@ -173,7 +173,7 @@ class _WorkspaceManagerReferenceFigureTool(_WorkspaceSweepFigureTool):
         del data
         if (
             not self._save_tool_data_references
-            or variable_name != imagetool_serialization.SAVED_TOOL_DATA_NAME
+            or variable_name != _persistence_constants.SAVED_TOOL_DATA_NAME
             or self._reference_uid is None
         ):
             return None
@@ -224,7 +224,7 @@ def _open_external_hdf5_imagetool_data(
             group=_current_workspace_payload_path(fname),
             **open_kwargs,
         )
-        data = ds[imagetool_serialization.ITOOL_DATA_NAME]
+        data = ds[_persistence_constants.ITOOL_DATA_NAME]
         data.set_close(ds.close)
         return data
     tree = xr.open_datatree(fname, **open_kwargs)
@@ -344,13 +344,11 @@ def _transaction_test_root_attrs(delta_save_count: int = 0) -> dict[str, object]
         "nodes": [],
     }
     if delta_save_count > 0:
-        manifest["transaction_protocol"] = (
-            workspace_format._WORKSPACE_TRANSACTION_PROTOCOL
-        )
+        manifest["transaction_protocol"] = "recoverable-delta-v1"
         manifest["delta_save_count"] = delta_save_count
     return {
         "imagetool_workspace_schema_version": 4,
-        workspace_format._WORKSPACE_MANIFEST_ATTR: json.dumps(manifest),
+        _persistence_constants.WORKSPACE_MANIFEST_ATTR: json.dumps(manifest),
     }
 
 
@@ -373,17 +371,17 @@ def _write_transaction_test_workspace(fname: pathlib.Path, value: float = 1.0) -
 def _assert_no_workspace_internal_groups(fname: pathlib.Path) -> None:
     with h5py.File(fname, "r") as h5_file:
         generation_groups = {
-            workspace_store._WORKSPACE_OBJECTS_GROUP,
-            workspace_store._WORKSPACE_STAGING_GROUP,
-            workspace_store._WORKSPACE_GENERATIONS_GROUP,
+            _persistence_constants.WORKSPACE_OBJECTS_GROUP,
+            _persistence_constants.WORKSPACE_STAGING_GROUP,
+            _persistence_constants.WORKSPACE_GENERATIONS_GROUP,
         }
         assert not any(
             workspace_format._is_workspace_internal_group_name(name)
             and name not in generation_groups
             for name in h5_file
         )
-        if workspace_store._WORKSPACE_STAGING_GROUP in h5_file:
-            assert len(h5_file[workspace_store._WORKSPACE_STAGING_GROUP]) == 0
+        if _persistence_constants.WORKSPACE_STAGING_GROUP in h5_file:
+            assert len(h5_file[_persistence_constants.WORKSPACE_STAGING_GROUP]) == 0
 
 
 def _rich_workspace_attr_value() -> dict[str, typing.Any]:

--- a/tests/interactive/imagetool/manager/workspace/test_arrays.py
+++ b/tests/interactive/imagetool/manager/workspace/test_arrays.py
@@ -9,7 +9,9 @@ import threading
 import types
 import typing
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 
+import h5netcdf
 import h5py
 import hdf5plugin
 import numpy as np
@@ -22,7 +24,7 @@ import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
+from erlab.interactive import _persistence_constants
 from tests.interactive.imagetool.manager.workspace._support import (
     _assert_rich_workspace_attr,
     _hdf5_blosc2_level_codec,
@@ -30,6 +32,273 @@ from tests.interactive.imagetool.manager.workspace._support import (
     _rich_workspace_attr_value,
     _write_transaction_test_workspace,
 )
+
+
+@contextlib.contextmanager
+def _numeric_workspace_reader(tmp_path, values, *, legacy=False):
+    path = tmp_path / "numeric-reader.itws"
+    group_path = (
+        "/legacy" if legacy else workspace_store.WorkspaceStore.object_path("payload")
+    )
+    with workspace_store.WorkspaceStore(path, create=True) as store:
+        with store.write_session() as h5_file:
+            workspace_arrays._write_workspace_dataset_group_to_file(
+                h5_file,
+                group_path,
+                xr.Dataset(
+                    {"data": (tuple(f"d{i}" for i in range(values.ndim)), values)}
+                ),
+                compression_mode="none",
+            )
+        manager = workspace_arrays.WorkspaceFileManager(
+            path, object_id=None if legacy else "payload", group_path=group_path
+        )
+        datastore = workspace_arrays._WorkspaceH5NetCDFStore(
+            manager, group=group_path, mode="r", lock=manager.lock
+        )
+        backend = workspace_arrays._WorkspaceBackendArray(
+            "data", datastore, shape=values.shape, dtype=values.dtype
+        )
+        try:
+            yield store, manager, backend
+        finally:
+            manager.close()
+
+
+@pytest.mark.parametrize("dtype", ["i2", "u4", "f4", "f8", ">f8"])
+def test_workspace_numeric_reads_preserve_indexing(monkeypatch, tmp_path, dtype):
+    values = np.arange(5 * 6 * 7).reshape(5, 6, 7).astype(dtype)
+    if values.dtype.kind == "f":
+        values[0, 0, :3] = [np.nan, np.inf, -np.inf]
+    with _numeric_workspace_reader(tmp_path, values) as (_, manager, backend):
+        selections = []
+        original = h5netcdf.Variable.__getitem__
+
+        def read(variable, key):
+            selections.append(key)
+            return original(variable, key)
+
+        monkeypatch.setattr(h5netcdf.Variable, "__getitem__", read)
+        basic_keys = [
+            (slice(None),) * 3,
+            (slice(1, 4, 2), slice(-4, None), slice(None, None, 3)),
+            (-1, slice(None), np.int64(2)),
+            (slice(0, 0), slice(None), slice(None)),
+            (1, 2, 3),
+            (slice(None, None, -1), slice(None), slice(None, None, -2)),
+        ]
+        for key in basic_keys:
+            result = backend[workspace_arrays.indexing.BasicIndexer(key)]
+            np.testing.assert_array_equal(result, values[key])
+            assert result.dtype == values[key].dtype
+        assert not selections
+        assert manager._direct_read_datasets["data"] is not None
+
+        # Vector indexing retains h5netcdf's semantics. The xarray adapter also
+        # supports unsorted indices, duplicates, and empty index arrays.
+        for indices in [np.array([3, 1, 3]), np.array([], dtype=int)]:
+            key = (indices, slice(None), slice(None))
+            result = backend[workspace_arrays.indexing.OuterIndexer(key)]
+            np.testing.assert_array_equal(result, values[key])
+        assert selections
+        np.testing.assert_array_equal(backend._getitem(Ellipsis), values)
+        with pytest.raises(IndexError):
+            backend[workspace_arrays.indexing.BasicIndexer((5, 0, 0))]
+
+
+def test_workspace_numeric_scalar_read(tmp_path):
+    values = np.array(4.5)
+    with _numeric_workspace_reader(tmp_path, values) as (_, manager, backend):
+        result = backend[workspace_arrays.indexing.BasicIndexer(())]
+        np.testing.assert_array_equal(result, values[()])
+        assert manager._direct_read_datasets["data"] is not None
+
+
+@pytest.mark.parametrize("copy_on_write", [False, True])
+def test_workspace_numeric_read_cache_obeys_handle_lifetime(tmp_path, copy_on_write):
+    values = np.arange(12.0).reshape(3, 4)
+    with _numeric_workspace_reader(tmp_path, values) as (store, manager, backend):
+        np.testing.assert_array_equal(backend._getitem((slice(None),) * 2), values)
+        cached = manager._direct_read_datasets["data"]
+        store._locking_supported = not copy_on_write
+        with store.write_session() as h5_file:
+            assert not manager._direct_read_datasets
+            assert not cached.id.valid
+            h5_file.attrs["saved"] = True
+            # Reads during an established write still use the stable read handle.
+            np.testing.assert_array_equal(backend._getitem((1, slice(None))), values[1])
+        assert not manager._direct_read_datasets
+        np.testing.assert_array_equal(backend._getitem((slice(None),) * 2), values)
+        assert manager._direct_read_datasets["data"] is not cached
+
+        # A serialized reader owns bounded handles and carries no cached Dataset.
+        worker_backend = pickle.loads(pickle.dumps(backend))
+        np.testing.assert_array_equal(
+            worker_backend._getitem((slice(None),) * 2), values
+        )
+        assert not worker_backend.datastore._manager._direct_read_datasets
+        manager.close()
+        assert not manager._direct_read_datasets
+        np.testing.assert_array_equal(backend._getitem((slice(None),) * 2), values)
+
+
+def test_workspace_numeric_reader_rebinds_legacy_payload(tmp_path):
+    values = np.arange(4.0)
+    with _numeric_workspace_reader(tmp_path, values, legacy=True) as (
+        store,
+        manager,
+        backend,
+    ):
+        np.testing.assert_array_equal(backend._getitem(slice(None)), values)
+        assert not manager._direct_read_datasets
+        with store.write_session() as h5_file:
+            h5_file[store.object_path("payload")] = h5_file["legacy"]
+        manager._rebind_legacy_group_to_object("payload")
+        np.testing.assert_array_equal(backend._getitem(slice(None)), values)
+        assert manager._direct_read_datasets["data"] is not None
+
+
+def test_workspace_numeric_read_keeps_handle_locked_until_selection_finishes(
+    monkeypatch, tmp_path
+):
+    values = np.arange(4.0)
+    with _numeric_workspace_reader(tmp_path, values) as (store, manager, backend):
+        np.testing.assert_array_equal(backend._getitem(slice(None)), values)
+        cached = manager._direct_read_datasets["data"]
+        reading = threading.Event()
+        release_read = threading.Event()
+        writing = threading.Event()
+        entered_write = threading.Event()
+        original = h5py.Dataset.__getitem__
+
+        def read(dataset, key, **kwargs):
+            if dataset is cached:
+                reading.set()
+                if not release_read.wait(5):
+                    raise TimeoutError("Reader was not released")
+            return original(dataset, key, **kwargs)
+
+        def write():
+            writing.set()
+            with store.write_session() as h5_file:
+                entered_write.set()
+                h5_file.attrs["saved"] = True
+
+        monkeypatch.setattr(h5py.Dataset, "__getitem__", read)
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            pending_read = executor.submit(backend._getitem, slice(None))
+            try:
+                assert reading.wait(5)
+                pending_write = executor.submit(write)
+                assert writing.wait(5)
+                assert not entered_write.wait(0.05)
+            finally:
+                release_read.set()
+            np.testing.assert_array_equal(pending_read.result(timeout=5), values)
+            pending_write.result(timeout=5)
+        assert entered_write.is_set()
+        assert not cached.id.valid
+        assert not manager._direct_read_datasets
+
+
+def test_workspace_numeric_reader_preserves_physical_name_and_decoding(
+    monkeypatch, tmp_path
+):
+    raw = np.array([1, 2, -99, 4], dtype=np.int16)
+    selections = []
+    original = h5netcdf.Variable.__getitem__
+
+    def read(variable, key):
+        selections.append(variable.name)
+        return original(variable, key)
+
+    monkeypatch.setattr(h5netcdf.Variable, "__getitem__", read)
+    with _numeric_workspace_reader(tmp_path, raw) as (store, _manager, _):
+        with store.write_session() as h5_file:
+            group = h5_file[store.object_path("payload")]
+            group.move("data", "_nc4_non_coord_data")
+            group["_nc4_non_coord_data"].attrs.update(
+                {"_FillValue": np.int16(-99), "scale_factor": 0.5, "add_offset": 10.0}
+            )
+        with workspace_arrays.open_workspace_dataset(
+            store.path, store.object_path("payload"), chunks={}
+        ) as opened:
+            xr.testing.assert_identical(
+                opened.compute(),
+                xr.Dataset(
+                    {"data": ("d0", [10.5, 11.0, np.nan, 12.0])},
+                    coords={"d0": np.arange(4)},
+                ),
+            )
+        assert not any(name.endswith("/data") for name in selections)
+
+
+@pytest.mark.parametrize(
+    "kind", ["string", "complex", "enum", "compound", "padded", "unlimited"]
+)
+def test_workspace_numeric_read_fallback_preserves_netcdf(monkeypatch, tmp_path, kind):
+    with _numeric_workspace_reader(tmp_path, np.arange(4.0)) as (store, _manager, _):
+        with (
+            store.write_session() as h5_file,
+            h5netcdf.File(h5_file, "a", invalid_netcdf=True) as netcdf_file,
+        ):
+            group = netcdf_file.create_group(store.object_path("special"))
+            group.dimensions["x"] = None if kind in {"padded", "unlimited"} else 4
+            if kind in {"padded", "unlimited"}:
+                group.resize_dimension("x", 4)
+            if kind == "string":
+                dtype = h5py.string_dtype()
+                values = np.array(["a", "beta", "", "δ"], dtype=object)
+            elif kind == "complex":
+                dtype = np.dtype(complex)
+                values = np.arange(4) + 2j
+            elif kind == "enum":
+                dtype = group.create_enumtype(np.uint8, "choice", {"a": 0, "b": 1})
+                values = np.array([0, 1, 0, 1], dtype=np.uint8)
+            elif kind == "compound":
+                dtype = group.create_cmptype(
+                    np.dtype([("a", "i4"), ("b", "f8")]), "pair"
+                )
+                values = np.array([(i, float(i)) for i in range(4)], dtype=dtype.dtype)
+            else:
+                dtype = np.dtype(float)
+                values = np.arange(4.0)
+            kwargs = {"maxshape": (4,)} if kind == "unlimited" else {}
+            variable = group.create_variable("data", ("x",), dtype=dtype, **kwargs)
+            variable[:] = values
+            if kind == "padded":
+                variable._h5ds.resize((2,))
+        special = workspace_arrays.WorkspaceFileManager(
+            store.path, object_id="special", group_path=store.object_path("special")
+        )
+        datastore = workspace_arrays._WorkspaceH5NetCDFStore(
+            special, group=special._group_path, mode="r", lock=special.lock
+        )
+        try:
+            with store.read_session():
+                variable = datastore._acquire(needs_lock=False).variables["data"]
+                expected = variable[:]
+                backend = workspace_arrays._WorkspaceBackendArray(
+                    "data", datastore, shape=variable.shape, dtype=variable.dtype
+                )
+            reads = []
+            original = h5netcdf.Variable.__getitem__
+
+            def read(variable, key):
+                reads.append(key)
+                return original(variable, key)
+
+            monkeypatch.setattr(h5netcdf.Variable, "__getitem__", read)
+            for _ in range(2):
+                np.testing.assert_array_equal(
+                    backend._getitem((slice(None),)), expected
+                )
+            assert len(reads) == 2
+            assert special._direct_read_datasets == {"data": None}
+            special.close()
+            assert not special._direct_read_datasets
+        finally:
+            special.close()
 
 
 def test_workspace_h5py_copy_rebuilds_attrs_and_dimension_scales(tmp_path) -> None:
@@ -158,11 +427,11 @@ def test_write_workspace_dataset_group_h5py_cleans_failed_independent_items(
     monkeypatch, tmp_path
 ) -> None:
     fname = tmp_path / "independent-items.itws"
-    saved_tool_data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
+    saved_tool_data_name = _persistence_constants.SAVED_TOOL_DATA_NAME
     ds = xr.Dataset(
         {
             saved_tool_data_name: (
-                (workspace_arrays._SAVED_TOOL_DATA_REFERENCE_DIM,),
+                (_persistence_constants.SAVED_TOOL_DATA_REFERENCE_DIM,),
                 np.empty(0, dtype=np.float64),
             )
         }
@@ -504,7 +773,7 @@ def test_workspace_file_manager_lifecycle_guards(tmp_path) -> None:
     ):
         manager = workspace_arrays.WorkspaceFileManager(
             path,
-            group_path=f"/{workspace_store._WORKSPACE_GENERATIONS_GROUP}/current",
+            group_path=f"/{_persistence_constants.WORKSPACE_GENERATIONS_GROUP}/current",
         )
         try:
             manager._attach_store(store)
@@ -568,7 +837,9 @@ def test_workspace_file_manager_serialization_pins_exact_payload(tmp_path) -> No
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("payload")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "payload"
+            )
             h5_file.create_group("legacy")
         store.publish({"schema_version": 5, "nodes": []})
         manager = workspace_arrays.WorkspaceFileManager(
@@ -623,7 +894,9 @@ def test_workspace_file_manager_rebinds_legacy_reader_to_immutable_object(
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
             h5_file.create_group("legacy")
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("payload")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "payload"
+            )
         store.publish({"schema_version": 6, "nodes": []})
         manager = workspace_arrays.WorkspaceFileManager(path, group_path="/legacy")
         try:
@@ -653,7 +926,7 @@ def test_workspace_dask_tokenization_pins_only_serialized_graph(tmp_path) -> Non
     data = xr.DataArray(
         np.arange(4.0),
         dims=("x",),
-        name=_ITOOL_DATA_NAME,
+        name=_persistence_constants.ITOOL_DATA_NAME,
     ).to_dataset()
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
@@ -671,7 +944,9 @@ def test_workspace_dask_tokenization_pins_only_serialized_graph(tmp_path) -> Non
         )
         try:
             assert store.serialized_object_ids == set()
-            pickle.dumps(opened[_ITOOL_DATA_NAME].data.__dask_graph__())
+            pickle.dumps(
+                opened[_persistence_constants.ITOOL_DATA_NAME].data.__dask_graph__()
+            )
             assert store.serialized_object_ids == {object_id}
         finally:
             opened.close()
@@ -774,7 +1049,9 @@ def test_workspace_root_attrs_require_valid_generation(tmp_path) -> None:
         workspace_arrays._read_workspace_root_attrs_h5py(path)
 
     with h5py.File(path, "r+") as h5_file:
-        generations = h5_file.create_group(workspace_store._WORKSPACE_GENERATIONS_GROUP)
+        generations = h5_file.create_group(
+            _persistence_constants.WORKSPACE_GENERATIONS_GROUP
+        )
         generations.create_group("invalid-name")
         generations.create_group("00000000000000000001")
     with pytest.raises(ValueError, match="no valid committed generation"):
@@ -900,6 +1177,33 @@ def test_workspace_h5py_attrs_and_root_validation(tmp_path) -> None:
         workspace_arrays._read_workspace_root_attrs_h5py(fname)
 
 
+def test_workspace_h5py_attrs_excludes_values_before_reading(
+    monkeypatch, tmp_path
+) -> None:
+    with h5py.File(tmp_path / "excluded-attrs.h5", "w") as h5_file:
+        workspace_arrays._replace_h5_attrs(
+            h5_file.attrs,
+            {"metadata": _rich_workspace_attr_value(), "name": "value"},
+        )
+        h5_file.attrs["excluded"] = np.arange(1000)
+        original_getitem = h5py.AttributeManager.__getitem__
+        reads = []
+
+        def _record_getitem(self, name):
+            reads.append(name)
+            return original_getitem(self, name)
+
+        monkeypatch.setattr(h5py.AttributeManager, "__getitem__", _record_getitem)
+        attrs = workspace_arrays._h5py_attrs_to_dict(
+            h5_file.attrs, exclude=("excluded", "absent")
+        )
+
+        assert "excluded" not in reads
+        assert set(attrs) == {"metadata", "name"}
+        assert attrs["name"] == "value"
+        _assert_rich_workspace_attr(attrs["metadata"])
+
+
 def test_replace_h5_attrs_drops_invalid_attr_names(tmp_path) -> None:
 
     fname = tmp_path / "replace-invalid-attrs.itws"
@@ -931,7 +1235,7 @@ def test_replace_h5_attrs_encodes_non_native_attr_values(tmp_path) -> None:
         )
 
         assert "Single Motor Scan" not in group.attrs
-        assert workspace_format._WORKSPACE_ENCODED_ATTRS_ATTR in group.attrs
+        assert _persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR in group.attrs
         decoded = workspace_arrays._h5py_attrs_to_dict(group.attrs)
         assert decoded["valid"] == "kept"
         _assert_rich_workspace_attr(decoded["Single Motor Scan"])
@@ -940,7 +1244,7 @@ def test_replace_h5_attrs_encodes_non_native_attr_values(tmp_path) -> None:
 def _assert_workspace_h5py_roundtrip(
     tmp_path: pathlib.Path, label: str, data: xr.DataArray
 ) -> tuple[xr.Dataset, xr.Dataset, pathlib.Path]:
-    data_name = _ITOOL_DATA_NAME
+    data_name = _persistence_constants.ITOOL_DATA_NAME
     fname = tmp_path / f"{label}.itws"
     ds = data.rename(data_name).to_dataset()
 
@@ -972,7 +1276,7 @@ def test_workspace_h5py_fast_path_roundtrips_scalar_coords(tmp_path) -> None:
         dims=("x", "y"),
         coords={"x": np.arange(2.0), "y": np.arange(3.0), "temperature": 20.0},
         attrs={"coordinates": b""},
-        name=_ITOOL_DATA_NAME,
+        name=_persistence_constants.ITOOL_DATA_NAME,
     )
     ds = data.to_dataset()
 
@@ -982,19 +1286,19 @@ def test_workspace_h5py_fast_path_roundtrips_scalar_coords(tmp_path) -> None:
     loaded = workspace_arrays._read_workspace_dataset_group_h5py(
         fname,
         "0/imagetool",
-        preferred_data_name=_ITOOL_DATA_NAME,
+        preferred_data_name=_persistence_constants.ITOOL_DATA_NAME,
     )
 
     assert loaded is not None
     expected = data.copy()
     expected.attrs.pop("coordinates")
     xr.testing.assert_equal(
-        loaded[_ITOOL_DATA_NAME],
+        loaded[_persistence_constants.ITOOL_DATA_NAME],
         expected,
     )
     assert loaded.coords["temperature"].item() == 20.0
     with h5py.File(fname, "r") as h5_file:
-        saved_data = h5_file["0/imagetool"][_ITOOL_DATA_NAME]
+        saved_data = h5_file["0/imagetool"][_persistence_constants.ITOOL_DATA_NAME]
         coordinates = saved_data.attrs["coordinates"]
     if isinstance(coordinates, bytes):
         coordinates = coordinates.decode()
@@ -1004,7 +1308,7 @@ def test_workspace_h5py_fast_path_roundtrips_scalar_coords(tmp_path) -> None:
 def test_workspace_writer_encodes_saved_tool_spaced_associated_coord(
     tmp_path,
 ) -> None:
-    data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
+    data_name = _persistence_constants.SAVED_TOOL_DATA_NAME
     data = xr.DataArray(
         np.arange(6.0).reshape(2, 3),
         dims=("x", "y"),
@@ -1039,7 +1343,7 @@ def test_workspace_h5py_fast_path_roundtrips_saved_tool_extra_blob(
 ) -> None:
     import hdf5plugin
 
-    data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
+    data_name = _persistence_constants.SAVED_TOOL_DATA_NAME
     primary = xr.DataArray(
         np.arange(6.0).reshape(2, 3),
         dims=("x", "y"),
@@ -1106,14 +1410,14 @@ def test_workspace_h5py_fast_path_roundtrips_saved_tool_extra_blob(
 
 
 def test_workspace_h5py_fast_path_roundtrips_saved_tool_references(tmp_path) -> None:
-    data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
+    data_name = _persistence_constants.SAVED_TOOL_DATA_NAME
     ds = xr.Dataset(
         {
             data_name: erlab.interactive.utils._tool_data_placeholder(),
             "data_1": erlab.interactive.utils._tool_data_placeholder(),
         },
         attrs={
-            erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+            _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                 {
                     data_name: {"kind": "manager_node", "node_uid": "uid-0"},
                     "data_1": {"kind": "manager_node", "node_uid": "uid-1"},
@@ -1132,19 +1436,19 @@ def test_workspace_h5py_fast_path_roundtrips_saved_tool_references(tmp_path) -> 
 
     assert loaded is not None
     assert set(loaded.data_vars) == {data_name, "data_1"}
-    reference_dim = erlab.interactive.utils._SAVED_TOOL_DATA_REFERENCE_DIM
+    reference_dim = _persistence_constants.SAVED_TOOL_DATA_REFERENCE_DIM
     assert loaded[data_name].dims == (reference_dim,)
     assert loaded["data_1"].dims == (reference_dim,)
     assert json.loads(
-        loaded.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
-    ) == json.loads(ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR])
+        loaded.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR]
+    ) == json.loads(ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR])
 
 
 def test_workspace_h5py_fast_path_roundtrips_associated_coords_and_xarray(
     tmp_path,
 ) -> None:
 
-    data_name = _ITOOL_DATA_NAME
+    data_name = _persistence_constants.ITOOL_DATA_NAME
     base = xr.DataArray(
         np.arange(6.0).reshape(2, 3),
         dims=("x", "y"),
@@ -1233,7 +1537,7 @@ def test_workspace_h5py_fast_path_roundtrips_associated_coords_and_xarray(
 
 
 def test_workspace_h5py_fast_path_keeps_numeric_since_units(tmp_path) -> None:
-    data_name = _ITOOL_DATA_NAME
+    data_name = _persistence_constants.ITOOL_DATA_NAME
     fname = tmp_path / "numeric-since-units.itws"
     data = xr.DataArray(
         [1.0, 2.0],
@@ -1269,7 +1573,7 @@ def test_workspace_writer_roundtrips_non_native_attr_values_from_fast_path(
     tmp_path,
 ) -> None:
 
-    data_name = _ITOOL_DATA_NAME
+    data_name = _persistence_constants.ITOOL_DATA_NAME
     fname = tmp_path / "rich-attrs-fast-path.itws"
     rich_attr = _rich_workspace_attr_value()
     data = xr.DataArray(
@@ -1302,8 +1606,8 @@ def test_workspace_writer_roundtrips_non_native_attr_values_from_fast_path(
         saved_data = group[data_name]
         assert "dataset_config" not in group.attrs
         assert "Single Motor Scan" not in saved_data.attrs
-        assert workspace_format._WORKSPACE_ENCODED_ATTRS_ATTR in group.attrs
-        assert workspace_format._WORKSPACE_ENCODED_ATTRS_ATTR in saved_data.attrs
+        assert _persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR in group.attrs
+        assert _persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR in saved_data.attrs
 
     loaded = workspace_arrays._read_workspace_dataset_group_h5py(
         fname, "0/imagetool", preferred_data_name=data_name
@@ -1326,7 +1630,7 @@ def test_workspace_writer_roundtrips_non_native_attr_values_from_fast_path(
 
 def test_workspace_writer_drops_invalid_attr_names_from_fast_path(tmp_path) -> None:
 
-    data_name = _ITOOL_DATA_NAME
+    data_name = _persistence_constants.ITOOL_DATA_NAME
     fname = tmp_path / "invalid-attrs-fast-path.itws"
     data = xr.DataArray(
         np.arange(2.0),
@@ -1431,8 +1735,8 @@ def test_workspace_writer_drops_invalid_attr_names_from_fallback(tmp_path) -> No
 def test_workspace_h5py_fast_path_rejects_invalid_payloads(
     caplog, monkeypatch, tmp_path
 ) -> None:
-    data_name = _ITOOL_DATA_NAME
-    private_attr = imagetool_serialization._PRIVATE_COORDS_ATTR
+    data_name = _persistence_constants.ITOOL_DATA_NAME
+    private_attr = imagetool_serialization.PRIVATE_COORDS_ATTR
 
     assert not workspace_arrays._workspace_dataset_can_write_h5py(
         xr.Dataset(
@@ -1509,8 +1813,8 @@ def test_workspace_h5py_fast_path_rejects_invalid_payloads(
 
 def test_workspace_h5py_reader_rejects_malformed_groups(tmp_path) -> None:
 
-    data_name = _ITOOL_DATA_NAME
-    private_attr = imagetool_serialization._PRIVATE_COORDS_ATTR
+    data_name = _persistence_constants.ITOOL_DATA_NAME
+    private_attr = imagetool_serialization.PRIVATE_COORDS_ATTR
     fname = tmp_path / "malformed-reader.itws"
 
     with h5py.File(fname, "w") as h5_file:
@@ -1643,8 +1947,8 @@ def test_workspace_h5py_reader_rejects_malformed_groups(tmp_path) -> None:
 
 def test_workspace_h5py_reader_restores_legacy_spaced_coords(tmp_path) -> None:
 
-    data_name = _ITOOL_DATA_NAME
-    private_attr = imagetool_serialization._PRIVATE_COORDS_ATTR
+    data_name = _persistence_constants.ITOOL_DATA_NAME
+    private_attr = imagetool_serialization.PRIVATE_COORDS_ATTR
     fname = tmp_path / "legacy-spaced-coord.itws"
 
     with h5py.File(fname, "w") as h5_file:
@@ -1700,8 +2004,8 @@ def test_workspace_h5py_reader_restores_legacy_spaced_coords(tmp_path) -> None:
 
 def test_workspace_h5py_writer_replaces_groups_and_preserves_attrs(tmp_path) -> None:
 
-    data_name = _ITOOL_DATA_NAME
-    private_attr = imagetool_serialization._PRIVATE_COORDS_ATTR
+    data_name = _persistence_constants.ITOOL_DATA_NAME
+    private_attr = imagetool_serialization.PRIVATE_COORDS_ATTR
     fname = tmp_path / "writer-attrs.itws"
     ds = xr.Dataset(
         {

--- a/tests/interactive/imagetool/manager/workspace/test_document.py
+++ b/tests/interactive/imagetool/manager/workspace/test_document.py
@@ -19,7 +19,6 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool._mainwindow as imagetool_mainwindow
-import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager as manager_module
 import erlab.interactive.imagetool.manager._desktop as manager_desktop
 import erlab.interactive.imagetool.manager._mainwindow as manager_mainwindow
@@ -29,6 +28,7 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.viewer as imagetool_viewer
+from erlab.interactive import _persistence_constants
 from erlab.interactive._fit1d import Fit1DTool
 from erlab.interactive._fit2d import Fit2DTool
 from erlab.interactive.derivative import DerivativeTool
@@ -783,10 +783,10 @@ def test_manager_workspace_tool_data_reference_roundtrip(
                 "xr.DataTree", tree[f"0/childtools/{child_uid}/tool"]
             ).to_dataset(inherit=False)
             references = json.loads(
-                ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
+                ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR]
             )
-            assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in references
-            assert ds[erlab.interactive.utils._SAVED_TOOL_DATA_NAME].size == 0
+            assert _persistence_constants.SAVED_TOOL_DATA_NAME in references
+            assert ds[_persistence_constants.SAVED_TOOL_DATA_NAME].size == 0
             with pytest.raises(ValueError, match="no manager-node resolver"):
                 erlab.interactive.utils.ToolWindow.from_dataset(ds)
 
@@ -829,9 +829,9 @@ def test_manager_workspace_tool_data_reference_falls_back_on_shape_mismatch(
             ds = typing.cast(
                 "xr.DataTree", tree[f"0/childtools/{child_uid}/tool"]
             ).to_dataset(inherit=False)
-            assert erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR not in ds.attrs
+            assert _persistence_constants.TOOL_DATA_REFERENCES_ATTR not in ds.attrs
             xr.testing.assert_identical(
-                ds[imagetool_serialization.SAVED_TOOL_DATA_NAME].rename(
+                ds[_persistence_constants.SAVED_TOOL_DATA_NAME].rename(
                     child.tool_data.name
                 ),
                 child.tool_data,

--- a/tests/interactive/imagetool/manager/workspace/test_format.py
+++ b/tests/interactive/imagetool/manager/workspace/test_format.py
@@ -14,6 +14,7 @@ import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._loading as workspace_loading
 from erlab.extensions._models import _script_name_key
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool._provenance._model import ScriptInput, script
 from tests.interactive.imagetool.manager.workspace._support import (
     _workspace_test_file_spec,
@@ -46,6 +47,423 @@ def test_tool_data_blob_preserves_none_name() -> None:
     restored = erlab.interactive.utils._tool_data_from_blob(blob)
 
     assert restored.name is None
+
+
+@pytest.mark.parametrize("name", [None, "source"])
+def test_tool_data_blob_preserves_nested_attrs(name) -> None:
+    data = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={
+            "x": [0.0, 1.0],
+            "y": [0.0, 1.0, 2.0],
+            "Fake Motor": ("x", [10.0, 20.0]),
+        },
+        name=name,
+        attrs={"nested": {"values": [1, 2, 3]}},
+    )
+    data.coords["Fake Motor"].attrs["calibration"] = {
+        "offset": None,
+        "limits": (1.0, 2.0),
+    }
+    before = data.copy(deep=True)
+
+    for _ in range(2):
+        blob = erlab.interactive.utils._tool_data_to_blob(data, "secondary")
+        restored = erlab.interactive.utils._tool_data_from_blob(blob)
+        xr.testing.assert_identical(restored, before)
+        xr.testing.assert_identical(data, before)
+        data = restored
+
+
+def _assert_tool_attr_equal(actual, expected) -> None:
+    assert type(actual) is type(expected)
+    if isinstance(expected, dict):
+        assert actual.keys() == expected.keys()
+        for key, value in expected.items():
+            _assert_tool_attr_equal(actual[key], value)
+    elif isinstance(expected, list | tuple):
+        assert len(actual) == len(expected)
+        for left, right in zip(actual, expected, strict=True):
+            _assert_tool_attr_equal(left, right)
+    elif isinstance(expected, np.str_ | np.bytes_):
+        assert actual.dtype == expected.dtype
+        assert len(actual) == len(expected)
+        assert actual.tobytes() == expected.tobytes()
+    elif isinstance(expected, np.ndarray):
+        assert actual.dtype == expected.dtype
+        assert actual.shape == expected.shape
+        if expected.dtype.kind == "O":
+            for left, right in zip(actual.flat, expected.flat, strict=True):
+                _assert_tool_attr_equal(left, right)
+        else:
+            np.testing.assert_array_equal(actual, expected, strict=True)
+    else:
+        np.testing.assert_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        {"bytes": b"plain bytes"},
+        b"\x00\xff",
+        "text\x00tail",
+        np.str_("sample\x00"),
+        np.bytes_(b"sample\x00"),
+        {
+            "sample": 1,
+            np.str_("sample\x00"): 2,
+            np.str_(""): 3,
+            np.str_("\x00"): 4,
+            (np.str_("β\x00"), np.bytes_(b"\xff\x00")): 5,
+        },
+        {
+            b"sample": 1,
+            np.bytes_(b"sample\x00"): 2,
+            np.bytes_(b""): 3,
+            np.bytes_(b"\x00"): 4,
+        },
+        {
+            "unicode": [
+                np.str_(text)
+                for text in (
+                    "",
+                    "plain",
+                    "\x00",
+                    "\x00\x00",
+                    "a\x00b\x00\x00",
+                    "\ufeffβ😀\ud800\x00",
+                )
+            ],
+            "bytes": [
+                np.bytes_(data)
+                for data in (b"", b"plain", b"\x00", b"\x00\x00", b"a\x00b\xff\x00\x00")
+            ],
+            "empty_unicode_array": np.ndarray((2,), dtype="U0"),
+            "empty_bytes_array": np.ndarray((0,), dtype="S0"),
+        },
+        [1, "text", None],
+        ("text", b"bytes"),
+        np.datetime64("2025-01-01", "ns"),
+        np.timedelta64(3, "ns"),
+        [np.timedelta64(1, "ns"), np.timedelta64(2, "ns")],
+        np.array([1, 2], dtype="timedelta64[ns]"),
+        np.array(["alpha", "β"]),
+        {"array": np.array([b"a\x00b", b"\xff"], dtype="S3")},
+        np.array(["a\x00b"]),
+        np.empty(0, dtype=object),
+        np.array([{"nested": (None, np.int16(3))}], dtype=object),
+        {
+            "array": np.arange(4, dtype=np.int16).reshape(2, 2),
+            "scalar": np.float32(1.5),
+            "tuple": (None, b"bytes", complex(2, 3)),
+            "mapping": {(1, "x"): [False, float("inf"), float("nan")]},
+        },
+    ],
+)
+def test_tool_dataset_attrs_roundtrip_typed_values(value) -> None:
+    ds = xr.Dataset(
+        {"data": ("x", [1.0, 2.0])},
+        coords={"x": [0, 1]},
+        attrs={"metadata": value},
+    )
+    ds["data"].attrs["metadata"] = value
+    ds["x"].attrs["metadata"] = value
+    # Both transport keys are user metadata here. Even a plausible envelope is literal.
+    ds.attrs[_persistence_constants.TOOL_ATTRS_VERSION_ATTR] = 99
+    ds.attrs[_persistence_constants.TOOL_ENCODED_ATTRS_ATTR] = json.dumps(
+        {"dataset": [], "variables": {}}
+    )
+    # NumPy's deep copy also strips trailing NULs from string scalars.
+    original = ds.copy(deep=False)
+
+    for _ in range(2):
+        prepared = imagetool_serialization.prepare_tool_dataset(ds)
+        raw = prepared.to_netcdf(engine="h5netcdf", invalid_netcdf=True)
+        opened = xr.load_dataset(memoryview(raw), engine="h5netcdf")
+        restored = imagetool_serialization.restore_tool_dataset_attrs(opened)
+        _assert_tool_attr_equal(restored.attrs, original.attrs)
+        _assert_tool_attr_equal(ds.attrs, original.attrs)
+        for name in original.variables:
+            _assert_tool_attr_equal(restored[name].attrs, original[name].attrs)
+            _assert_tool_attr_equal(ds[name].attrs, original[name].attrs)
+            np.testing.assert_array_equal(restored[name].values, original[name].values)
+        ds = restored
+
+
+def test_tool_dataset_native_attrs_keep_legacy_storage(monkeypatch) -> None:
+    ds = xr.Dataset({"data": ("x", [1.0, 2.0])}, coords={"x": [0, 1]})
+    ds.attrs.update(
+        title="source",
+        count=3,
+        valid=True,
+        scalar=np.float32(1.5),
+        numbers=[1, 2, 3],
+        names=("one", "two"),
+        empty=[],
+        coefficients=np.array([1 + 2j, 3 + 4j]),
+        bytes=b"text",
+        bytes_array=np.array([b"one", b"two"]),
+        object_strings=np.array(["one", "two"], dtype=object),
+        object_bytes=np.array([b"one", b"two"], dtype=object),
+        compound=np.array([(1, 2), (3, 4)], dtype=[("first", "i4"), ("second", "i4")]),
+        void_array=np.array([b"ab", b"cd"], dtype="V2"),
+        dtype_metadata=np.array([1, 2], dtype=np.dtype("i4", metadata={"units": "x"})),
+    )
+    ds["data"].attrs["units"] = "counts"
+
+    def fail_if_encoded(value):
+        raise AssertionError("Native attributes must not use the typed codec")
+
+    monkeypatch.setattr(imagetool_serialization, "encode_attr_value", fail_if_encoded)
+    prepared = imagetool_serialization.prepare_tool_dataset(ds)
+    assert _persistence_constants.TOOL_ATTRS_VERSION_ATTR not in prepared.attrs
+    assert imagetool_serialization.restore_tool_dataset_attrs(prepared) is prepared
+    baseline = xr.load_dataset(
+        memoryview(ds.to_netcdf(engine="h5netcdf", invalid_netcdf=True)),
+        engine="h5netcdf",
+    )
+    restored = xr.load_dataset(
+        memoryview(prepared.to_netcdf(engine="h5netcdf", invalid_netcdf=True)),
+        engine="h5netcdf",
+    )
+    xr.testing.assert_identical(restored, baseline)
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_tool_dataset_metadata_preparation_shares_buffers(lazy) -> None:
+    import dask.array
+    from dask.callbacks import Callback
+
+    data = np.arange(6.0).reshape(2, 3)
+    coord = np.arange(6.0).reshape(2, 3) + 10
+    if lazy:
+        data = dask.array.from_array(data, chunks=(1, 3))
+        coord = dask.array.from_array(coord, chunks=(1, 3))
+    ds = xr.Dataset({"data": (("x", "y"), data)}, coords={"aux": (("x", "y"), coord)})
+    ds["data"].attrs["metadata"] = {"values": [1, 2, 3]}
+    ds["data"].encoding = {"compression": "unknown", "dtype": np.dtype("float64")}
+    ds["aux"].encoding = {"source": "old-file"}
+    attrs = ds["data"].attrs.copy()
+    executed = []
+    with Callback(posttask=lambda *args: executed.append(args)):
+        prepared = imagetool_serialization.prepare_tool_dataset(
+            ds, strip_backend_encoding=True
+        )
+        restored = imagetool_serialization.restore_tool_dataset_attrs(prepared)
+
+    assert not executed
+    for name in ds.variables:
+        assert prepared[name].data is ds[name].data
+        assert restored[name].data is ds[name].data
+    assert prepared["data"].encoding == {"dtype": np.dtype("float64")}
+    assert prepared["aux"].encoding == {}
+    assert ds["data"].encoding["compression"] == "unknown"
+    assert ds["aux"].encoding == {"source": "old-file"}
+    assert ds["data"].attrs == attrs
+    assert restored["data"].attrs == attrs
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        object(),
+        np.array([(1,)], dtype=[("field", "i4")]),
+        np.array([(object(),)], dtype=[("field", object)]),
+        np.array([1], dtype=np.dtype("i4", metadata={"units": "x"})),
+        np.array(["short", "long" * 20], dtype=np.dtypes.StringDType()),
+    ],
+)
+def test_tool_dataset_attrs_reject_unsupported_nested_values(value) -> None:
+    ds = xr.Dataset({"data": ("x", [1.0])})
+    metadata = {"nested": value}
+    ds["data"].attrs["metadata"] = metadata
+    with pytest.raises(TypeError, match="Cannot serialize tool attribute 'metadata'"):
+        imagetool_serialization.prepare_tool_dataset(ds)
+    assert ds["data"].attrs["metadata"] is metadata
+
+
+@pytest.mark.parametrize(
+    "value", [object(), np.array(["text"], dtype=np.dtypes.StringDType())]
+)
+def test_tool_dataset_attrs_reject_unsupported_direct_values(value) -> None:
+    ds = xr.Dataset(attrs={"metadata": value})
+    with pytest.raises(TypeError, match="Cannot serialize tool attribute 'metadata'"):
+        imagetool_serialization.prepare_tool_dataset(ds)
+
+
+@pytest.mark.parametrize("container", [list, tuple, lambda value: [value]])
+def test_tool_dataset_native_structured_sequences(container) -> None:
+    values = np.array([(1, 2.0), (3, 4.0)], dtype=[("count", "i4"), ("value", "f8")])
+    ds = xr.Dataset(attrs={"metadata": container(list(values))})
+    prepared = imagetool_serialization.prepare_tool_dataset(ds)
+    assert _persistence_constants.TOOL_ATTRS_VERSION_ATTR not in prepared.attrs
+    baseline = xr.load_dataset(
+        memoryview(ds.to_netcdf(engine="h5netcdf", invalid_netcdf=True)),
+        engine="h5netcdf",
+    )
+    restored = xr.load_dataset(
+        memoryview(prepared.to_netcdf(engine="h5netcdf", invalid_netcdf=True)),
+        engine="h5netcdf",
+    )
+    xr.testing.assert_identical(restored, baseline)
+
+
+def test_tool_dataset_native_vlen_attributes() -> None:
+    import h5py
+
+    ds = xr.Dataset(
+        attrs={"metadata": np.array(["first", "second"], dtype=h5py.string_dtype())}
+    )
+    prepared = imagetool_serialization.prepare_tool_dataset(ds)
+    assert _persistence_constants.TOOL_ATTRS_VERSION_ATTR not in prepared.attrs
+    baseline = xr.load_dataset(
+        memoryview(ds.to_netcdf(engine="h5netcdf", invalid_netcdf=True)),
+        engine="h5netcdf",
+    )
+    restored = xr.load_dataset(
+        memoryview(prepared.to_netcdf(engine="h5netcdf", invalid_netcdf=True)),
+        engine="h5netcdf",
+    )
+    xr.testing.assert_identical(restored, baseline)
+
+
+def test_tool_dataset_attrs_reject_object_sequences_and_cycles() -> None:
+    sequence = np.empty(1, dtype=object)
+    sequence[0] = [1, 2]
+    cycle = {}
+    cycle["self"] = cycle
+    cyclic_list = []
+    cyclic_list.append(cyclic_list)
+    for value in (sequence, cycle, cyclic_list):
+        ds = xr.Dataset(attrs={"metadata": value})
+        with pytest.raises(
+            TypeError, match="Cannot serialize tool attribute 'metadata'"
+        ):
+            imagetool_serialization.prepare_tool_dataset(ds)
+
+
+@pytest.mark.parametrize("name", ["", 1])
+def test_tool_dataset_attrs_reject_invalid_names(name) -> None:
+    with pytest.raises(TypeError, match="non-empty strings"):
+        imagetool_serialization.prepare_tool_dataset(xr.Dataset(attrs={name: "value"}))
+
+
+def test_tool_dataset_attrs_reject_non_string_variable_name() -> None:
+    ds = xr.Dataset({1: ("x", [1.0])})
+    ds[1].attrs["metadata"] = None
+    with pytest.raises(TypeError, match="variable names must be strings"):
+        imagetool_serialization.prepare_tool_dataset(ds)
+
+
+@pytest.mark.parametrize("version", [0, 2, True, "1", [1]])
+def test_tool_dataset_attrs_reject_unknown_version(version) -> None:
+    ds = xr.Dataset(attrs={_persistence_constants.TOOL_ATTRS_VERSION_ATTR: version})
+    with pytest.raises(ValueError, match="Unsupported tool attribute encoding version"):
+        imagetool_serialization.restore_tool_dataset_attrs(ds)
+
+
+@pytest.mark.parametrize("payload", [None, "{bad-json", [], {}, {"dataset": []}])
+def test_tool_dataset_attrs_reject_invalid_envelope(payload) -> None:
+    ds = xr.Dataset(attrs={_persistence_constants.TOOL_ATTRS_VERSION_ATTR: 1})
+    if payload is not None:
+        ds.attrs[_persistence_constants.TOOL_ENCODED_ATTRS_ATTR] = (
+            payload if isinstance(payload, str) else json.dumps(payload)
+        )
+    with pytest.raises(ValueError, match=r"[Ii]nvalid.*tool attribute"):
+        imagetool_serialization.restore_tool_dataset_attrs(ds)
+
+
+def test_tool_dataset_attrs_reject_invalid_variable_table() -> None:
+    ds = xr.Dataset(
+        attrs={
+            _persistence_constants.TOOL_ATTRS_VERSION_ATTR: 1,
+            _persistence_constants.TOOL_ENCODED_ATTRS_ATTR: json.dumps(
+                {"dataset": [], "variables": []}
+            ),
+        }
+    )
+    with pytest.raises(TypeError, match="must be a mapping"):
+        imagetool_serialization.restore_tool_dataset_attrs(ds)
+
+
+@pytest.mark.parametrize(
+    ("scope", "entries", "error"),
+    [
+        (None, {}, "must be a list"),
+        (None, [[{}]], "Invalid encoded tool attribute entry"),
+        (None, [[{}, {"kind": "none"}]], "Invalid encoded tool attribute name"),
+        (None, [[{"kind": "str", "value": ""}, {"kind": "none"}]], "attribute name"),
+        (None, [[{"kind": "int", "value": 1}, {"kind": "none"}]], "attribute name"),
+        (
+            None,
+            [[{"kind": "str", "value": "new", "extra": 1}, {"kind": "none"}]],
+            "attribute name",
+        ),
+        (None, [[{"kind": "str", "value": "new"}, {}]], "attribute value"),
+        (
+            None,
+            [[{"kind": "str", "value": "new"}, {"kind": "bool", "value": "true"}]],
+            "attribute value",
+        ),
+        ("missing", [], "missing variable"),
+        (
+            "data",
+            [[{"kind": "str", "value": "units"}, {"kind": "none"}]],
+            "cannot replace metadata",
+        ),
+        (
+            None,
+            [[{"kind": "str", "value": "new"}, {"kind": "none"}]] * 2,
+            "cannot replace metadata",
+        ),
+    ],
+)
+def test_tool_dataset_attrs_reject_invalid_entries(scope, entries, error) -> None:
+    ds = xr.Dataset({"data": ("x", [1.0])})
+    ds["data"].attrs["units"] = "counts"
+    ds.attrs[_persistence_constants.TOOL_ATTRS_VERSION_ATTR] = 1
+    ds.attrs[_persistence_constants.TOOL_ENCODED_ATTRS_ATTR] = json.dumps(
+        {
+            "dataset": entries if scope is None else [],
+            "variables": {} if scope is None else {scope: entries},
+        }
+    )
+    before = ds.copy(deep=True)
+    with pytest.raises((TypeError, ValueError), match=error):
+        imagetool_serialization.restore_tool_dataset_attrs(ds)
+    xr.testing.assert_identical(ds, before)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "tool_cls_qualname",
+        "tool_state",
+        "tool_script_inputs",
+        "erlab_code_trust_payload_entries",
+    ],
+)
+def test_tool_dataset_attrs_keep_control_metadata_native(key, monkeypatch) -> None:
+    with pytest.raises(TypeError, match="control attribute"):
+        imagetool_serialization.prepare_tool_dataset(
+            xr.Dataset(attrs={key: {"bad": 1}})
+        )
+
+    def fail_if_decoded(value):
+        raise AssertionError("Control metadata must be rejected before decoding values")
+
+    monkeypatch.setattr(imagetool_serialization, "_decode_array", fail_if_decoded)
+    ds = xr.Dataset(attrs={_persistence_constants.TOOL_ATTRS_VERSION_ATTR: 1})
+    ds.attrs[_persistence_constants.TOOL_ENCODED_ATTRS_ATTR] = json.dumps(
+        {
+            "dataset": [[{"kind": "str", "value": key}, {"kind": "ndarray"}]],
+            "variables": {},
+        }
+    )
+    with pytest.raises(ValueError, match="cannot replace metadata"):
+        imagetool_serialization.restore_tool_dataset_attrs(ds)
 
 
 def test_workspace_file_suffix_helpers_collect_nested_inputs(tmp_path) -> None:
@@ -335,9 +753,9 @@ def test_qt_window_state_restores_maximized_normal_geometry(qtbot) -> None:
 
 
 def test_imagetool_private_coord_serialization_edge_cases() -> None:
-    private_attr = imagetool_serialization._PRIVATE_COORDS_ATTR
-    private_prefix = imagetool_serialization._PRIVATE_COORD_VAR_PREFIX
-    data_name = imagetool_serialization.ITOOL_DATA_NAME
+    private_attr = imagetool_serialization.PRIVATE_COORDS_ATTR
+    private_prefix = "__erlab_imagetool_coord_"
+    data_name = _persistence_constants.ITOOL_DATA_NAME
     valid_payload = json.dumps(
         [{"coord_name": "Fake Motor", "variable_name": "private", "dims": ["x"]}]
     )
@@ -391,8 +809,8 @@ def test_imagetool_private_coord_serialization_edge_cases() -> None:
 
 
 def test_imagetool_private_coord_restore_ignores_invalid_records() -> None:
-    private_attr = imagetool_serialization._PRIVATE_COORDS_ATTR
-    data_name = imagetool_serialization.ITOOL_DATA_NAME
+    private_attr = imagetool_serialization.PRIVATE_COORDS_ATTR
+    data_name = _persistence_constants.ITOOL_DATA_NAME
     missing_data = xr.Dataset({"other": ("x", [1.0])})
 
     assert imagetool_serialization.restore_private_coords(missing_data) is missing_data
@@ -434,29 +852,27 @@ def test_imagetool_private_coord_restore_ignores_invalid_records() -> None:
 
 
 def test_workspace_attr_native_detection_handles_edge_types() -> None:
-    assert workspace_format._workspace_attr_value_writes_natively(b"ok")
-    assert not workspace_format._workspace_attr_value_writes_natively(b"\xff")
-    assert not workspace_format._workspace_attr_value_writes_natively(b"a\x00")
-    assert workspace_format._workspace_attr_value_writes_natively(
+    assert imagetool_serialization.attr_value_writes_natively(b"ok")
+    assert not imagetool_serialization.attr_value_writes_natively(b"\xff")
+    assert not imagetool_serialization.attr_value_writes_natively(b"a\x00")
+    assert imagetool_serialization.attr_value_writes_natively(
         np.array([1, 2], dtype=np.int16)
     )
-    assert not workspace_format._workspace_attr_value_writes_natively(
+    assert not imagetool_serialization.attr_value_writes_natively(
         np.array([object()], dtype=object)
     )
-    assert workspace_format._workspace_attr_value_writes_natively(np.float64(1.0))
-    assert not workspace_format._workspace_attr_value_writes_natively(
+    assert imagetool_serialization.attr_value_writes_natively(np.float64(1.0))
+    assert not imagetool_serialization.attr_value_writes_natively(
         np.datetime64("2024-01-01")
     )
-    assert workspace_format._workspace_attr_value_writes_natively(("left", "right"))
-    assert workspace_format._workspace_attr_value_writes_natively((b"left", b"right"))
-    assert workspace_format._workspace_attr_value_writes_natively(
+    assert imagetool_serialization.attr_value_writes_natively(("left", "right"))
+    assert imagetool_serialization.attr_value_writes_natively((b"left", b"right"))
+    assert imagetool_serialization.attr_value_writes_natively(
         (np.bool_(True), complex(1.0, 2.0))
     )
-    assert not workspace_format._workspace_attr_value_writes_natively([1, "text"])
-    assert not workspace_format._workspace_attr_value_writes_natively(
-        ("text", b"bytes")
-    )
-    assert not workspace_format._workspace_attr_value_writes_natively(([1],))
+    assert not imagetool_serialization.attr_value_writes_natively([1, "text"])
+    assert not imagetool_serialization.attr_value_writes_natively(("text", b"bytes"))
+    assert not imagetool_serialization.attr_value_writes_natively(([1],))
 
 
 def test_workspace_mixed_scalar_attrs_use_typed_encoding() -> None:
@@ -475,6 +891,141 @@ def test_workspace_mixed_scalar_attrs_use_typed_encoding() -> None:
     assert restored["mixed_list"] == [1, "text"]
     assert restored["mixed_tuple"] == ("text", b"bytes")
     assert restored["native_numbers"] == [1, 2.0]
+
+
+@pytest.mark.parametrize("dtype", ["S1", "<U1", ">U1"])
+def test_workspace_legacy_empty_numpy_string_attrs_roundtrip(dtype, tmp_path) -> None:
+    # Released writers expanded empty scalars to one zero code unit.
+    scalar = {
+        "kind": "numpy_scalar",
+        "dtype": dtype,
+        "shape": [],
+        "data": "AA==" if dtype == "S1" else "AAAAAA==",
+    }
+    entries = [
+        [
+            {"kind": "str", "value": "metadata"},
+            {
+                "kind": "dict",
+                "items": [[{"kind": "str", "value": "empty"}, scalar]],
+            },
+        ]
+    ]
+    ds = xr.Dataset(
+        attrs={
+            _persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR: json.dumps(
+                {"version": 1, "attrs": entries}
+            )
+        }
+    )
+    path = tmp_path / "legacy-attrs.nc"
+    ds.to_netcdf(path, engine="h5netcdf")
+    opened = xr.load_dataset(path, engine="h5netcdf")
+    expected = np.bytes_(b"") if dtype == "S1" else np.str_("")
+
+    for attrs in (
+        workspace_format._restore_workspace_serialized_attrs(opened.attrs),
+        workspace_format._restore_workspace_manifest_attrs(entries),
+    ):
+        _assert_tool_attr_equal(attrs["metadata"]["empty"], expected)
+        assert not attrs["metadata"]["empty"]
+        # A new save must retain the old value after conversion to the new record.
+        restored = workspace_format._restore_workspace_manifest_attrs(
+            workspace_format._workspace_manifest_attrs(attrs)
+        )
+        _assert_tool_attr_equal(restored["metadata"]["empty"], expected)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        np.str_(""),
+        np.bytes_(b""),
+        np.str_("β\x00\x00"),
+        np.bytes_(b"\xff\x00\x00"),
+        np.datetime64("2025-01-01", "ns"),
+        np.timedelta64(3, "ns"),
+        np.datetime64("NaT"),
+        np.timedelta64("NaT"),
+    ],
+)
+def test_workspace_numpy_keys_preserve_type_and_contents(key) -> None:
+    decoded = imagetool_serialization.decode_attr_key(
+        imagetool_serialization.encode_attr_key(key)
+    )
+    _assert_tool_attr_equal(decoded, key)
+
+
+@pytest.mark.parametrize("key", [np.datetime64("NaT"), np.timedelta64("NaT")])
+def test_tool_dataset_attrs_keep_nat_keys_distinct_from_none(key) -> None:
+    ds = xr.Dataset(attrs={"metadata": {None: "none", key: "nat"}})
+    for _ in range(2):
+        prepared = imagetool_serialization.prepare_tool_dataset(ds)
+        raw = prepared.to_netcdf(engine="h5netcdf", invalid_netcdf=True)
+        opened = xr.load_dataset(memoryview(raw), engine="h5netcdf")
+        ds = imagetool_serialization.restore_tool_dataset_attrs(opened)
+        metadata = ds.attrs["metadata"]
+        assert len(metadata) == 2
+        assert metadata[None] == "none"
+        restored_key = next(item for item in metadata if item is not None)
+        _assert_tool_attr_equal(restored_key, key)
+        assert metadata[restored_key] == "nat"
+
+
+@pytest.mark.parametrize("tuple_keys", [False, True])
+def test_tool_dataset_attrs_preserve_distinct_nan_keys(tuple_keys) -> None:
+    keys = [float("nan"), float("nan")]
+    if tuple_keys:
+        keys = [(key,) for key in keys]
+    ds = xr.Dataset(attrs={"metadata": dict(zip(keys, [1, 2], strict=True))})
+    for _ in range(2):
+        prepared = imagetool_serialization.prepare_tool_dataset(ds)
+        raw = prepared.to_netcdf(engine="h5netcdf", invalid_netcdf=True)
+        opened = xr.load_dataset(memoryview(raw), engine="h5netcdf")
+        ds = imagetool_serialization.restore_tool_dataset_attrs(opened)
+        metadata = ds.attrs["metadata"]
+        assert len(metadata) == 2
+        assert list(metadata.values()) == [1, 2]
+        assert all(np.isnan(key[0] if tuple_keys else key) for key in metadata)
+
+
+@pytest.mark.parametrize("byteorder", ["<", ">"])
+def test_workspace_attr_numpy_unicode_scalar_byteorder(byteorder) -> None:
+    text = "\ufeffβ😀\ud800\x00\x00"
+    array = np.array(text, dtype=f"{byteorder}U{len(text)}")
+    payload = imagetool_serialization.encode_attr_value(array)
+    payload["kind"] = "numpy_string"
+
+    decoded = imagetool_serialization.decode_attr_value(payload)
+
+    _assert_tool_attr_equal(decoded, np.str_(text))
+
+
+@pytest.mark.parametrize("kind", ["numpy_scalar", "numpy_string"])
+@pytest.mark.parametrize("dtype", ["U0", "S0"])
+def test_workspace_attr_zero_width_strings_reject_nonempty_data(dtype, kind) -> None:
+    payload = {"kind": kind, "dtype": dtype, "shape": [], "data": "AA=="}
+
+    with pytest.raises(ValueError, match="zero-width string array must have no data"):
+        imagetool_serialization.decode_attr_value(payload)
+
+
+@pytest.mark.parametrize("kind", ["numpy_scalar", "numpy_string"])
+@pytest.mark.parametrize("dtype", ["U1", "S1", "i4"])
+def test_workspace_attr_numpy_scalar_rejects_array_shape(dtype, kind) -> None:
+    payload = imagetool_serialization.encode_attr_value(np.zeros(1, dtype=dtype))
+    payload["kind"] = kind
+
+    with pytest.raises(ValueError, match="scalar must have an empty shape"):
+        imagetool_serialization.decode_attr_value(payload)
+
+
+def test_workspace_attr_numpy_string_rejects_nonstring_dtype() -> None:
+    payload = imagetool_serialization.encode_attr_value(np.float64(1.0))
+    payload["kind"] = "numpy_string"
+
+    with pytest.raises(TypeError, match="string must have a string dtype"):
+        imagetool_serialization.decode_attr_value(payload)
 
 
 def test_workspace_attr_typed_encoding_roundtrips_safe_values(caplog) -> None:
@@ -496,8 +1047,8 @@ def test_workspace_attr_typed_encoding_roundtrips_safe_values(caplog) -> None:
         ],
     }
 
-    decoded = workspace_format._workspace_decode_attr_value(
-        workspace_format._workspace_encode_attr_value(value)
+    decoded = imagetool_serialization.decode_attr_value(
+        imagetool_serialization.encode_attr_value(value)
     )
 
     assert decoded[None] is None
@@ -514,15 +1065,15 @@ def test_workspace_attr_typed_encoding_roundtrips_safe_values(caplog) -> None:
     assert decoded[("tuple", 2)][1][0]["nested"] == (None, complex(3.0, 4.0))
 
     with pytest.raises(TypeError, match="unsupported attr key type"):
-        workspace_format._workspace_encode_attr_key(["bad"])
+        imagetool_serialization.encode_attr_key(["bad"])
     with pytest.raises(TypeError, match="unsupported numeric attr type"):
-        workspace_format._workspace_encode_attr_value(decimal.Decimal("1.0"))
+        imagetool_serialization.encode_attr_value(decimal.Decimal("1.0"))
     with pytest.raises(TypeError, match="must be a mapping"):
-        workspace_format._workspace_decode_attr_value([])
+        imagetool_serialization.decode_attr_value([])
     with pytest.raises(TypeError, match="unknown workspace attr value kind"):
-        workspace_format._workspace_decode_attr_value({"kind": "unknown"})
+        imagetool_serialization.decode_attr_value({"kind": "unknown"})
     with pytest.raises(TypeError, match="not hashable"):
-        workspace_format._workspace_decode_attr_key({"kind": "list", "items": []})
+        imagetool_serialization.decode_attr_key({"kind": "list", "items": []})
 
     assert workspace_format._workspace_encoded_attr_entries(b"\xff") is None
     assert workspace_format._workspace_encoded_attr_entries(1) is None
@@ -537,7 +1088,7 @@ def test_workspace_attr_typed_encoding_roundtrips_safe_values(caplog) -> None:
         workspace_format._workspace_encoded_attr_entries(
             json.dumps(
                 {
-                    "version": workspace_format._WORKSPACE_ENCODED_ATTRS_VERSION,
+                    "version": _persistence_constants.WORKSPACE_ENCODED_ATTRS_VERSION,
                     "attrs": [["too-short"]],
                 }
             )
@@ -547,13 +1098,13 @@ def test_workspace_attr_typed_encoding_roundtrips_safe_values(caplog) -> None:
 
     invalid_payload = json.dumps(
         {
-            "version": workspace_format._WORKSPACE_ENCODED_ATTRS_VERSION,
+            "version": _persistence_constants.WORKSPACE_ENCODED_ATTRS_VERSION,
             "attrs": [[{"kind": "list", "items": []}, {"kind": "str", "value": "x"}]],
         }
     )
     with caplog.at_level(logging.WARNING):
         restored = workspace_format._restore_workspace_serialized_attrs(
-            {workspace_format._WORKSPACE_ENCODED_ATTRS_ATTR: invalid_payload}
+            {_persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR: invalid_payload}
         )
     assert restored == {}
     assert "Ignoring invalid encoded workspace attribute" in caplog.text
@@ -568,16 +1119,16 @@ def test_workspace_metadata_helpers_cover_invalid_payloads() -> None:
     raw_manifest = json.dumps(manifest)
 
     encoded_manifest = workspace_format._workspace_manifest_from_attrs(
-        {workspace_format._WORKSPACE_MANIFEST_ATTR: raw_manifest.encode()}
+        {_persistence_constants.WORKSPACE_MANIFEST_ATTR: raw_manifest.encode()}
     )
     assert encoded_manifest["root_order"] == ["1"]
     decoded_manifest = workspace_format._workspace_manifest_from_attrs(
-        {workspace_format._WORKSPACE_MANIFEST_ATTR: raw_manifest}
+        {_persistence_constants.WORKSPACE_MANIFEST_ATTR: raw_manifest}
     )
     assert decoded_manifest["nodes"] == [{"path": "1"}]
     assert (
         workspace_format._workspace_manifest_from_attrs(
-            {workspace_format._WORKSPACE_MANIFEST_ATTR: "{not-json"}
+            {_persistence_constants.WORKSPACE_MANIFEST_ATTR: "{not-json"}
         )
         == {}
     )

--- a/tests/interactive/imagetool/manager/workspace/test_loading.py
+++ b/tests/interactive/imagetool/manager/workspace/test_loading.py
@@ -18,7 +18,6 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive._qt_state as qt_state
-import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager as manager_module
 import erlab.interactive.imagetool.manager._desktop as manager_desktop
 import erlab.interactive.imagetool.manager._workspace._arrays as workspace_arrays
@@ -29,6 +28,7 @@ import erlab.interactive.imagetool.manager._workspace._storage as workspace_stor
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.plot_items as imagetool_plot_items
 import erlab.interactive.imagetool.viewer as imagetool_viewer
+from erlab.interactive import _persistence_constants
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._load_source import _serialize_loader_kwargs
@@ -1180,11 +1180,11 @@ def test_managed_tool_rebuilds_input_provenance_from_parent(
         manager._workspace_controller.saving._save_workspace_document(fname)
         node_path = f"0/childtools/{child_uid}"
         attrs = _current_workspace_payload_attrs(fname, node_path)
-        assert erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
+        assert _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
         with h5py.File(fname, "r") as h5_file:
             payload = h5_file[_current_workspace_payload_path(fname, node_path)]
             assert (
-                erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
+                _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR
                 not in payload.attrs
             )
 
@@ -1238,12 +1238,12 @@ def test_legacy_tool_input_provenance_is_not_raw_copied(
     node_path = f"0/childtools/{child_uid}"
     encoded_injection = json.dumps(_injected_input_provenance().model_dump(mode="json"))
     with _edit_current_workspace_payload_attrs(fname, node_path) as attrs:
-        attrs[erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
+        attrs[_persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
             encoded_injection
         )
     with h5py.File(fname, "a") as h5_file:
         payload = h5_file[_current_workspace_payload_path(fname, node_path)]
-        payload.attrs[erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
+        payload.attrs[_persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
             encoded_injection
         )
 
@@ -1258,7 +1258,7 @@ def test_legacy_tool_input_provenance_is_not_raw_copied(
         )
         child_node = manager._child_node(child_uid)
         assert child_node.pending_workspace_tool_payload is not None
-        assert erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR in (
+        assert _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR in (
             child_node.pending_workspace_payload_attrs or {}
         )
 
@@ -1277,11 +1277,11 @@ def test_legacy_tool_input_provenance_is_not_raw_copied(
         assert "attacker" not in current.display_code()
 
         attrs = _current_workspace_payload_attrs(fname, node_path)
-        assert erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
+        assert _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
         with h5py.File(fname, "r") as h5_file:
             payload = h5_file[_current_workspace_payload_path(fname, node_path)]
             assert (
-                erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR
+                _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR
                 not in payload.attrs
             )
         manager._workspace_controller._drain_workspace_deferred_events()
@@ -1851,7 +1851,7 @@ def test_eager_tool_reference_does_not_read_associated_workspace(
         reference = {"kind": "manager_node", "node_uid": "missing-source"}
         ds = xr.Dataset(
             attrs={
-                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                     {"data": reference}
                 )
             }
@@ -1892,7 +1892,7 @@ def test_pending_tool_reference_reads_owner_workspace(
         }
         ds = xr.Dataset(
             attrs={
-                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                     {"data": reference}
                 )
             }
@@ -2562,7 +2562,7 @@ def test_manager_workspace_roundtrip_restores_full_serializable_state(
             assert "auxiliary" in tool_group
             assert (
                 tool_group["auxiliary"].attrs[
-                    workspace_arrays._TOOL_DATA_BLOB_NAME_ATTR
+                    _persistence_constants.TOOL_DATA_BLOB_NAME_ATTR
                 ]
                 == extra_data.name
             )
@@ -3177,8 +3177,8 @@ def test_manager_workspace_partially_loads_corrupted_child_with_warning(
                 "xr.DataTree", tree[f"0/childtools/{child_uid}/tool"]
             ).to_dataset(inherit=False)
             child_ds = child_ds.copy(deep=True)
-            child_ds.attrs.pop(erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR, None)
-            saved_data_name = imagetool_serialization.SAVED_TOOL_DATA_NAME
+            child_ds.attrs.pop(_persistence_constants.TOOL_DATA_REFERENCES_ATTR, None)
+            saved_data_name = _persistence_constants.SAVED_TOOL_DATA_NAME
             child_ds[saved_data_name] = xr.DataArray(
                 np.arange(50.0).reshape(2, 5, 5),
                 dims=("z", "y", "x"),
@@ -4245,6 +4245,90 @@ def test_manager_workspace_load_uses_h5py_fast_path(
         np.testing.assert_array_equal(loaded._data.values, data.values)
 
 
+@pytest.mark.parametrize(
+    "attrs_mode", ["missing", "empty", "invalid", "hidden", "visible"]
+)
+def test_manager_h5py_workspace_load_decodes_manifest_attrs_once(
+    qtbot, monkeypatch, tmp_path, manager_context, attrs_mode
+) -> None:
+    data = xr.DataArray(
+        np.arange(25.0).reshape(5, 5),
+        dims=("x", "y"),
+        coords={"x": np.arange(5), "y": np.arange(5)},
+        name="source",
+    )
+    with manager_context() as manager:
+        for _ in range(2):
+            manager.add_imagetool(
+                erlab.interactive.imagetool.ImageTool(data, _in_manager=True),
+                show=False,
+            )
+        fname = tmp_path / "manifest-attrs.itws"
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        manifest = _current_workspace_manifest(fname)
+        entry = manifest["nodes"][1]
+        expected_attrs = _current_workspace_payload_attrs(fname, "1")
+        if attrs_mode == "missing":
+            del entry["payload_attrs"]
+        elif attrs_mode == "empty":
+            entry["payload_attrs"] = []
+            expected_attrs = {}
+        elif attrs_mode == "invalid":
+            entry["payload_attrs"] = {"invalid": True}
+        else:
+            expected_attrs.pop("itool_window_state")
+            expected_attrs["itool_visible"] = attrs_mode == "visible"
+            expected_attrs["manager_node_note"] = "Updated manifest note"
+            expected_attrs["calibration"] = np.arange(3, dtype=np.int16)
+            expected_attrs["metadata"] = (1, {"gain": 2})
+            entry["payload_attrs"] = workspace_format._workspace_manifest_attrs(
+                expected_attrs
+            )
+
+        loader = manager._workspace_controller.loading
+        original_decode = workspace_format._restore_workspace_manifest_attrs
+        original_load = loader._load_workspace_imagetool_dataset
+        decoded_payloads = []
+        loaded_datasets = {}
+
+        def _record_decode(payload):
+            decoded_payloads.append(payload)
+            return original_decode(payload)
+
+        def _record_load(ds, **kwargs):
+            loaded_datasets[kwargs["node_path"]] = ds.copy(deep=False)
+            return original_load(ds, **kwargs)
+
+        monkeypatch.setattr(
+            workspace_format, "_restore_workspace_manifest_attrs", _record_decode
+        )
+        monkeypatch.setattr(loader, "_load_workspace_imagetool_dataset", _record_load)
+
+        assert loader._from_h5py_workspace_file(
+            fname, manifest, replace=True, mark_dirty=False
+        )
+        assert len(decoded_payloads) == (1 if attrs_mode == "missing" else 2)
+        if attrs_mode != "invalid":
+            xr.testing.assert_identical(
+                xr.Dataset(attrs=loaded_datasets["1"].attrs),
+                xr.Dataset(attrs=expected_attrs),
+            )
+        if attrs_mode in {"empty", "invalid"}:
+            assert manager.ntools == 1
+            assert len(loader._skipped_workspace_nodes) == 1
+            error = loader._skipped_workspace_nodes[0][3]
+            assert isinstance(error, KeyError if attrs_mode == "empty" else TypeError)
+        else:
+            assert manager.ntools == 2
+            assert loader._skipped_workspace_nodes == []
+            node = manager._node_for_target(1)
+            if node.pending_workspace_memory_payload is not None:
+                assert loader.pending._materialize_pending_workspace_payload(node)
+            xr.testing.assert_identical(
+                manager.get_imagetool(1).slicer_area._data, data
+            )
+
+
 def test_manager_h5py_workspace_load_defers_hidden_imagetool_refresh_and_profiles(
     qtbot,
     monkeypatch,
@@ -4319,6 +4403,90 @@ def test_manager_h5py_workspace_load_defers_hidden_imagetool_refresh_and_profile
         assert profiler._durations["imagetool manager registration"] > 0.0
         assert "imagetool state restore: layout" in profiler._durations
         assert "imagetool state refresh" not in profiler._durations
+
+
+@pytest.mark.parametrize("use_dask", [False, True])
+@pytest.mark.parametrize("current_cursor", [0, 1])
+@pytest.mark.parametrize(
+    ("ndim", "transpose"), [(1, False), (1, True), (2, False), (3, False)]
+)
+def test_manager_workspace_load_restores_active_cursor_preview_once(
+    qtbot,
+    tmp_path,
+    use_dask: bool,
+    current_cursor: int,
+    ndim: int,
+    transpose: bool,
+    manager_context: Callable[
+        ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
+    ],
+) -> None:
+    from dask.callbacks import Callback
+
+    from erlab.interactive.imagetool.manager._wrapper import (
+        _preview_curve_from_imagetool,
+    )
+
+    shape = (4, 5, 6)[-ndim:]
+    data = xr.DataArray(
+        np.arange(np.prod(shape), dtype=np.float32).reshape(shape),
+        dims=("x", "y", "z")[-ndim:],
+        coords={"z": np.linspace(-1, 1, 6)},
+    )
+    if use_dask:
+        data = data.chunk(dict.fromkeys(data.dims, 2))
+    with manager_context() as manager:
+        root = erlab.interactive.imagetool.ImageTool(data, auto_compute=False)
+        manager.add_imagetool(root, show=True)
+        qtbot.waitUntil(lambda: root.isVisible())
+        root.slicer_area.add_cursor()
+        root.slicer_area.set_current_cursor(current_cursor)
+        if ndim == 3:
+            root.slicer_area.set_index(2, 3)
+            root.slicer_area.array_slicer.set_bins(current_cursor, [1, 1, 3])
+        if transpose:
+            root.slicer_area.transpose_main_image()
+        expected_image = root.slicer_area.main_image.slicer_data_items[
+            current_cursor
+        ].image.copy()
+        expected_slice = root.slicer_area.array_slicer.state
+        expected_curve = _preview_curve_from_imagetool(root)
+        fname = tmp_path / "active-cursor.itws"
+        manager._workspace_controller.saving._save_workspace_document(fname)
+        manager.remove_all_tools()
+        QtWidgets.QApplication.processEvents()
+
+        computations: list[None] = []
+        with Callback(start=lambda _graph: computations.append(None)):
+            assert manager._workspace_controller.loading._load_workspace_file(
+                fname, replace=True, associate=True, mark_dirty=False, select=False
+            )
+            loaded = manager.get_imagetool(0).slicer_area
+            qtbot.waitUntil(lambda: not loaded._update_delayed)
+            node = manager._node_for_target(0)
+            # Details requests a curve before the image. Neither preview should
+            # compute the inactive cursor or repeat the initial display load.
+            curve = _preview_curve_from_imagetool(node.imagetool)
+            ratio, pixmap = node._preview_image
+
+        assert computations == ([None] if use_dask else [])
+        assert (loaded.data.chunks is not None) is use_dask
+        assert loaded.current_cursor == current_cursor
+        assert loaded.array_slicer.state == expected_slice
+        image_item = loaded.main_image.slicer_data_items[current_cursor]
+        np.testing.assert_array_equal(image_item.image, expected_image)
+        assert np.isfinite(ratio)
+        assert not pixmap.isNull()
+        expected_pixmap = image_item.getPixmap().transformed(
+            QtGui.QTransform().scale(1.0, -1.0)
+        )
+        assert pixmap.toImage() == expected_pixmap.toImage()
+        if expected_curve is None:
+            assert curve is None
+        else:
+            assert curve is not None
+            np.testing.assert_array_equal(curve[0], expected_curve[0])
+            np.testing.assert_array_equal(curve[1], expected_curve[1])
 
 
 def test_manager_h5py_workspace_load_defers_hidden_secondary_plot_widgets(
@@ -4515,12 +4683,8 @@ def test_manager_workspace_load_dialog_skips_stale_internal_groups(
         fname = tmp_path / "stale-dialog.itws"
         manager._workspace_controller.saving._save_workspace_document(fname)
         with h5py.File(fname, "a") as h5_file:
-            h5_file.create_group(
-                f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}stale"
-            )
-            h5_file.create_group(
-                f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}stale"
-            )
+            h5_file.create_group("__itws_pending_stale")
+            h5_file.create_group("__itws_backup_stale")
 
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)

--- a/tests/interactive/imagetool/manager/workspace/test_pending.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending.py
@@ -15,7 +15,6 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 import erlab
 import erlab.interactive.imagetool._load_source as imagetool_load_source
-import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.dialogs as imagetool_dialogs
 import erlab.interactive.imagetool.manager._console as manager_console
 import erlab.interactive.imagetool.manager._lineage as manager_lineage
@@ -26,9 +25,9 @@ import erlab.interactive.imagetool.manager._workspace._loading as workspace_load
 import erlab.interactive.imagetool.manager._workspace._pending as workspace_pending
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 import erlab.interactive.imagetool.viewer as imagetool_viewer
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool import itool
 from erlab.interactive.imagetool._load_source import _register_local_callable_loader
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     ScriptInput,
@@ -92,10 +91,10 @@ def test_workspace_dependency_rebase_updates_tool_data_references() -> None:
 
         def __init__(self) -> None:
             self.attrs = {
-                erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR: json.dumps(
+                _persistence_constants.TOOL_SCRIPT_INPUTS_ATTR: json.dumps(
                     [script_input.model_dump(mode="json")]
                 ),
-                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                     references
                 ),
             }
@@ -109,7 +108,7 @@ def test_workspace_dependency_rebase_updates_tool_data_references() -> None:
             return tuple(
                 ScriptInput.model_validate(item)
                 for item in json.loads(
-                    self.attrs[erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR]
+                    self.attrs[_persistence_constants.TOOL_SCRIPT_INPUTS_ATTR]
                 )
             )
 
@@ -151,11 +150,9 @@ def test_workspace_dependency_rebase_updates_tool_data_references() -> None:
     controller._rebase_node_dependency_refs(nodes, {saved_uid: actual_uid})
 
     assert pending_node.tool_script_inputs[0].node_uid == actual_uid
-    assert (
-        pending_node.attrs[erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR] == "data"
-    )
+    assert pending_node.attrs[_persistence_constants.TOOL_PRIMARY_INPUT_ATTR] == "data"
     pending_references = json.loads(
-        pending_node.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR]
+        pending_node.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR]
     )
     assert pending_references["<saved-tool-data>"]["node_uid"] == actual_uid
     assert pending_references["legacy"]["node_uid"] == saved_uid
@@ -1452,7 +1449,7 @@ def test_pending_workspace_link_payload_helper_fallbacks(
         )
 
         def _metadata_dataset(*_args, **_kwargs):
-            return xr.Dataset({_ITOOL_DATA_NAME: data})
+            return xr.Dataset({_persistence_constants.ITOOL_DATA_NAME: data})
 
         monkeypatch.setattr(
             controller.loading,
@@ -2055,7 +2052,7 @@ def test_manager_workspace_file_backed_data_can_load_into_memory(
     workspace_arrays._write_workspace_dataset_group_to_file(
         source_file,
         "0/imagetool",
-        source.to_dataset(name=_ITOOL_DATA_NAME),
+        source.to_dataset(name=_persistence_constants.ITOOL_DATA_NAME),
     )
     with h5py.File(source_file, "a") as h5_file:
         h5_file.attrs.update(_transaction_test_root_attrs())
@@ -2153,9 +2150,9 @@ def test_pending_workspace_data_roles_match_materialized_filtered_nonuniform_dat
 
     stored = xr.Dataset(
         {
-            _ITOOL_DATA_NAME: saved[_ITOOL_DATA_NAME].transpose(
-                "sample_temp", "eV", "alpha"
-            )
+            _persistence_constants.ITOOL_DATA_NAME: saved[
+                _persistence_constants.ITOOL_DATA_NAME
+            ].transpose("sample_temp", "eV", "alpha")
         },
         attrs=dict(saved.attrs),
     )
@@ -2293,7 +2290,7 @@ def test_detached_pending_workspace_source_preserves_promoted_1d_marker(
     ],
 ) -> None:
     data = xr.DataArray(np.arange(3.0), dims=("x",), name="source")
-    opened = xr.Dataset({_ITOOL_DATA_NAME: data})
+    opened = xr.Dataset({_persistence_constants.ITOOL_DATA_NAME: data})
 
     with manager_context() as manager:
         pending = manager._workspace_controller.loading.pending
@@ -2611,7 +2608,7 @@ def test_pending_toolwindow_reference_availability_rejects_unsupported_kind(
             tmp_path / "source.itws",
             f"0/childtools/{child_uid}/tool",
             payload_attrs={
-                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                     {"data": {"kind": "manager_node", "node_uid": root_uid}}
                 )
             },
@@ -2621,7 +2618,7 @@ def test_pending_toolwindow_reference_availability_rejects_unsupported_kind(
 
         child_node.update_pending_workspace_payload_attrs(
             {
-                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                     {"data": {"kind": "future_reference", "node_uid": root_uid}}
                 )
             }
@@ -2634,7 +2631,7 @@ def test_pending_toolwindow_reference_availability_rejects_unsupported_kind(
 
         child_node.update_pending_workspace_payload_attrs(
             {
-                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                     {"data": {"kind": "manager_node", "node_uid": "missing"}}
                 )
             }
@@ -2984,7 +2981,7 @@ def test_manager_workspace_child_tool_reference_materializes_only_child_data(
                 "tool_data_references"
             ]
         )
-        reference = references[imagetool_serialization.SAVED_TOOL_DATA_NAME]
+        reference = references[_persistence_constants.SAVED_TOOL_DATA_NAME]
         assert reference["kind"] == "manager_node"
         assert reference["node_uid"] == root_node.uid
         assert reference["node_snapshot_token"] == root_node.snapshot_token
@@ -3071,11 +3068,11 @@ def test_manager_workspace_tool_reference_materializes_without_opening_source(
             figure_group = h5_file[
                 _current_workspace_payload_path(fname, f"figures/{figure_uid}")
             ]
-            assert references[imagetool_serialization.SAVED_TOOL_DATA_NAME] == {
+            assert references[_persistence_constants.SAVED_TOOL_DATA_NAME] == {
                 "kind": "manager_node",
                 "node_uid": wrapper.uid,
             }
-            assert figure_group[imagetool_serialization.SAVED_TOOL_DATA_NAME].shape == (
+            assert figure_group[_persistence_constants.SAVED_TOOL_DATA_NAME].shape == (
                 0,
             )
 
@@ -3242,7 +3239,7 @@ def test_manager_workspace_replacing_pending_memory_data_clears_pending_payload(
                 "replacement"
             )
             np.testing.assert_array_equal(
-                group[_ITOOL_DATA_NAME][...],
+                group[_persistence_constants.ITOOL_DATA_NAME][...],
                 replacement.values,
             )
 
@@ -3313,6 +3310,6 @@ def test_manager_workspace_attr_update_keeps_pending_hidden_memory_unmaterialize
         with h5py.File(fname, "r") as h5_file:
             group = h5_file[_current_workspace_payload_path(fname)]
             np.testing.assert_array_equal(
-                group[_ITOOL_DATA_NAME][...],
+                group[_persistence_constants.ITOOL_DATA_NAME][...],
                 data.values,
             )

--- a/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_persistence.py
@@ -18,8 +18,8 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 import erlab.interactive.imagetool.manager._workspace._loading as workspace_loading
 import erlab.interactive.imagetool.manager._workspace._pending as workspace_pending
 import erlab.interactive.imagetool.viewer_linking as imagetool_viewer_linking
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool import itool
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._model import (
     FileDataSelection,
     compose_display_provenance,
@@ -807,7 +807,11 @@ def test_pending_workspace_lazy_source_data_matches_saved_semantic_order(
     assert tuple(state["slice"]["dims"]) == data.dims
 
     stored = xr.Dataset(
-        {_ITOOL_DATA_NAME: saved[_ITOOL_DATA_NAME].transpose("hv", "y", "x")},
+        {
+            _persistence_constants.ITOOL_DATA_NAME: saved[
+                _persistence_constants.ITOOL_DATA_NAME
+            ].transpose("hv", "y", "x")
+        },
         attrs=dict(saved.attrs),
     )
     fname = tmp_path / "pending-saved-dim-order.itws"
@@ -995,7 +999,7 @@ def test_pending_workspace_source_data_decodes_saved_state_attrs(
         ..., typing.ContextManager[erlab.interactive.imagetool.manager.ImageToolManager]
     ],
 ) -> None:
-    data_name = _ITOOL_DATA_NAME
+    data_name = _persistence_constants.ITOOL_DATA_NAME
     payload = xr.Dataset(
         {data_name: xr.DataArray(np.arange(3.0), dims=("x",), name=data_name)}
     )
@@ -1286,10 +1290,8 @@ def test_generation_save_embeds_pending_tool_data_after_source_removal(
             payload = h5_file[
                 _current_workspace_payload_path(fname, f"figures/{figure_uid}")
             ]
-            assert erlab.interactive.utils._SAVED_TOOL_DATA_NAME in payload
-            assert (
-                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR not in payload.attrs
-            )
+            assert _persistence_constants.SAVED_TOOL_DATA_NAME in payload
+            assert _persistence_constants.TOOL_DATA_REFERENCES_ATTR not in payload.attrs
 
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False
@@ -1426,11 +1428,11 @@ def test_pending_toolwindow_legacy_binding_is_materialized_by_saved_input_decode
             squeeze=True,
         )
         attrs = {
-            erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR: json.dumps(
+            _persistence_constants.TOOL_SOURCE_BINDING_ATTR: json.dumps(
                 binding.model_dump(mode="json")
             ),
-            erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR: b"stale",
-            erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR: True,
+            _persistence_constants.TOOL_SOURCE_STATE_ATTR: b"stale",
+            _persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR: True,
         }
 
         loader = manager._workspace_controller.loading
@@ -1439,17 +1441,17 @@ def test_pending_toolwindow_legacy_binding_is_materialized_by_saved_input_decode
             parent_target=0,
         )
         script_inputs = parse_script_inputs(
-            deferred.attrs[erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR]
+            deferred.attrs[_persistence_constants.TOOL_SCRIPT_INPUTS_ATTR]
         )
         assert len(script_inputs) == 1
         assert script_inputs[0].data_role == "displayed"
         assert script_inputs[0].node_uid == root_node.uid
         assert script_inputs[0].node_snapshot_token == root_node.snapshot_token
         assert script_inputs[0].source_spec is None
-        assert erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR in deferred.attrs
+        assert _persistence_constants.TOOL_SOURCE_BINDING_ATTR in deferred.attrs
 
         assert bool(
-            deferred.attrs.get(erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR)
+            deferred.attrs.get(_persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR)
         )
         assert loader._workspace_tool_source_state_from_attrs(deferred.attrs) == "stale"
 
@@ -1472,7 +1474,7 @@ def test_pending_toolwindow_legacy_binding_is_materialized_by_saved_input_decode
         xr.testing.assert_identical(source_spec.apply(data), data.isel(x=0))
 
         invalid_attrs = dict(deferred.attrs)
-        invalid_attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = "not-valid"
+        invalid_attrs[_persistence_constants.TOOL_SOURCE_STATE_ATTR] = "not-valid"
         assert loader._workspace_tool_source_state_from_attrs(invalid_attrs) == "fresh"
 
 
@@ -1500,10 +1502,10 @@ def test_legacy_toolwindow_reload_applies_source_spec_once(
     legacy_tool = _AddedTimeChildTool(resolved)
     qtbot.addWidget(legacy_tool)
     legacy_ds = legacy_tool.to_dataset()
-    legacy_ds.attrs[erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR] = json.dumps(
+    legacy_ds.attrs[_persistence_constants.TOOL_SOURCE_SPEC_ATTR] = json.dumps(
         source_spec.model_dump(mode="json")
     )
-    legacy_ds.attrs[erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
+    legacy_ds.attrs[_persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
         json.dumps(legacy_input_provenance.model_dump(mode="json"))
     )
 
@@ -1560,11 +1562,11 @@ def test_legacy_toolwindow_input_provenance_binds_live_parent(
     legacy_tool = _AddedTimeChildTool(data)
     qtbot.addWidget(legacy_tool)
     legacy_ds = legacy_tool.to_dataset()
-    legacy_ds.attrs[erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
+    legacy_ds.attrs[_persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
         json.dumps(input_provenance.model_dump(mode="json"))
     )
-    legacy_ds.attrs[erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR] = True
-    legacy_ds.attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = "fresh"
+    legacy_ds.attrs[_persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR] = True
+    legacy_ds.attrs[_persistence_constants.TOOL_SOURCE_STATE_ATTR] = "fresh"
 
     with manager_context() as manager:
         qtbot.wait_until(erlab.interactive.imagetool.manager.is_running)

--- a/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
+++ b/tests/interactive/imagetool/manager/workspace/test_pending_preview.py
@@ -21,8 +21,8 @@ import erlab.interactive.imagetool.manager._workspace._pending as workspace_pend
 import erlab.interactive.imagetool.manager._wrapper as manager_wrapper
 import erlab.interactive.imagetool.plot_items as imagetool_plot_items
 import erlab.interactive.utils
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool import itool
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._model import full_data
 from tests.interactive.imagetool.manager.helpers import select_tools
 from tests.interactive.imagetool.manager.workspace._support import (
@@ -281,10 +281,10 @@ def test_pending_workspace_metadata_coord_load_failure_falls_back(
         np.arange(6, dtype=np.float64).reshape((2, 3)),
         dims=["x", "y"],
         coords={"x": [0.0, 1.0], "y": [10.0, 11.0, 12.0], "temperature": 12.0},
-        name=_ITOOL_DATA_NAME,
+        name=_persistence_constants.ITOOL_DATA_NAME,
     )
     ds = xr.Dataset(
-        {_ITOOL_DATA_NAME: data},
+        {_persistence_constants.ITOOL_DATA_NAME: data},
         attrs={"itool_name": "pending"},
     )
     assert workspace_arrays._write_workspace_dataset_group_h5py(
@@ -790,8 +790,10 @@ def test_manager_wrapper_preview_curve_handles_unavailable_live_items(
             self,
             main_image: object | None,
             coord_values: np.ndarray | None = None,
+            current_cursor: int = 0,
         ) -> None:
             self._main_image = main_image
+            self.current_cursor = current_cursor
             if coord_values is None:
                 coord_values = np.arange(3.0)
             self.array_slicer = types.SimpleNamespace(
@@ -824,6 +826,16 @@ def test_manager_wrapper_preview_curve_handles_unavailable_live_items(
     empty_image = types.SimpleNamespace(slicer_data_items=[])
     valid_objects.add(id(empty_image))
     assert manager_wrapper._preview_curve_from_imagetool(_tool(empty_image)) is None
+
+    for cursor in (-1, 1):
+        assert (
+            manager_wrapper._preview_curve_from_imagetool(
+                types.SimpleNamespace(
+                    slicer_area=_FakeArea(empty_image, current_cursor=cursor)
+                )
+            )
+            is None
+        )
 
     invalid_item = types.SimpleNamespace()
     item_image = types.SimpleNamespace(slicer_data_items=[invalid_item])
@@ -1164,7 +1176,7 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
             np.arange(4 * 5 * 6, dtype=np.float64).reshape((4, 5, 6)),
             dims=["x", "y", "z"],
             coords={"x": np.arange(4), "y": np.arange(5), "z": np.arange(6)},
-            name=_ITOOL_DATA_NAME,
+            name=_persistence_constants.ITOOL_DATA_NAME,
         )
         state = {
             "slice": {
@@ -1180,7 +1192,7 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
             },
         }
         ds = xr.Dataset(
-            {_ITOOL_DATA_NAME: data},
+            {_persistence_constants.ITOOL_DATA_NAME: data},
             attrs={"itool_state": json.dumps(state), "itool_name": "pending"},
         )
         assert workspace_arrays._write_workspace_dataset_group_h5py(
@@ -1211,7 +1223,7 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
                 "eV": np.arange(5, dtype=np.float64),
                 "z": np.arange(6, dtype=np.float64),
             },
-            name=_ITOOL_DATA_NAME,
+            name=_persistence_constants.ITOOL_DATA_NAME,
         )
         nonuniform_state = {
             "slice": {
@@ -1223,7 +1235,7 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
             "color": {"cmap": "viridis"},
         }
         nonuniform_ds = xr.Dataset(
-            {_ITOOL_DATA_NAME: nonuniform_data},
+            {_persistence_constants.ITOOL_DATA_NAME: nonuniform_data},
             attrs={
                 "itool_state": json.dumps(nonuniform_state),
                 "itool_name": "nonuniform",
@@ -1238,7 +1250,7 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
                 "alpha_physical_scale", data=np.array([-2.0, -0.4, 0.2, 2.1])
             )
             physical_coord.make_scale("alpha")
-            data_dataset = group[_ITOOL_DATA_NAME]
+            data_dataset = group[_persistence_constants.ITOOL_DATA_NAME]
             data_dataset.dims[0].attach_scale(physical_coord)
             assert len(list(data_dataset.dims[0].keys())) > 1
         node.pending_workspace_memory_payload = (nonuniform_fname, "0/imagetool")
@@ -1258,7 +1270,7 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
                 "eV": np.linspace(-0.5, 0.5, 5),
                 "alpha": np.linspace(-2.0, 2.0, 4),
             },
-            name=_ITOOL_DATA_NAME,
+            name=_persistence_constants.ITOOL_DATA_NAME,
         )
         permuted_state = {
             "slice": {
@@ -1270,7 +1282,7 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
             "color": {"cmap": "viridis"},
         }
         permuted_ds = xr.Dataset(
-            {_ITOOL_DATA_NAME: permuted_data},
+            {_persistence_constants.ITOOL_DATA_NAME: permuted_data},
             attrs={
                 "itool_state": json.dumps(permuted_state),
                 "itool_name": "permuted",
@@ -1280,7 +1292,9 @@ def test_pending_workspace_preview_and_metadata_reader_fallbacks(
             permuted_fname, "0/imagetool", permuted_ds
         )
         with h5py.File(permuted_fname, "r") as h5_file:
-            data_dataset = h5_file[f"0/imagetool/{_ITOOL_DATA_NAME}"]
+            data_dataset = h5_file[
+                f"0/imagetool/{_persistence_constants.ITOOL_DATA_NAME}"
+            ]
             assert loader.pending._pending_preview_dataset_dims(
                 data_dataset, ("alpha", "eV", "sample_temp_idx")
             ) == (("sample_temp_idx", "eV", "alpha"), None)

--- a/tests/interactive/imagetool/manager/workspace/test_saving.py
+++ b/tests/interactive/imagetool/manager/workspace/test_saving.py
@@ -27,11 +27,11 @@ import erlab.interactive.imagetool.manager._workspace._state as workspace_state
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
 import erlab.interactive.imagetool.viewer as imagetool_viewer
+from erlab.interactive import _persistence_constants
 from erlab.interactive._code_trust import new_document_trust
 from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.derivative import DerivativeTool
 from erlab.interactive.imagetool import itool
-from erlab.interactive.imagetool._mainwindow import _ITOOL_DATA_NAME
 from erlab.interactive.imagetool._provenance._model import ScriptInput, full_data
 from erlab.interactive.imagetool._provenance._operations import (
     ImageToolSelectionSourceBinding,
@@ -177,7 +177,7 @@ def test_manager_workspace_restores_hidden_ktool_added_coordinates_and_angle_sca
         saved_attrs = _current_workspace_payload_attrs(
             workspace_path, f"0/childtools/{tool_uid}"
         )
-        assert erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR not in saved_attrs
+        assert _persistence_constants.TOOL_DATA_REFERENCES_ATTR not in saved_attrs
         assert manager._workspace_controller.loading._load_workspace_file(
             workspace_path,
             replace=True,
@@ -1567,7 +1567,7 @@ def test_manager_legacy_itws_schema_save_helpers(
         )
         manager._workspace_controller._associate_loaded_workspace_file(
             tmp_path / "legacy-schema.itws",
-            workspace_format._WORKSPACE_LEGACY_SCHEMA_VERSION - 1,
+            _persistence_constants.WORKSPACE_LEGACY_SCHEMA_VERSION - 1,
         )
 
         assert manager._workspace_state.path is None
@@ -1822,9 +1822,9 @@ def test_pending_workspace_tool_attrs_update_script_inputs() -> None:
     pending_base = {
         "tool_display_name": "old",
         "tool_title": "prefix old",
-        erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR: "stale",
-        erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR: "legacy",
-        erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR: "data",
+        _persistence_constants.TOOL_SOURCE_BINDING_ATTR: "stale",
+        _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR: "legacy",
+        _persistence_constants.TOOL_PRIMARY_INPUT_ATTR: "data",
     }
     saver._pending_workspace_node_attrs = types.MethodType(
         lambda _self, _node, _attrs, *, kind: dict(pending_base),
@@ -1843,33 +1843,29 @@ def test_pending_workspace_tool_attrs_update_script_inputs() -> None:
     attrs = saver._pending_workspace_tool_attrs(node)
 
     assert attrs["tool_title"] == "prefix new"
-    assert json.loads(attrs[erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR]) == [
+    assert json.loads(attrs[_persistence_constants.TOOL_SCRIPT_INPUTS_ATTR]) == [
         script_input.model_dump(mode="json")
     ]
-    assert attrs[erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR] == "data"
-    assert erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR not in attrs
-    assert erlab.interactive.utils._TOOL_SOURCE_BINDING_ATTR not in attrs
-    assert attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] == "valid"
-    assert attrs[erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR] is True
-    assert erlab.interactive.utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
+    assert attrs[_persistence_constants.TOOL_PRIMARY_INPUT_ATTR] == "data"
+    assert _persistence_constants.TOOL_SOURCE_SPEC_ATTR not in attrs
+    assert _persistence_constants.TOOL_SOURCE_BINDING_ATTR not in attrs
+    assert attrs[_persistence_constants.TOOL_SOURCE_STATE_ATTR] == "valid"
+    assert attrs[_persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR] is True
+    assert _persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR not in attrs
 
     pending_base.clear()
     pending_base.update(
         {
-            erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR: json.dumps(
+            _persistence_constants.TOOL_SOURCE_SPEC_ATTR: json.dumps(
                 full_data().model_dump(mode="json")
             ),
-            erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
-                {
-                    erlab.interactive.utils._SAVED_TOOL_DATA_NAME: {
-                        "kind": "parent_source"
-                    }
-                }
+            _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                {_persistence_constants.SAVED_TOOL_DATA_NAME: {"kind": "parent_source"}}
             ),
         }
     )
     attrs = saver._pending_workspace_tool_attrs(node)
-    assert erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR in attrs
+    assert _persistence_constants.TOOL_SOURCE_SPEC_ATTR in attrs
 
     node.name = "plain"
     node.tool_script_inputs = ()
@@ -1877,10 +1873,10 @@ def test_pending_workspace_tool_attrs_update_script_inputs() -> None:
     attrs = saver._pending_workspace_tool_attrs(node)
 
     assert attrs["tool_title"] == "plain"
-    assert erlab.interactive.utils._TOOL_SCRIPT_INPUTS_ATTR not in attrs
-    assert erlab.interactive.utils._TOOL_PRIMARY_INPUT_ATTR not in attrs
-    assert erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR not in attrs
-    assert erlab.interactive.utils._TOOL_SOURCE_AUTO_UPDATE_ATTR not in attrs
+    assert _persistence_constants.TOOL_SCRIPT_INPUTS_ATTR not in attrs
+    assert _persistence_constants.TOOL_PRIMARY_INPUT_ATTR not in attrs
+    assert _persistence_constants.TOOL_SOURCE_STATE_ATTR not in attrs
+    assert _persistence_constants.TOOL_SOURCE_AUTO_UPDATE_ATTR not in attrs
 
 
 def test_workspace_reference_uid_detection_and_invalid_reader_path() -> None:
@@ -1965,7 +1961,7 @@ def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
         is_imagetool=False,
         pending_workspace_payload=("workspace.itws", "/tool"),
         pending_workspace_payload_attrs={
-            erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+            _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                 {
                     "data": {
                         "kind": "manager_node",
@@ -2001,26 +1997,26 @@ def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
     [
         (None, None, {}, ()),
         (
-            {erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: b"\xff"},
+            {_persistence_constants.TOOL_DATA_REFERENCES_ATTR: b"\xff"},
             None,
             {},
             (),
         ),
         (
-            {erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: "not-json"},
+            {_persistence_constants.TOOL_DATA_REFERENCES_ATTR: "not-json"},
             None,
             {},
             (),
         ),
         (
-            {erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: "[]"},
+            {_persistence_constants.TOOL_DATA_REFERENCES_ATTR: "[]"},
             None,
             {},
             (),
         ),
         (
             {
-                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                     {
                         "invalid": None,
                         "parent": {"kind": "parent_source"},
@@ -2039,7 +2035,7 @@ def test_serialize_workspace_node_rejects_invalid_pending_tool() -> None:
         ),
         (
             {
-                erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                     {"parent": {"kind": "parent_source"}}
                 )
             },
@@ -2971,11 +2967,13 @@ def test_manager_opens_schema_5_immutable_generation_workspace(
 
         with h5py.File(fname, "r+") as h5_file:
             h5_file.attrs["imagetool_workspace_schema_version"] = 5
-            generation_root = h5_file[workspace_store._WORKSPACE_GENERATIONS_GROUP]
+            generation_root = h5_file[
+                _persistence_constants.WORKSPACE_GENERATIONS_GROUP
+            ]
             for generation in generation_root.values():
                 manifest = workspace_store.WorkspaceStore._read_manifest(generation)
                 manifest["schema_version"] = 5
-                del generation[workspace_store._WORKSPACE_MANIFEST_DATASET]
+                del generation["manifest"]
                 workspace_store.WorkspaceStore._write_manifest(generation, manifest)
 
         extra = itool(data + 1, manager=False, execute=False)
@@ -3444,7 +3442,9 @@ def test_manager_offload_to_workspace_saves_dirty_workspace_before_rebind(
         assert not manager.is_workspace_modified
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][
+                _persistence_constants.ITOOL_DATA_NAME
+            ]
             assert saved[0, 0] == 10.0
 
 
@@ -3488,7 +3488,9 @@ def test_manager_compute_offloaded_workspace_data_marks_backing_dirty(
         assert not manager.is_workspace_modified
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][
+                _persistence_constants.ITOOL_DATA_NAME
+            ]
             assert saved.chunks is None
 
 
@@ -3690,14 +3692,18 @@ def test_manager_manual_chunk_edits_persist_on_next_workspace_save(
         assert manager.is_workspace_modified
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][
+                _persistence_constants.ITOOL_DATA_NAME
+            ]
             assert saved.chunks is None
 
         assert _request_workspace_save_and_wait(qtbot, manager)
         assert not manager.is_workspace_modified
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][
+                _persistence_constants.ITOOL_DATA_NAME
+            ]
             assert saved.chunks == (2, 3)
 
         opened = workspace_arrays.open_workspace_dataset(
@@ -3706,7 +3712,7 @@ def test_manager_manual_chunk_edits_persist_on_next_workspace_save(
             chunks={},
         )
         try:
-            rebound = opened[_ITOOL_DATA_NAME]
+            rebound = opened[_persistence_constants.ITOOL_DATA_NAME]
             assert rebound.chunks == ((2, 2, 1), (3, 2))
         finally:
             opened.close()
@@ -4568,7 +4574,7 @@ def test_manager_workspace_compact_drops_history_and_keeps_store(
         store = manager._workspace_controller._workspace_store
         assert store is not None
         with store.read_session() as h5_file:
-            assert len(h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) >= 2
+            assert len(h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) >= 2
 
         monkeypatch.setattr(
             erlab.interactive.utils,
@@ -4583,7 +4589,7 @@ def test_manager_workspace_compact_drops_history_and_keeps_store(
             assert h5_file.id.valid
         _assert_no_workspace_internal_groups(fname)
         with store.read_session() as h5_file:
-            assert set(h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+            assert set(h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == {
                 current_entry["payload_object_id"]
             }
         generations = store.generations()
@@ -4626,7 +4632,9 @@ def test_manager_workspace_save_deduplicates_legacy_payload_in_place(
         manifest = manager._workspace_controller.saving._workspace_manifest()
         manifest["schema_version"] = schema_version
         tree.attrs["imagetool_workspace_schema_version"] = schema_version
-        tree.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(manifest)
+        tree.attrs[_persistence_constants.WORKSPACE_MANIFEST_ATTR] = json.dumps(
+            manifest
+        )
         tree.to_netcdf(path, engine="h5netcdf", invalid_netcdf=True)
         tree.close()
 
@@ -4808,7 +4816,9 @@ def test_manager_workspace_save_as_and_compact_deduplicates_legacy_payload(
         manifest = manager._workspace_controller.saving._workspace_manifest()
         manifest["schema_version"] = 4
         tree.attrs["imagetool_workspace_schema_version"] = 4
-        tree.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(manifest)
+        tree.attrs[_persistence_constants.WORKSPACE_MANIFEST_ATTR] = json.dumps(
+            manifest
+        )
         tree.to_netcdf(old_path, engine="h5netcdf", invalid_netcdf=True)
         tree.close()
 
@@ -4873,7 +4883,9 @@ def test_manager_workspace_save_as_and_compact_deduplicates_legacy_payload(
         with store.read_session() as h5_file:
             assert legacy_path not in h5_file
         np.testing.assert_array_equal(manager._get_imagetool_data(0), data)
-        np.testing.assert_array_equal(stale_legacy[_ITOOL_DATA_NAME], data)
+        np.testing.assert_array_equal(
+            stale_legacy[_persistence_constants.ITOOL_DATA_NAME], data
+        )
         stale_legacy.close()
 
 
@@ -4902,7 +4914,9 @@ def test_manager_workspace_save_as_preserves_legacy_dependency_for_dirty_data(
         manifest["schema_version"] = 4
         manifest["nodes"][0]["data_backing"] = "dask"
         tree.attrs["imagetool_workspace_schema_version"] = 4
-        tree.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(manifest)
+        tree.attrs[_persistence_constants.WORKSPACE_MANIFEST_ATTR] = json.dumps(
+            manifest
+        )
         tree.to_netcdf(old_path, engine="h5netcdf", invalid_netcdf=True)
         tree.close()
 
@@ -4986,7 +5000,9 @@ def test_manager_workspace_upgrade_repoints_pending_payload_before_compaction(
         manifest["schema_version"] = 4
         manifest["nodes"][0]["data_backing"] = "memory"
         tree.attrs["imagetool_workspace_schema_version"] = 4
-        tree.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(manifest)
+        tree.attrs[_persistence_constants.WORKSPACE_MANIFEST_ATTR] = json.dumps(
+            manifest
+        )
         payload_attrs = tree["0/imagetool"].attrs
         payload_attrs.pop("itool_window_state", None)
         payload_attrs["itool_visible"] = False
@@ -5049,7 +5065,7 @@ def test_manager_releases_eager_legacy_source_when_conversion_is_canceled(
         manager.add_imagetool(root, show=False)
         tree = manager._workspace_controller.saving._to_datatree()
         tree.attrs["imagetool_workspace_schema_version"] = 2
-        tree.attrs.pop(workspace_format._WORKSPACE_MANIFEST_ATTR, None)
+        tree.attrs.pop(_persistence_constants.WORKSPACE_MANIFEST_ATTR, None)
         tree.to_netcdf(fname, engine="h5netcdf", invalid_netcdf=True)
         tree.close()
         manager.remove_all_tools()
@@ -5124,7 +5140,7 @@ def test_manager_workspace_save_collects_old_generations_in_background(
         assert store is not None
         assert len(store.generations()) == 2
         with store.read_session() as h5_file:
-            object_group = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            object_group = h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]
             assert first_object_id not in object_group
             assert len(object_group) == 2
 
@@ -5720,10 +5736,102 @@ def test_manager_workspace_full_save_drops_empty_attr_name(
         assert "" in root.slicer_area._data.attrs
         with h5py.File(fname, "r") as h5_file:
             saved_attrs = h5_file[_current_workspace_payload_path(fname)][
-                _ITOOL_DATA_NAME
+                _persistence_constants.ITOOL_DATA_NAME
             ].attrs
             assert "" not in list(saved_attrs)
             assert saved_attrs["note"] == ""
+
+
+def test_manager_workspace_stale_figure_preserves_nested_attrs(
+    qtbot, tmp_path, manager_context
+) -> None:
+    from erlab.interactive._figurecomposer import (
+        FigureComposerTool,
+        FigureRecipeState,
+        FigureSourceState,
+    )
+    from erlab.interactive.imagetool import ImageTool
+
+    original = xr.DataArray(
+        np.arange(20.0).reshape(4, 5),
+        dims=("x", "y"),
+        coords={"x": np.arange(4.0), "y": np.arange(5.0)},
+        attrs={"nested": {"values": [1, 2, 3]}},
+        name="source",
+    )
+    changed = original.copy(deep=True)
+    changed.data = changed.values + 500
+    path = tmp_path / "original.itws"
+    copy_path = tmp_path / "copy.itws"
+
+    with manager_context() as manager:
+        controller = manager._workspace_controller
+        root = ImageTool(original.copy(deep=True), _in_manager=True)
+        manager.add_imagetool(root, show=False, uid="source")
+        source = root.slicer_area._data
+        script_input = manager._lineage_controller._script_input_for_node(
+            manager._node_for_target("source")
+        )
+        assert script_input.node_snapshot_token is not None
+        state = FigureSourceState.from_script_input(script_input).model_copy(
+            update={"name": "primary"}
+        )
+        figure = FigureComposerTool(
+            source,
+            recipe=FigureRecipeState(sources=(state,), primary_source="primary"),
+            source_data={"primary": source},
+        )
+        (duplicate,) = figure._document.duplicate_sources(("primary",))
+        manager.add_figuretool(figure, show=False, uid="figure")
+
+        def check(expected_root: xr.DataArray) -> None:
+            root_node = manager._node_for_target("source")
+            figure_node = manager._node_for_target("figure")
+            root_node.show()
+            figure_node.show()
+            xr.testing.assert_identical(
+                root_node.imagetool.slicer_area._data.compute(), expected_root
+            )
+            restored = figure_node.tool_window
+            assert isinstance(restored, FigureComposerTool)
+            assert set(restored.source_data()) == {"primary", duplicate}
+            for payload in restored.source_data().values():
+                xr.testing.assert_identical(payload.compute(), original)
+
+        def reopen(filename) -> None:
+            assert controller.loading._load_workspace_file(
+                filename,
+                replace=True,
+                associate=True,
+                mark_dirty=False,
+                select=False,
+            )
+            assert not controller.loading._skipped_workspace_nodes
+
+        controller.saving._save_workspace_document(path)
+        reopen(path)
+        check(original)
+        manager._node_for_target("source").imagetool.slicer_area.replace_source_data(
+            changed, auto_compute=False
+        )
+        qtbot.wait_until(
+            lambda: (
+                manager._node_for_target("source").snapshot_token_for_role(
+                    script_input.data_role
+                )
+                != script_input.node_snapshot_token
+            )
+        )
+        check(changed)
+
+        controller.saving._save_workspace_document(path)
+        reopen(path)
+        check(changed)
+        assert controller.compact_workspace()
+        check(changed)
+        controller.saving._save_workspace_document(copy_path)
+        reopen(copy_path)
+        check(changed)
 
 
 def test_manager_workspace_full_save_roundtrips_non_native_data_attrs(
@@ -5763,15 +5871,17 @@ def test_manager_workspace_full_save_roundtrips_non_native_data_attrs(
         assert root.slicer_area._data.attrs["Single Motor Scan"] is live_rich_attr
         assert root.slicer_area._data.coords["x"].attrs["axis_config"] is live_axis_attr
         assert (
-            workspace_format._WORKSPACE_ENCODED_ATTRS_ATTR
+            _persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR
             not in root.slicer_area._data.attrs
         )
         with h5py.File(fname, "r") as h5_file:
             saved_data = h5_file[_current_workspace_payload_path(fname)][
-                _ITOOL_DATA_NAME
+                _persistence_constants.ITOOL_DATA_NAME
             ]
             assert "Single Motor Scan" not in saved_data.attrs
-            assert workspace_format._WORKSPACE_ENCODED_ATTRS_ATTR in saved_data.attrs
+            assert (
+                _persistence_constants.WORKSPACE_ENCODED_ATTRS_ATTR in saved_data.attrs
+            )
 
         manager.remove_all_tools()
         qtbot.wait_until(lambda: manager.ntools == 0, timeout=5000)
@@ -5795,7 +5905,7 @@ def test_manager_workspace_full_save_roundtrips_non_native_data_attrs(
         )
         try:
             restored = workspace_format._restore_workspace_dataset_attrs(opened)
-            loaded = restored[_ITOOL_DATA_NAME]
+            loaded = restored[_persistence_constants.ITOOL_DATA_NAME]
         finally:
             opened.close()
         _assert_rich_workspace_attr(loaded.attrs["Single Motor Scan"])
@@ -5922,7 +6032,24 @@ def test_manager_workspace_delta_save_splits_state_and_data_writes(
         assert isinstance(root, erlab.interactive.imagetool.ImageTool)
         manager.add_imagetool(root, show=False)
         fname = tmp_path / "delta.itws"
+        encoded_attrs = []
+        original_encode = workspace_format._workspace_manifest_attrs
+
+        def _record_encode(attrs):
+            encoded = original_encode(attrs)
+            encoded_attrs.append(encoded)
+            return encoded
+
+        monkeypatch.setattr(
+            workspace_format, "_workspace_manifest_attrs", _record_encode
+        )
         manager._workspace_controller.saving._save_workspace_document(fname)
+        assert len(encoded_attrs) == 1
+        assert (
+            _current_workspace_manifest(fname)["nodes"][0]["payload_attrs"]
+            == (encoded_attrs[0])
+        )
+        encoded_attrs.clear()
         adopt_workspace_path(manager, fname)
 
         dataset_writes: list[str | None] = []
@@ -5937,17 +6064,38 @@ def test_manager_workspace_delta_save_splits_state_and_data_writes(
         manager.rename_imagetool(0, "state only")
         assert _request_workspace_save_and_wait(qtbot, manager)
         assert dataset_writes == []
+        assert len(encoded_attrs) == 1
+        assert (
+            _current_workspace_manifest(fname)["nodes"][0]["payload_attrs"]
+            == (encoded_attrs[0])
+        )
+        encoded_attrs.clear()
 
         replacement = data.copy(deep=True)
         replacement.data = np.asarray(replacement.data) + 10
         root.slicer_area.replace_source_data(replacement)
         assert _request_workspace_save_and_wait(qtbot, manager)
+        assert len(encoded_attrs) == 1
+        assert (
+            _current_workspace_manifest(fname)["nodes"][0]["payload_attrs"]
+            == (encoded_attrs[0])
+        )
+        encoded_attrs.clear()
 
         import h5py
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
-            assert saved[0, 0] == 10
+            saved = h5_file[_current_workspace_payload_path(fname)][
+                _persistence_constants.ITOOL_DATA_NAME
+            ]
+            np.testing.assert_array_equal(saved[...], replacement.values)
+
+        snapshot = manager._workspace_controller.saving._workspace_save_snapshot(fname)
+        try:
+            assert encoded_attrs == []
+            assert all(obj.dataset is None for obj in snapshot.generation_plan.objects)
+        finally:
+            snapshot.close()
 
 
 def test_manager_workspace_full_save_keeps_full_persistence_for_serialized_nodes(
@@ -6090,7 +6238,9 @@ def test_manager_workspace_lazy_data_delta_save_uses_pending_group_before_replac
         import h5py
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][
+                _persistence_constants.ITOOL_DATA_NAME
+            ]
             assert saved[0, 0] == 10
 
 
@@ -6131,7 +6281,9 @@ def test_manager_workspace_same_file_lazy_data_delta_save_does_not_deadlock(
         import h5py
 
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][
+                _persistence_constants.ITOOL_DATA_NAME
+            ]
             assert saved[0, 0] == 0
             assert saved.chunks == (128, 64)
 
@@ -6183,9 +6335,11 @@ def test_manager_workspace_lazy_data_delta_pending_failure_preserves_old_group(
         assert not _request_workspace_save_and_wait(qtbot, manager)
         assert _current_workspace_manifest(fname) == manifest_before
         with h5py.File(fname, "r") as h5_file:
-            saved = h5_file[_current_workspace_payload_path(fname)][_ITOOL_DATA_NAME]
+            saved = h5_file[_current_workspace_payload_path(fname)][
+                _persistence_constants.ITOOL_DATA_NAME
+            ]
             assert saved[0, 0] == 0
-            assert set(h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == set(
+            assert set(h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == set(
                 workspace_store.WorkspaceStore.manifest_object_ids(manifest_before)
             )
 
@@ -6209,12 +6363,8 @@ def test_manager_workspace_stale_pending_groups_do_not_poison_open_or_save(
         fname = tmp_path / "stale-pending.itws"
         manager._workspace_controller.saving._save_workspace_document(fname)
         with h5py.File(fname, "a") as h5_file:
-            h5_file.create_group(
-                f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}stale"
-            )
-            h5_file.create_group(
-                f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}stale"
-            )
+            h5_file.create_group("__itws_pending_stale")
+            h5_file.create_group("__itws_backup_stale")
 
         assert manager._workspace_controller.loading._load_workspace_file(
             fname, replace=True, associate=True, mark_dirty=False, select=False

--- a/tests/interactive/imagetool/manager/workspace/test_storage.py
+++ b/tests/interactive/imagetool/manager/workspace/test_storage.py
@@ -17,6 +17,7 @@ import erlab.interactive.imagetool.manager._workspace._arrays as workspace_array
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._storage as workspace_storage
 import erlab.interactive.imagetool.manager._workspace._store as workspace_store
+from erlab.interactive import _persistence_constants
 from tests.interactive.imagetool.manager.workspace._support import (
     _assert_no_workspace_internal_groups,
     _transaction_test_dataset,
@@ -46,9 +47,9 @@ def _create_legacy_transaction(
     status: str,
     group_replacements: list[dict[str, object]] | None = None,
 ) -> tuple[h5py.Group, str, str]:
-    txn_path = f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
-    pending_root = f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}{txn_id}"
-    backup_root = f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}{txn_id}"
+    txn_path = f"{_persistence_constants.WORKSPACE_TRANSACTION_GROUP_PREFIX}{txn_id}"
+    pending_root = f"__itws_pending_{txn_id}"
+    backup_root = f"__itws_backup_{txn_id}"
     txn_group = h5_file.create_group(txn_path)
     txn_group.attrs.update(
         {
@@ -398,10 +399,8 @@ def test_workspace_recovery_cleans_orphan_internal_groups(tmp_path) -> None:
     fname = tmp_path / "orphan-internal.itws"
     _write_transaction_test_workspace(fname)
     with h5py.File(fname, "a") as h5_file:
-        h5_file.create_group(
-            f"{workspace_format._WORKSPACE_PENDING_GROUP_PREFIX}orphan"
-        )
-        h5_file.create_group(f"{workspace_format._WORKSPACE_BACKUP_GROUP_PREFIX}orphan")
+        h5_file.create_group("__itws_pending_orphan")
+        h5_file.create_group("__itws_backup_orphan")
 
     workspace_storage._recover_workspace_transactions(fname)
 
@@ -661,7 +660,7 @@ def test_workspace_h5_transaction_helper_edge_cases(tmp_path) -> None:
         assert workspace_storage._workspace_txn_attr_target(h5_file, "/missing") is None
 
         txn = h5_file.create_group(
-            f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}x"
+            f"{_persistence_constants.WORKSPACE_TRANSACTION_GROUP_PREFIX}x"
         )
         txn_name = txn.name.strip("/")
         workspace_storage._restore_workspace_attr_backups(h5_file, txn)
@@ -718,12 +717,16 @@ def test_workspace_h5_transaction_helper_edge_cases(tmp_path) -> None:
 def test_recover_workspace_transactions_ignores_non_workspace_file(tmp_path) -> None:
     fname = tmp_path / "plain.itws"
     with h5py.File(fname, "w") as h5_file:
-        h5_file.create_group(f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}x")
+        h5_file.create_group(
+            f"{_persistence_constants.WORKSPACE_TRANSACTION_GROUP_PREFIX}x"
+        )
 
     workspace_storage._recover_workspace_transactions(fname)
 
     with h5py.File(fname, "r") as h5_file:
-        assert f"{workspace_format._WORKSPACE_TRANSACTION_GROUP_PREFIX}x" in h5_file
+        assert (
+            f"{_persistence_constants.WORKSPACE_TRANSACTION_GROUP_PREFIX}x" in h5_file
+        )
 
 
 def test_workspace_storage_links_and_compares_immutable_payload_groups(
@@ -785,7 +788,7 @@ def test_workspace_blob_and_dataset_comparison_edge_cases(tmp_path) -> None:
             compression_mode="none",
         )
     with h5py.File(path, "r+") as h5_file:
-        h5_file[f"{workspace_store._WORKSPACE_OBJECTS_GROUP}/blob"].attrs[
+        h5_file[f"{_persistence_constants.WORKSPACE_OBJECTS_GROUP}/blob"].attrs[
             "erlab_object_kind"
         ] = np.bytes_(b"kind")
 

--- a/tests/interactive/imagetool/manager/workspace/test_store.py
+++ b/tests/interactive/imagetool/manager/workspace/test_store.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from erlab.interactive import _persistence_constants
 from erlab.interactive.imagetool.manager._workspace import _arrays as workspace_arrays
 from erlab.interactive.imagetool.manager._workspace import _storage as workspace_storage
 from erlab.interactive.imagetool.manager._workspace import _store as workspace_store
@@ -114,7 +115,7 @@ def test_workspace_store_manifest_validation_contract() -> None:
         ) -> None:
             super().__init__()
             if dataset is not None:
-                self[workspace_store._WORKSPACE_MANIFEST_DATASET] = dataset
+                self["manifest"] = dataset
             self.file = set() if objects is None else objects
 
     def _group(manifest: object, *, objects: set[str] | None = None) -> _Group:
@@ -229,7 +230,9 @@ def test_workspace_store_rebinds_only_existing_legacy_payloads(tmp_path) -> None
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("payload")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "payload"
+            )
         matching = _Reader("/legacy/tool")
         unrelated = _Reader("/other/tool")
         store.register_reader(matching)
@@ -271,7 +274,7 @@ def test_workspace_compaction_allows_missing_optional_extension_source(
 def test_workspace_store_identity_helpers_decode_bytes() -> None:
     class _File:
         def __init__(self, value: object) -> None:
-            self.attrs = {workspace_store._WORKSPACE_ID_ATTR: value}
+            self.attrs = {_persistence_constants.WORKSPACE_ID_ATTR: value}
             self.flush_count = 0
 
         def flush(self) -> None:
@@ -288,7 +291,7 @@ def test_workspace_store_identity_helpers_decode_bytes() -> None:
     missing = _File(None)
     generated = workspace_store.WorkspaceStore._ensure_workspace_id(missing)
     assert generated
-    assert missing.attrs[workspace_store._WORKSPACE_ID_ATTR] == generated
+    assert missing.attrs[_persistence_constants.WORKSPACE_ID_ATTR] == generated
     assert missing.flush_count == 1
     assert workspace_store.WorkspaceStore._workspace_id_from_file(_File("")) is None
     assert (
@@ -302,7 +305,7 @@ def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None
     with workspace_store.WorkspaceStore(path, create=True):
         pass
     with h5py.File(path, "a") as h5_file:
-        del h5_file.attrs[workspace_store._WORKSPACE_ID_ATTR]
+        del h5_file.attrs[_persistence_constants.WORKSPACE_ID_ATTR]
         h5_file.attrs["imagetool_workspace_schema_version"] = 4
 
     unchanged = path.read_bytes()
@@ -319,7 +322,7 @@ def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None
         assert store.serialized_legacy_group_paths == {"/legacy"}
     assert path.read_bytes() == unchanged
     with h5py.File(path, "r") as h5_file:
-        assert workspace_store._WORKSPACE_ID_ATTR not in h5_file.attrs
+        assert _persistence_constants.WORKSPACE_ID_ATTR not in h5_file.attrs
 
     with workspace_store.WorkspaceStore(path) as store:
         store.publish(_manifest())
@@ -343,7 +346,7 @@ def test_workspace_store_defers_missing_identity_until_publish(tmp_path) -> None
 
     assert workspace_id
     with h5py.File(path, "r") as h5_file:
-        assert h5_file.attrs[workspace_store._WORKSPACE_ID_ATTR] == workspace_id
+        assert h5_file.attrs[_persistence_constants.WORKSPACE_ID_ATTR] == workspace_id
 
 
 def test_hdf5_error_filters_cover_platform_independent_messages() -> None:
@@ -636,9 +639,11 @@ def test_workspace_store_rejects_invalid_gc_limit_and_clears_staging(
 
         store.clear_staging()
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_STAGING_GROUP].create_group("orphan")
+            h5_file[_persistence_constants.WORKSPACE_STAGING_GROUP].create_group(
+                "orphan"
+            )
         store.clear_staging()
-        assert len(store.h5_file[workspace_store._WORKSPACE_STAGING_GROUP]) == 0
+        assert len(store.h5_file[_persistence_constants.WORKSPACE_STAGING_GROUP]) == 0
 
 
 def test_workspace_store_publishes_valid_generations(
@@ -647,7 +652,7 @@ def test_workspace_store_publishes_valid_generations(
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            objects = h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]
             objects.create_group("first")
             objects.create_group("second")
         first = store.publish(_manifest("first"))
@@ -669,22 +674,20 @@ def test_workspace_store_publishes_valid_generations(
         assert second.sequence == 2
         assert store.current_generation() == second
         assert read_names == [
-            f"/{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}"
+            f"/{_persistence_constants.WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}"
         ]
 
         with store.write_session() as h5_file:
             generation_group = h5_file[
-                f"{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}"
+                f"{_persistence_constants.WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}"
             ]
-            generation_group[workspace_store._WORKSPACE_MANIFEST_DATASET].attrs[
-                "sha256"
-            ] = "invalid"
+            generation_group["manifest"].attrs["sha256"] = "invalid"
 
         read_names.clear()
         assert store.current_generation() == first
         assert read_names == [
-            f"/{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}",
-            f"/{workspace_store._WORKSPACE_GENERATIONS_GROUP}/{first.sequence:020d}",
+            f"/{_persistence_constants.WORKSPACE_GENERATIONS_GROUP}/{second.sequence:020d}",
+            f"/{_persistence_constants.WORKSPACE_GENERATIONS_GROUP}/{first.sequence:020d}",
         ]
 
 
@@ -697,7 +700,7 @@ def test_workspace_store_rejects_generation_with_missing_object(
             store.publish(_manifest("missing"))
 
         assert store.generations() == ()
-        assert len(store.h5_file[workspace_store._WORKSPACE_STAGING_GROUP]) == 0
+        assert len(store.h5_file[_persistence_constants.WORKSPACE_STAGING_GROUP]) == 0
 
 
 def test_workspace_store_limits_writable_handle_to_write_session(
@@ -876,7 +879,7 @@ def test_workspace_store_gc_retains_two_generations_and_leases(
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            objects = h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]
             for object_id in ("first", "second", "third"):
                 objects.create_group(object_id)
         store.publish(_manifest("first"))
@@ -885,7 +888,7 @@ def test_workspace_store_gc_retains_two_generations_and_leases(
         store.publish(_manifest("third"))
 
         assert not store.collect_garbage(max_objects=10)
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+        assert set(store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == {
             "first",
             "second",
             "third",
@@ -894,7 +897,7 @@ def test_workspace_store_gc_retains_two_generations_and_leases(
 
         store.release_object("first")
         assert not store.collect_garbage(max_objects=10)
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+        assert set(store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == {
             "second",
             "third",
         }
@@ -906,7 +909,7 @@ def test_workspace_store_gc_preserves_serialized_reader_objects(
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            objects = h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]
             for object_id in ("first", "second", "third"):
                 objects.create_group(object_id)
         first_generation = store.publish(_manifest("first"))
@@ -921,7 +924,7 @@ def test_workspace_store_gc_preserves_serialized_reader_objects(
 
         assert not store.collect_garbage(max_objects=1)
         assert len(store.generations()) == 2
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+        assert set(store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == {
             "first",
             "second",
             "third",
@@ -936,7 +939,9 @@ def test_workspace_store_gc_preserves_serialized_reader_objects(
         reopened.clear_serialized_reader_pins()
         assert not reopened.has_serialized_readers
         assert not reopened.collect_garbage(max_objects=10)
-        assert set(reopened.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+        assert set(
+            reopened.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]
+        ) == {
             "second",
             "third",
         }
@@ -956,7 +961,9 @@ def test_workspace_reader_export_waits_for_compaction_boundary(tmp_path) -> None
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("obsolete")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "obsolete"
+            )
 
         def _export_reader() -> None:
             export_started.set()
@@ -976,7 +983,9 @@ def test_workspace_reader_export_waits_for_compaction_boundary(tmp_path) -> None
             assert export_started.wait(timeout=2)
             assert not export_finished.wait(timeout=0.05)
             with store.write_session() as h5_file:
-                del h5_file[f"{workspace_store._WORKSPACE_OBJECTS_GROUP}/obsolete"]
+                del h5_file[
+                    f"{_persistence_constants.WORKSPACE_OBJECTS_GROUP}/obsolete"
+                ]
 
         export_thread.join(timeout=2)
         assert not export_thread.is_alive()
@@ -1017,16 +1026,20 @@ def test_workspace_store_gc_removes_malformed_generation_names(
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "current"
+            )
         store.publish(_manifest("current"))
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_GENERATIONS_GROUP].create_group("1")
+            h5_file[_persistence_constants.WORKSPACE_GENERATIONS_GROUP].create_group(
+                "1"
+            )
 
         assert not store.collect_garbage(max_objects=1)
 
-        assert set(store.h5_file[workspace_store._WORKSPACE_GENERATIONS_GROUP]) == {
-            "00000000000000000001"
-        }
+        assert set(
+            store.h5_file[_persistence_constants.WORKSPACE_GENERATIONS_GROUP]
+        ) == {"00000000000000000001"}
 
 
 def test_workspace_generation_write_blocks_concurrent_gc(
@@ -1096,7 +1109,9 @@ def test_workspace_generation_write_blocks_concurrent_gc(
         assert not gc_thread.is_alive()
         assert errors == []
         assert store.current_generation().manifest == _manifest("pending")
-        assert "pending" in store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+        assert (
+            "pending" in store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]
+        )
 
 
 def test_workspace_generation_removes_partial_object_after_write_error(
@@ -1139,7 +1154,9 @@ def test_workspace_generation_removes_partial_object_after_copy_error(
     target_path = tmp_path / "target.itws"
     with workspace_store.WorkspaceStore(source_path, create=True) as source_store:
         with source_store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("source")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "source"
+            )
         source_store.publish(_manifest("source"))
 
     def _copy_partial_then_fail(
@@ -1198,7 +1215,9 @@ def test_workspace_generation_removes_all_new_objects_after_plan_error(
                 store, plan, compression_mode="none"
             )
 
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == set()
+        assert (
+            set(store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == set()
+        )
         assert store.generations() == ()
 
 
@@ -1302,7 +1321,9 @@ def test_workspace_generation_keeps_objects_referenced_by_committed_generation(
             )
 
         assert store.current_generation().manifest == _manifest("committed")
-        assert "committed" in store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+        assert (
+            "committed" in store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]
+        )
 
 
 def test_workspace_store_shares_lazy_reader_and_generation_writer(
@@ -1730,7 +1751,7 @@ def test_workspace_compaction_keeps_current_state_and_reopens_store(
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            objects = h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]
             objects.create_group("obsolete").create_dataset(
                 "data", data=np.ones(2_000_000, dtype=np.float64)
             )
@@ -1747,7 +1768,7 @@ def test_workspace_compaction_keeps_current_state_and_reopens_store(
         assert workspace_store.WorkspaceStore.active(path) is store
         assert store.workspace_id == workspace_id
         assert store.h5_file.id.valid
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+        assert set(store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == {
             "current"
         }
         generations = store.generations()
@@ -1764,12 +1785,16 @@ def test_workspace_store_active_waits_for_file_replacement(
     prepared_path = tmp_path / "prepared.itws"
     with workspace_store.WorkspaceStore(prepared_path, create=True) as prepared_store:
         with prepared_store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("prepared")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "prepared"
+            )
         prepared_store.publish(_manifest("prepared"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "current"
+            )
         store.publish(_manifest("current"))
         replacement_started = threading.Event()
         allow_replacement = threading.Event()
@@ -1839,7 +1864,9 @@ def test_workspace_store_uses_prepared_recovery_if_original_cannot_reopen(
     prepared_path = tmp_path / "prepared.itws"
     with workspace_store.WorkspaceStore(prepared_path, create=True) as prepared_store:
         with prepared_store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("prepared")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "prepared"
+            )
         prepared_store.publish(_manifest("prepared"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
@@ -1873,7 +1900,9 @@ def test_workspace_store_retries_reopen_after_successful_replacement(
     prepared_path = tmp_path / "prepared.itws"
     with workspace_store.WorkspaceStore(prepared_path, create=True) as prepared_store:
         with prepared_store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("prepared")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "prepared"
+            )
         prepared_store.publish(_manifest("prepared"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
@@ -1914,7 +1943,9 @@ def test_workspace_compaction_retains_prepared_recovery_file(
     recovery_path: pathlib.Path | None = None
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "current"
+            )
         store.publish(_manifest("current"))
 
         def _deny_reopen(*, create: bool, workspace_id: str | None = None) -> None:
@@ -1951,12 +1982,16 @@ def test_workspace_compaction_does_not_overwrite_external_replacement(
     external_path = tmp_path / "external.itws"
     with workspace_store.WorkspaceStore(external_path, create=True) as external_store:
         with external_store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("external")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "external"
+            )
         external_store.publish(_manifest("external"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "current"
+            )
         store.publish(_manifest("current"))
         original_release = store._release_handle
         replacement_installed = False
@@ -1991,12 +2026,16 @@ def test_workspace_compaction_rejects_replacement_after_identity_check(
     external_path = tmp_path / "external.itws"
     with workspace_store.WorkspaceStore(external_path, create=True) as external_store:
         with external_store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("external")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "external"
+            )
         external_store.publish(_manifest("external"))
 
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "current"
+            )
         store.publish(_manifest("current"))
         original_require_identity = store._require_path_identity
 
@@ -2026,7 +2065,7 @@ def test_workspace_compaction_preserves_leased_and_serialized_payloads(
     path = tmp_path / "workspace.itws"
     with workspace_store.WorkspaceStore(path, create=True) as store:
         with store.write_session() as h5_file:
-            objects = h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]
+            objects = h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]
             objects.create_group("leased")
             objects.create_group("serialized")
             objects.create_group("current")
@@ -2042,7 +2081,7 @@ def test_workspace_compaction_preserves_leased_and_serialized_payloads(
 
         workspace_storage._compact_workspace_store(store)
 
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+        assert set(store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == {
             "current",
             "leased",
             "serialized",
@@ -2060,7 +2099,7 @@ def test_workspace_compaction_preserves_leased_and_serialized_payloads(
             discard_serialized_reader_pins=confirmed_pins,
         )
 
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+        assert set(store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == {
             "current",
             "leased",
             "serialized",
@@ -2072,7 +2111,7 @@ def test_workspace_compaction_preserves_leased_and_serialized_payloads(
             discard_serialized_reader_pins=discarded_pins,
         )
 
-        assert set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP]) == {
+        assert set(store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP]) == {
             "current",
             "leased",
         }
@@ -2081,7 +2120,7 @@ def test_workspace_compaction_preserves_leased_and_serialized_payloads(
         assert not store.has_serialized_readers
         store.release_object("leased")
         assert not store.collect_garbage(max_objects=1)
-        remaining = set(store.h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP])
+        remaining = set(store.h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP])
         assert remaining == {"current"}
 
 
@@ -2095,7 +2134,9 @@ def test_workspace_compaction_preserves_serialized_legacy_group(
             workspace_arrays._write_workspace_dataset_group_to_file(
                 h5_file, "legacy/imagetool", dataset, compression_mode="none"
             )
-            h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group("current")
+            h5_file[_persistence_constants.WORKSPACE_OBJECTS_GROUP].create_group(
+                "current"
+            )
         store.publish(_manifest("current"))
         manager = workspace_arrays.WorkspaceFileManager(
             path,
@@ -2229,9 +2270,9 @@ def test_workspace_store_conflict_keeps_lazy_data_for_save_as(
         try:
             with workspace_store.WorkspaceStore(replacement, create=True) as other:
                 with other.write_session() as h5_file:
-                    h5_file[workspace_store._WORKSPACE_OBJECTS_GROUP].create_group(
-                        "external"
-                    )
+                    h5_file[
+                        _persistence_constants.WORKSPACE_OBJECTS_GROUP
+                    ].create_group("external")
                 other.publish(_manifest("external"))
             replacement.replace(path)
 

--- a/tests/interactive/imagetool/manager/workspace/test_trust.py
+++ b/tests/interactive/imagetool/manager/workspace/test_trust.py
@@ -14,10 +14,11 @@ import pytest
 import xarray as xr
 from qtpy import QtWidgets
 
+import erlab.interactive.imagetool._serialization as imagetool_serialization
 import erlab.interactive.imagetool.manager._workspace._format as workspace_format
 import erlab.interactive.imagetool.manager._workspace._trust as workspace_trust
 import erlab.interactive.utils as interactive_utils
-from erlab.interactive import _saved_tools
+from erlab.interactive import _persistence_constants, _saved_tools
 from erlab.interactive._code_trust import (
     create_entry,
     create_manifest,
@@ -37,10 +38,7 @@ from erlab.interactive._code_trust._application import (
     save_document_trust,
 )
 from erlab.interactive._code_trust._core import CodeTrustReason
-from erlab.interactive._code_trust._payloads import (
-    CODE_PAYLOAD_ENTRIES_ATTR,
-    store_code_payload_entries,
-)
+from erlab.interactive._code_trust._payloads import store_code_payload_entries
 from erlab.interactive._figurecomposer import FigureComposerTool, FigureSourceState
 from erlab.interactive._figurecomposer import _rendering as figure_rendering
 from erlab.interactive._figurecomposer._model._state import (
@@ -548,14 +546,16 @@ def test_trusting_legacy_pending_fit_payload_completes_manifest_before_save(
         fit_tool.hide()
         tree = manager._workspace_controller.saving._to_datatree()
         child = typing.cast("xr.DataTree", tree[f"0/childtools/{fit_uid}/tool"])
-        child.attrs.pop(CODE_PAYLOAD_ENTRIES_ATTR)
-        child.attrs[interactive_utils._TOOL_INPUT_PROVENANCE_SPEC_ATTR] = json.dumps(
-            full_data().model_dump(mode="json")
+        child.attrs.pop(_persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR)
+        child.attrs[_persistence_constants.TOOL_INPUT_PROVENANCE_SPEC_ATTR] = (
+            json.dumps(full_data().model_dump(mode="json"))
         )
         manifest = manager._workspace_controller.saving._workspace_manifest()
         manifest["schema_version"] = 4
         tree.attrs["imagetool_workspace_schema_version"] = 4
-        tree.attrs[workspace_format._WORKSPACE_MANIFEST_ATTR] = json.dumps(manifest)
+        tree.attrs[_persistence_constants.WORKSPACE_MANIFEST_ATTR] = json.dumps(
+            manifest
+        )
         tree.to_netcdf(workspace_path, engine="h5netcdf", invalid_netcdf=True)
         tree.close()
 
@@ -605,6 +605,115 @@ def test_trusting_legacy_pending_fit_payload_completes_manifest_before_save(
         node = manager._child_node(fit_uid)
         assert node.pending_workspace_tool_payload is not None
         assert node.tool_window is None
+
+
+@pytest.mark.parametrize("reloads", [0, 1, 2])
+@pytest.mark.parametrize("hook", ["none", "live", "dataset", "saved", "invalid_saved"])
+def test_pending_payload_inspection_preserves_hooks_across_utils_reload(
+    monkeypatch, reloads: int, hook: str
+) -> None:
+    entry = create_payload_entry(
+        "test.reload-payload", "payload", "payload_code()", b"saved payload"
+    )
+    inspected = []
+    opened = []
+    closed = []
+
+    def make_tool_class(base: type) -> type:
+        class ReloadProbe(base):
+            def __init__(self, *args, **kwargs):
+                pytest.fail("pending payload inspection must not construct the tool")
+
+        def live_payload(self):
+            pytest.fail("pending payload inspection must not use a live tool hook")
+
+        def dataset_payload(self, ds):
+            pytest.fail("pending payload inspection must use the saved inspector")
+
+        def saved_payload(cls, ds):
+            inspected.append((cls, ds))
+            return None if hook == "invalid_saved" else (entry,)
+
+        if hook == "live":
+            ReloadProbe._code_trust_payload_entries = live_payload
+        elif hook == "dataset":
+            ReloadProbe._code_trust_payload_entries_from_dataset = dataset_payload
+        elif hook in {"saved", "invalid_saved"}:
+            ReloadProbe._code_trust_payload_entries = live_payload
+            ReloadProbe._code_trust_payload_entries_from_saved_dataset = classmethod(
+                saved_payload
+            )
+        return ReloadProbe
+
+    before_reload = make_tool_class(interactive_utils.ToolWindow)
+    for _ in range(reloads):
+        importlib.reload(interactive_utils)
+    after_reload = make_tool_class(interactive_utils.ToolWindow)
+
+    class InheritedBeforeReload(before_reload):
+        pass
+
+    class InheritedAfterReload(after_reload):
+        pass
+
+    def open_payload(path, group, *, chunks):
+        assert (path, group, chunks) == ("legacy.itws", "tools/0", {})
+        dataset = xr.Dataset()
+        dataset.set_close(lambda: closed.append(dataset))
+        opened.append(dataset)
+        return dataset
+
+    monkeypatch.setattr(
+        workspace_trust.workspace_arrays, "open_workspace_dataset", open_payload
+    )
+    for tool_cls in (
+        before_reload,
+        after_reload,
+        InheritedBeforeReload,
+        InheritedAfterReload,
+    ):
+        inspected.clear()
+        opened.clear()
+        closed.clear()
+        updated_attrs = []
+        attrs = {"tool_cls_qualname": "test:ReloadProbe"}
+        node = SimpleNamespace(
+            pending_workspace_tool_payload=("legacy.itws", "tools/0"),
+            pending_workspace_payload_attrs=attrs,
+            update_pending_workspace_payload_attrs=updated_attrs.append,
+        )
+        manager = SimpleNamespace(_tool_graph=SimpleNamespace(nodes={"0": node}))
+        monkeypatch.setattr(
+            workspace_trust,
+            "resolve_saved_tool_class",
+            lambda _identifier, cls=tool_cls: cls,
+        )
+
+        if hook in {"live", "dataset", "invalid_saved"}:
+            error = (
+                "did not return entries"
+                if hook == "invalid_saved"
+                else "opaque payload cannot be inspected"
+            )
+            with pytest.raises(TypeError, match=error):
+                workspace_trust.inspect_pending_workspace_code_payloads(manager)
+        else:
+            workspace_trust.inspect_pending_workspace_code_payloads(manager)
+
+        if hook in {"saved", "invalid_saved"}:
+            assert len(opened) == len(closed) == len(inspected) == 1
+            assert closed[0] is opened[0]
+            assert inspected[0][0] is tool_cls
+            assert inspected[0][1] is opened[0]
+        else:
+            assert opened == closed == inspected == []
+        if hook == "saved":
+            expected_attrs = dict(attrs)
+            store_code_payload_entries(expected_attrs, (entry,))
+            assert updated_attrs == [expected_attrs]
+        else:
+            assert updated_attrs == []
+        assert _persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR not in attrs
 
 
 def test_legacy_pending_opaque_payload_without_saved_inspector_fails_closed(
@@ -950,7 +1059,7 @@ def test_signed_workspace_materializes_child_parent_source_code(
                 workspace_path, f"0/childtools/{child_uid}"
             )["tool_data_references"]
         )
-        reference = references[interactive_utils._SAVED_TOOL_DATA_NAME]
+        reference = references[_persistence_constants.SAVED_TOOL_DATA_NAME]
         assert reference["kind"] == "manager_node"
         assert reference["input_name"] == "data"
         assert reference["node_uid"] == parent_uid
@@ -1672,7 +1781,7 @@ def test_workspace_code_trust_manifest_does_not_decode_unrelated_arrays(
     def fail_if_decoded(*_args, **_kwargs):
         raise AssertionError("unrelated array metadata was decoded")
 
-    monkeypatch.setattr(workspace_format, "_workspace_decode_array", fail_if_decoded)
+    monkeypatch.setattr(imagetool_serialization, "_decode_array", fail_if_decoded)
 
     assert workspace_code_trust_manifest(manifest).has_executable_code
 
@@ -1693,7 +1802,7 @@ def test_workspace_code_trust_manifest_rejects_array_in_code_attribute_without_d
     def fail_if_decoded(*_args, **_kwargs):
         raise AssertionError("array metadata was decoded")
 
-    monkeypatch.setattr(workspace_format, "_workspace_decode_array", fail_if_decoded)
+    monkeypatch.setattr(imagetool_serialization, "_decode_array", fail_if_decoded)
 
     with pytest.raises(TypeError, match="must be a string"):
         workspace_code_trust_manifest(manifest)

--- a/tests/interactive/imagetool/test_imagetool.py
+++ b/tests/interactive/imagetool/test_imagetool.py
@@ -30,6 +30,7 @@ import erlab.interactive.imagetool.manager._server as imagetool_manager_server
 import erlab.interactive.imagetool.viewer as imagetool_viewer
 import erlab.interactive.imagetool.viewer_linking as imagetool_viewer_linking
 import erlab.interactive.imagetool.viewer_state as imagetool_viewer_state
+from erlab.interactive import _persistence_constants
 from erlab.interactive._code_trust import (
     issue_complete_execution_capability,
     new_document_trust,
@@ -4849,8 +4850,8 @@ def test_itool_save_preserves_filter_state_and_exports_displayed_data(
     state = json.loads(ds.attrs["itool_state"])
     assert state["filter_operation"] == operation.model_dump(mode="json")
     xarray.testing.assert_identical(
-        ds[imagetool_mainwindow._ITOOL_DATA_NAME],
-        data.rename(imagetool_mainwindow._ITOOL_DATA_NAME),
+        ds[_persistence_constants.ITOOL_DATA_NAME],
+        data.rename(_persistence_constants.ITOOL_DATA_NAME),
     )
     restored = ImageTool.from_dataset(ds)
     qtbot.addWidget(restored)
@@ -8265,6 +8266,105 @@ def test_owned_values_copy_handles_dask_and_array_fallback() -> None:
     fake = types.SimpleNamespace(data=(1, 2, 3))
     fallback = ImageSlicerArea._owned_values_copy(fake)
     np.testing.assert_array_equal(fallback, np.array([1, 2, 3]))
+
+
+@pytest.mark.parametrize("defer_state_refresh", [False, True])
+def test_dask_state_refresh_waits_for_delayed_initial_update(
+    qtbot, defer_state_refresh: bool
+) -> None:
+    from dask.callbacks import Callback
+
+    values = np.arange(4 * 5 * 6, dtype=np.float32).reshape(4, 5, 6)
+    data = xr.DataArray(values, dims=("x", "y", "z"))
+    reference = ImageTool(data)
+    qtbot.addWidget(reference)
+    expected_area = reference.slicer_area
+    expected_area.add_cursor()
+    expected_area.array_slicer.set_indices(0, [1, 2, 3])
+    expected_area.array_slicer.set_bins(0, [1, 3, 1])
+    expected_area.array_slicer.set_indices(1, [2, 3, 4])
+    state = expected_area.state
+
+    win = ImageTool(
+        data.chunk({"x": 2, "y": 5, "z": 3}),
+        auto_compute=False,
+        _in_manager=True,
+        _defer_state_refresh=defer_state_refresh,
+    )
+    qtbot.addWidget(win)
+    area = win.slicer_area
+    computations: list[None] = []
+    bin_updates = []
+    point_values: list[float] = []
+    area.sigBinChanged.connect(lambda *args: bin_updates.append(args))
+    area.sigPointValueChanged.connect(point_values.append)
+
+    with Callback(start=lambda _graph: computations.append(None)):
+        area.state = state
+
+    assert bin_updates == [(area.current_cursor, (0, 1, 2))]
+    if defer_state_refresh:
+        assert computations == []
+        assert point_values == []
+    else:
+        assert computations
+        assert point_values
+
+    def assert_display_matches_reference() -> None:
+        for actual_axis, expected_axis in zip(
+            area._materialized_axes(), expected_area._materialized_axes(), strict=True
+        ):
+            for actual, expected in zip(
+                actual_axis.slicer_data_items,
+                expected_axis.slicer_data_items,
+                strict=True,
+            ):
+                assert actual.isVisible() == expected.isVisible()
+                if not actual.isVisible():
+                    continue
+                if actual_axis.is_image:
+                    np.testing.assert_array_equal(actual.image, expected.image)
+                else:
+                    for actual_values, expected_values in zip(
+                        actual.getData(), expected.getData(), strict=True
+                    ):
+                        np.testing.assert_array_equal(actual_values, expected_values)
+        assert point_values[-1] == pytest.approx(
+            expected_area.array_slicer.point_value(
+                expected_area.current_cursor, binned=True
+            )
+        )
+
+    for tool in (reference, win):
+        with qtbot.waitExposed(tool):
+            tool.show()
+
+    computations.clear()
+    with Callback(start=lambda _graph: computations.append(None)):
+        area._update_if_delayed()
+        area._update_if_delayed()
+    assert computations == [None]
+    assert_display_matches_reference()
+
+    # Once initialized, cursor and bin changes must refresh immediately.
+    for update in (
+        lambda target: target.set_index(2, 2),
+        lambda target: target.array_slicer.set_bins(target.current_cursor, [3, 1, 1]),
+        lambda target: target.set_current_cursor(0),
+    ):
+        update(expected_area)
+        computations.clear()
+        with Callback(start=lambda _graph: computations.append(None)):
+            update(area)
+        assert computations == [None]
+        assert_display_matches_reference()
+
+    computations.clear()
+    with Callback(start=lambda _graph: computations.append(None)):
+        area.state = state
+    assert computations
+    reference.close()
+    win.close()
 
 
 def test_dask_refresh_defers_only_while_workspace_write_is_active(

--- a/tests/interactive/test_code_trust.py
+++ b/tests/interactive/test_code_trust.py
@@ -14,6 +14,7 @@ from qtpy import QtCore, QtWidgets
 import erlab.interactive._code_trust as code_trust
 import erlab.interactive._code_trust._application as _application
 import erlab.interactive._code_trust._notary as _notary
+from erlab.interactive import _persistence_constants
 from erlab.interactive._code_trust import (
     approve_document_trust,
     document_trust_has_trusted_lineage,
@@ -35,7 +36,6 @@ from erlab.interactive._code_trust._locations import (
 )
 from erlab.interactive._code_trust._notary import CodeTrustError, CodeTrustNotary
 from erlab.interactive._code_trust._payloads import (
-    CODE_PAYLOAD_ENTRIES_ATTR,
     code_payload_entries_from_metadata,
     store_code_payload_entries,
 )
@@ -1150,7 +1150,9 @@ def test_code_payload_metadata_validates_saved_values() -> None:
     )
     attrs: dict[str, object] = {}
     store_code_payload_entries(attrs, (entry,))
-    attrs[CODE_PAYLOAD_ENTRIES_ATTR] = str(attrs[CODE_PAYLOAD_ENTRIES_ATTR]).encode()
+    attrs[_persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR] = str(
+        attrs[_persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR]
+    ).encode()
 
     assert code_payload_entries_from_metadata(attrs) == (entry,)
 
@@ -1175,7 +1177,9 @@ def test_code_payload_metadata_validates_saved_values() -> None:
     )
     for raw, message in invalid_metadata:
         with pytest.raises(TypeError, match=message):
-            code_payload_entries_from_metadata({CODE_PAYLOAD_ENTRIES_ATTR: raw})
+            code_payload_entries_from_metadata(
+                {_persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR: raw}
+            )
 
 
 def test_code_payload_metadata_rejects_invalid_entries() -> None:
@@ -1202,9 +1206,9 @@ def test_code_payload_metadata_rejects_invalid_entries() -> None:
     with pytest.raises(ValueError, match="unique locations"):
         store_code_payload_entries({}, (entry, duplicate))
 
-    attrs = {CODE_PAYLOAD_ENTRIES_ATTR: "stale"}
+    attrs = {_persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR: "stale"}
     store_code_payload_entries(attrs, ())
-    assert CODE_PAYLOAD_ENTRIES_ATTR not in attrs
+    assert _persistence_constants.CODE_PAYLOAD_ENTRIES_ATTR not in attrs
 
 
 def test_code_trust_notary_sign_check_remove_and_domain_separation(tmp_path) -> None:

--- a/tests/interactive/test_fit1d.py
+++ b/tests/interactive/test_fit1d.py
@@ -7,6 +7,8 @@ import threading
 import typing
 import weakref
 
+from erlab.interactive import _persistence_constants
+
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -670,7 +672,7 @@ def test_fit1d_managed_uncertainty_uses_named_persistence_input(qtbot) -> None:
     replacement_uncertainty = uncertainty + 0.1
     win._replace_persistence_data_items(
         {
-            erlab.interactive.utils._SAVED_TOOL_DATA_NAME: replacement_data,
+            _persistence_constants.SAVED_TOOL_DATA_NAME: replacement_data,
             "uncertainty": replacement_uncertainty,
         },
         xr.Dataset(),

--- a/tests/interactive/test_kspace.py
+++ b/tests/interactive/test_kspace.py
@@ -14,6 +14,7 @@ from qtpy import QtCore
 import erlab
 from erlab.accessors.kspace import IncompleteDataError, MomentumAccessor
 from erlab.constants import AxesConfiguration
+from erlab.interactive import _persistence_constants
 from erlab.interactive._options.schema import AppOptions
 from erlab.interactive.imagetool import _dialog_widgets, _kspace_conversion
 from erlab.interactive.imagetool import dialogs as imagetool_dialogs
@@ -3107,10 +3108,10 @@ def test_ktool_restore_prepares_referenced_data_from_saved_coordinates(
     )
     expected = tool._converted_output()
     saved = tool.to_dataset()
-    saved.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = json.dumps(
-        {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: {"kind": "parent_source"}}
+    saved.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR] = json.dumps(
+        {_persistence_constants.SAVED_TOOL_DATA_NAME: {"kind": "parent_source"}}
     )
-    saved_tool_data = saved[erlab.interactive.utils._SAVED_TOOL_DATA_NAME]
+    saved_tool_data = saved[_persistence_constants.SAVED_TOOL_DATA_NAME]
     assert saved_tool_data.dims == ("alpha", "eV")
     assert float(saved_tool_data.xi) == pytest.approx(0.0)
     assert float(saved_tool_data.chi) == pytest.approx(0.0)
@@ -3201,8 +3202,8 @@ def test_ktool_restore_rejects_unrecoverable_referenced_data(
     saved.attrs["tool_state"] = tool.tool_status.model_copy(
         update=status_update
     ).model_dump_json()
-    saved.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = json.dumps(
-        {erlab.interactive.utils._SAVED_TOOL_DATA_NAME: {"kind": "parent_source"}}
+    saved.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR] = json.dumps(
+        {_persistence_constants.SAVED_TOOL_DATA_NAME: {"kind": "parent_source"}}
     )
 
     with pytest.raises(ValueError, match=error_match):

--- a/tests/interactive/test_utils.py
+++ b/tests/interactive/test_utils.py
@@ -11,6 +11,8 @@ import typing
 import warnings
 from collections.abc import Callable, Mapping
 
+import dask
+import dask.array
 import lmfit
 import numpy as np
 import pydantic
@@ -23,6 +25,7 @@ from qtpy import PYQT6, QtCore, QtGui, QtTest, QtWidgets
 import erlab.interactive._plot_state
 import erlab.interactive.colors
 import erlab.interactive.utils
+from erlab.interactive import _persistence_constants
 from erlab.interactive._code_trust import (
     create_entry,
     create_manifest,
@@ -256,7 +259,7 @@ class _TwoInputPersistentTool(_PersistentTool):
 
     def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
         return {
-            erlab.interactive.utils._SAVED_TOOL_DATA_NAME: self._data,
+            _persistence_constants.SAVED_TOOL_DATA_NAME: self._data,
             "weights": self.weights,
         }
 
@@ -4468,7 +4471,7 @@ def test_tool_window_dataset_normalizes_invalid_source_state(qtbot) -> None:
         state="stale",
     )
     saved = tool.to_dataset()
-    saved.attrs[erlab.interactive.utils._TOOL_SOURCE_STATE_ATTR] = "unknown"
+    saved.attrs[_persistence_constants.TOOL_SOURCE_STATE_ATTR] = "unknown"
 
     restored = erlab.interactive.utils.ToolWindow.from_dataset(saved)
     qtbot.addWidget(restored)
@@ -4556,6 +4559,69 @@ def test_tool_window_dataset_roundtrips_script_inputs(qtbot) -> None:
     missing.set_script_inputs(inputs, primary_input="data")
     with pytest.raises(ValueError, match="canonical input item 'weights'"):
         missing.to_dataset()
+
+
+def test_tool_window_file_roundtrips_nested_input_attrs(qtbot, tmp_path) -> None:
+    strings = {
+        "unicode": np.str_("β😀\x00\x00"),
+        "bytes": np.bytes_(b"\xff\x00\x00"),
+        "empty_unicode": np.str_(""),
+        "empty_bytes": np.bytes_(b""),
+        "null_unicode": np.str_("\x00"),
+        "null_bytes": np.bytes_(b"\x00"),
+    }
+    keyed = {
+        "sample": 1,
+        np.str_("sample\x00"): 2,
+        b"sample": 3,
+        np.bytes_(b"sample\x00"): 4,
+        (np.str_("\x00"), np.bytes_(b"\x00")): 5,
+    }
+    data = xr.DataArray(
+        np.arange(4.0),
+        dims="x",
+        coords={"x": np.arange(4.0), "Fake Motor": ("x", np.arange(4.0) + 10)},
+        attrs={"nested": {"values": [1, 2, 3]}},
+        name="source",
+    )
+    data.coords["Fake Motor"].attrs["calibration"] = {"offset": None}
+    weights = data.copy(deep=True).rename("weights")
+    weights.attrs["nested"] = {"values": [4, 5, 6]}
+    # Add the scalars after copying: NumPy's deep copy strips trailing NULs.
+    for input_data in (data, weights):
+        input_data.attrs["strings"] = strings
+        input_data.attrs["keyed"] = keyed
+        input_data.coords["x"].attrs["strings"] = strings
+        input_data.coords["x"].attrs["keyed"] = keyed
+        input_data.coords["Fake Motor"].attrs["strings"] = strings
+        input_data.coords["Fake Motor"].attrs["keyed"] = keyed
+    tool = _TwoInputPersistentTool(data, weights)
+    qtbot.addWidget(tool)
+    tool.set_script_inputs(
+        (ScriptInput(name="data"), ScriptInput(name="weights")), primary_input="data"
+    )
+    path = tmp_path / "tool.nc"
+
+    for _ in range(2):
+        tool.to_file(path)
+        restored = erlab.interactive.utils.ToolWindow.from_file(path)
+        qtbot.addWidget(restored)
+        xr.testing.assert_identical(restored.tool_data, data)
+        xr.testing.assert_identical(restored.weights, weights)
+        for restored_input in (restored.tool_data, restored.weights):
+            for attrs in (
+                restored_input.attrs,
+                restored_input.coords["x"].attrs,
+                restored_input.coords["Fake Motor"].attrs,
+            ):
+                assert attrs["keyed"] == keyed
+                for key, expected in strings.items():
+                    actual = attrs["strings"][key]
+                    assert type(actual) is type(expected)
+                    assert actual.dtype == expected.dtype
+                    assert len(actual) == len(expected)
+                    assert actual.tobytes() == expected.tobytes()
+        tool = restored
 
 
 def test_tool_window_named_input_update_validates_before_mutation(qtbot) -> None:
@@ -4679,7 +4745,7 @@ def test_tool_window_persistence_replacement_uses_complete_named_inputs(
 
         def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
             return {
-                erlab.interactive.utils._SAVED_TOOL_DATA_NAME: self._data,
+                _persistence_constants.SAVED_TOOL_DATA_NAME: self._data,
                 "weights": self.weights,
                 "auxiliary": self.auxiliary,
             }
@@ -4725,7 +4791,7 @@ def test_tool_window_persistence_replacement_uses_complete_named_inputs(
         state="stale",
     )
 
-    saved_name = erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+    saved_name = _persistence_constants.SAVED_TOOL_DATA_NAME
     replacement_data = (data + 10.0).rename("stored-data")
     replacement_weights = (weights + 1.0).rename("stored-weights")
     replacement_auxiliary = xr.DataArray(2.0)
@@ -4767,7 +4833,7 @@ def test_tool_window_persistence_replacement_uses_complete_named_inputs(
 
 def test_source_free_persistence_replacement_requires_direct_restore(qtbot) -> None:
     data = xr.DataArray(np.arange(3.0), dims="x")
-    saved_name = erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+    saved_name = _persistence_constants.SAVED_TOOL_DATA_NAME
     tool = _PersistentTool(data)
     qtbot.addWidget(tool)
     with pytest.raises(NotImplementedError, match="_restore_persistence_data_items"):
@@ -4793,7 +4859,7 @@ def test_tool_window_deferred_named_input_update_commits_current_bindings(
     class _DeferredMultiInputTool(_PersistentTool):
         def _persistence_data_items(self) -> Mapping[str, xr.DataArray]:
             return {
-                erlab.interactive.utils._SAVED_TOOL_DATA_NAME: self._data,
+                _persistence_constants.SAVED_TOOL_DATA_NAME: self._data,
                 "weights": self.weights,
             }
 
@@ -5402,7 +5468,7 @@ def test_tool_window_saved_reference_requires_matching_resolved_data(qtbot) -> N
     with tool._save_tool_data_reference_context(available_node_uids=frozenset()):
         assert (
             tool._tool_data_reference_payload(
-                erlab.interactive.utils._SAVED_TOOL_DATA_NAME,
+                _persistence_constants.SAVED_TOOL_DATA_NAME,
                 tool_data,
             )
             is None
@@ -5479,14 +5545,14 @@ def test_tool_window_rejects_invalid_reference_payload(qtbot) -> None:
     qtbot.addWidget(list_payload_tool)
     with pytest.raises(TypeError, match="must be a dictionary"):
         list_payload_tool._reference_saved_tool_data(
-            erlab.interactive.utils._SAVED_TOOL_DATA_NAME, data
+            _persistence_constants.SAVED_TOOL_DATA_NAME, data
         )
 
     missing_kind_tool = _PayloadTool(data, {"kind": ""})
     qtbot.addWidget(missing_kind_tool)
     with pytest.raises(ValueError, match="non-empty kind"):
         missing_kind_tool._reference_saved_tool_data(
-            erlab.interactive.utils._SAVED_TOOL_DATA_NAME, data
+            _persistence_constants.SAVED_TOOL_DATA_NAME, data
         )
 
 
@@ -5509,7 +5575,7 @@ def test_tool_window_rejects_invalid_persistence_data_items(qtbot) -> None:
     empty_name = _BadItemsTool(
         data,
         {
-            erlab.interactive.utils._SAVED_TOOL_DATA_NAME: data,
+            _persistence_constants.SAVED_TOOL_DATA_NAME: data,
             "": data,
         },
     )
@@ -5519,22 +5585,22 @@ def test_tool_window_rejects_invalid_persistence_data_items(qtbot) -> None:
 
 
 def test_tool_window_rejects_invalid_saved_reference_metadata() -> None:
-    ds = xr.Dataset({erlab.interactive.utils._SAVED_TOOL_DATA_NAME: xr.DataArray(0)})
-    ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = ["not-json"]
+    ds = xr.Dataset({_persistence_constants.SAVED_TOOL_DATA_NAME: xr.DataArray(0)})
+    ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR] = ["not-json"]
     with pytest.raises(TypeError, match="JSON text"):
         erlab.interactive.utils.ToolWindow._saved_tool_data_references(ds)
 
-    ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = json.dumps([])
+    ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR] = json.dumps([])
     with pytest.raises(TypeError, match="JSON object"):
         erlab.interactive.utils.ToolWindow._saved_tool_data_references(ds)
 
-    ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = json.dumps(
+    ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR] = json.dumps(
         {"": {"kind": "manager_node"}}
     )
     with pytest.raises(TypeError, match="names must be strings"):
         erlab.interactive.utils.ToolWindow._saved_tool_data_references(ds)
 
-    ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = json.dumps(
+    ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR] = json.dumps(
         {"data": "manager_node"}
     )
     with pytest.raises(TypeError, match="must be an object"):
@@ -5573,7 +5639,7 @@ def test_tool_window_rejects_unreplayable_saved_source_reference() -> None:
 
 def test_tool_window_resolves_saved_reference_errors() -> None:
     data = xr.DataArray(np.arange(2.0), dims=("x",))
-    ds = xr.Dataset({erlab.interactive.utils._SAVED_TOOL_DATA_NAME: data})
+    ds = xr.Dataset({_persistence_constants.SAVED_TOOL_DATA_NAME: data})
 
     with pytest.raises(ValueError, match="parent data is unavailable"):
         erlab.interactive.utils.ToolWindow._resolve_saved_tool_data_reference(
@@ -5617,8 +5683,8 @@ def test_tool_window_saved_source_reference_authorizes_before_execution(
 ) -> None:
     data = xr.DataArray(np.arange(4.0), dims=("x",), coords={"x": np.arange(4.0)})
     operation = _expression_fit_operation()
-    ds = xr.Dataset({erlab.interactive.utils._SAVED_TOOL_DATA_NAME: data})
-    ds.attrs[erlab.interactive.utils._TOOL_SOURCE_SPEC_ATTR] = json.dumps(
+    ds = xr.Dataset({_persistence_constants.SAVED_TOOL_DATA_NAME: data})
+    ds.attrs[_persistence_constants.TOOL_SOURCE_SPEC_ATTR] = json.dumps(
         full_data(operation).model_dump(mode="json")
     )
     executions: list[None] = []
@@ -5840,8 +5906,8 @@ def test_tool_window_rejects_partial_capability_from_document_host(qtbot) -> Non
 
 
 def test_tool_window_resolves_references_with_missing_placeholder_variables() -> None:
-    ds = xr.Dataset({erlab.interactive.utils._SAVED_TOOL_DATA_NAME: xr.DataArray(0)})
-    ds.attrs[erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR] = json.dumps(
+    ds = xr.Dataset({_persistence_constants.SAVED_TOOL_DATA_NAME: xr.DataArray(0)})
+    ds.attrs[_persistence_constants.TOOL_DATA_REFERENCES_ATTR] = json.dumps(
         {"missing": {"kind": "manager_node", "node_uid": "missing"}}
     )
 
@@ -5853,16 +5919,16 @@ def test_tool_window_resolves_references_with_missing_placeholder_variables() ->
 
     xr.testing.assert_identical(data_items["missing"], xr.DataArray(1))
     xr.testing.assert_identical(
-        data_items[erlab.interactive.utils._SAVED_TOOL_DATA_NAME],
-        xr.DataArray(0, name=erlab.interactive.utils._SAVED_TOOL_DATA_NAME),
+        data_items[_persistence_constants.SAVED_TOOL_DATA_NAME],
+        xr.DataArray(0, name=_persistence_constants.SAVED_TOOL_DATA_NAME),
     )
     primary_only = erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(
         ds,
         source_parent_data=None,
         reference_resolver=None,
-        variable_names={erlab.interactive.utils._SAVED_TOOL_DATA_NAME},
+        variable_names={_persistence_constants.SAVED_TOOL_DATA_NAME},
     )
-    assert tuple(primary_only) == (erlab.interactive.utils._SAVED_TOOL_DATA_NAME,)
+    assert tuple(primary_only) == (_persistence_constants.SAVED_TOOL_DATA_NAME,)
 
     with pytest.raises(ValueError, match="could not be resolved"):
         erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(
@@ -5882,10 +5948,10 @@ def test_tool_window_resolves_references_with_missing_placeholder_variables() ->
 
 def test_tool_window_materializes_referenced_data_without_mutating_source() -> None:
     source = xr.DataArray(np.arange(4.0), dims=("x",)).chunk({"x": 2})
-    variable_name = erlab.interactive.utils._SAVED_TOOL_DATA_NAME
+    variable_name = _persistence_constants.SAVED_TOOL_DATA_NAME
     ds = xr.Dataset(
         attrs={
-            erlab.interactive.utils._TOOL_DATA_REFERENCES_ATTR: json.dumps(
+            _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
                 {variable_name: {"kind": "manager_node", "node_uid": "source"}}
             )
         }
@@ -5901,6 +5967,322 @@ def test_tool_window_materializes_referenced_data_without_mutating_source() -> N
     assert source.chunks is not None
     assert data_items[variable_name].chunks is None
     xr.testing.assert_identical(data_items[variable_name], source.compute())
+
+
+@pytest.mark.parametrize("materialize", [False, True])
+@pytest.mark.parametrize("lazy_data", [False, True])
+@pytest.mark.parametrize("lazy_coordinate", [False, True])
+def test_tool_window_reuses_materialized_references_with_independent_items(
+    materialize: bool,
+    lazy_data: bool,
+    lazy_coordinate: bool,
+) -> None:
+    values = np.arange(6.0).reshape(2, 3)
+    reads = {"data": 0, "coordinate": 0}
+
+    @dask.delayed
+    def read_values(kind: str) -> np.ndarray:
+        reads[kind] += 1
+        return values.copy() + (10 if kind == "coordinate" else 0)
+
+    source = xr.DataArray(
+        dask.array.from_delayed(read_values("data"), shape=(2, 3), dtype=float)
+        if lazy_data
+        else values.copy(),
+        name="source",
+        dims=("x", "y"),
+        coords={
+            "calibration": (
+                ("x", "y"),
+                dask.array.from_delayed(
+                    read_values("coordinate"), shape=(2, 3), dtype=float
+                )
+                if lazy_coordinate
+                else values.copy() + 10,
+            )
+        },
+        attrs={"metadata": {"label": "source"}},
+    )
+    expected = xr.DataArray(
+        values,
+        name="source",
+        dims=("x", "y"),
+        coords={"calibration": (("x", "y"), values + 10)},
+        attrs={"metadata": {"label": "source"}},
+    )
+    source_data = source.data
+    source_coordinate = source.calibration.data
+    primary = _persistence_constants.SAVED_TOOL_DATA_NAME
+    ds = xr.Dataset(
+        attrs={
+            _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                {
+                    name: {"kind": "manager_node", "node_uid": "source"}
+                    for name in (primary, "secondary")
+                }
+            )
+        }
+    )
+    resolutions = []
+
+    def resolve(reference):
+        resolutions.append(reference)
+        return source
+
+    for restoration in range(1, 3):
+        items = erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(
+            ds,
+            source_parent_data=None,
+            reference_resolver=resolve,
+            materialize_references=materialize,
+        )
+        assert len(resolutions) == 2 * restoration
+        assert source.data is source_data
+        assert source.calibration.data is source_coordinate
+        assert reads == {
+            "data": restoration if materialize and lazy_data else 0,
+            "coordinate": restoration if materialize and lazy_coordinate else 0,
+        }
+        if materialize:
+            for item in items.values():
+                assert item.chunks is None
+                xr.testing.assert_identical(item, expected)
+            assert (
+                np.shares_memory(items[primary].data, items["secondary"].data)
+                is not lazy_data
+            )
+            assert (
+                np.shares_memory(
+                    items[primary].calibration.data, items["secondary"].calibration.data
+                )
+                is not lazy_coordinate
+            )
+            if lazy_data:
+                items["secondary"].data[0, 0] = -1
+            else:
+                assert np.shares_memory(items["secondary"].data, source_data)
+            if lazy_coordinate:
+                items["secondary"].calibration.data[0, 0] = -2
+            else:
+                assert np.shares_memory(
+                    items["secondary"].calibration.data, source_coordinate
+                )
+            xr.testing.assert_identical(items[primary], expected)
+            assert source.attrs == expected.attrs
+        else:
+            assert items[primary] is items["secondary"] is source
+
+
+def test_tool_window_materialization_keeps_distinct_reference_results() -> None:
+    source = xr.DataArray(np.arange(6.0), dims="x").chunk({"x": 2})
+    primary = _persistence_constants.SAVED_TOOL_DATA_NAME
+    selection_spec = full_data(IselOperation(kwargs={"x": slice(0, 2)}))
+    ds = xr.Dataset(
+        attrs={
+            _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                {
+                    primary: {"kind": "manager_node", "node_uid": "source"},
+                    "selection": {
+                        "kind": "manager_node",
+                        "node_uid": "source",
+                        "source_spec": selection_spec.model_dump(mode="json"),
+                    },
+                    "other": {"kind": "manager_node", "node_uid": "other"},
+                }
+            )
+        }
+    )
+    other = source + 10
+    items = erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(
+        ds,
+        source_parent_data=None,
+        reference_resolver=lambda reference: (
+            source if reference["node_uid"] == "source" else other
+        ),
+        materialize_references=True,
+    )
+
+    xr.testing.assert_identical(items[primary], source.compute())
+    xr.testing.assert_identical(
+        items["selection"], source.isel(x=slice(0, 2)).compute()
+    )
+    xr.testing.assert_identical(items["other"], other.compute())
+    assert source.chunks is not None
+    assert other.chunks is not None
+
+
+@pytest.mark.parametrize("resident", [None, "data", "calibration"])
+def test_tool_window_materializes_backend_references_once(
+    tmp_path, monkeypatch, resident: str | None
+) -> None:
+    import xarray.backends.h5netcdf_
+
+    expected = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        name="data",
+        dims=("x", "y"),
+        coords={
+            "x": [0.0, 1.0],
+            "y": [2.0, 3.0, 4.0],
+            "calibration": (("x", "y"), np.arange(6.0).reshape(2, 3) + 10),
+        },
+    )
+    path = tmp_path / "reference.h5"
+    expected.to_netcdf(path, engine="h5netcdf")
+    primary = _persistence_constants.SAVED_TOOL_DATA_NAME
+    ds = xr.Dataset(
+        attrs={
+            _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                {
+                    name: {"kind": "manager_node", "node_uid": "source"}
+                    for name in (primary, "secondary", "third")
+                }
+            )
+        }
+    )
+    with xr.open_dataarray(path, engine="h5netcdf", chunks=None) as source:
+        if resident == "data":
+            source.variable.load()
+        elif resident == "calibration":
+            source.calibration.variable.load()
+        source_data = source.variable._data
+        source_coordinate = source.calibration.variable._data
+        reads: list[str] = []
+        original_getitem = xarray.backends.h5netcdf_.H5NetCDFArrayWrapper._getitem
+
+        def read_values(self, key):
+            reads.append(self.variable_name)
+            return original_getitem(self, key)
+
+        monkeypatch.setattr(
+            xarray.backends.h5netcdf_.H5NetCDFArrayWrapper, "_getitem", read_values
+        )
+        items = erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(
+            ds,
+            source_parent_data=None,
+            reference_resolver=lambda _reference: source,
+            materialize_references=True,
+        )
+        assert sorted(reads) == sorted(
+            name for name in ("data", "calibration") if name != resident
+        )
+        assert source.variable._data is source_data
+        assert source.calibration.variable._data is source_coordinate
+        assert source.variable._in_memory is (resident == "data")
+        assert source.calibration.variable._in_memory is (resident == "calibration")
+        for item in items.values():
+            xr.testing.assert_identical(item, expected)
+            for dim in expected.dims:
+                assert item.indexes[dim].equals(expected.indexes[dim])
+        for name in ("secondary", "third"):
+            assert np.shares_memory(items[primary].data, items[name].data) is (
+                resident == "data"
+            )
+            assert np.shares_memory(
+                items[primary].calibration.data, items[name].calibration.data
+            ) is (resident == "calibration")
+        if resident != "data":
+            items["secondary"].data[0, 0] = -1
+        if resident != "calibration":
+            items["secondary"].calibration.data[0, 0] = -2
+        xr.testing.assert_identical(items[primary], expected)
+        xr.testing.assert_identical(items["third"], expected)
+
+
+def test_tool_window_materialization_keeps_unindexed_lazy_coordinates() -> None:
+    reads: list[None] = []
+
+    @dask.delayed
+    def read_coordinate() -> np.ndarray:
+        reads.append(None)
+        return np.arange(3.0)
+
+    source = xr.DataArray(
+        np.arange(3.0),
+        dims="x",
+        coords=xr.Coordinates(
+            {
+                "x": xr.Variable(
+                    "x",
+                    dask.array.from_delayed(read_coordinate(), shape=(3,), dtype=float),
+                )
+            },
+            indexes={},
+        ),
+    )
+    primary = _persistence_constants.SAVED_TOOL_DATA_NAME
+    ds = xr.Dataset(
+        attrs={
+            _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                {
+                    name: {"kind": "manager_node", "node_uid": "source"}
+                    for name in (primary, "secondary")
+                }
+            )
+        }
+    )
+    items = erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(
+        ds,
+        source_parent_data=None,
+        reference_resolver=lambda _reference: source,
+        materialize_references=True,
+    )
+    assert reads == [None]
+    assert source.x.chunks is not None
+    for item in items.values():
+        assert not item.xindexes
+        assert item.x.chunks is None
+        np.testing.assert_array_equal(item.x.data, np.arange(3.0))
+    assert not np.shares_memory(items[primary].x.data, items["secondary"].x.data)
+    assert np.shares_memory(items[primary].data, items["secondary"].data)
+    xr.testing.assert_identical(items[primary], items["secondary"])
+
+
+@pytest.mark.parametrize("kind", ["eager", "lazy", "index", "level"])
+def test_tool_window_materialization_preserves_multiindex_references(kind: str) -> None:
+    stacked = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("x", "y"),
+        coords={"x": [10, 20], "y": [1, 2, 3]},
+    ).stack(z=("x", "y"))
+    if kind == "index":
+        source = stacked.z
+    elif kind == "level":
+        source = stacked.x
+    elif kind == "lazy":
+        source = stacked.chunk({"z": 2})
+    else:
+        source = stacked
+    primary = _persistence_constants.SAVED_TOOL_DATA_NAME
+    ds = xr.Dataset(
+        attrs={
+            _persistence_constants.TOOL_DATA_REFERENCES_ATTR: json.dumps(
+                {
+                    name: {"kind": "manager_node", "node_uid": "source"}
+                    for name in (primary, "secondary")
+                }
+            )
+        }
+    )
+    items = erlab.interactive.utils.ToolWindow._tool_data_items_from_dataset(
+        ds,
+        source_parent_data=None,
+        reference_resolver=lambda _reference: source,
+        materialize_references=True,
+    )
+    for item in items.values():
+        xr.testing.assert_identical(item, source.compute())
+        assert set(item.xindexes) == set(source.xindexes)
+        assert item.indexes["z"].equals(source.indexes["z"])
+        xr.testing.assert_identical(
+            item.sel(z=(10, 2)), source.sel(z=(10, 2)).compute()
+        )
+        assert type(item.variable) is type(source.variable)
+    if kind in {"eager", "lazy"}:
+        assert np.shares_memory(items[primary].data, items["secondary"].data) is (
+            kind == "eager"
+        )
+        assert (source.chunks is not None) is (kind == "lazy")
 
 
 def test_tool_window_without_inputs_has_no_source_controls(qtbot) -> None:


### PR DESCRIPTION
## Changes

Workspace restoration repeats metadata reads and can compute deferred data before a window is shown. Tool files also cannot preserve nested metadata through the existing HDF5 attribute path.

- Cache eligible numeric HDF5 reads within the active store session. Clear cached handles when the session changes.
- Restore manifest metadata once, defer hidden data restoration, and reuse saved previews and materialized source data.
- Share the typed attribute codec between tool files and workspaces. Preserve nested values on data and coordinates, including secondary tool inputs and stale Figure Composer sources.
- Preserve NumPy string contents, trailing NUL characters, and typed dictionary keys. Keep legacy scalar decoding compatible.
- Retain trust inspection across tool class reloads and consolidate shared persistence keys and format constants.

## Validation

- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync mypy src` — passed for 296 source files.
- `uv run --no-sync python -m scripts.ci_test_groups --check-partition`
- `git diff --check`
- The command below passed with both `QT_API=pyqt6` and `QT_API=pyside6`, with `QT_QPA_PLATFORM=offscreen`: 463 tests per binding.

```sh
uv run --no-sync pytest -q \
  tests/interactive/test_utils.py \
  tests/interactive/imagetool/manager/workspace/test_arrays.py \
  tests/interactive/imagetool/manager/workspace/test_format.py \
  tests/interactive/imagetool/manager/workspace/test_saving.py::test_manager_workspace_full_save_roundtrips_non_native_data_attrs \
  tests/interactive/imagetool/manager/workspace/test_saving.py::test_manager_workspace_stale_figure_preserves_nested_attrs
```

An additional 140 HDF5 metadata round-trip checks passed during review. These cover numeric arrays, Unicode and byte strings, date/time values, object arrays, and nested metadata. The full test suite was not rerun after the final codec fixes. There are no visual layout changes.
