### PR TITLE
fix(ftool): persist the Fit2D parameter plot selection

### DIFF
--- a/src/erlab/interactive/_fit1d.py
+++ b/src/erlab/interactive/_fit1d.py
@@ -768,6 +768,7 @@ class _State2D(pydantic.BaseModel):
     params_from_coord_full: list[dict[str, str]]
     fill_mode: typing.Literal["previous", "extrapolate", "none"]
     y_limits: tuple[int, int] | None = None
+    param_plot_selection: str = ""
     param_plot_overlay_states: dict[str, bool] = pydantic.Field(default_factory=dict)
 
 

--- a/src/erlab/interactive/_fit2d.py
+++ b/src/erlab/interactive/_fit2d.py
@@ -674,6 +674,7 @@ class Fit2DTool(Fit1DTool):
         self._fit_2d_last_live_refresh: float = 0.0
         self._fit_2d_live_refresh_pending: bool = False
         self._fit_2d_param_plot_refresh_pending: bool = False
+        self._pending_param_plot_selection: str = ""
         self._fit_2d_last_completed_idx: int | None = None
         self._fit_2d_last_completed_elapsed: float | None = None
         self._fit_2d_sequence_write_history: bool | None = None
@@ -1505,6 +1506,10 @@ class Fit2DTool(Fit1DTool):
                 self.fill_mode_combo.currentText().lower(),
             ),
             y_limits=(self.y_min_spin.value(), self.y_max_spin.value()),
+            param_plot_selection=(
+                self._pending_param_plot_selection
+                or self.param_plot_combo.currentText()
+            ),
             param_plot_overlay_states={
                 name: checked
                 for name, checked in self._param_plot_overlay_states.items()
@@ -1540,6 +1545,9 @@ class Fit2DTool(Fit1DTool):
     ) -> None:
         """Apply base and per-slice state under one execution capability."""
         state2d = status.state2d
+        self._pending_param_plot_selection = (
+            state2d.param_plot_selection if state2d is not None else ""
+        )
         restored_data = self._data_with_saved_dims(self._data_full, state2d)
         if restored_data.dims != self._data_full.dims:
             with self._history_suppressed():
@@ -1703,9 +1711,14 @@ class Fit2DTool(Fit1DTool):
     @QtCore.Slot()
     def _update_param_plot_options(self) -> None:
         with QtCore.QSignalBlocker(self.param_plot_combo):
-            prev_param = self.param_plot_combo.currentText()
+            prev_param = (
+                self._pending_param_plot_selection
+                or self.param_plot_combo.currentText()
+            )
             self.param_plot_combo.clear()
             updated_names = self._param_plot_names()
+            if updated_names:
+                self._pending_param_plot_selection = ""
             self.param_plot_combo.addItems(updated_names)
             for name in updated_names:
                 self._param_plot_overlay_states.setdefault(name, False)

--- a/tests/interactive/test_fit2d.py
+++ b/tests/interactive/test_fit2d.py
@@ -2419,8 +2419,9 @@ def test_fit2d_rejects_ambiguous_internal_weighting(qtbot) -> None:
         )
 
 
+@pytest.mark.parametrize("defer_restore", [False, True])
 def test_fit2d_persistence_roundtrip_preserves_fit_results(
-    qtbot, exp_decay_model
+    qtbot, exp_decay_model, defer_restore
 ) -> None:
     t = np.linspace(0.0, 4.0, 25)
     y = np.arange(3)
@@ -2435,24 +2436,64 @@ def test_fit2d_persistence_roundtrip_preserves_fit_results(
     assert isinstance(win, Fit2DTool)
 
     _seed_fit2d_full_results(win, exp_decay_model, params)
+    win.param_plot_combo.setCurrentIndex(1)
+    selected_param = win.param_plot_combo.currentText()
+    assert selected_param
     expected_results = [
         None if ds is None else ds.copy(deep=True) for ds in win._result_ds_full
     ]
     expected_status = win.tool_status.model_dump()
 
     win_restored = erlab.interactive.utils.ToolWindow.from_dataset(
-        win.to_dataset(), _code_trust=new_document_trust()
+        win.to_dataset(),
+        _code_trust=new_document_trust(),
+        _defer_restore_work=defer_restore,
     )
     qtbot.addWidget(win_restored)
     assert isinstance(win_restored, Fit2DTool)
 
+    if defer_restore:
+        saved_status = json.loads(win_restored.to_dataset().attrs["tool_state"])
+        assert saved_status["state2d"]["param_plot_selection"] == selected_param
+        win_restored._flush_restore_work()
     assert win_restored._fit_is_current
+    assert win_restored.param_plot_combo.currentText() == selected_param
+    plot_y, values, _ = win_restored._param_plot_data(selected_param)
+    plot_x, actual_y = win_restored.param_plot_scatter.getData()
+    np.testing.assert_array_equal(plot_x, values)
+    np.testing.assert_array_equal(actual_y, plot_y)
     assert all(ds is not None for ds in win_restored._result_ds_full)
     _assert_fit_result_list_equivalent(win_restored._result_ds_full, expected_results)
     assert win_restored.tool_status.model_dump() == expected_status
     assert win_restored.copy_full_button.isEnabled()
     assert win_restored.save_full_button.isEnabled()
     assert win_restored.current_provenance_spec() is not None
+
+
+@pytest.mark.parametrize("selection", [None, "unavailable_parameter"])
+def test_fit2d_restore_missing_param_plot_selection(
+    qtbot, exp_decay_model, selection
+) -> None:
+    params = exp_decay_model.make_params(n0=1.0, tau=1.0)
+    win = erlab.interactive.ftool(
+        _make_2d_data(), model=exp_decay_model, params=params, execute=False
+    )
+    qtbot.addWidget(win)
+    _seed_fit2d_full_results(win, exp_decay_model, params)
+    dataset = win.to_dataset()
+    status = json.loads(dataset.attrs["tool_state"])
+    if selection is None:
+        del status["state2d"]["param_plot_selection"]
+    else:
+        status["state2d"]["param_plot_selection"] = selection
+    dataset.attrs["tool_state"] = json.dumps(status)
+
+    restored = erlab.interactive.utils.ToolWindow.from_dataset(
+        dataset, _code_trust=new_document_trust()
+    )
+    qtbot.addWidget(restored)
+    assert restored.param_plot_combo.currentIndex() == 0
+    assert restored.param_plot_combo.currentText() == win.param_plot_combo.itemText(0)
 
 
 def test_fit2d_irregular_current_slice_disables_unsafe_segments(


### PR DESCRIPTION
Fit2D loses the selected parameter in the parameter plot when an ImageTool workspace is reopened. Save the selection in the tool state and restore it when the fit results populate the parameter list. Preserve the selection when a hidden tool is saved before deferred restoration completes. Older files and unavailable parameter names retain the default selection.

Regression tests check the selected parameter and plotted values after eager and deferred restoration. They also cover saving before deferred restoration and missing or unavailable selections.

Validation:
- `PYTHONPATH=src QT_API=pyqt6 ERLAB_TEST_DATA_DIR=/Users/khan/Source/python/erlabpy-data /Users/khan/Source/python/erlabpy/.venv/bin/python -m pytest -q tests/interactive/test_fit2d.py` — 235 passed.
- The same Python environment with `QT_API=pyside6`, running `test_fit2d_persistence_roundtrip_preserves_fit_results`, `test_fit2d_restore_missing_param_plot_selection`, `test_fit2d_tool_status_restore`, and `test_fit2d_tool_status_overlay_and_limits` — 6 passed.
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run python -m scripts.ci_test_groups --check-partition`
- `git diff --check`
