### PR TITLE
fix(imagetool): preserve colorbar zoom during limit edits

### DIFF
--- a/src/erlab/interactive/colors.py
+++ b/src/erlab/interactive/colors.py
@@ -486,6 +486,7 @@ class _ColorBarLimitWidget(QtWidgets.QWidget):
     def reset(self):
         self._set_spin_values(-np.inf, np.inf)
         self.update_region()
+        self.cb.vb.setRange(xRange=(0.0, 1.0), yRange=self.cb.limits, padding=0.0)
 
     @QtCore.Slot()
     def update_region(self):
@@ -631,7 +632,8 @@ class BetterColorBarItem(pg.PlotItem):
 
         self.addItem(self._span)
 
-        self._fixedlimits: tuple[float, float] | None = None
+        self._fixed_limits: tuple[float, float] | None = None
+        self._view_limits: tuple[float, float] | None = None
         self.setAutoLevels(autoLevels)
         self._images: set[weakref.ref[BetterImageItem]] = set()
         self._primary_image: weakref.ref[BetterImageItem] | None = None
@@ -721,8 +723,8 @@ class BetterColorBarItem(pg.PlotItem):
 
     @property
     def limits(self) -> tuple[float, float]:
-        if self._fixedlimits is not None:
-            return self._fixedlimits
+        if self._fixed_limits is not None:
+            return self._fixed_limits
         image = self.primary_image()
         limits = tuple(float(value) for value in image.quickMinMax(targetSize=2**16))
         if all(np.isfinite(value) for value in limits):
@@ -859,7 +861,7 @@ class BetterColorBarItem(pg.PlotItem):
             if levels is None:
                 levels = self.spanRegion()
 
-        self._fixedlimits = limits
+        self._fixed_limits = limits
         if self._primary_image is not None:
             if levels is not None:
                 self._set_span_region_blocked(levels)
@@ -1038,14 +1040,16 @@ class BetterColorBarItem(pg.PlotItem):
         if not hasattr(self, "limits"):
             return
         self.color_changed()
-        # if (self._fixedlimits is not None) or (mn is None):
+        # if (self._fixed_limits is not None) or (mn is None):
         mn, mx = self.limits
         self._colorbar.setTransform(self._colorbar_image_transform())
         self._span.setTransform(self._normalized_transform())
         if self.levels is not None:
             self._colorbar.setLevels(self._levels_to_span_units(self.levels))
         self._span.setBounds((0.0, 1.0))
-        self.vb.setRange(xRange=(0.0, 1.0), yRange=(mn, mx), padding=0.0)
+        if self._view_limits != (mn, mx):
+            self.vb.setRange(xRange=(0.0, 1.0), yRange=(mn, mx), padding=0.0)
+            self._view_limits = (mn, mx)
 
     # def cmap_changed(self):
     #     cmap = self.imageItem()._colorMap

--- a/tests/interactive/test_colors.py
+++ b/tests/interactive/test_colors.py
@@ -490,6 +490,86 @@ def test_colorbar_image_maps_to_large_data_limits(qtbot):
     assert mapped_rect.bottom() == pytest.approx(mx)
 
 
+@pytest.fixture(params=["standalone", "imagetool"])
+def zoomed_colorbar(qtbot, request):
+    data = np.arange(100, dtype=float).reshape(10, 10)
+    if request.param == "imagetool":
+        window = erlab.interactive.itool(data, execute=False)
+        qtbot.addWidget(window)
+        window.show()
+        window.slicer_area.lock_levels(True)
+        widget = window.slicer_area._colorbar
+        colorbar = widget.cb
+    else:
+        image = BetterImageItem(data)
+        image.set_colormap("viridis", gamma=1.0)
+        colorbar = BetterColorBarItem(image=image)
+        widget = pg.PlotWidget(plotItem=colorbar)
+        qtbot.addWidget(widget)
+        widget.resize(150, 400)
+        widget.show()
+
+    QtWidgets.QApplication.processEvents()
+    colorbar.setSpanRegion((20.0, 80.0))
+    colorbar.vb.setYRange(15.0, 90.0, padding=0.0)
+    QtWidgets.QApplication.processEvents()
+    # Retain the image or window until qtbot closes the widgets.
+    return widget, colorbar, window if request.param == "imagetool" else image
+
+
+@pytest.mark.parametrize("level", [20.0, 50.0, 80.0])
+def test_colorbar_drag_preserves_zoom(qtbot, zoomed_colorbar, level):
+    widget, colorbar, _owner = zoomed_colorbar
+    start = widget.mapFromScene(colorbar.vb.mapViewToScene(pg.Point(0.5, level)))
+    end = start - QtCore.QPoint(0, 12)
+    delta = (
+        colorbar.vb.mapSceneToView(widget.mapToScene(end)).y()
+        - colorbar.vb.mapSceneToView(widget.mapToScene(start)).y()
+    )
+
+    qtbot.mousePress(widget.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=start)
+    qtbot.mouseMove(widget.viewport(), pos=end)
+    qtbot.mouseRelease(widget.viewport(), QtCore.Qt.MouseButton.LeftButton, pos=end)
+    QtWidgets.QApplication.processEvents()
+
+    expected = (
+        20.0 + (delta if level != 80.0 else 0.0),
+        80.0 + (delta if level != 20.0 else 0.0),
+    )
+    assert colorbar.spanRegion() == pytest.approx(expected)
+    assert colorbar.levels == pytest.approx(expected)
+    assert colorbar.vb.viewRange()[1] == pytest.approx((15.0, 90.0))
+
+
+@pytest.mark.parametrize("edit_min", [True, False])
+def test_colorbar_limit_editor_preserves_zoom(qtbot, zoomed_colorbar, edit_min):
+    _, colorbar, _owner = zoomed_colorbar
+    colorbar.vb.getMenu(None)
+    menu = colorbar._clim_menu
+    editor = colorbar._clim_widget
+    menu.popup(QtCore.QPoint(0, 0))
+    QtWidgets.QApplication.processEvents()
+
+    assert colorbar.spanRegion() == pytest.approx((20.0, 80.0))
+    assert colorbar.vb.viewRange()[1] == pytest.approx((15.0, 90.0))
+    spin = editor.min_spin if edit_min else editor.max_spin
+    spin.setValue(21.0 if edit_min else 79.0)
+
+    expected = (21.0, 80.0) if edit_min else (20.0, 79.0)
+    assert colorbar.spanRegion() == pytest.approx(expected)
+    assert colorbar.levels == pytest.approx(expected)
+    assert colorbar.vb.viewRange()[1] == pytest.approx((15.0, 90.0))
+
+    for _ in range(2):
+        # Reset also restores the view when the selected levels are already full range.
+        colorbar.vb.setYRange(15.0, 90.0, padding=0.0)
+        qtbot.mouseClick(editor.rst_btn, QtCore.Qt.MouseButton.LeftButton)
+        assert colorbar.spanRegion() == pytest.approx((0.0, 99.0))
+        assert colorbar.levels == pytest.approx((0.0, 99.0))
+        assert colorbar.vb.viewRange()[1] == pytest.approx((0.0, 99.0))
+    menu.close()
+
+
 def test_colorbar_limit_change_preserves_data_levels(qtbot):
     image = BetterImageItem(np.arange(100, dtype=float).reshape(10, 10))
     image.set_colormap("viridis", gamma=1.0)
@@ -501,11 +581,15 @@ def test_colorbar_limit_change_preserves_data_levels(qtbot):
     QtWidgets.QApplication.processEvents()
 
     colorbar.setSpanRegion((2.0, 8.0))
+    colorbar.vb.setYRange(1.0, 9.0, padding=0.0)
+    colorbar.setLimits((0.0, 10.0))
+    assert colorbar.vb.viewRange()[1] == pytest.approx((1.0, 9.0))
     colorbar.setLimits((0.0, 20.0))
     QtWidgets.QApplication.processEvents()
 
     assert colorbar.spanRegion() == pytest.approx((2.0, 8.0))
     assert image.getLevels() == pytest.approx((2.0, 8.0))
+    assert colorbar.vb.viewRange()[1] == pytest.approx((0.0, 20.0))
 
 
 def test_colorbar_normalized_helpers_handle_invalid_limits(qtbot, monkeypatch):
@@ -515,7 +599,7 @@ def test_colorbar_normalized_helpers_handle_invalid_limits(qtbot, monkeypatch):
     widget = pg.PlotWidget(plotItem=colorbar)
     qtbot.addWidget(widget)
 
-    colorbar._fixedlimits = (np.inf, np.inf)
+    colorbar._fixed_limits = (np.inf, np.inf)
     monkeypatch.setattr(colorbar._colorbar, "width", lambda: 0)
     monkeypatch.setattr(colorbar._colorbar, "height", lambda: 0)
 
@@ -528,7 +612,7 @@ def test_colorbar_normalized_helpers_handle_invalid_limits(qtbot, monkeypatch):
         QtCore.QRectF(0.0, 0.0, 1.0, 1.0)
     )
 
-    colorbar._fixedlimits = (5.0, 5.0)
+    colorbar._fixed_limits = (5.0, 5.0)
 
     assert colorbar._level_to_span_unit(np.nan) == 0.0
     assert colorbar._level_to_span_unit(6.0) == 0.0


### PR DESCRIPTION
Editing color limits after zooming the colorbar resets its visible range to the full data range. Preserve zoom and pan while dragging either handle, dragging the selected region, or editing numeric limits. Restore the full view on Reset or when the full scale bounds change.

Track the scale bounds used for the view. Rename `_fixedlimits` to `_fixed_limits` for consistent naming. Add regression tests for standalone colorbars and ImageTool.

Validation on the latest `main`:

- `QT_API=pyqt6 PYTEST_QT_API=pyqt6 PYTHONPATH=src uv run --no-sync pytest tests/interactive/test_colors.py -q` — 58 passed.
- `QT_API=pyside6 PYTEST_QT_API=pyside6 PYTHONPATH=src uv run --no-sync pytest tests/interactive/test_colors.py -q` — 58 passed.
- `uv run --no-sync ruff format .`
- `uv run --no-sync ruff check --fix .`
- `uv run --no-sync python -m scripts.ci_test_groups --check-partition`
- `git diff --check origin/main...HEAD`
- Commit hooks passed.

The commands used the existing development environment through `UV_PROJECT_ENVIRONMENT`.

Visual verification used an offscreen ImageTool window with data spanning 0–99, selected limits 20–80, and a visible range of 15–90. Changing the lower limit to 21 produced the following results:

| State | Selected limits | Visible range |
| --- | --- | --- |
| Before | 21–80 | 0–99 |
| After | 21–80 | 15–90 |

Before-and-after screenshots were captured locally. They are not attached because the available GitHub browser session is signed out.
